### PR TITLE
Add rolespath to JWT authentication

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -40,7 +40,7 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 
-import com.amazon.dlic.util.Roles;
+import com.amazon.dlic.util.RolesUtil;
 import com.amazon.opendistroforelasticsearch.security.auth.HTTPAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.jayway.jsonpath.Configuration;
@@ -68,7 +68,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String jsonRolesPath;
-    private Configuration jsonPathConfig;
+    private final Configuration jsonPathConfig;
     private final String subjectKey;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
@@ -123,7 +123,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
         // throw exception when settings provided both roles_key and roles_path
         if (rolesKey != null && jsonRolesPath != null) {
-            throw new IllegalStateException("Both roles_key and roles_path have simultaneously provided." +
+            throw new IllegalStateException("Both roles_key and roles_path are simultaneously provided." +
                     " Please provide only one combination.");
         }
         jsonPathConfig = Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST);
@@ -254,7 +254,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     	// get roles from roles_path if roles_path is specified
     	if (jsonRolesPath != null){
     	    try {
-                return Roles.split(JsonPath.using(jsonPathConfig).parse(claims).read(jsonRolesPath));
+                return RolesUtil.split(JsonPath.using(jsonPathConfig).parse(claims).read(jsonRolesPath));
             } catch (PathNotFoundException e) {
                 log.error("The provided JSON path {} could not be found ", jsonRolesPath);
                 return new String[0];
@@ -268,7 +268,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     		return new String[0];
     	}
 
-    	return Roles.split(rolesObject);
+    	return RolesUtil.split(rolesObject);
     }
 
     private static PublicKey getPublicKey(final byte[] keyBytes, final String algo) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -40,8 +40,14 @@ import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 
+import com.amazon.dlic.util.Roles;
 import com.amazon.opendistroforelasticsearch.security.auth.HTTPAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.PathNotFoundException;
+
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
@@ -61,6 +67,8 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
     private final String rolesKey;
+    private final String jsonRolesPath;
+    private Configuration jsonPathConfig;
     private final String subjectKey;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
@@ -109,8 +117,16 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         jwtHeaderName = settings.get("jwt_header", HttpHeaders.AUTHORIZATION);
         isDefaultAuthHeader = HttpHeaders.AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
+        jsonRolesPath = settings.get("roles_path");
         subjectKey = settings.get("subject_key");
         jwtParser = _jwtParser;
+
+        // throw exception when settings provided both roles_key and roles_path
+        if (rolesKey != null && jsonRolesPath != null) {
+            throw new IllegalStateException("Both roles_key and roles_path have simultaneously provided." +
+                    " Please provide only one combination.");
+        }
+        jsonPathConfig = Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST);
     }
 
 
@@ -231,9 +247,20 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     @SuppressWarnings("unchecked")
     protected String[] extractRoles(final Claims claims, final RestRequest request) {
     	// no roles key specified
-    	if(rolesKey == null) {
+    	if(rolesKey == null && jsonRolesPath == null) {
     		return new String[0];
     	}
+
+    	// get roles from roles_path if roles_path is specified
+    	if (jsonRolesPath != null){
+    	    try {
+                return Roles.split(JsonPath.using(jsonPathConfig).parse(claims).read(jsonRolesPath));
+            } catch (PathNotFoundException e) {
+                log.error("The provided JSON path {} could not be found ", jsonRolesPath);
+                return new String[0];
+            }
+        }
+
 		// try to get roles from claims, first as Object to avoid having to catch the ExpectedTypeException
     	final Object rolesObject = claims.get(rolesKey, Object.class);
     	if(rolesObject == null) {
@@ -241,20 +268,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     		return new String[0];
     	}
 
-    	String[] roles = String.valueOf(rolesObject).split(",");
-
-    	// We expect a String or Collection. If we find something else, convert to String but issue a warning
-    	if (!(rolesObject instanceof String) && !(rolesObject instanceof Collection<?>)) {
-    		log.warn("Expected type String or Collection for roles in the JWT for roles_key {}, but value was '{}' ({}). Will convert this value to String.", rolesKey, rolesObject, rolesObject.getClass());
-		} else if (rolesObject instanceof Collection<?>) {
-		    roles = ((Collection<String>) rolesObject).toArray(new String[0]);
-		}
-
-    	for (int i = 0; i < roles.length; i++) {
-    	    roles[i] = roles[i].trim();
-    	}
-
-    	return roles;
+    	return Roles.split(rolesObject);
     }
 
     private static PublicKey getPublicKey(final byte[] keyBytes, final String algo) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/src/main/java/com/amazon/dlic/util/Roles.java
+++ b/src/main/java/com/amazon/dlic/util/Roles.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.dlic.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Roles {
+    private static final Logger log = LogManager.getLogger(Roles.class);
+
+    public static String[] split(Object rolesObject) {
+        if (rolesObject == null) {
+            return new String[0];
+        } else if (rolesObject instanceof Collection) {
+            List<String> roles = new ArrayList<>();
+            for (Object object : (Collection<?>) rolesObject) {
+                if (object instanceof Collection) {
+                    for (Object subObject : (Collection<?>) object) {
+                        roles.addAll(Arrays.asList(splitString(String.valueOf(subObject))));
+                    }
+                } else {
+                    if (!(object instanceof String)) {
+                        // We expect a String or Collection. If we find something else, convert to
+                        // String but issue a warning
+                        log.warn(
+                                "Expected type String or Collection for roles in the JWT for roles_key {}, but value was '{}' ({}). Will convert this value to String.",
+                                object, object.getClass());
+                    }
+                    roles.addAll(Arrays.asList(splitString(String.valueOf(object))));
+                }
+            }
+
+            return roles.toArray(new String[roles.size()]);
+        } else {
+            if (!(rolesObject instanceof String)) {
+                // We expect a String or Collection. If we find something else, convert to
+                // String but issue a warning
+                log.warn(
+                        "Expected type String or Collection for roles in the JWT for roles_key {}, but value was '{}' ({}). Will convert this value to String.",
+                        rolesObject, rolesObject.getClass());
+            }
+
+            return splitString(String.valueOf(rolesObject));
+        }
+    }
+
+    public static String[] splitString(String string) {
+        String[] result = string.split(",");
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = result[i].trim();
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/amazon/dlic/util/RolesUtil.java
+++ b/src/main/java/com/amazon/dlic/util/RolesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License").
  *  You may not use this file except in compliance with the License.
@@ -23,9 +23,34 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class Roles {
-    private static final Logger log = LogManager.getLogger(Roles.class);
+public class RolesUtil {
+    private static final Logger log = LogManager.getLogger(RolesUtil.class);
 
+    /*
+     * Split the given rolesObject to one or several roles
+     * rolesObject should be a String if given by roles_key
+     * rolesObject should always be net.minidev.json.JSONArray if given by roles_path (jayway config set to ALWAYS_RETURN_LIST)
+     *
+     * Here are some examples:
+     *
+     *   JWT paylaoad contains:
+     *     "access": {
+     *       "roles": [
+     *         "readall, testrole",
+     *         "admin",
+     *         "kibanauser"
+     *       ]
+     *     }
+     *  if contains a Json array, it will convert all elements to String and split by comma to get roles.
+     *    roles_path = $["access"]["roles"]
+     *    the result should be ("readall", "testrole", "admin", "kibanauser")
+     *  if contains a String, it will split by comma to get roles.
+     *    roles_path = $["access"]["roles"][0]
+     *    the result should be ("readall", "testrole")
+     *  if contains neither Json array nor String, e.g. Json Object, it will convert the value to String and split by comma to get roles
+     *    roles_path = $["access"]
+     *    the result should be ("{roles=[readall", "testrole", "admin", "kinanauser]}")
+     */
     public static String[] split(Object rolesObject) {
         if (rolesObject == null) {
             return new String[0];

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.settings.Settings;
 
 import org.apache.http.HttpHeaders;
@@ -230,9 +231,6 @@ public class HTTPJwtAuthenticatorTest {
 
     @Test
     public void testRolesPathJSONArray() throws Exception {
-
-
-
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))
                 .put("roles_path", "$[\"access\"][\"roles\"]")
@@ -254,18 +252,14 @@ public class HTTPJwtAuthenticatorTest {
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
         Assert.assertNotNull(creds);
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(4, creds.getBackendRoles().size());
-        Assert.assertTrue(creds.getBackendRoles().contains("a"));
-        Assert.assertTrue(creds.getBackendRoles().contains("b"));
+        Assert.assertEquals(3, creds.getBackendRoles().size());
+        Assert.assertTrue(creds.getBackendRoles().contains("a, b"));
         Assert.assertTrue(creds.getBackendRoles().contains("c"));
         Assert.assertTrue(creds.getBackendRoles().contains("3rd"));
     }
 
     @Test
     public void testRolesPathSingleString() throws Exception {
-
-
-
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))
                 .put("roles_path", "$[\"access\"][\"roles\"][0]")
@@ -293,13 +287,65 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
-    public void testRolesPathJSONObject() throws Exception {
-
-
-
+    public void testRolesPathJSONArrayWithNonString() throws Exception {
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_path", "$[\"access\"]")
+                .put("roles_path", "$[\"access\"][\"roles\"]")
+                .build();
+
+        String jwsToken = Jwts.builder()
+                .setPayload("{"+
+                        "\"sub\": \"Leonard McCoy\","+
+                        "\"access\": {"+
+                        "\"roles\": [\"a, b\", 123,\"3rd\"]"+
+                        "}"+
+                        "}")
+                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", jwsToken);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+        Assert.assertNotNull(creds);
+        Assert.assertEquals("Leonard McCoy", creds.getUsername());
+        Assert.assertEquals(2, creds.getBackendRoles().size());
+        Assert.assertTrue(creds.getBackendRoles().contains("a, b"));
+        Assert.assertTrue(creds.getBackendRoles().contains("3rd"));
+    }
+
+    @Test
+    public void testRolesJSONArrayWithSingleString() throws Exception {
+        Settings settings = Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKey))
+                .put("roles_path", "$[\"access\"][\"roles\"]")
+                .build();
+
+        String jwsToken = Jwts.builder()
+                .setPayload("{"+
+                        "\"sub\": \"Leonard McCoy\","+
+                        "\"access\": {"+
+                        "\"roles\": [\"a, b, c\"]"+
+                        "}"+
+                        "}")
+                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", jwsToken);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+        Assert.assertNotNull(creds);
+        Assert.assertEquals("Leonard McCoy", creds.getUsername());
+        Assert.assertEquals(1, creds.getBackendRoles().size());
+        Assert.assertTrue(creds.getBackendRoles().contains("a, b, c"));
+    }
+
+    @Test
+    public void testRolesPathNotFound() throws Exception {
+        Settings settings = Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKey))
+                .put("roles_path", "$[\"wrong_path\"]")
                 .build();
 
         String jwsToken = Jwts.builder()
@@ -318,18 +364,11 @@ public class HTTPJwtAuthenticatorTest {
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
         Assert.assertNotNull(creds);
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(4, creds.getBackendRoles().size());
-        Assert.assertTrue(creds.getBackendRoles().contains("{roles=[a"));
-        Assert.assertTrue(creds.getBackendRoles().contains("b"));
-        Assert.assertTrue(creds.getBackendRoles().contains("c"));
-        Assert.assertTrue(creds.getBackendRoles().contains("3rd]}"));
+        Assert.assertEquals(0, creds.getBackendRoles().size());
     }
 
     @Test(expected = IllegalStateException.class)
     public void testRolesBothSpecified() throws Exception {
-
-
-
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))
                 .put("roles_key", "roles")
@@ -351,7 +390,6 @@ public class HTTPJwtAuthenticatorTest {
         headers.put("Authorization", jwsToken);
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
     }
-
 
     @Test
     public void testConfigRolesMissing() throws Exception {
@@ -401,11 +439,8 @@ public class HTTPJwtAuthenticatorTest {
         Assert.assertEquals(0, creds.getBackendRoles().size());
     }
 
-    @Test
+    @Test(expected = ElasticsearchSecurityException.class)
     public void testNonStringClaim() throws Exception {
-
-
-
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))
                 .put("roles_key", "roles")
@@ -419,12 +454,7 @@ public class HTTPJwtAuthenticatorTest {
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", jwsToken);
-
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(1, creds.getBackendRoles().size());
-        Assert.assertTrue( creds.getBackendRoles().contains("123"));
     }
 
     @Test

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -227,6 +227,38 @@ public class HTTPJwtAuthenticatorTest {
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
         Assert.assertEquals(2, creds.getBackendRoles().size());
     }
+    @Test
+    public void testRolesPath() throws Exception {
+
+
+
+        Settings settings = Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKey))
+                .put("roles_path", "$[\"access\"][\"roles\"]")
+                .build();
+
+        String jwsToken = Jwts.builder()
+                .setPayload("{"+
+                        "\"sub\": \"Leonard McCoy\","+
+                        "\"access\": {"+
+                        "\"roles\": [\"a, b\",\"c\",\"3rd\"]"+
+                        "}"+
+                        "}")
+                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", jwsToken);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+        Assert.assertNotNull(creds);
+        Assert.assertEquals("Leonard McCoy", creds.getUsername());
+        Assert.assertEquals(4, creds.getBackendRoles().size());
+        Assert.assertTrue(creds.getBackendRoles().contains("a"));
+        Assert.assertTrue(creds.getBackendRoles().contains("b"));
+        Assert.assertTrue(creds.getBackendRoles().contains("c"));
+        Assert.assertTrue(creds.getBackendRoles().contains("3rd"));
+    }
 
     @Test
     public void testNullClaim() throws Exception {


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Enhancement
 
 
 2. __Github Issue # or road-map entry, if available:__
#1003 

 3. __Description of changes:__
Introduce `roles_path` to JWT authentication so that users can use JSON path expression to the payload to get user's roles.


 4. __Why these changes are required?__ 

 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
 Before: `roles_key` only accepts a single string.
 After: you can give a JSON path to `roles_path` such as $["access"]["roles"]. `roles_path` accepts string or Json array. You can only specify one of `roles_key` and `roles_path`.

 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 Unit tests to cover different cases of roles_path.
  
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)

 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
