### PR TITLE
Add parameters to authorize index_global_state restore

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -998,6 +998,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
 
             // system integration
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_SECURITYINDEX_ENABLED, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_GLOBAL_STATE_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS, false, Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/SnapshotRestoreEvaluator.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/privileges/SnapshotRestoreEvaluator.java
@@ -51,11 +51,13 @@ public class SnapshotRestoreEvaluator {
     private final String opendistrosecurityIndex;
     private final AuditLog auditLog;
     private final boolean restoreSecurityIndexEnabled;
+    private final boolean restoreGlobalStateEnabled;
     
     public SnapshotRestoreEvaluator(final Settings settings, AuditLog auditLog) {
         this.enableSnapshotRestorePrivilege = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE,
                 ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_ENABLE_SNAPSHOT_RESTORE_PRIVILEGE);
         this.restoreSecurityIndexEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_SECURITYINDEX_ENABLED, false);
+        this.restoreGlobalStateEnabled = settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_GLOBAL_STATE_ENABLED, false);
 
         this.opendistrosecurityIndex = settings.get(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);
         this.auditLog = auditLog;
@@ -91,7 +93,7 @@ public class SnapshotRestoreEvaluator {
         final RestoreSnapshotRequest restoreRequest = (RestoreSnapshotRequest) request;
 
         // Do not allow restore of global state
-        if (restoreRequest.includeGlobalState()) {
+        if (restoreRequest.includeGlobalState() && !restoreGlobalStateEnabled) {
             auditLog.logSecurityIndexAttempt(request, action, task);
             log.warn(action + " with 'include_global_state' enabled is not allowed");
             presponse.allowed = false;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -245,6 +245,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "opendistro_security.unsupported.disable_rest_auth_initially";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY = "opendistro_security.unsupported.disable_intertransport_auth_initially";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_SECURITYINDEX_ENABLED = "opendistro_security.unsupported.restore.securityindex.enabled";
+    public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_GLOBAL_STATE_ENABLED = "opendistro_security.unsupported.restore.global.state.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_ALLOW_NOW_IN_DLS = "opendistro_security.unsupported.allow_now_in_dls";

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/privileges/SnapshotRestoreEvaluatorTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/privileges/SnapshotRestoreEvaluatorTests.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2015-2018 _floragunn_ GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Portions Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistroforelasticsearch.security.privileges;
+
+import com.amazon.opendistroforelasticsearch.security.OpenDistroSecurityPlugin;
+import com.amazon.opendistroforelasticsearch.security.auditlog.NullAuditLog;
+import com.amazon.opendistroforelasticsearch.security.configuration.ClusterInfoHolder;
+import org.apache.lucene.index.IndexCommit;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.RepositoryMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.Lifecycle;
+import org.elasticsearch.common.component.LifecycleListener;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.snapshots.IndexShardSnapshotStatus;
+import org.elasticsearch.index.store.Store;
+import org.elasticsearch.indices.recovery.RecoveryState;
+import org.elasticsearch.repositories.*;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+
+public class SnapshotRestoreEvaluatorTests {
+
+    private SnapshotRestoreEvaluator snapshotRestoreEvaluator;
+    private RestoreSnapshotRequest restoreRequest;
+    private Task task;
+    private ClusterInfoHolder clusterInfoHolder;
+    private PrivilegesEvaluatorResponse presponse;
+
+
+    private class TestRepository implements Repository {
+
+        private boolean isClosed;
+        private boolean isStarted;
+
+        private final RepositoryMetadata metadata;
+
+        private TestRepository(RepositoryMetadata metadata) {
+            this.metadata = metadata;
+        }
+
+        @Override
+        public RepositoryMetadata getMetadata() {
+            return metadata;
+        }
+
+        @Override
+        public SnapshotInfo getSnapshotInfo(SnapshotId snapshotId) {
+            return null;
+        }
+
+        @Override
+        public Metadata getSnapshotGlobalMetadata(SnapshotId snapshotId) {
+            return null;
+        }
+
+        @Override
+        public IndexMetadata getSnapshotIndexMetaData(RepositoryData repositoryData, SnapshotId snapshotId, IndexId index) {
+            return null;
+        }
+
+        @Override
+        public void getRepositoryData(ActionListener<RepositoryData> listener) {
+            RepositoryData repositoryData = new RepositoryData(1, new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
+                ShardGenerations.EMPTY, IndexMetaDataGenerations.EMPTY);
+            listener.onResponse(repositoryData);
+        }
+
+        @Override
+        public void initializeSnapshot(SnapshotId snapshotId, List<IndexId> indices, Metadata metadata) {
+
+        }
+
+        @Override
+        public void finalizeSnapshot(ShardGenerations shardGenerations, long repositoryStateId, Metadata clusterMetadata,
+                                     SnapshotInfo snapshotInfo, Version repositoryMetaVersion,
+                                     Function<ClusterState, ClusterState> stateTransformer,
+                                     ActionListener<RepositoryData> listener) {
+            listener.onResponse(null);
+        }
+
+        @Override
+        public void deleteSnapshots(Collection<SnapshotId> snapshotIds, long repositoryStateId, Version repositoryMetaVersion,
+                                    ActionListener<RepositoryData> listener) {
+            listener.onResponse(null);
+        }
+
+        @Override
+        public long getSnapshotThrottleTimeInNanos() {
+            return 0;
+        }
+
+        @Override
+        public long getRestoreThrottleTimeInNanos() {
+            return 0;
+        }
+
+        @Override
+        public String startVerification() {
+            return null;
+        }
+
+        @Override
+        public void endVerification(String verificationToken) {
+
+        }
+
+        @Override
+        public void verify(String verificationToken, DiscoveryNode localNode) {
+
+        }
+
+        @Override
+        public boolean isReadOnly() {
+            return false;
+        }
+
+        @Override
+        public void snapshotShard(Store store, MapperService mapperService, SnapshotId snapshotId, IndexId indexId,
+                                  IndexCommit snapshotIndexCommit, String shardStateIdentifier, IndexShardSnapshotStatus snapshotStatus,
+                                  Version repositoryMetaVersion, Map<String, Object> userMetadata, ActionListener<String> listener) {
+
+        }
+
+        @Override
+        public void restoreShard(Store store, SnapshotId snapshotId, IndexId indexId, ShardId snapshotShardId,
+                                 RecoveryState recoveryState, ActionListener<Void> listener) {
+
+        }
+
+        @Override
+        public IndexShardSnapshotStatus getShardSnapshotStatus(SnapshotId snapshotId, IndexId indexId, ShardId shardId) {
+            return null;
+        }
+
+        @Override
+        public void updateState(final ClusterState state) {
+        }
+
+        @Override
+        public void executeConsistentStateUpdate(Function<RepositoryData, ClusterStateUpdateTask> createUpdateTask, String source,
+                                                 Consumer<Exception> onFailure) {
+        }
+
+        @Override
+        public void cloneShardSnapshot(SnapshotId source, SnapshotId target, RepositoryShardId shardId, String shardGeneration,
+                                       ActionListener<String> listener) {
+
+        }
+
+        @Override
+        public Lifecycle.State lifecycleState() {
+            return null;
+        }
+
+        @Override
+        public void addLifecycleListener(LifecycleListener listener) {
+
+        }
+
+        @Override
+        public void removeLifecycleListener(LifecycleListener listener) {
+
+        }
+
+        @Override
+        public void start() {
+            isStarted = true;
+        }
+
+        @Override
+        public void stop() {
+
+        }
+
+        @Override
+        public void close() {
+            isClosed = true;
+        }
+    }
+
+    @Before
+    public void init() {
+        restoreRequest = Mockito.mock(RestoreSnapshotRequest.class);
+        Mockito.when(restoreRequest.includeGlobalState()).thenReturn(true);
+        task = Mockito.mock(Task.class);
+        clusterInfoHolder = Mockito.mock(ClusterInfoHolder.class);
+        Mockito.when(clusterInfoHolder.isLocalNodeElectedMaster()).thenReturn(true);
+        presponse = new PrivilegesEvaluatorResponse();
+        
+        RepositoriesService repositoriesService = Mockito.mock(RepositoriesService.class);
+        TestRepository repository = new TestRepository(Mockito.mock(RepositoryMetadata.class));
+        Mockito.when(repositoriesService.repository(Mockito.any())).thenReturn(repository);
+        TransportService remoteClusterService = Mockito.mock(TransportService.class);
+        new OpenDistroSecurityPlugin.GuiceHolder(repositoriesService, remoteClusterService);
+    }
+
+
+    @Test
+    public void testSnapshotNotAllowedWithGlobalState() throws Exception {
+        final Settings settings = Settings.builder()
+            .build();
+
+        snapshotRestoreEvaluator = new SnapshotRestoreEvaluator(settings, new NullAuditLog());
+
+        snapshotRestoreEvaluator.evaluate(restoreRequest, task, "action", clusterInfoHolder, presponse);
+        Assert.assertFalse(presponse.allowed);
+        Assert.assertTrue(PrivilegesEvaluatorResponse.PrivilegesEvaluatorResponseState.COMPLETE.equals(presponse.state));
+
+    }
+
+    @Test
+    public void testSnapshotAllowedWithGlobalState() throws Exception {
+        final Settings settings = Settings.builder()
+            .put("opendistro_security.unsupported.restore.global.state.enabled", true)
+            .build();
+
+        snapshotRestoreEvaluator = new SnapshotRestoreEvaluator(settings, new NullAuditLog());
+
+        snapshotRestoreEvaluator.evaluate(restoreRequest, task, "action", clusterInfoHolder, presponse);
+        Assert.assertFalse(presponse.allowed);
+        Assert.assertTrue(PrivilegesEvaluatorResponse.PrivilegesEvaluatorResponseState.PENDING.equals(presponse.state));
+    }
+
+}


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ Enhancement
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__

Add possibility to authorize snapshot restore with index global state

 4. __Why these changes are required?__ 

Needed to restore templates, ILM and ilm state on index when restoring indices

 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)

index_global_state is just not authorized

 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
