### PR TITLE
Initialize OpenDistro Index if InjectedUser is enabled. 

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -110,6 +110,7 @@ public class BackendRegistry implements ConfigurationChangeListener {
     private final AdminDNs adminDns;
     private final XFFResolver xffResolver;
     private volatile boolean anonymousAuthEnabled = false;
+    private volatile boolean injectedUserEnabled = false;
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab;
@@ -354,6 +355,8 @@ public class BackendRegistry implements ConfigurationChangeListener {
         anonymousAuthEnabled = settings.getAsBoolean("opendistro_security.dynamic.http.anonymous_auth_enabled", false)
                 && !esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false);
 
+        injectedUserEnabled = esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED,false);
+
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
@@ -367,7 +370,7 @@ public class BackendRegistry implements ConfigurationChangeListener {
         authBackendFailureListeners = Multimaps.unmodifiableMultimap(authBackendFailureListeners0);
 
         //Open Distro Security no default authc
-        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled;
+        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled || injectedUserEnabled;
 
         if(originalDestroyableComponents != null) {
             destroyDestroyables(originalDestroyableComponents);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -93,6 +93,24 @@ public class InitializationIntegrationTests extends SingleClusterTest {
     }
 
     @Test
+    public void testInitWithInjectedUser() throws Exception {
+
+        final Settings settings = Settings.builder()
+                .putList("path.repo", repositoryPath.getRoot().getAbsolutePath())
+                .put("opendistro_security.unsupported.inject_user.enabled", true)
+                .build();
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_disable_all.yml"), settings, true);
+
+        RestHelper rh = nonSslRestHelper();
+
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/config/0", "{}", encodeBasicHeader("___", "")).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/sg/config", "{}", encodeBasicHeader("___", "")).getStatusCode());
+
+    }
+
+
+    @Test
     public void testWhoAmI() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityInternalUsers("internal_empty.yml")
                 .setSecurityRoles("roles_deny.yml"), Settings.EMPTY, true);

--- a/src/test/resources/config_disable_all.yml
+++ b/src/test/resources/config_disable_all.yml
@@ -1,0 +1,18 @@
+opendistro_security:
+  dynamic:
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: 192\.168\.0\.10|192\.168\.0\.11
+        remoteIpHeader: "x-forwarded-for"
+        proxiesHeader: "x-forwarded-by"
+        trustedProxies: "proxy1|proxy2"
+    authc:
+      authentication_domain_basic_internal:
+        enabled: false
+        order: 0
+        http_authenticator:
+          type: basic
+        authentication_backend:
+          type: intern


### PR DESCRIPTION
Currently, if you disable basic auth and anonymous auth, open distro index in uninitialized. This is a real problem when we have just an injected_user enabled. In a case like this, doing any API call would return a 503 - internal service error, with a cryptic message of "OpenDistro Index not Initialized". We would like to initialize the index if injected_user is enabled. This way, even if the authentication fails, you will get something that makes sense, like a 401 UNAUTHORIZED with a message of Authentication Finally failed. 