### PR TITLE
Initialize index if injected_user var set

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -110,6 +110,7 @@ public class BackendRegistry implements ConfigurationChangeListener {
     private final AdminDNs adminDns;
     private final XFFResolver xffResolver;
     private volatile boolean anonymousAuthEnabled = false;
+    private volatile boolean injectedUserEnabled = false;
     private final Settings esSettings;
     private final Path configPath;
     private final InternalAuthenticationBackend iab;
@@ -354,6 +355,8 @@ public class BackendRegistry implements ConfigurationChangeListener {
         anonymousAuthEnabled = settings.getAsBoolean("opendistro_security.dynamic.http.anonymous_auth_enabled", false)
                 && !esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false);
 
+        injectedUserEnabled = esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED,false);
+
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
@@ -367,7 +370,7 @@ public class BackendRegistry implements ConfigurationChangeListener {
         authBackendFailureListeners = Multimaps.unmodifiableMultimap(authBackendFailureListeners0);
 
         //Open Distro Security no default authc
-        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled;
+        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled || injectedUserEnabled;
 
         if(originalDestroyableComponents != null) {
             destroyDestroyables(originalDestroyableComponents);

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -93,6 +93,24 @@ public class InitializationIntegrationTests extends SingleClusterTest {
     }
 
     @Test
+    public void testInitWithInjectedUser() throws Exception {
+
+        final Settings settings = Settings.builder()
+                .putList("path.repo", repositoryPath.getRoot().getAbsolutePath())
+                .put("opendistro_security.unsupported.inject_user.enabled", true)
+                .build();
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_disable_all.yml"), settings, true);
+
+        RestHelper rh = nonSslRestHelper();
+
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/config/0", "{}", encodeBasicHeader("___", "")).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest(".opendistro_security/sg/config", "{}", encodeBasicHeader("___", "")).getStatusCode());
+
+    }
+
+
+    @Test
     public void testWhoAmI() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityInternalUsers("internal_empty.yml")
                 .setSecurityRoles("roles_deny.yml"), Settings.EMPTY, true);

--- a/src/test/resources/config_disable_all.yml
+++ b/src/test/resources/config_disable_all.yml
@@ -1,0 +1,18 @@
+opendistro_security:
+  dynamic:
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: 192\.168\.0\.10|192\.168\.0\.11
+        remoteIpHeader: "x-forwarded-for"
+        proxiesHeader: "x-forwarded-by"
+        trustedProxies: "proxy1|proxy2"
+    authc:
+      authentication_domain_basic_internal:
+        enabled: false
+        order: 0
+        http_authenticator:
+          type: basic
+        authentication_backend:
+          type: intern


### PR DESCRIPTION
Currently, if you disable basic auth and anonymous auth, open distro index in uninitialized. This is a real problem when we have just an injected_user enabled. In a case like this, doing any API call would return a 503 - internal service error, with a cryptic message of "OpenDistro Index not Initialized". We would like to initialize the index if injected_user is enabled. This way, even if the authentication fails, you will get something that makes sense, like a 401 UNAUTHORIZED with a message of Authentication Finally failed.

Ran tests -> (OpenSSL failing, but that's due to the OpenSSL missing/var not set)

Advanced Modules:
[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 551, Failures: 0, Errors: 0, Skipped: 5
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Users/nprashar/ws/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.2.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security_advanced_modules ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security_advanced_modules ---
[INFO] Building jar: /Users/nprashar/ws/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.2-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security_advanced_modules ---
[INFO] Installing /Users/nprashar/ws/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.2.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.2/opendistro_security_advanced_modules-0.9.0.2.jar
[INFO] Installing /Users/nprashar/ws/security-advanced-modules/pom.xml to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.2/opendistro_security_advanced_modules-0.9.0.2.pom
[INFO] Installing /Users/nprashar/ws/security-advanced-modules/target/opendistro_security_advanced_modules-0.9.0.2-tests.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security_advanced_modules/0.9.0.2/opendistro_security_advanced_modules-0.9.0.2-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11:41 min
[INFO] Finished at: 2019-08-27T16:03:53-07:00
[INFO] ------------------------------------------------------------------------

Security :

[INFO]
[INFO] Results:
[INFO]
[WARNING] Tests run: 100, Failures: 0, Errors: 0, Skipped: 4
[INFO]
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:jar (default-jar) @ opendistro_security ---
[INFO] Building jar: /Users/nprashar/ws/security/target/opendistro_security-0.9.0.2.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.3:validateRevision (validate-the-git-infos) @ opendistro_security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.0:test-jar (default) @ opendistro_security ---
[INFO] Building jar: /Users/nprashar/ws/security/target/opendistro_security-0.9.0.2-tests.jar
[INFO]
[INFO] --- maven-install-plugin:2.4:install (default-install) @ opendistro_security ---
[INFO] Installing /Users/nprashar/ws/security/target/opendistro_security-0.9.0.2.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.2/opendistro_security-0.9.0.2.jar
[INFO] Installing /Users/nprashar/ws/security/pom.xml to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.2/opendistro_security-0.9.0.2.pom
[INFO] Installing /Users/nprashar/ws/security/target/opendistro_security-0.9.0.2-tests.jar to /Users/nprashar/.m2/repository/com/amazon/opendistroforelasticsearch/opendistro_security/0.9.0.2/opendistro_security-0.9.0.2-tests.jar
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 05:44 min
[INFO] Finished at: 2019-08-27T15:50:11-07:00
[INFO] ————————————————————————————————————




[WARNING] Tests run: 23, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 166.811 s - in com.amazon.opendistroforelasticsearch.security.ssl.SSLTest
[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   OpenSSLTest.testHttpPlainFail
Expected: an instance of org.apache.http.NoHttpResponseException
     but: <java.net.SocketException: Connection reset> is a java.net.SocketException
Stacktrace was: java.net.SocketException: Connection reset
    at java.net.SocketInputStream.read(SocketInputStream.java:210)
    at java.net.SocketInputStream.read(SocketInputStream.java:141)
    at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137)
    at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153)
    at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:282)
    at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138)
    at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56)
    at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259)
    at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163)
    at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:165)
    at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273)
    at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125)
    at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272)
    at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185)
    at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
    at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:111)
    at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
    at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
    at com.amazon.opendistroforelasticsearch.security.ssl.AbstractUnitTest.executeSimpleRequest(AbstractUnitTest.java:288)
    at com.amazon.opendistroforelasticsearch.security.ssl.SSLTest.testHttpPlainFail(SSLTest.java:395)
    at com.amazon.opendistroforelasticsearch.security.ssl.OpenSSLTest.testHttpPlainFail(OpenSSLTest.java:93)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
    at org.junit.rules.TestWatcher$1.evaluate(TestWatcher.java:55)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
    at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
    at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
    at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
    at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
    at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
    at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)

[ERROR] Errors:
[ERROR]   OpenSSLTest>SSLTest.testCRL:769->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest>SSLTest.testCRLPem:745->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest>SSLTest.testCustomPrincipalExtractor:710->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest.testHttpsAndNodeSSL:86->SSLTest.testHttpsAndNodeSSL:263->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest>SSLTest.testHttpsAndNodeSSLKeyPass:839->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest.testHttpsAndNodeSSLPem:180->SSLTest.testHttpsAndNodeSSLPem:301->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest.testHttpsAndNodeSSLPemEnc:186->SSLTest.testHttpsAndNodeSSLPemEnc:335->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest.testHttpsNoEnforce:100->SSLTest.testHttpsNoEnforce:416->AbstractUnitTest.executeSimpleRequest:288 » Socket
[ERROR]   OpenSSLTest.testHttpsOptionalAuth:135->SSLTest.testHttpsOptionalAuth:232->AbstractUnitTest.executeSimpleRequest:288 » Socket
[INFO]
[ERROR] Tests run: 53, Failures: 1, Errors: 9, Skipped: 3
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 05:44 min
[INFO] Finished at: 2019-08-27T15:34:43-07:00
[INFO] ------------------------------------------------------------------------

