### PR TITLE
Upgrade Gradle and nebula.ospackage version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Uses Gradle to build RPMs since that's what we use for the other plugins. When all you have is a hammer...
 plugins {
-   id "nebula.ospackage" version "5.3.0"
+   id "nebula.ospackage" version "8.5.6"
 }
 
 // To prevent conflicts with maven build under build/
@@ -59,10 +59,24 @@ ospackage {
 buildRpm {
     arch = 'NOARCH'
     addParentDirs = false
-    archiveName "${packageName}-${version}.rpm"
+    finalizedBy 'renameRpm'
+    task renameRpm(type: Copy) {
+        from("$buildDir/distributions")
+        into("$buildDir/distributions")
+        include archiveName
+        rename archiveName, "${packageName}-${version}.rpm"
+        doLast { delete file("$buildDir/distributions/$archiveName") }
+    }
 }
 
 buildDeb {
     arch = 'all'
-    archiveName "${packageName}-${version}.deb"
+    finalizedBy 'renameDeb'
+    task renameDeb(type: Copy) {
+        from("$buildDir/distributions")
+        into("$buildDir/distributions")
+        include archiveName
+        rename archiveName, "${packageName}-${version}.deb"
+        doLast { delete file("$buildDir/distributions/$archiveName") }
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
Upgrade Gradle and nebula.ospackage version


 4. __Why these changes are required?__ 
It's necessary for build system migration from Maven to Gradle


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)

- UT
- Manual Testing:
     - Run `./gradlew clean build buildDeb buildRpm --no-daemon -ParchivePath=`ls $(pwd)/target/releases/opendistro-security-*.zip | grep -v admin-standalone` -Dbuild.snapshot=false`
     - `opendistro-security-1.13.1.0.deb` and `opendistro-security-1.13.1.0.rpm` get generated properly
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
