### PR TITLE
Tenant Permissions : added the possibility to specify tenants via par…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/ConfigModelV7.java
@@ -979,6 +979,7 @@ public class ConfigModelV7 extends ConfigModel {
             final ExecutorService execs = Executors.newFixedThreadPool(10);
 
             for(Entry<String, RoleV7> securityRole: roles.getCEntries().entrySet()) {
+
                 if(securityRole.getValue() == null) {
                     continue;
                 }
@@ -988,7 +989,6 @@ public class ConfigModelV7 extends ConfigModel {
                     public Tuple<String, Set<Tuple<String, Boolean>>> call() throws Exception {
                         final Set<Tuple<String, Boolean>> tuples = new HashSet<>();
                         final List<RoleV7.Tenant> tenants = securityRole.getValue().getTenant_permissions();
-
                         if (tenants != null) {
                             
                             for (RoleV7.Tenant tenant : tenants) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/ConfigModelV7.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -96,13 +97,13 @@ public class ConfigModelV7 extends ConfigModel {
             log.error("Cannot apply roles mapping resolution", e);
             rolesMappingResolution = ConfigConstants.RolesMappingResolution.MAPPING_ONLY;
         }
-        
+
         agr = reloadActionGroups(actiongroups);
         securityRoles = reload(roles);
         tenantHolder = new TenantHolder(roles, tenants);
         roleMappingHolder = new RoleMappingHolder(rolemappings, dcm.getHostsResolverMode());
     }
-    
+
     public Set<String> getAllConfiguredTenantNames() {
         return Collections.unmodifiableSet(tenants.getCEntries().keySet());
     }
@@ -114,7 +115,7 @@ public class ConfigModelV7 extends ConfigModel {
     private static interface ActionGroupResolver {
         Set<String> resolvedActions(final List<String> actions);
     }
-    
+
     private ActionGroupResolver reloadActionGroups(SecurityDynamicConfiguration<ActionGroupsV7> actionGroups) {
         return new ActionGroupResolver() {
             
@@ -968,10 +969,6 @@ public class ConfigModelV7 extends ConfigModel {
                 );
     }
     
-    
-    
-    //#######
-    
     private class TenantHolder {
 
         private SetMultimap<String, Tuple<String, Boolean>> tenantsMM = null;
@@ -982,7 +979,6 @@ public class ConfigModelV7 extends ConfigModel {
             final ExecutorService execs = Executors.newFixedThreadPool(10);
 
             for(Entry<String, RoleV7> securityRole: roles.getCEntries().entrySet()) {
-                
                 if(securityRole.getValue() == null) {
                     continue;
                 }
@@ -996,9 +992,17 @@ public class ConfigModelV7 extends ConfigModel {
                         if (tenants != null) {
                             
                             for (RoleV7.Tenant tenant : tenants) {
-                                
-                                for(String matchingTenant: WildcardMatcher.from(tenant.getTenant_patterns()).getMatchAny(definedTenants.getCEntries().keySet(), Collectors.toList())) {
+
+                                // find Wildcarded tenant patterns
+                                List<String> matchingTenants = WildcardMatcher.from(tenant.getTenant_patterns()).getMatchAny(definedTenants.getCEntries().keySet(), Collectors.toList()) ;
+                                for(String matchingTenant: matchingTenants ) {
                                     tuples.add(new Tuple<String, Boolean>(matchingTenant, agr.resolvedActions(tenant.getAllowed_actions()).contains("kibana:saved_objects/*/write")));
+                                }
+                                // find parameter substitution specified tenant
+                                Pattern parameterPattern = Pattern.compile("^\\$\\{attr");
+                                List<String> matchingParameterTenantList = tenant.getTenant_patterns().stream().filter(parameterPattern.asPredicate()).collect(Collectors.toList());
+                                for(String matchingParameterTenant : matchingParameterTenantList ) {
+                                    tuples.add(new Tuple<String, Boolean>(matchingParameterTenant,agr.resolvedActions(tenant.getAllowed_actions()).contains("kibana:saved_objects/*/write"))) ;
                                 }
                             }
                         }
@@ -1050,11 +1054,22 @@ public class ConfigModelV7 extends ConfigModel {
             result.put(user.getName(), true);
 
             tenantsMM.entries().stream().filter(e -> roles.contains(e.getKey())).filter(e -> !user.getName().equals(e.getValue().v1())).forEach(e -> {
-                final String tenant = e.getValue().v1();
+
+                // replaceProperties for tenant name because
+                // at this point e.getValue().v1() can be in this form : "${attr.[internal|jwt|proxy|ldap].*}"
+                // let's substitute it with the eventual value of the user's attribute
+                final String tenant = replaceProperties(e.getValue().v1(),user);
                 final boolean rw = e.getValue().v2();
 
                 if (rw || !result.containsKey(tenant)) { //RW outperforms RO
-                    result.put(tenant, rw);
+
+                    // We want to make sure that we add a tenant that exissts
+                    // Indeed, because we don't have control over what will be
+                    // passed on as values of users' attributes, we have to make
+                    // sure that we don't allow them to select tenants that do not exist.
+                    if(ConfigModelV7.this.tenants.getCEntries().keySet().contains(tenant)) {
+                        result.put(tenant, rw);
+                    }
                 }
             });
             

--- a/src/test/resources/multitenancy/internal_users.yml
+++ b/src/test/resources/multitenancy/internal_users.yml
@@ -148,3 +148,11 @@ kibanaro:
   backend_roles: []
   attributes: {}
   description: "Migrated from v6"
+user_tenant_parameters_substitution:
+  hash: "$2y$12$xgJfGiHpYOkRpF9W9dXYZOpJJ4bHz3VTwdv7ZZYTwlvx7NbH62qUi"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes:
+    attribute1: "tenant_parameters_substitution"
+  description: "PR# 819 / Issue#817"

--- a/src/test/resources/multitenancy/roles.yml
+++ b/src/test/resources/multitenancy/roles.yml
@@ -463,3 +463,20 @@ opendistro_security_role_starfleet_captains:
     - "command_tenant"
     allowed_actions:
     - "kibana_all_write"
+opendistro_security_role_tenant_parameters_substitution:
+  reserved: false
+  hidden: false
+  description: "PR#819 / Issue#817"
+  cluster_permissions:
+  - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS"
+  index_permissions:
+  - index_patterns:
+    - "?kibana"
+    allowed_actions:
+    - "ALL"
+  tenant_permissions:
+  - tenant_patterns:
+    - "${attr.internal.attribute1}"
+    - "${attr.internal.attribute1}_1"
+    allowed_actions:
+    - "kibana_all_write"

--- a/src/test/resources/multitenancy/roles_mapping.yml
+++ b/src/test/resources/multitenancy/roles_mapping.yml
@@ -160,3 +160,12 @@ opendistro_security_kibana4_testindex:
   - "test"
   and_backend_roles: []
   description: "Migrated from v6"
+opendistro_security_role_tenant_parameters_substitution:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+  - "user_tenant_parameters_substitution"
+  and_backend_roles: []
+  description: "PR#819 / Issue#817"

--- a/src/test/resources/multitenancy/roles_tenants.yml
+++ b/src/test/resources/multitenancy/roles_tenants.yml
@@ -54,3 +54,12 @@ human_resources:
   reserved: false
   hidden: false
   description: "Migrated from v6"
+tenant_parameters_substitution:
+  reserved: false
+  hidden: false
+  description: "PR#819 / Issue#817"
+tenant_parameters_substitution_1:
+  reserved: false
+  hidden: false
+  description: "PR#819 / Issue#817"
+


### PR DESCRIPTION
Please provide as much details as possible to get feedback/acceptance on your PR quickly

**Category: (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)**
    Enhancement / New Feature : specify tenants in roles via parameter substitution (like for indexes and DLS)

    Github Issue # or road-map entry, if available: 
    #817 

**Description of changes:**
The idea would be that this user :
```yaml
new-user:
  hash: "*************"
  reserved: false
  hidden: false
  opendistro_security_roles:
  - "role-tenant1"
  attributes:
    attribute1: "tenant1"
  static: false
```
Would only have access to the tenant tenant1 if the role role-tenant1 was defined like this :

```yaml
role-tenant1:
 reserved: false
 hidden: false
 cluster_permissions:
 - "read"
 - "cluster:monitor/nodes/stats"
 - "cluster:monitor/task/get"
 tenant_permissions:
 - tenant_patterns:
   - ${attr.internal.attribute1}
   allowed_actions:
   - "kibana_all_write"
 static: false
_meta:
 type: "roles"
 config_version: 2
```

**Why these changes are required?**
    Enhancement of the way tenants are specified in roles definitions. Allows for more generic roles to be created with information being received from the authorization backend for instance.

**What is the old behavior before changes and new behavior after changes? (Please add any example/logs/screen-shot if available)**
   Before the change, tenants could only be specified statically or via patterns in role definitions

**Testing done: (Please provide details of testing done: Unit testing, integration testing and manual testing)**
     Testing done manually

**TO-DOs, if any: (Please describe pending items and provide Github issues# for each of them)**
    Provide proper tests units.

**Is it backport from master branch? (If yes, please add backport PR # and commits #)**
    No

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.