### PR TITLE
Allow attempt to load security config in case of plugin restart even …

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
@@ -131,21 +131,20 @@ public class ConfigurationRepository {
                                 try(StoredContext ctx = threadContext.stashContext()) {
                                     threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
 
-                                    final boolean isSecurityIndexCreated = createSecurityIndexIfAbsent();
-                                    if (isSecurityIndexCreated) {
-                                        ConfigHelper.uploadFile(client, cd+"config.yml", opendistrosecurityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
-                                        ConfigHelper.uploadFile(client, cd+"roles.yml", opendistrosecurityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
-                                        ConfigHelper.uploadFile(client, cd+"roles_mapping.yml", opendistrosecurityIndex, CType.ROLESMAPPING, DEFAULT_CONFIG_VERSION);
-                                        ConfigHelper.uploadFile(client, cd+"internal_users.yml", opendistrosecurityIndex, CType.INTERNALUSERS, DEFAULT_CONFIG_VERSION);
-                                        ConfigHelper.uploadFile(client, cd+"action_groups.yml", opendistrosecurityIndex, CType.ACTIONGROUPS, DEFAULT_CONFIG_VERSION);
-                                        if(DEFAULT_CONFIG_VERSION == 2) {
-                                            ConfigHelper.uploadFile(client, cd+"tenants.yml", opendistrosecurityIndex, CType.TENANTS, DEFAULT_CONFIG_VERSION);
-                                        }
-                                        final boolean populateEmptyIfFileMissing = true;
-                                        ConfigHelper.uploadFile(client, cd+"nodes_dn.yml", opendistrosecurityIndex, CType.NODESDN, DEFAULT_CONFIG_VERSION, populateEmptyIfFileMissing);
-                                        ConfigHelper.uploadFile(client, cd + "whitelist.yml", opendistrosecurityIndex, CType.WHITELIST, DEFAULT_CONFIG_VERSION, populateEmptyIfFileMissing);
-                                        LOGGER.info("Default config applied");
+                                    createSecurityIndexIfAbsent();
+
+                                    ConfigHelper.uploadFile(client, cd+"config.yml", opendistrosecurityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
+                                    ConfigHelper.uploadFile(client, cd+"roles.yml", opendistrosecurityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
+                                    ConfigHelper.uploadFile(client, cd+"roles_mapping.yml", opendistrosecurityIndex, CType.ROLESMAPPING, DEFAULT_CONFIG_VERSION);
+                                    ConfigHelper.uploadFile(client, cd+"internal_users.yml", opendistrosecurityIndex, CType.INTERNALUSERS, DEFAULT_CONFIG_VERSION);
+                                    ConfigHelper.uploadFile(client, cd+"action_groups.yml", opendistrosecurityIndex, CType.ACTIONGROUPS, DEFAULT_CONFIG_VERSION);
+                                    if(DEFAULT_CONFIG_VERSION == 2) {
+                                        ConfigHelper.uploadFile(client, cd+"tenants.yml", opendistrosecurityIndex, CType.TENANTS, DEFAULT_CONFIG_VERSION);
                                     }
+                                    final boolean populateEmptyIfFileMissing = true;
+                                    ConfigHelper.uploadFile(client, cd+"nodes_dn.yml", opendistrosecurityIndex, CType.NODESDN, DEFAULT_CONFIG_VERSION, populateEmptyIfFileMissing);
+                                    ConfigHelper.uploadFile(client, cd + "whitelist.yml", opendistrosecurityIndex, CType.WHITELIST, DEFAULT_CONFIG_VERSION, populateEmptyIfFileMissing);
+                                    LOGGER.info("Default config applied");
 
                                     // audit.yml is not packaged by default
                                     final String auditConfigPath = cd + "audit.yml";
@@ -157,7 +156,7 @@ public class ConfigurationRepository {
                                 LOGGER.error("{} does not exist", confFile.getAbsolutePath());
                             }
                         } catch (Exception e) {
-                            LOGGER.debug("Cannot apply default config (this is maybe not an error!) due to {}", e.getMessage());
+                            LOGGER.error("Cannot apply default config (this is maybe not an error!) due to {}", e.getMessage());
                         }
                     }
 

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -199,6 +199,29 @@ public class InitializationIntegrationTests extends SingleClusterTest {
     }
 
     @Test
+    public void testInvalidDefaultConfig() throws Exception {
+        String defaultInitDirectory = System.getProperty("security.default_init.dir");
+        try {
+            System.setProperty("security.default_init.dir", new File("./src/test/resources/invalid_config").getAbsolutePath());
+            final Settings settings = Settings.builder()
+                    .put(ConfigConstants.OPENDISTRO_SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
+                    .build();
+            setup(Settings.EMPTY, null, settings, false);
+            RestHelper rh = nonSslRestHelper();
+            Thread.sleep(10000);
+            Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
+
+            System.setProperty("security.default_init.dir", new File(defaultInitDirectory).getAbsolutePath());
+            restart(Settings.EMPTY, null, settings, false);
+            rh = nonSslRestHelper();
+            Thread.sleep(10000);
+            Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
+        } finally {
+            System.setProperty("security.default_init.dir", new File(defaultInitDirectory).getAbsolutePath());
+        }
+    }
+
+    @Test
     public void testDisabled() throws Exception {
     
         final Settings settings = Settings.builder().put("opendistro_security.disabled", true).build();

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
@@ -71,6 +71,13 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
         setup(initTransportClientSettings, dynamicSecuritySettings, nodeOverride, initOpendistroSecurityIndex, ClusterConfiguration.DEFAULT);
     }
 
+    protected void restart(Settings initTransportClientSettings, DynamicSecurityConfig dynamicSecuritySettings, Settings nodeOverride, boolean initOpendistroSecurityIndex) throws Exception {
+        clusterInfo = clusterHelper.restartCluster(minimumSecuritySettings(ccs(nodeOverride)), ClusterConfiguration.DEFAULT);
+        if(initOpendistroSecurityIndex && dynamicSecuritySettings != null) {
+            initialize(clusterInfo, initTransportClientSettings, dynamicSecuritySettings);
+        }
+    }
+
     private Settings ccs(Settings nodeOverride) throws Exception {
         if(remoteClusterHelper != null) {
             Assert.assertNull("No remote clusters", remoteClusterInfo);
@@ -96,7 +103,7 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
     protected void setup(Settings initTransportClientSettings, DynamicSecurityConfig dynamicSecuritySettings, Settings nodeOverride
             , boolean initOpendistroSecurityIndex, ClusterConfiguration clusterConfiguration, int timeout, Integer nodes) throws Exception {
         Assert.assertNull("No cluster", clusterInfo);
-        clusterInfo = clusterHelper.startCluster(minimumSecuritySettings(ccs(nodeOverride)), clusterConfiguration, timeout, nodes);
+        clusterInfo = clusterHelper.startCluster(minimumSecuritySettings(ccs(nodeOverride)), clusterConfiguration, timeout, nodes, false);
         if(initOpendistroSecurityIndex) {
             initialize(clusterInfo, initTransportClientSettings, dynamicSecuritySettings);
         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
@@ -97,18 +97,24 @@ public final class ClusterHelper {
      */
 
     public final ClusterInfo startCluster(final NodeSettingsSupplier nodeSettingsSupplier, ClusterConfiguration clusterConfiguration) throws Exception {
-        return startCluster(nodeSettingsSupplier, clusterConfiguration, 10, null);
+        return startCluster(nodeSettingsSupplier, clusterConfiguration, 10, null, false);
     }
 
+    public final ClusterInfo restartCluster(final NodeSettingsSupplier nodeSettingsSupplier, ClusterConfiguration clusterConfiguration) throws Exception {
+        stopClusterWithoutDeletingData();
+        return startCluster(nodeSettingsSupplier, clusterConfiguration, 10, null, true);
+    }
 
-    public final synchronized ClusterInfo startCluster(final NodeSettingsSupplier nodeSettingsSupplier, ClusterConfiguration clusterConfiguration, int timeout, Integer nodes)
+    public final synchronized ClusterInfo startCluster(final NodeSettingsSupplier nodeSettingsSupplier, ClusterConfiguration clusterConfiguration, int timeout, Integer nodes, boolean isRestart)
             throws Exception {
 
         if (!esNodes.isEmpty()) {
             throw new RuntimeException("There are still " + esNodes.size() + " nodes instantiated, close them first.");
         }
 
-        FileUtils.deleteDirectory(new File("./target/data/"+clustername));
+        if(!isRestart) {
+            FileUtils.deleteDirectory(new File("./target/data/" + clustername));
+        }
 
         List<NodeSettings> internalNodeSettings = clusterConfiguration.getNodeSettings();
 
@@ -231,15 +237,21 @@ public final class ClusterHelper {
     }
 
     public final void stopCluster() throws Exception {
+        closeAllNodes();
+        FileUtils.deleteDirectory(new File("./target/data/"+clustername));
+    }
 
+    public final void stopClusterWithoutDeletingData() throws Exception {
+        closeAllNodes();
+    }
+
+    private void closeAllNodes() throws  Exception {
         //close non master nodes
         esNodes.stream().filter(n->!n.isMasterEligible()).forEach(node->closeNode(node));
 
         //close master nodes
         esNodes.stream().filter(n->n.isMasterEligible()).forEach(node->closeNode(node));
         esNodes.clear();
-
-        FileUtils.deleteDirectory(new File("./target/data/"+clustername));
     }
 
     private static void closeNode(Node node) {

--- a/src/test/resources/invalid_config/config.yml
+++ b/src/test/resources/invalid_config/config.yml
@@ -1,0 +1,13 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+
+INVALID_BLOB_HERE
+
+config:
+  dynamic:
+    filtered_alias_mode: "disallow"
+    disable_rest_auth: false
+    disable_intertransport_auth: false
+    respect_request_indices_options: false


### PR DESCRIPTION
…if security index already exists


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 1. __Category:__ (_Enhancement)
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__ Making changes to plugin bootstrap to attempt to load static configuration from static files even the security index already exists.



 4. __Why these changes are required?__ In case of issues with loading static configuration from files during plugin bootstrap, we currently need to fix the issue, delete security index and restart a plugin. This change will allow us to just fix the issue and restart the plugin without needing to delete the security index. 


 5. __What is the old behaviour before changes and new behaviour after changes?__ (_Please add any example/logs/screen-shot if available_)
[Docker Setup - 2 nodes cluster]
__Old Behaviour:__
Corrupt one of the static securityconfig files and start the nodes in the cluster. Verify cluster requests fail. Fix the corrupt file and restart a node. Verify cluster requests fail.
__New Behaviour:__
Corrupt one of the static securityconfig files and start the nodes in the cluster. Verify cluster requests fail. Fix the corrupt file and restart a node. Verify cluster requests succeed.
Note: Each time security plugin bootstraps, there will be an attempt to load all securityconfig files into security index. Attempting to index a document from static files when it already exists will throw a `VersionConflictEngineException` which is anyway swallowed and is a no/op, so this will not be a cause of concern.



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 __Old Behaviour:__
```
elasticsearch1    | [2021-04-03T16:31:56,632][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Doc with id 'config' and version 2 is updated in .opendistro_security index.
elasticsearch1    | [2021-04-03T16:31:56,632][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Will update 'roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch1    | [2021-04-03T16:31:56,641][ERROR][c.a.o.s.c.ConfigurationRepository] [elasticsearch1] Cannot apply default config (this is maybe not an error!) due to while parsing a block mapping
elasticsearch1    |  in 'reader', line 1, column 1:
elasticsearch1    |     _meta:
elasticsearch1    |     ^
elasticsearch1    | expected <block end>, but found '<scalar>'
elasticsearch1    |  in 'reader', line 13, column 2:
elasticsearch1    |      INVALID_DATA_HERE
elasticsearch1    |      ^
elasticsearch1    |
elasticsearch1    |  at [Source: (FileReader); line: 13, column: 2]
elasticsearch2    | [2021-04-03T16:31:56,650][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch2] Doc with id 'audit' and version 2 is updated in .opendistro_security index.
elasticsearch1    | [2021-04-03T16:31:56,947][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:31:56,948][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:31:57,003][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:31:57,005][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:31:57,198][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:31:57,199][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:31:57,202][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:31:57,548][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:31:57,550][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:31:57,553][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)

dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> curl "https://localhost:9200/_cat/nodes?v" -k -u admin:admin
Open Distro Security not initialized.⏎
dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> docker exec -it elasticsearch1 /bin/bash
[root@008f7b698c7f elasticsearch]# vi plugins/opendistro_security/securityconfig/roles.yml # FIXED roles.yml HERE
[root@008f7b698c7f elasticsearch]# exit
exit
dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> docker restart elasticsearch1
elasticsearch1
dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> curl "https://localhost:9200/_cat/nodes?v" -k -u admin:admin
Open Distro Security not initialized.⏎
```

__New Behaviour:__
```
elasticsearch2    | [2021-04-03T16:53:04,382][INFO ][c.a.o.s.c.ConfigurationRepository] [elasticsearch2] Index .opendistro_security already exists
elasticsearch2    | [2021-04-03T16:53:04,389][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch2] Will update 'config' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch2    | [2021-04-03T16:53:04,959][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch2] Doc with id 'config' and version 2 is updated in .opendistro_security index.
elasticsearch2    | [2021-04-03T16:53:04,959][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch2] Will update 'roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch2    | [2021-04-03T16:53:04,965][ERROR][c.a.o.s.c.ConfigurationRepository] [elasticsearch2] Cannot apply default config (this is maybe not an error!) due to while parsing a block mapping
elasticsearch2    |  in 'reader', line 1, column 1:
elasticsearch2    |     _meta:
elasticsearch2    |     ^
elasticsearch2    | expected <block end>, but found '<scalar>'
elasticsearch2    |  in 'reader', line 13, column 2:
elasticsearch2    |      INVALID_DATA_HERE
elasticsearch2    |      ^
elasticsearch2    |
elasticsearch2    |  at [Source: (FileReader); line: 13, column: 2]
elasticsearch2    | [2021-04-03T16:53:05,179][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:53:05,181][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:53:05,314][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:53:05,320][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch2    | [2021-04-03T16:53:05,328][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:05,733][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Index .opendistro_security already contains doc with id config, skipping update.
elasticsearch1    | [2021-04-03T16:53:05,734][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Will update 'roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch1    | [2021-04-03T16:53:05,740][ERROR][c.a.o.s.c.ConfigurationRepository] [elasticsearch1] Cannot apply default config (this is maybe not an error!) due to while parsing a block mapping
elasticsearch1    |  in 'reader', line 1, column 1:
elasticsearch1    |     _meta:
elasticsearch1    |     ^
elasticsearch1    | expected <block end>, but found '<scalar>'
elasticsearch1    |  in 'reader', line 13, column 2:
elasticsearch1    |      INVALID_DATA_HERE
elasticsearch1    |      ^
elasticsearch1    |
elasticsearch1    |  at [Source: (FileReader); line: 13, column: 2]
elasticsearch1    | [2021-04-03T16:53:05,845][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:05,846][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:06,025][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:06,027][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:06,028][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)
elasticsearch1    | [2021-04-03T16:53:06,970][INFO ][o.e.c.r.a.AllocationService] [elasticsearch1] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[.opendistro_security][0]]]).
elasticsearch2    | [2021-04-03T16:53:13,113][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=_doc)

dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> docker exec -it elasticsearch1 /bin/bash
[root@70c45c060e53 elasticsearch]# vi plugins/opendistro_security/securityconfig/roles.yml # FIXED roles.yml HERE
[root@70c45c060e53 elasticsearch]# exit
exit
dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> docker restart elasticsearch1
elasticsearch1

elasticsearch1    | [2021-04-03T16:54:34,669][INFO ][o.e.c.s.ClusterApplierService] [elasticsearch1] added {{elasticsearch2}{gEdbQA5ISwKPf0VHBkNRyA}{DWciasNGT9Sq_ftXgl1SRA}{172.31.0.3}{172.31.0.3:9300}{dir}}, term: 2, version: 12, reason: Publication{term=2, version=12}
elasticsearch1    | [2021-04-03T16:54:35,188][INFO ][o.e.c.r.a.AllocationService] [elasticsearch1] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[.opendistro_security][0]]]).
elasticsearch1    | [2021-04-03T16:54:35,931][WARN ][o.e.c.r.a.AllocationService] [elasticsearch1] [.opendistro_security][0] marking unavailable shards as stale: [qv7nUU8yS2K7_cUNnxS5jQ]
elasticsearch1    | [2021-04-03T16:54:36,691][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Index .opendistro_security already contains doc with id config, skipping update.
elasticsearch1    | [2021-04-03T16:54:36,692][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Will update 'roles' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/roles.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch1    | [2021-04-03T16:54:37,450][INFO ][o.e.c.m.MetadataMappingService] [elasticsearch1] [.opendistro_security/9zrUWomFQpO7x1bppVVJ8w] update_mapping [_doc]
elasticsearch1    | [2021-04-03T16:54:38,206][INFO ][o.e.c.r.a.AllocationService] [elasticsearch1] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[.opendistro_security][0]]]).
elasticsearch1    | [2021-04-03T16:54:38,941][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Doc with id 'roles' and version 2 is updated in .opendistro_security index.


dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> curl "https://localhost:9200/_cat/nodes?v" -k -u admin:admin
ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
172.31.0.2           17          21  13    0.70    1.68     1.40 dimr      *      elasticsearch1
172.31.0.3           40          21  23    0.70    1.68     1.40 dir       -      elasticsearch2
dhireshj@f45c899db61b ~/w/d/dhi_security (improve_security_index_bootstrap)> curl "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k -u admin:admin
{
  "user" : "User [name=admin, backend_roles=[admin], requestedTenant=null]",
  "user_name" : "admin",
  "user_requested_tenant" : null,
  "remote_address" : "172.31.0.1:58882",
  "backend_roles" : [
    "admin"
  ],
  "custom_attribute_names" : [ ],
  "roles" : [
    "own_index",
    "all_access"
  ],
  "tenants" : {
    "global_tenant" : true,
    "admin_tenant" : true,
    "admin" : true
  },
  "principal" : null,
  "peer_certificates" : "0",
  "sso_logout_url" : null
}

```

7. _Setup Instructions_

-> Checkout https://github.com/opendistro-for-elasticsearch/opendistro-build
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Create directory build/elasticsearch/plugins/
-> Create file build/elasticsearch/plugins/plugins.list
-> Pull changes of this PR locally
-> cd into plugin directory
-> Add invalid config to any configuration file in `securityconfig` directory
-> Build the plugin: mvn clean package -Padvanced -DskipTests
-> Copy artifact target/releases/*.zip to ../opendistro-build/elasticsearch/docker/build/elasticsearch/plugins/
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Add the artifact name to the plugins.list file
-> run make-build [TIP: Remove knn dependencies from Dockerfile to speed up build. We do no require knn anyway)
-> run make-cluster
-> Once the cluster is up with two nodes, verify requests fail with `Open Distro Security not initialised`
-> Log into a docker container `docker exec -it elasticsearch1 /bin/bash`
-> Fix the corrupted configuration file in `plugins/opendistro_security/securityconfig/` directory
-> Exit docker container and restart it `docker restart elasticsearch1`
-> Cluster should be up and requests to it should succeed now
-> Without the plugin changes, the previous step would still fail


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).