### PR TITLE
Making disable_anonymous_authentication elasticsearch setting dynamic

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -48,6 +48,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.amazon.opendistroforelasticsearch.security.auditlog.NullAuditLog;
+import com.amazon.opendistroforelasticsearch.security.setting.DisableAnonymousAuthComplianceSetting;
+import com.amazon.opendistroforelasticsearch.security.setting.ElasticsearchDynamicSetting;
 import com.amazon.opendistroforelasticsearch.security.configuration.OpenDistroSecurityFlsDlsIndexSearcherWrapper;
 import com.amazon.opendistroforelasticsearch.security.configuration.Salt;
 import com.amazon.opendistroforelasticsearch.security.ssl.rest.OpenDistroSecuritySSLReloadCertsAction;
@@ -195,6 +197,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     private volatile NamedXContentRegistry namedXContentRegistry = null;
     private volatile DlsFlsRequestValve dlsFlsValve = null;
     private volatile Salt salt;
+    private volatile ElasticsearchDynamicSetting<Boolean> anonymousAuthComplianceSetting;
 
     public static boolean isActionTraceEnabled() {
         return actionTrace.isTraceEnabled();
@@ -242,6 +245,9 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
 
         disabled = isDisabled(settings);
         sslCertReloadEnabled = isSslCertReloadEnabled(settings);
+
+        // Elasticsearch dynamic setting trackers
+        anonymousAuthComplianceSetting = new DisableAnonymousAuthComplianceSetting(settings);
 
         if (disabled) {
             this.dlsFlsAvailable = false;
@@ -739,6 +745,9 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
                     repositoriesServiceSupplier
             );
         }
+
+        //Register elasticsearch dynamic settings
+        anonymousAuthComplianceSetting.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         
         this.threadPool = threadPool;
         this.cs = clusterService;
@@ -778,7 +787,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         cr = ConfigurationRepository.create(settings, this.configPath, threadPool, localClient, clusterService, auditLog);
 
         final XFFResolver xffResolver = new XFFResolver(threadPool);
-        backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool);
+        backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, anonymousAuthComplianceSetting, threadPool);
 
         final CompatConfig compatConfig = new CompatConfig(environment);
 
@@ -985,10 +994,10 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_IGNORE_USERS, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_IGNORE_USERS, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
-            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_IMMUTABLE_INDICES, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
             settings.add(Setting.simpleString(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_SALT, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, false, Property.NodeScope, Property.Filtered));
+            settings.add(anonymousAuthComplianceSetting.getDynamicSetting());
 
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_FILTER_SECURITYINDEX_FROM_ALL_REQUESTS, false, Property.NodeScope,
                     Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/auth/BackendRegistry.java
@@ -72,6 +72,7 @@ import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import com.amazon.opendistroforelasticsearch.security.support.HTTPHelper;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.amazon.opendistroforelasticsearch.security.user.User;
+import com.amazon.opendistroforelasticsearch.security.setting.ElasticsearchDynamicSetting;
 
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
@@ -92,6 +93,8 @@ public class BackendRegistry {
     private Multimap<String, AuthFailureListener> authBackendFailureListeners;
     private List<ClientBlockRegistry<InetAddress>> ipClientBlockRegistries;
     private Multimap<String, ClientBlockRegistry<String>> authBackendClientBlockRegistries;
+
+    private ElasticsearchDynamicSetting<Boolean> disableAnonymousAuthComplianceSetting;
 
     private volatile boolean initialized;
     private volatile boolean injectedUserEnabled = false;
@@ -175,11 +178,14 @@ public class BackendRegistry {
     }
 
     public BackendRegistry(final Settings settings, final AdminDNs adminDns,
-            final XFFResolver xffResolver, final AuditLog auditLog, final ThreadPool threadPool) {
+            final XFFResolver xffResolver, final AuditLog auditLog,
+                           final ElasticsearchDynamicSetting<Boolean> disableAnonymousAuthComplianceSetting,
+                           final ThreadPool threadPool) {
         this.adminDns = adminDns;
         this.esSettings = settings;
         this.xffResolver = xffResolver;
         this.auditLog = auditLog;
+        this.disableAnonymousAuthComplianceSetting = disableAnonymousAuthComplianceSetting;
         this.threadPool = threadPool;
         this.userInjector = new UserInjector(settings, threadPool, auditLog, xffResolver);
 
@@ -211,8 +217,7 @@ public class BackendRegistry {
 
         invalidateCache();
         transportUsernameAttribute = dcm.getTransportUsernameAttribute();// config.dynamic.transport_userrname_attribute;
-        anonymousAuthEnabled = dcm.isAnonymousAuthenticationEnabled()//config.dynamic.http.anonymous_auth_enabled
-                && !esSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false);
+        anonymousAuthEnabled = dcm.isAnonymousAuthenticationEnabled();//config.dynamic.http.anonymous_auth_enabled
 
         restAuthDomains = Collections.unmodifiableSortedSet(dcm.getRestAuthDomains());
         transportAuthDomains = Collections.unmodifiableSortedSet(dcm.getTransportAuthDomains());
@@ -225,7 +230,11 @@ public class BackendRegistry {
         authBackendClientBlockRegistries = dcm.getAuthBackendClientBlockRegistries();
 
         //Open Distro Security no default authc
-        initialized = !restAuthDomains.isEmpty() || anonymousAuthEnabled  || injectedUserEnabled;
+        initialized = !restAuthDomains.isEmpty() || isAnonymousAuthEnabled()  || injectedUserEnabled;
+    }
+
+    private boolean isAnonymousAuthEnabled() {
+        return anonymousAuthEnabled && disableAnonymousAuthComplianceSetting.getDynamicSettingValue() == Boolean.FALSE;
     }
 
     public User authenticate(final TransportRequest request, final String sslPrincipal, final Task task, final String action) {
@@ -438,7 +447,7 @@ public class BackendRegistry {
 
             if (ac == null) {
                 //no credentials found in request
-                if(anonymousAuthEnabled) {
+                if(isAnonymousAuthEnabled()) {
                     continue;
                 }
 
@@ -512,7 +521,7 @@ public class BackendRegistry {
                 log.debug("User still not authenticated after checking {} auth domains", restAuthDomains.size());
             }
 
-            if(authCredenetials == null && anonymousAuthEnabled) {
+            if(authCredenetials == null && isAnonymousAuthEnabled()) {
             	threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, User.ANONYMOUS);
             	auditLog.logSucceededLogin(User.ANONYMOUS.getName(), false, null, request);
                 if(log.isDebugEnabled()) {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/setting/DisableAnonymousAuthComplianceSetting.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/setting/DisableAnonymousAuthComplianceSetting.java
@@ -1,0 +1,24 @@
+package com.amazon.opendistroforelasticsearch.security.setting;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+
+public class DisableAnonymousAuthComplianceSetting extends ElasticsearchDynamicSetting<Boolean>{
+
+    public DisableAnonymousAuthComplianceSetting(final Settings settings) {
+        super(Setting.boolSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION,
+                false,
+                Setting.Property.NodeScope, Setting.Property.Filtered, Setting.Property.Dynamic),
+                settings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false));
+    }
+
+    @Override
+    protected String getClusterChangeMessage(final Boolean dynamicSettingNewValue) {
+        return String.format("Detected change in settings, cluster setting for anonymousAuthSettingDisabled is %s", dynamicSettingNewValue ? "enabled" : "disabled");
+    }
+}

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/setting/ElasticsearchDynamicSetting.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/setting/ElasticsearchDynamicSetting.java
@@ -1,0 +1,48 @@
+package com.amazon.opendistroforelasticsearch.security.setting;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+
+/**
+ * An abstract class to track the state of an elasticsearch dynamic setting.
+ * To instantiate for a dynamic setting, pass the Setting and the Setting's fetched value to the constructor
+ * @param <T> The type of the Setting
+ */
+public abstract class ElasticsearchDynamicSetting<T> {
+    private volatile T dynamicSettingValue;
+    private final Setting<T> dynamicSetting;
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    public ElasticsearchDynamicSetting(Setting<T> dynamicSetting, T dynamicSettingValue) {
+        this.dynamicSettingValue = dynamicSettingValue;
+        this.dynamicSetting = dynamicSetting;
+    }
+
+    public void registerClusterSettingsChangeListener(final ClusterSettings clusterSettings) {
+        clusterSettings.addSettingsUpdateConsumer(dynamicSetting,
+                dynamicSettingNewValue -> {
+                    logger.info(getClusterChangeMessage(dynamicSettingNewValue));
+                    setDynamicSettingValue(dynamicSettingNewValue);
+                });
+    }
+
+    protected String getClusterChangeMessage(final T dynamicSettingNewValue) {
+        return String.format("Detected change in settings, updated cluster setting value is %s", dynamicSettingNewValue);
+    }
+
+    private void setDynamicSettingValue(final T dynamicSettingValue) {
+        this.dynamicSettingValue = dynamicSettingValue;
+    }
+
+    public T getDynamicSettingValue() {
+        return dynamicSettingValue;
+    }
+
+    public Setting<T> getDynamicSetting() {
+        return dynamicSetting;
+    }
+
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/HttpIntegrationTests.java
@@ -38,6 +38,8 @@ import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.message.BasicHeader;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
@@ -341,6 +343,51 @@ public class HttpIntegrationTests extends SingleClusterTest {
             Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode());
             Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode());
             Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
+    }
+
+    @Test
+    public void testHTTPAnonDynamic() throws Exception {
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_anon.yml"), Settings.EMPTY, true);
+        RestHelper rh = nonSslRestHelper();
+
+        anonEnabledCommonTests(rh);
+
+        TransportClient tc = getInternalTransportClient();
+        ClusterUpdateSettingsResponse resp = tc.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest()
+                .transientSettings(Settings.builder()
+                        .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, true)
+                )).actionGet();
+        anonDisabledCommonTests(rh);
+
+        tc.index(new IndexRequest(".opendistro_security").type(getType()).id("config").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("config", FileHelper.readYamlContent("config.yml"))).actionGet();
+        tc.index(new IndexRequest(".opendistro_security").type(getType()).setRefreshPolicy(RefreshPolicy.IMMEDIATE).id("internalusers").source("internalusers", FileHelper.readYamlContent("internal_users.yml"))).actionGet();
+        ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[]{"config","roles","rolesmapping","internalusers","actiongroups"})).actionGet();
+        Assert.assertFalse(cur.hasFailures());
+        anonDisabledCommonTests(rh);
+
+        tc.index(new IndexRequest(".opendistro_security").type(getType()).id("config").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("config", FileHelper.readYamlContent("config_anon.yml"))).actionGet();
+        tc.index(new IndexRequest(".opendistro_security").type(getType()).setRefreshPolicy(RefreshPolicy.IMMEDIATE).id("internalusers").source("internalusers", FileHelper.readYamlContent("internal_users.yml"))).actionGet();
+        cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[]{"config","roles","rolesmapping","internalusers","actiongroups"})).actionGet();
+        Assert.assertFalse(cur.hasFailures());
+        anonDisabledCommonTests(rh);
+
+        resp = tc.admin().cluster().updateSettings(new ClusterUpdateSettingsRequest()
+                .transientSettings(Settings.builder()
+                        .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_DISABLE_ANONYMOUS_AUTHENTICATION, false)
+                )).actionGet();
+        anonEnabledCommonTests(rh);
+    }
+
+    private void anonDisabledCommonTests(final RestHelper rh) throws Exception {
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
+    }
+
+    private void anonEnabledCommonTests(final RestHelper rh) throws Exception {
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("").getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
     }
 
     @Test


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ Enhancement
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__ Toggling on/off of anonymous authentication is currently dictated by two settings: security index setting "http.anonymous_auth_enabled" and elasticsearch setting "opendistro_security.compliance.disable_anonymous_authentication". The former setting is dynamically changeable via securityconfig api, while the latter is a static setting requiring a node restart. The changes in this PR aim to make the elasticsearch setting dynamic too so anonymous auth can truly be dynamically toggable.



 4. __Why these changes are required?__  To satisfy a use case where anonymous auth needs to be dynamically toggled on/off via elasticsearch cluster setting.



 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Old Behaviour: Anonymous requests are unauthorized. Update opendistro_security.compliance.disable_anonymous_authentication from false to true. Anonymous requests are still unauthorized.
New Behaviour: Anonymous requests are unauthorized. Update opendistro_security.compliance.disable_anonymous_authentication from false to true. Anonymous requests are still authorized.


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
```
 dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic) [SIGINT]> curl "https://localhost:9200/_cluster/settings?pretty" -k -u admin:admin
{
  "persistent" : { },
  "transient" : { }
}

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo" -k -u admin:admin
{"user":"User [name=admin, backend_roles=[admin], requestedTenant=null]","user_name":"admin","user_requested_tenant":null,"remote_address":"192.168.112.1:63502","backend_roles":["admin"],"custom_attribute_names":[],"roles":["own_index","all_access"],"tenants":{"global_tenant":true,"admin_tenant":true,"admin":true},"principal":null,"peer_certificates":"0","sso_logout_url":null}⏎

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k
Unauthorized⏎


dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X PATCH "https://localhost:9200/_opendistro/_security/api/securityconfig/" -H 'Content-Type: application/json' -d'
                                                                    [
                                                                      {
                                                                        "op": "add", "path": "/config/dynamic/http/anonymous_auth_enabled", "value": "true"
                                                                      }
                                                                    ]' -k -u admin:admin
{"status":"OK","message":"Resource updated."}⏎

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k
{
  "user" : "User [name=opendistro_security_anonymous, backend_roles=[opendistro_security_anonymous_backendrole], requestedTenant=null]",
  "user_name" : "opendistro_security_anonymous",
  "user_requested_tenant" : null,
  "remote_address" : "192.168.112.1:63518",
  "backend_roles" : [
    "opendistro_security_anonymous_backendrole"
  ],
  "custom_attribute_names" : [ ],
  "roles" : [
    "own_index"
  ],
  "tenants" : {
    "opendistro_security_anonymous" : true
  },
  "principal" : null,
  "peer_certificates" : "0",
  "sso_logout_url" : null
}


dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X PUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
                                                                   {
                                                                     "persistent" : {
                                                                       "opendistro_security.compliance.disable_anonymous_authentication": true
                                                                     }
                                                                   }' -k -u admin:admin

{"acknowledged":true,"persistent":{"opendistro_security":{"compliance":{"disable_anonymous_authentication":"true"}}},"transient":{}}⏎

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k
Unauthorized⏎


dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X PUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
                                                                   {
                                                                     "persistent" : {
                                                                       "opendistro_security.compliance.disable_anonymous_authentication": false
                                                                     }
                                                                   }' -k -u admin:admin
{"acknowledged":true,"persistent":{"opendistro_security":{"compliance":{"disable_anonymous_authentication":"false"}}},"transient":{}}⏎

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k
{
  "user" : "User [name=opendistro_security_anonymous, backend_roles=[opendistro_security_anonymous_backendrole], requestedTenant=null]",
  "user_name" : "opendistro_security_anonymous",
  "user_requested_tenant" : null,
  "remote_address" : "192.168.112.1:63538",
  "backend_roles" : [
    "opendistro_security_anonymous_backendrole"
  ],
  "custom_attribute_names" : [ ],
  "roles" : [
    "own_index"
  ],
  "tenants" : {
    "opendistro_security_anonymous" : true
  },
  "principal" : null,
  "peer_certificates" : "0",
  "sso_logout_url" : null
}

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X PATCH "https://localhost:9200/_opendistro/_security/api/securityconfig/" -H 'Content-Type: application/json' -d'
                                                                                                   [
                                                                                                     {
                                                                                                       "op": "replace", "path": "/config/dynamic/http/anonymous_auth_enabled", "value": "false"
                                                                                                     }
                                                                                                   ]' -k -u admin:admin
{"status":"OK","message":"Resource updated."}⏎

dhireshj@f45c899db61b ~/w/d/dhi_security (anonymous_auth_dynamic)> curl -X GET "https://localhost:9200/_opendistro/_security/authinfo?pretty" -k
Unauthorized⏎
```
 
 
 7. Setup Instructions
-> Checkout https://github.com/opendistro-for-elasticsearch/opendistro-build
-> cd into `{$PATH}/opendistro-build/elasticsearch/docker `
-> Create directory `build/elasticsearch/plugins/`
-> Create file `build/elasticsearch/plugins/plugins.list`
-> Pull changes of this PR locally.
-> cd into plugin directory
-> Build the plugin: `mvn clean package -Padvanced -DskipTests`
-> Copy artifact `target/releases/*.zip` to `../opendistro-build/elasticsearch/docker/build/elasticsearch/plugins/`
-> cd into `{$PATH}/opendistro-build/elasticsearch/docker`
-> Add the artifact name to the plugins.list file
-> run `make-build` [TIP: Remove knn dependencies from Dockerfile to speed up build. We do no require knn anyway)
-> run `make-cluster`
-> Once the cluster is up with two nodes, you can check Testing section above to see what paths to test





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).