### PR TITLE
fix #13 fix for : DLS overrides broader permissions

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsNoDlsAndDlsAtTheSameTime.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/dlic/dlsfls/DlsNoDlsAndDlsAtTheSameTime.java
@@ -1,0 +1,123 @@
+package com.amazon.opendistroforelasticsearch.security.dlic.dlsfls;
+
+import org.apache.http.HttpStatus;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.transport.TransportClient;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class DlsNoDlsAndDlsAtTheSameTime extends AbstractDlsFlsTest{
+
+    // ## How have these tests been built ?? ##
+    // Tests for PR #1078 and Issue #13
+    // https://github.com/opendistro-for-elasticsearch/security/pull/1078
+    // The idea here is to make sure that when a user has 2 or more distinct roles
+    // pointing at the same indices via index patterns that are either directly
+    // declared, via wilcards or via user attributes, if one of those roles has NO
+    // DLS declared, that we make sure that the user has access to ALL the documents
+    // of these indices.
+    // Tests are organized like this :
+    // * user : user_with_dls_and_no_dls_at_the_same_time (declared in internal_users.yml
+    // declared in the corresponding resources folder)
+    // * roles (declared in roles.yml in the corresponding resources folder):
+    //   - opendistro_no_dls : role pointing to the test indices with no DLS declared
+    //   - opendistro_dls : role pointing to the test indices with no DLS declared
+    // * indices :
+    //   - dls_no_dls_index_simple : this index is directly declared in the index patterns of the role def
+    //   - dls_no_dls_index_wildcard : can be declared in the index patterns of the role def via a wildcard
+    //   - dls_no_dls_index_attribute : can be declared in the index patterns of the role def via a user attribute substitution
+    //   - dls_no_dls_index_mixed : can ne declared in the index patterns via a user attribute substitution plus a wildcard
+    //   - dls_no_dls_only_dls : This index is used to ensure that the dls is working and will filter on documents with field1 = value1
+
+    // our test indices variable
+    List<String> indices_with_dls_and_no_dls = Arrays.asList("dls_no_dls_index_simple",
+                                                             "dls_no_dls_index_wildcard",
+                                                             "dls_no_dls_index_attribute",
+                                                             "dls_no_dls_index_mixed");
+
+    String index_with_only_dls = "dls_no_dls_only_dls" ;
+
+
+    protected void populateData(TransportClient tc) {
+
+        // Create indices that are pointed by both role with dls and no dls at the same time
+        List <String> all_indices = new ArrayList<>(indices_with_dls_and_no_dls);
+        all_indices.add(index_with_only_dls) ;
+
+        all_indices.forEach((index) -> {
+        tc.index(new IndexRequest(index).type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"field1\": \"value1\", \"id\": 1}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest(index).type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"field1\": \"value2\", \"id\": 2}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest(index).type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"field1\": \"value3\", \"id\": 3}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest(index).type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source("{\"field1\": \"value1\", \"id\": 4}", XContentType.JSON)).actionGet();
+        });
+    }
+
+    @Test
+    public void testDlsAccess() throws Exception {
+
+        setup();
+
+        HttpResponse res;
+        String current_index = "" ;
+        // Loop through our indices that are pointed by both role with dls and no dls at the same time
+        for (int i = 0; i < indices_with_dls_and_no_dls.size() ; i++) {
+            try {
+                current_index = indices_with_dls_and_no_dls.get(i);
+                res = rh.executeGetRequest("/"+current_index+"/_search?pretty",
+                                           encodeBasicHeader("user_with_dls_and_no_dls_at_the_same_time",
+                                                   "user_with_dls_and_no_dls_at_the_same_time")) ;
+                System.out.println("###>>>### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+current_index+", Response Body // Start // : ");
+
+                Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+                System.out.println(res.getBody());
+                System.out.println("###<<<### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+current_index+", Response Body // End //");
+                Assert.assertTrue(res.getBody().contains("\"id\" : 1"));
+                Assert.assertTrue(res.getBody().contains("\"id\" : 2"));
+                Assert.assertTrue(res.getBody().contains("\"id\" : 3"));
+                Assert.assertTrue(res.getBody().contains("\"id\" : 4"));
+
+            } catch(Exception e) {
+                System.out.println("###!!!>>>### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+current_index+", Exception :" );
+                System.out.println(e.toString());
+                System.out.println("###!!!<<<### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+current_index+", Exception :" );
+            }
+        }
+
+        // Ensure dls is working with index pointed only by dls.
+        String index = index_with_only_dls ;
+        try {
+            res = rh.executeGetRequest("/"+index+"/_search?pretty",
+                    encodeBasicHeader("user_with_dls_and_no_dls_at_the_same_time",
+                            "user_with_dls_and_no_dls_at_the_same_time")) ;
+            System.out.println("###>>>### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+index+", Response Body // Start // : ");
+
+            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+
+            System.out.println(res.getBody());
+            System.out.println("###<<<### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+index+", Response Body // End //");
+            Assert.assertTrue(res.getBody().contains("\"id\" : 1"));
+            Assert.assertTrue(! res.getBody().contains("\"id\" : 2"));
+            Assert.assertTrue(! res.getBody().contains("\"id\" : 3"));
+            Assert.assertTrue(res.getBody().contains("\"id\" : 4"));
+
+        } catch(Exception e) {
+            System.out.println("###!!!>>>### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+index+", Exception :" );
+            System.out.println(e.toString());
+            System.out.println("###!!!<<<### Test : DlsNoDlsAndDlsAtTheSameTime ### Tested Index "+index+", Exception :" );
+        }
+    }
+}
+

--- a/src/test/resources/dlsfls/internal_users.yml
+++ b/src/test/resources/dlsfls/internal_users.yml
@@ -171,3 +171,9 @@ date_math:
 fls_exists:
   #password
   hash: $2a$12$YCBrpxYyFusK609FurY5Ee3BlmuzWw0qHwpwqEyNhM2.XnQY3Bxpe
+user_with_dls_and_no_dls_at_the_same_time:
+  hash: $2y$12$59388eoP6F/eIGJ6PIKvkuVDcSCe544T/YKGvL7jWuUzrJgC.URvm
+  description: "Issue #13, PR #1078 : DLS overrides broader permissions"
+  attributes:
+    attribute1: dls_no_dls_index_attribute
+    attribute2: dls_no_dls_index

--- a/src/test/resources/dlsfls/roles.yml
+++ b/src/test/resources/dlsfls/roles.yml
@@ -2466,3 +2466,61 @@ opendistro_security_combined:
     allowed_actions:
     - "OPENDISTRO_SECURITY_READ"
   tenant_permissions: []
+
+opendistro_no_dls:
+  reserved: true
+  hidden: false
+  description: "Issue #13, PR #1078 : DLS overrides broader permissions, This role has no DLS"
+  index_permissions:
+  - index_patterns:
+    - 'dls_no_dls_index_simple'
+    dls: null
+    allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
+  - index_patterns:
+    - 'dls_no_dls_index_*'
+    dls: null
+    allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
+  - index_patterns:
+    - "${attr.internal.attribute1}"
+    dls: null
+    allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
+  - index_patterns:
+    - "${attr.internal.attribute2}_*"
+    dls: null
+    allowed_actions:
+      - "OPENDISTRO_SECURITY_READ"
+
+
+opendistro_dls:
+  reserved: true
+  hidden: false
+  description: "Issue #13, PR #1078 : DLS overrides broader permissions, this role has DLS"
+  index_permissions:
+    - index_patterns:
+      - 'dls_no_dls_index_simple'
+      dls: '{"term": {"field1":"value1"}}'
+      allowed_actions:
+      - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+      - 'dls_no_dls_index_wildcard'
+      dls: '{"term": {"field1":"value1"}}'
+      allowed_actions:
+      - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+      - 'dls_no_dls_index_attribute'
+      dls: '{"term": {"field1":"value1"}}'
+      allowed_actions:
+      - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+      - 'dls_no_dls_index_mixed'
+      dls: '{"term": {"field1":"value1"}}'
+      allowed_actions:
+      - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+        - 'dls_no_dls_only_dls'
+      dls: '{"term": {"field1":"value1"}}'
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"

--- a/src/test/resources/dlsfls/roles_mapping.yml
+++ b/src/test/resources/dlsfls/roles_mapping.yml
@@ -234,3 +234,9 @@ opendistro_security_date_math:
 opendistro_security_fls_exists:
   users:
     - fls_exists
+opendistro_dls:
+  users:
+    - user_with_dls_and_no_dls_at_the_same_time
+opendistro_no_dls:
+  users:
+    - user_with_dls_and_no_dls_at_the_same_time


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_
This PR fixes the issue #13 that describes how a user with :

1. one or more role that has some DLS configuration for document filtering 
2. one or more role with no DLS filtering (i.e. has access to everything)

still sees only the conjunction of DLS restriction instead of the conjunction of DLS + everything = everything.
 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__
#13


 3. __Description of changes:__
The idea of the change is to position a dummy __dlsfullaccess__ string inside the DLS object, this way when the whole map is parsed, if this string is found, all other entry are cleared for the specified index pattern.


 4. __Why these changes are required?__ 
This is a a bug the behavior of the plugin does not reflect what has been configured.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
```bash
##############################
Create internal user ...

{
  "status" : "CREATED",
  "message" : "'my_user' created."
}

##############################
Create 'regular' role with dls on index 'my_index' ...

{
  "status" : "CREATED",
  "message" : "'my_role1' created."
}

##############################
Map 'regular' role with dls filtering on index my_index ...

{"status":"CREATED","message":"'my_role1' created."}
##############################
Create 'admin' (all access) role without dls filtering ...

{
  "status" : "CREATED",
  "message" : "'my_admin_role_without_dls_match_all' created."
}

##############################
Map 'admin' (all access) role without dls filtering ...

{"status":"OK","message":"'my_admin_role_without_dls_match_all' updated."}
##############################
Get authinfo ...

{
  "user" : "User [name=my_user, backend_roles=[], requestedTenant=null]",
  "user_name" : "my_user",
  "user_requested_tenant" : null,
  "remote_address" : "[::1]:55724",
  "backend_roles" : [ ],
  "custom_attribute_names" : [ ],
  "roles" : [
    "my_role1",
    "own_index",
    "my_admin_role_without_dls_match_all"
  ],
  "tenants" : {
    "my_user" : true
  },
  "principal" : null,
  "peer_certificates" : "0",
  "sso_logout_url" : null
}

##############################
Get my_index data ...

{
  "took" : 86,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 1,
      "relation" : "eq"
    },
    "max_score" : 2.0,
    "hits" : [
      {
        "_index" : "my_index",
        "_type" : "_doc",
        "_id" : "1",
        "_score" : 2.0,
        "_source" : {
          "field1" : "value1"
        }
      }
    ]
  }
}

```
Here the user should see more fields. 
~~I will provide more data/scripts to test against from within the PR.~~
I have provided proper test units from within the PR

 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 The testing has, for the moment, been done only with custom script, I have yet to familiarize myself with the testing framework provided with the code.
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)
Not that I know or can think of.


 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)
No



By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
