### PR TITLE
Introducing passive_intertransport_auth to facilitate communication b…

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/OpenDistroSecurityPlugin.java
@@ -185,6 +185,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
     private volatile ClusterService cs;
     private volatile AuditLog auditLog;
     private volatile BackendRegistry backendRegistry;
+    private volatile CompatConfig compatConfig;
     private volatile SslExceptionHandler sslExceptionHandler;
     private volatile Client localClient;
     private final boolean disabled;
@@ -780,7 +781,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         final XFFResolver xffResolver = new XFFResolver(threadPool);
         backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool);
 
-        final CompatConfig compatConfig = new CompatConfig(environment);
+        compatConfig = new CompatConfig(environment);
 
         evaluator = new PrivilegesEvaluator(clusterService, threadPool, cr, resolver, auditLog,
                 settings, privilegesInterceptor, cih, irr, advancedModulesEnabled);
@@ -813,7 +814,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
         cr.setDynamicConfigFactory(dcf);
 
         odsi = new OpenDistroSecurityInterceptor(settings, threadPool, backendRegistry, auditLog, principalExtractor,
-                interClusterRequestEvaluator, cs, Objects.requireNonNull(sslExceptionHandler), Objects.requireNonNull(cih));
+                interClusterRequestEvaluator, cs, Objects.requireNonNull(sslExceptionHandler), Objects.requireNonNull(cih), openDistroSSLConfig);
         components.add(principalExtractor);
 
         // NOTE: We need to create DefaultInterClusterRequestEvaluator before creating ConfigurationRepository since the latter requires security index to be accessible which means
@@ -996,6 +997,7 @@ public final class OpenDistroSecurityPlugin extends OpenDistroSecuritySSLPlugin 
             //compat
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY, false, Property.NodeScope, Property.Filtered));
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY, false, Property.NodeScope, Property.Filtered));
 
             // system integration
             settings.add(Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_SECURITYINDEX_ENABLED, false, Property.NodeScope, Property.Filtered));

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/CompatConfig.java
@@ -100,4 +100,28 @@ public class CompatConfig {
             return true;
         }
     }
+
+    /**
+     * Returns true if passive transport auth is enabled
+     */
+    public boolean transportInterClusterPassiveAuthEnabled() {
+        final boolean interClusterAuthInitiallyPassive = staticSettings.getAsBoolean(ConfigConstants.OPENDISTRO_SECURITY_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY, false);
+
+            if(interClusterAuthInitiallyPassive) {
+                if(dcm == null) {
+                    if(log.isTraceEnabled()) {
+                        log.trace("dynamicSecurityConfig is null, initially static interClusterAuthPassive");
+                    }
+                    return false;
+                } else {
+                    final boolean interClusterAuthDynamicallyPassive = dcm.isInterTransportAuthPassive();
+                    if(log.isTraceEnabled()) {
+                        log.trace("opendistro_security.dynamic.passive_intertransport_auth {}", interClusterAuthDynamicallyPassive);
+                    }
+                    return interClusterAuthDynamicallyPassive;
+                }
+            } else {
+                return false;
+            }
+    }
 }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/filter/OpenDistroSecurityFilter.java
@@ -271,14 +271,19 @@ public class OpenDistroSecurityFilter implements ActionFilter {
                     return;
                 }
 
+                boolean skipSecurityIfDualMode = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_DUAL_MODE_SKIP_SECURITY) == Boolean.TRUE;
                 if((interClusterRequest || trustedClusterRequest || request.remoteAddress() == null) && !compatConfig.transportInterClusterAuthEnabled()) {
                     chain.proceed(task, action, request, listener);
                     return;
+                } else if((interClusterRequest || trustedClusterRequest || request.remoteAddress() == null || skipSecurityIfDualMode) && compatConfig.transportInterClusterPassiveAuthEnabled()) {
+                    log.info("Transport auth in passive mode and no user found. Injecting default user");
+                    user = User.DEFAULT_TRANSPORT_USER;
+                    threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
+                } else {
+                    log.error("No user found for " + action + " from " + request.remoteAddress() + " " + threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN) + " via " + threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CHANNEL_TYPE) + " " + threadContext.getHeaders());
+                    listener.onFailure(new ElasticsearchSecurityException("No user found for " + action, RestStatus.INTERNAL_SERVER_ERROR));
+                    return;
                 }
-
-                log.error("No user found for "+ action+" from "+request.remoteAddress()+" "+threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN)+" via "+threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CHANNEL_TYPE)+" "+threadContext.getHeaders());
-                listener.onFailure(new ElasticsearchSecurityException("No user found for "+action, RestStatus.INTERNAL_SERVER_ERROR));
-                return;
             }
 
             final PrivilegesEvaluator eval = evalp;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModel.java
@@ -72,6 +72,7 @@ public abstract class DynamicConfigModel {
     public abstract String getRemoteIpHeader();
     public abstract boolean isRestAuthDisabled();
     public abstract boolean isInterTransportAuthDisabled();
+    public abstract boolean isInterTransportAuthPassive();
     public abstract boolean isRespectRequestIndicesEnabled();
     public abstract String getKibanaServerUsername();
     public abstract String getKibanaOpendistroRole();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV6.java
@@ -137,6 +137,10 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         return config.dynamic.disable_intertransport_auth;
     }
     @Override
+    public boolean isInterTransportAuthPassive() {
+            return config.dynamic.passive_intertransport_auth;
+    }
+    @Override
     public boolean isRespectRequestIndicesEnabled() {
         return config.dynamic.respect_request_indices_options;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/DynamicConfigModelV7.java
@@ -137,6 +137,10 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         return config.dynamic.disable_intertransport_auth;
     }
     @Override
+    public boolean isInterTransportAuthPassive() {
+        return config.dynamic.passive_intertransport_auth;
+    }
+    @Override
     public boolean isRespectRequestIndicesEnabled() {
         return config.dynamic.respect_request_indices_options;
     }

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v6/ConfigV6.java
@@ -61,6 +61,7 @@ public class ConfigV6 {
         public String filtered_alias_mode = "warn";
         public boolean disable_rest_auth;
         public boolean disable_intertransport_auth;
+        public boolean passive_intertransport_auth;
         public boolean respect_request_indices_options;
         public String license;
         public Kibana kibana = new Kibana();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/securityconf/impl/v7/ConfigV7.java
@@ -59,6 +59,7 @@ public class ConfigV7 {
         dynamic.filtered_alias_mode = c6.dynamic.filtered_alias_mode;
         dynamic.disable_rest_auth = c6.dynamic.disable_rest_auth;
         dynamic.disable_intertransport_auth = c6.dynamic.disable_intertransport_auth;
+        dynamic.passive_intertransport_auth = c6.dynamic.passive_intertransport_auth;
         dynamic.respect_request_indices_options = c6.dynamic.respect_request_indices_options;
         dynamic.license = c6.dynamic.license;
         dynamic.do_not_fail_on_forbidden = c6.dynamic.do_not_fail_on_forbidden || c6.dynamic.kibana.do_not_fail_on_forbidden;
@@ -112,6 +113,7 @@ public class ConfigV7 {
         public String filtered_alias_mode = "warn";
         public boolean disable_rest_auth;
         public boolean disable_intertransport_auth;
+        public boolean passive_intertransport_auth;
         public boolean respect_request_indices_options;
         public String license;
         public Kibana kibana = new Kibana();

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/OpenDistroSecuritySSLPlugin.java
@@ -259,7 +259,7 @@ public class OpenDistroSecuritySSLPlugin extends Plugin implements SystemIndexPl
         List<TransportInterceptor> interceptors = new ArrayList<TransportInterceptor>(1);
         
         if(transportSSLEnabled && !client) {
-            interceptors.add(new OpenDistroSecuritySSLTransportInterceptor(settings, null, null, NOOP_SSL_EXCEPTION_HANDLER));
+            interceptors.add(new OpenDistroSecuritySSLTransportInterceptor(settings, null, null, openDistroSSLConfig, NOOP_SSL_EXCEPTION_HANDLER));
         }
         
         return interceptors;

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSSLConfig.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSSLConfig.java
@@ -35,10 +35,6 @@ public class OpenDistroSSLConfig {
     public OpenDistroSSLConfig(final boolean sslOnly, final boolean dualModeEnabled) {
         this.sslOnly = sslOnly;
         this.dualModeEnabled = dualModeEnabled;
-        if (this.dualModeEnabled && !this.sslOnly) {
-            logger.warn("opendistro_security_config.ssl_dual_mode_enabled is enabled but opendistro_security.ssl_only mode is disabled. "
-                + "SSL Dual mode is supported only when security plugin is in ssl_only mode");
-        }
         logger.info("SSL dual mode is {}", isDualModeEnabled() ? "enabled" : "disabled");
     }
 
@@ -60,8 +56,7 @@ public class OpenDistroSSLConfig {
     }
 
     public boolean isDualModeEnabled() {
-        // currently dual mode can be enabled only when SSLOnly is enabled. This stance can change in future.
-        return sslOnly && dualModeEnabled;
+        return dualModeEnabled;
     }
 
     public boolean isSslOnlyMode() {

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLRequestHandler.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 
+import com.amazon.opendistroforelasticsearch.security.auditlog.AuditLog.Origin;
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
@@ -54,14 +56,17 @@ implements TransportRequestHandler<T> {
     protected final Logger log = LogManager.getLogger(this.getClass());
     private final PrincipalExtractor principalExtractor;
     private final SslExceptionHandler errorHandler;
+    private final OpenDistroSSLConfig openDistroSSLConfig;
 
     public OpenDistroSecuritySSLRequestHandler(String action, TransportRequestHandler<T> actualHandler, 
-            ThreadPool threadPool, final PrincipalExtractor principalExtractor, final SslExceptionHandler errorHandler) {
+            ThreadPool threadPool, final PrincipalExtractor principalExtractor, final OpenDistroSSLConfig openDistroSSLConfig,
+                                               final SslExceptionHandler errorHandler) {
         super();
         this.action = action;
         this.actualHandler = actualHandler;
         this.threadPool = threadPool;
         this.principalExtractor = principalExtractor;
+        this.openDistroSSLConfig = openDistroSSLConfig;
         this.errorHandler = errorHandler;
     }
     
@@ -69,7 +74,7 @@ implements TransportRequestHandler<T> {
         if(threadPool == null) {
             return null;
         }
-        
+
         return threadPool.getThreadContext();
     }
 
@@ -111,6 +116,12 @@ implements TransportRequestHandler<T> {
             final SslHandler sslhandler = (SslHandler) nettyChannel.getNettyChannel().pipeline().get("ssl_server");
 
             if (sslhandler == null) {
+                if (openDistroSSLConfig.isDualModeEnabled()) {
+                    log.info("Communication in dual mode. Skipping SSL handler check");
+                    threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_DUAL_MODE_SKIP_SECURITY, Boolean.TRUE);
+                    messageReceivedDecorate(request, actualHandler, channel, task);
+                    return;
+                }
                 final String msg = "No ssl handler found (SG 11)";
                 //log.error(msg);
                 final Exception exception = new ElasticsearchException(msg);

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLTransportInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/ssl/transport/OpenDistroSecuritySSLTransportInterceptor.java
@@ -33,18 +33,21 @@ public final class OpenDistroSecuritySSLTransportInterceptor implements Transpor
     protected final ThreadPool threadPool;
     protected final PrincipalExtractor principalExtractor;
     protected final SslExceptionHandler errorHandler;
+    protected final OpenDistroSSLConfig openDistroSSLConfig;
     
     public OpenDistroSecuritySSLTransportInterceptor(final Settings settings, final  ThreadPool threadPool, 
-            PrincipalExtractor principalExtractor, final SslExceptionHandler errorHandler) {
+            PrincipalExtractor principalExtractor, final OpenDistroSSLConfig openDistroSSLConfig,
+                                                     final SslExceptionHandler errorHandler) {
         this.threadPool = threadPool;
         this.principalExtractor = principalExtractor;
         this.errorHandler = errorHandler;
+        this.openDistroSSLConfig = openDistroSSLConfig;
     }
 
     @Override
     public <T extends TransportRequest> TransportRequestHandler<T> interceptHandler(String action, String executor, boolean forceExecution,
             TransportRequestHandler<T> actualHandler) {
-        return new OpenDistroSecuritySSLRequestHandler<T>(action, actualHandler, threadPool, principalExtractor, errorHandler);
+        return new OpenDistroSecuritySSLRequestHandler<T>(action, actualHandler, threadPool, principalExtractor, openDistroSSLConfig, errorHandler);
     }
     
     

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/support/ConfigConstants.java
@@ -224,6 +224,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED  = "opendistro_security.compliance.history.internal_config_enabled";
     public static final String OPENDISTRO_SECURITY_SSL_ONLY = "opendistro_security.ssl_only";
     public static final String OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED = "opendistro_security_config.ssl_dual_mode_enabled";
+    public static final String OPENDISTRO_SECURITY_SSL_DUAL_MODE_SKIP_SECURITY = OPENDISTRO_SECURITY_CONFIG_PREFIX+"passive_security";
     public static final String OPENDISTRO_SECURITY_SSL_CERT_RELOAD_ENABLED = "opendistro_security.ssl_cert_reload_enabled";
     public static final String OPENDISTRO_SECURITY_DISABLE_ENVVAR_REPLACEMENT = "opendistro_security.disable_envvar_replacement";
 
@@ -244,6 +245,7 @@ public class ConfigConstants {
     // Illegal Opcodes from here on
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "opendistro_security.unsupported.disable_rest_auth_initially";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY = "opendistro_security.unsupported.disable_intertransport_auth_initially";
+    public static final String OPENDISTRO_SECURITY_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY = "opendistro_security.unsupported.passive_intertransport_auth_initially";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_RESTORE_SECURITYINDEX_ENABLED = "opendistro_security.unsupported.restore.securityindex.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_USER_ENABLED = "opendistro_security.unsupported.inject_user.enabled";
     public static final String OPENDISTRO_SECURITY_UNSUPPORTED_INJECT_ADMIN_USER_ENABLED = "opendistro_security.unsupported.inject_user.admin.enabled";

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/transport/OpenDistroSecurityInterceptor.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import com.amazon.opendistroforelasticsearch.security.ssl.transport.OpenDistroSSLConfig;
 import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -87,6 +88,7 @@ public class OpenDistroSecurityInterceptor {
     private final Settings settings;
     private final SslExceptionHandler sslExceptionHandler;
     private final ClusterInfoHolder clusterInfoHolder;
+    private final OpenDistroSSLConfig openDistroSSLConfig;
 
     public OpenDistroSecurityInterceptor(final Settings settings,
             final ThreadPool threadPool, final BackendRegistry backendRegistry,
@@ -94,7 +96,8 @@ public class OpenDistroSecurityInterceptor {
             final InterClusterRequestEvaluator requestEvalProvider,
             final ClusterService cs,
             final SslExceptionHandler sslExceptionHandler,
-            final ClusterInfoHolder clusterInfoHolder) {
+            final ClusterInfoHolder clusterInfoHolder,
+            final OpenDistroSSLConfig openDistroSSLConfig) {
         this.backendRegistry = backendRegistry;
         this.auditLog = auditLog;
         this.threadPool = threadPool;
@@ -104,12 +107,13 @@ public class OpenDistroSecurityInterceptor {
         this.settings = settings;
         this.sslExceptionHandler = sslExceptionHandler;
         this.clusterInfoHolder = clusterInfoHolder;
+        this.openDistroSSLConfig = openDistroSSLConfig;
     }
 
     public <T extends TransportRequest> OpenDistroSecurityRequestHandler<T> getHandler(String action,
             TransportRequestHandler<T> actualHandler) {
         return new OpenDistroSecurityRequestHandler<T>(action, actualHandler, threadPool, backendRegistry, auditLog,
-                principalExtractor, requestEvalProvider, cs, sslExceptionHandler);
+                principalExtractor, requestEvalProvider, cs, openDistroSSLConfig, sslExceptionHandler);
     }
 
 

--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/user/User.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Lists;
 public class User implements Serializable, Writeable, CustomAttributesAware {
 
     public static final User ANONYMOUS = new User("opendistro_security_anonymous", Lists.newArrayList("opendistro_security_anonymous_backendrole"), null);
+    public static final User DEFAULT_TRANSPORT_USER = new User("opendistro_security_default_transport_user", Lists.newArrayList("opendistro_security_default_transport_backendrole"), null);
     
     private static final long serialVersionUID = -5500938501822658596L;
     private final String name;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/AdvancedSecurityMigrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/AdvancedSecurityMigrationTests.java
@@ -1,0 +1,284 @@
+package com.amazon.opendistroforelasticsearch.security;
+
+import com.amazon.opendistroforelasticsearch.security.support.ConfigConstants;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.ClusterConfiguration;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+public class AdvancedSecurityMigrationTests extends SingleClusterTest {
+
+    @Before
+    public void setupBefore() {
+        System.setProperty("security.default_init.dir", new File("./src/test/resources/security_passive").getAbsolutePath());
+    }
+
+    @After
+    public void cleanupAfter() {
+        System.setProperty("security.default_init.dir", new File("./securityconfig").getAbsolutePath());
+    }
+
+    /**
+     * 2 data nodes are adv sec enabled. 1 master node and 1 data node are SSL only.
+     * Rest request lands on SSL only data node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledDataNodeWithSSlOnlyMasterNode_ReqOnSSLNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettings().build();
+        final Settings sslOnlySettings = getSSLOnlyModeSettings().build();
+
+        setupGenericNodes(Arrays.asList(sslOnlySettings, advSecSettings, advSecSettings, sslOnlySettings),
+                Arrays.asList(true, false, false, true), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), null);
+    }
+
+    /**
+     * 2 data nodes are adv sec enabled. 1 master node and 1 data node are SSL only.
+     * Rest request lands on adv sec data node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledDataNodeWithSSlOnlyMasterNode_ReqOnAdvSecNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettings().build();
+        final Settings sslOnlySettings = getSSLOnlyModeSettings().build();
+
+        setupGenericNodes(Arrays.asList(advSecSettings, sslOnlySettings, advSecSettings, sslOnlySettings),
+                Arrays.asList(false, true, false, true), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), encodeBasicHeader("admin", "admin"));
+    }
+
+    /**
+     * 1 Master node and 1 Data node is adv sec enabled. 2 Data nodes are SSL only.
+     * Rest request lands on ssl only data node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledMasterNodeWithSSlOnlyDataNode_ReqOnSSLNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettings().build();
+        final Settings sslOnlySettings = getSSLOnlyModeSettings().build();
+
+        setupGenericNodes(Arrays.asList(sslOnlySettings, sslOnlySettings, advSecSettings, advSecSettings),
+                Arrays.asList(true, true, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(),null);
+    }
+
+    /**
+     * 1 Master node and 1 Data node is adv sec enabled. 2 Data nodes are SSL only.
+     * Rest request lands on adv sec data node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledMasterNodeWithSSlOnlyDataNode_ReqOnAdvSecNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettings().build();
+        final Settings sslOnlySettings = getSSLOnlyModeSettings().build();
+
+        setupGenericNodes(Arrays.asList(advSecSettings, sslOnlySettings, sslOnlySettings, advSecSettings),
+                Arrays.asList(false, true, true, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), encodeBasicHeader("admin", "admin"));
+    }
+
+    /**
+     * 2 Data nodes are adv sec enabled. 1 Master node and 1 Data node are plugin disabled.
+     * Rest request lands on plugin disabled node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledDataNodeWithDisabledMasterNode_ReqOnDisabledNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettingsDualMode().build();
+        final Settings disabledSettings = getDisabledSettings().build();
+
+        setupGenericNodes(Arrays.asList(disabledSettings, advSecSettings, advSecSettings, disabledSettings),
+                Arrays.asList(false, false, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(),null);
+    }
+
+    /**
+     * 2 Data nodes are adv sec enabled. 1 Master node and 1 Data node are plugin disabled.
+     * Rest request lands on adv sec data node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledDataNodeWithDisabledMasterNode_ReqOnAdvSecNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettingsDualMode().build();
+        final Settings disabledSettings = getDisabledSettings().build();
+
+        setupGenericNodes(Arrays.asList(advSecSettings, disabledSettings, advSecSettings, disabledSettings),
+                Arrays.asList(false, false, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), encodeBasicHeader("admin", "admin"));
+    }
+
+    /**
+     * 1 Master node and 1 Data node are adv sec enabled. 2 Data nodes are plugin disabled.
+     * Rest request lands on plugin disabled node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledMasterNodeWithDisabledDataNode_ReqOnDisabledNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettingsDualMode().build();
+        final Settings disabledSettings = getDisabledSettings().build();
+
+        setupGenericNodes(Arrays.asList(disabledSettings, disabledSettings, advSecSettings, advSecSettings),
+                Arrays.asList(false, false, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), null);
+    }
+
+    /**
+     * 1 Master node and 2 Data nodes are adv sec enabled. 1 Data node is plugin disabled.
+     * Rest request lands on plugin adv sec node
+     * @throws Exception
+     */
+    @Test
+    public void testPluginEnabledMasterNodeWithDisabledDataNode_ReqOnAdvSecNode() throws Exception {
+        final Settings advSecSettings = getAdvSecSettingsDualMode().build();
+        final Settings disabledSettings = getDisabledSettings().build();
+
+        setupGenericNodes(Arrays.asList(advSecSettings, disabledSettings, advSecSettings, advSecSettings),
+                Arrays.asList(false, false, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        commonTestsForAdvancedSecurityMigration(nonSslRestHelper(), encodeBasicHeader("admin", "admin"));
+    }
+
+    @Test
+    public void testWithPassiveAuthDisabled() throws Exception {
+        final Settings advSecSettings = getAdvSecSettings()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY, false)
+                .build();
+        final Settings sslOnlySettings = getSSLOnlyModeSettings().build();
+
+        setupGenericNodes(Arrays.asList(sslOnlySettings, sslOnlySettings, advSecSettings, advSecSettings),
+                Arrays.asList(true, true, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+        Thread.sleep(10000);
+
+        RestHelper.HttpResponse res;
+        RestHelper rh = nonSslRestHelper();
+        res = rh.executeGetRequest("/_cluster/health", null);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_INTERNAL_SERVER_ERROR, res.getStatusCode());
+    }
+
+    @Test
+    public void testWithPassiveAuthDisabledDynamic() throws Exception {
+        System.setProperty("security.default_init.dir", new File("./securityconfig").getAbsolutePath());
+
+        final Settings advSecSettings = getAdvSecSettingsDualMode().build();
+        final Settings disabledSettings = getDisabledSettings().build();
+
+        setupGenericNodes(Arrays.asList(disabledSettings, disabledSettings, advSecSettings, advSecSettings),
+                Arrays.asList(false, false, false, false), ClusterConfiguration.ONE_MASTER_THREE_DATA);
+
+        RestHelper.HttpResponse res;
+        RestHelper rh = nonSslRestHelper();
+        res = rh.executeGetRequest("/_cluster/health", null);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_INTERNAL_SERVER_ERROR, res.getStatusCode());
+
+    }
+
+    private void commonTestsForAdvancedSecurityMigration(final RestHelper rh, final Header basicHeaders) throws Exception {
+        //Thread.sleep(5*1000);
+
+        RestHelper.HttpResponse res;
+        res = rh.executePutRequest("testindex", getIndexSettingsForAdvSec(), basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+
+        res = rh.executePutRequest("testindex2", getIndexSettingForSSLOnlyNode(), basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+
+        res = rh.executeGetRequest("/_cluster/health", basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executeGetRequest("/_cat/shards", basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+
+        commonTestsForAnIndex(rh, "testindex", basicHeaders);
+        commonTestsForAnIndex(rh, "testindex2", basicHeaders);
+    }
+
+    private void commonTestsForAnIndex(final RestHelper rh, final String index, final Header basicHeaders) throws Exception {
+        RestHelper.HttpResponse res;
+        String slashIndex = "/" + index;
+
+        res = rh.executeGetRequest(slashIndex, basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executePutRequest(slashIndex + "/_doc/1", "{}", basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_CREATED, res.getStatusCode());
+        res = rh.executePutRequest(slashIndex + "/_doc/1", "{}", basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executeDeleteRequest(slashIndex + "/_doc/1", basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        res = rh.executeDeleteRequest(slashIndex, basicHeaders);
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+    }
+
+    private Settings.Builder getAdvSecSettings() {
+        return Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
+                .put(ConfigConstants.OPENDISTRO_SECURITY_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY, true)
+                .put(ConfigConstants.OPENDISTRO_SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true)
+                .put("node.attr.custom_node", true);
+    }
+
+    private Settings.Builder getAdvSecSettingsDualMode() {
+        return getAdvSecSettings()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true);
+    }
+
+    private Settings.Builder getSSLOnlyModeSettings() {
+        return Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_SSL_ONLY, true);
+    }
+
+    private Settings.Builder getDisabledSettings() {
+        return Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_DISABLED, true);
+    }
+
+    // Create index with shards only in adv sec nodes
+    private String getIndexSettingsForAdvSec() {
+        return "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 2, \n" +
+                "            \"number_of_replicas\" : 1, \n" +
+                "            \"routing.allocation.include.custom_node\" : true \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+    }
+
+    // Create index with shards only in non adv sec nodes
+    private String getIndexSettingForSSLOnlyNode() {
+        return "{\n" +
+                "    \"settings\" : {\n" +
+                "        \"index\" : {\n" +
+                "            \"number_of_shards\" : 2, \n" +
+                "            \"number_of_replicas\" : 1, \n" +
+                "            \"routing.allocation.exclude.custom_node\" : true \n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+    }
+}

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/InitializationIntegrationTests.java
@@ -196,6 +196,8 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         Thread.sleep(10000);
         
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
+        HttpResponse res = rh.executeGetRequest("/_cluster/health", encodeBasicHeader("admin", "admin"));
+        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/AbstractSecurityUnitTest.java
@@ -276,6 +276,18 @@ public abstract class AbstractSecurityUnitTest {
         };
     }
 
+    protected NodeSettingsSupplier genericMinimumSecuritySettings(List<Settings> others, List<Boolean> sslOnly) {
+
+        return i -> {
+            try {
+                i = i-1;
+                return minimumSecuritySettingsBuilder(i, sslOnly.get(i), hasCustomTransportSettings(others.get(i))).put(others.get(i)).build();
+            } catch (IndexOutOfBoundsException e) {
+                return minimumSecuritySettingsBuilder(i, false, false).build();
+            }
+        };
+    }
+
     protected void initialize(ClusterInfo info) {
         initialize(info, Settings.EMPTY, new DynamicSecurityConfig());
     }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/SingleClusterTest.java
@@ -40,6 +40,8 @@ import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.Cluste
 import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.ClusterInfo;
 import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
 
+import java.util.List;
+
 public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
 
     private static final int DEFAULT_MASTER_NODE_NUM = 3;
@@ -121,6 +123,12 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
         Assert.assertNull("No cluster", clusterInfo);
         clusterInfo = clusterHelper.startCluster(minimumSecuritySettingsSslOnlyWithOneNodeNonSSL(nodeOverride,
                 DEFAULT_FIRST_DATA_NODE_NUM), ClusterConfiguration.DEFAULT_ONE_DATA_NODE_WITHOUT_SECURITY_PLUGIN);
+    }
+
+    protected void setupGenericNodes(List<Settings> nodeOverride, List<Boolean> sslOnly, ClusterConfiguration clusterConfiguration) throws Exception {
+        Assert.assertNull("No cluster", clusterInfo);
+        clusterInfo = clusterHelper.startCluster(genericMinimumSecuritySettings(nodeOverride, sslOnly),
+                clusterConfiguration);
     }
 
     protected RestHelper restHelper() {

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterConfiguration.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterConfiguration.java
@@ -55,6 +55,9 @@ public enum ClusterConfiguration {
     //3 nodes (1m, 2d)
     DEFAULT(new NodeSettings(true, false), new NodeSettings(false, true), new NodeSettings(false, true)),
 
+	//2 nodes (1m, 3d)
+	ONE_MASTER_THREE_DATA(new NodeSettings(true, false), new NodeSettings(false, true), new NodeSettings(false, true), new NodeSettings(false, true)),
+
 	DEFAULT_MASTER_WITHOUT_SECURITY_PLUGIN(new NodeSettings(true, false)
 			.removePluginIfPresent(OpenDistroSecurityPlugin.class)
 			, new NodeSettings(false, true)

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/cluster/ClusterHelper.java
@@ -32,6 +32,7 @@ package com.amazon.opendistroforelasticsearch.security.test.helper.cluster;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -286,6 +287,8 @@ public final class ClusterHelper {
 
             final List<NodeInfo> masterNodes = nodes.stream().filter(n->n.getNode().getRoles().contains(DiscoveryNodeRole.MASTER_ROLE)).collect(Collectors.toList());
             final List<NodeInfo> dataNodes = nodes.stream().filter(n->n.getNode().getRoles().contains(DiscoveryNodeRole.DATA_ROLE) && !n.getNode().getRoles().contains(DiscoveryNodeRole.MASTER_ROLE)).collect(Collectors.toList());
+            // Sorting the nodes so that the node receiving the http requests is always deterministic
+            dataNodes.sort(Comparator.comparing(nodeInfo -> nodeInfo.getNode().getName()));
             final List<NodeInfo> clientNodes = nodes.stream().filter(n->!n.getNode().getRoles().contains(DiscoveryNodeRole.MASTER_ROLE) && !n.getNode().getRoles().contains(DiscoveryNodeRole.DATA_ROLE)).collect(Collectors.toList());
 
 

--- a/src/test/resources/security_passive/action_groups.yml
+++ b/src/test/resources/security_passive/action_groups.yml
@@ -1,0 +1,148 @@
+---
+_meta:
+  type: "actiongroups"
+  config_version: 2
+OPENDISTRO_SECURITY_CLUSTER_ALL:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "cluster:*"
+  type: "cluster"
+  description: "Migrated from v6"
+ALL:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_CRUD:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
+    - "OPENDISTRO_SECURITY_WRITE"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_SEARCH:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/read/search*"
+    - "indices:data/read/msearch*"
+    - "OPENDISTRO_SECURITY_SUGGEST"
+  type: "index"
+  description: "Migrated from v6"
+MONITOR:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:monitor/*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_DATA_ACCESS:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/*"
+    - "indices:admin/mapping/put"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_CREATE_INDEX:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:admin/create"
+    - "indices:admin/mapping/put"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_WRITE:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/write*"
+    - "indices:admin/mapping/put"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_MANAGE_ALIASES:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:admin/aliases*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_READ:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/read*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_DELETE:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/write/delete*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/write/bulk"
+    - "indices:admin/aliases*"
+    - "indices:data/write/reindex"
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  type: "cluster"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/read/mget"
+    - "indices:data/read/msearch"
+    - "indices:data/read/mtv"
+    - "indices:data/read/coordinate-msearch*"
+    - "indices:admin/aliases/exists*"
+    - "indices:admin/aliases/get*"
+  type: "cluster"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_GET:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/read/get*"
+    - "indices:data/read/mget*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_MANAGE:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:monitor/*"
+    - "indices:admin/*"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_CLUSTER_MONITOR:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "cluster:monitor/*"
+  type: "cluster"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_INDEX:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/write/index*"
+    - "indices:data/write/update*"
+    - "indices:admin/mapping/put"
+  type: "index"
+  description: "Migrated from v6"
+OPENDISTRO_SECURITY_SUGGEST:
+  reserved: false
+  hidden: false
+  allowed_actions:
+    - "indices:data/read/suggest*"
+  type: "index"
+  description: "Migrated from v6"

--- a/src/test/resources/security_passive/audit.yml
+++ b/src/test/resources/security_passive/audit.yml
@@ -1,0 +1,85 @@
+_meta:
+  type: "audit"
+  config_version: 2
+
+config:
+  # enable/disable audit logging
+  enabled: true
+
+  audit:
+    # Enable/disable REST API auditing
+    enable_rest: true
+
+    # Categories to exclude from REST API auditing
+    disabled_rest_categories:
+      - AUTHENTICATED
+      - GRANTED_PRIVILEGES
+
+    # Enable/disable Transport API auditing
+    enable_transport: true
+
+    # Categories to exclude from Transport API auditing
+    disabled_transport_categories:
+      - AUTHENTICATED
+      - GRANTED_PRIVILEGES
+
+    # Users to be excluded from auditing. Wildcard patterns are supported. Eg:
+    # ignore_users: ["test-user", "employee-*"]
+    ignore_users:
+      - kibanaserver
+
+    # Requests to be excluded from auditing. Wildcard patterns are supported. Eg:
+    # ignore_requests: ["indices:data/read/*", "SearchRequest"]
+    ignore_requests: []
+
+    # Log individual operations in a bulk request
+    resolve_bulk_requests: false
+
+    # Include the body of the request (if available) for both REST and the transport layer
+    log_request_body: true
+
+    # Logs all indices affected by a request. Resolves aliases and wildcards/date patterns
+    resolve_indices: true
+
+    # Exclude sensitive headers from being included in the logs. Eg: Authorization
+    exclude_sensitive_headers: true
+
+  compliance:
+    # enable/disable compliance
+    enabled: true
+
+    # Log updates to internal security changes
+    internal_config: true
+
+    # Log external config files for the node
+    external_config: false
+
+    # Log only metadata of the document for read events
+    read_metadata_only: true
+
+    # Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields. Eg:
+    # read_watched_fields: {
+    #   "twitter": ["message"]
+    #   "logs-*": ["id", "attr*"]
+    # }
+    read_watched_fields: {}
+
+    # List of users to ignore for read events. Wildcard patterns are supported. Eg:
+    # read_ignore_users: ["test-user", "employee-*"]
+    read_ignore_users:
+      - kibanaserver
+
+    # Log only metadata of the document for write events
+    write_metadata_only: true
+
+    # Log only diffs for document updates
+    write_log_diffs: false
+
+    # List of indices to watch for write events. Wildcard patterns are supported
+    # write_watched_indices: ["twitter", "logs-*"]
+    write_watched_indices: []
+
+    # List of users to ignore for write events. Wildcard patterns are supported. Eg:
+    # write_ignore_users: ["test-user", "employee-*"]
+    write_ignore_users:
+      - kibanaserver

--- a/src/test/resources/security_passive/config.yml
+++ b/src/test/resources/security_passive/config.yml
@@ -1,0 +1,97 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+config:
+  dynamic:
+    filtered_alias_mode: "disallow"
+    disable_rest_auth: false
+    disable_intertransport_auth: false
+    passive_intertransport_auth: true
+    respect_request_indices_options: false
+    kibana:
+      multitenancy_enabled: true
+      server_username: "kibanaserver"
+      index: ".kibana"
+    http:
+      anonymous_auth_enabled: false
+      xff:
+        enabled: false
+        internalProxies: "192\\.168\\.0\\.10|192\\.168\\.0\\.11"
+        remoteIpHeader: "x-forwarded-for"
+
+
+    authc:
+      authentication_domain_kerb:
+        http_enabled: false
+        transport_enabled: false
+        order: 3
+        http_authenticator:
+          challenge: true
+          type: "kerberos"
+          config: {}
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_proxy:
+        http_enabled: false
+        transport_enabled: false
+        order: 2
+        http_authenticator:
+          challenge: true
+          type: "proxy"
+          config:
+            user_header: "x-proxy-user"
+            roles_header: "x-proxy-roles"
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_clientcert:
+        http_enabled: false
+        transport_enabled: false
+        order: 1
+        http_authenticator:
+          challenge: true
+          type: "clientcert"
+          config: {}
+        authentication_backend:
+          type: "noop"
+          config: {}
+        description: "Migrated from v6"
+      authentication_domain_basic_internal:
+        http_enabled: true
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          challenge: true
+          type: "basic"
+          config: {}
+        authentication_backend:
+          type: "intern"
+          config: {}
+        description: "Migrated from v6"
+    authz:
+      roles_from_xxx:
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          type: "xxx"
+          config: {}
+        description: "Migrated from v6"
+      roles_from_myldap:
+        http_enabled: false
+        transport_enabled: false
+        authorization_backend:
+          type: "ldap"
+          config:
+            rolesearch: "(uniqueMember={0})"
+            resolve_nested_roles: true
+            rolebase: "ou=groups,o=TEST"
+            rolename: "cn"
+        description: "Migrated from v6"
+    do_not_fail_on_forbidden: false
+    multi_rolespan_enabled: false
+    hosts_resolver_mode: "ip-only"
+    transport_userrname_attribute: null

--- a/src/test/resources/security_passive/internal_users.yml
+++ b/src/test/resources/security_passive/internal_users.yml
@@ -1,0 +1,343 @@
+---
+_meta:
+  type: "internalusers"
+  config_version: 2
+admin:
+  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+bug.99:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+user_c:
+  hash: "$2a$04$jQcEXpODnTFoGDuA7DPdSevA84CuH/7MOYkb80M3XZIrH76YMWS9G"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "uc"
+  attributes: {}
+  description: "Migrated from v6"
+user_b:
+  hash: "$2a$04$idGSEpNOhFbyiRL6toGPT.orh7ENOEU8kAqwkRFaXWRdA6wVgyqUu"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "ub"
+  attributes: {}
+  description: "Migrated from v6"
+snapresuser:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+user_a:
+  hash: "$2a$04$NDy7mGbRNrmPMh9nSnIB.OTMFkcioEd69A04ReSGkJDd7QHxnCcVC"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "ua"
+  attributes: {}
+  description: "Migrated from v6"
+sarek:
+  hash: "$2a$12$Ioo1uXmH.Nq/lS5dUVBEsePSmZ5pSIpVO/xKHaquU/Jvq97I7nAgG"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+crusherw:
+  hash: "$2a$12$61vXe3cXy32p0cjsW0Y/SeZa7kEVSWuQK0jg98D9d5zOGXfo5NgyC"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "starfleet_academy"
+  attributes: {}
+  description: "Migrated from v6"
+kibanaserver:
+  hash: "$2a$12$4AcgAt3xwOWadA5s5blL6ev39OXDNhmOesEoo33eZtrq2N0YrU3H."
+  reserved: true
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+theindexadmin:
+  hash: "$2a$12$P.QbiwOsnxgz7kLBT10F7u6GhY7//Keyz7Xwf7lNzskRxpo9.zxFS"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+aliastest:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+opendistro_security_logstash:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+twitter:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+mindex12:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+spock:
+  hash: "$2a$12$GI9JXffO3WUjTsU7Yy3E4.LBxC2ILo66Zg/rr79BpikSL2IIRezQa"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "vulcan"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+knuddel:
+  hash: "_imponly_"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes:
+    test1: test2
+  description: "Migrated from v6"
+557:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "557"
+  attributes: {}
+  description: "Migrated from v6"
+baz:
+  hash: "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+picard:
+  hash: "$2a$12$wkY2BsRneCU5za1OPYlzsehQit6gu2vprVv/4jHiSEEBv2ThunaTS"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "captains"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+bug108:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+nagilum:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+custattr:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes:
+    c1: "v1"
+    c2: "v2"
+    c3.c4.cd: "test1"
+    c4.c4.cd: "test2"
+    c5: null
+    null: "abc"
+  description: "Migrated from v6"
+restoreuser:
+  hash: "$2a$12$JU2QjYVTlI24Q/enEOpf2uTLCPGchN.eXWCsrBiieUcRoeh53NB0y"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+CN=spock,OU=client,O=client,L=Test,C=DE:
+  hash: "_impersonation_only_"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "vulcan"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+abc:
+  hash: "$2a$12$bP0CO5d5nhmaTOj7mGteHugXQQ8jlSV0dxcl5//moZ1xnI.pVPXfe"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+kirk:
+  hash: "$2a$12$xZOcnwYPYQ3zIadnlQIJ0eNhX1ngwMkTN.oMwkKxoGvDVPn4/6XtO"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "captains"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+§ÄÖÜäöüß:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+ccsresolv:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+itt1635:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "esb_1"
+    - "esb_3"
+    - "esb_5"
+  attributes: {}
+  description: "Migrated from v6"
+rexclude:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+user_role01_role02_role03:
+  hash: "$2a$12$6.4Y6L//xeKQ7t8YEG0s6OH4F4q9gMw0J8E0GjmUMNZeyIWu1IRWS"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "role01"
+    - "role02"
+    - "role03"
+  attributes: {}
+  description: "Migrated from v6"
+underscore:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+dlsnoinvest:
+  hash: "$2a$12$9Zr4IgoJRqK6xJq4xjoa6OZAnY4QOQ6xIhcCxeYoQtB/HriMkeJSC"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+aliasmngt:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "aliasmngt"
+  attributes: {}
+  description: "Migrated from v6"
+'"''+-,;_?*@<>!$%&/()=#':
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+userwithnopasswd:
+  hash: null
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+worf:
+  hash: "$2a$12$A41IxPXV1/Dx46C6i1ufGubv.p3qYX7xVcY46q33sylYbIqQVwTMu"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+writer:
+  hash: "$2a$12$LZvbDVnegkTbEFTu9hHnWO4HIrdB9rGaKcEOID5n0VV4j58cnvyZ."
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
+user_role01:
+  hash: "$2a$12$XrBfLQh2T8wIzpxE5vzhUOPjjGfONcD8UEjd5IT5KveG8ULZaj04."
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "role01"
+  attributes: {}
+  description: "Migrated from v6"
+bulk:
+  hash: "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m"
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "bulk"
+  attributes: {}
+  description: "Migrated from v6"
+userwithblankpasswd:
+  hash: ""
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+    - "starfleet"
+  attributes: {}
+  description: "Migrated from v6"
+env.replace@example.comp.com:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+static_role_user:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+foo_index:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+foo_all:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+bulk_test_user:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum

--- a/src/test/resources/security_passive/nodes_dn.yml
+++ b/src/test/resources/security_passive/nodes_dn.yml
@@ -1,0 +1,8 @@
+_meta:
+  type: "nodesdn"
+  config_version: 2
+
+# Define nodesdn mapping name and corresponding values
+# cluster1:
+#   nodes_dn:
+#       - CN=*.example.com

--- a/src/test/resources/security_passive/roles.yml
+++ b/src/test/resources/security_passive/roles.yml
@@ -1,0 +1,1080 @@
+---
+_meta:
+  type: "roles"
+  config_version: 2
+unittest_1:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+rexclude:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "/(?!special|alsonotallowed)(\\S|\\s)*/"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+underscore:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*abc_xyz_*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+shakespeare:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/nodes/info"
+    - "cluster:monitor/health"
+    - "indices:admin/template/get"
+    - "indices:admin/exists"
+  index_permissions:
+    - index_patterns:
+        - "shakespeare"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+        - "indices:data/write/bulk*"
+        - "indices:admin/validate/query*"
+        - "indices:admin/exists"
+        - "indices:admin/get*"
+        - "indices:admin/mappings/fields/get*"
+  tenant_permissions: []
+aliasmngt:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "logstash-*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/aliases*"
+        - "indices:data/write/*"
+        - "indices:data/read/*"
+        - "OPENDISTRO_SECURITY_CREATE_INDEX"
+  tenant_permissions: []
+transport_client:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/nodes/liveness"
+  index_permissions: []
+  tenant_permissions: []
+user1:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "alias1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+ccsresolv:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "?abc*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/*"
+  tenant_permissions: []
+user2:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "alias2"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+role_starfleet_captains:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor*"
+  index_permissions:
+    - index_patterns:
+        - "sf"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_CRUD"
+    - index_patterns:
+        - "public"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_CRUD"
+  tenant_permissions: []
+restore:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:admin/snapshot/restore"
+  index_permissions:
+    - index_patterns:
+        - "vulcangov_restore_1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:admin/create"
+    - index_patterns:
+        - "vulcangov_restore_2a"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/create"
+    - index_patterns:
+        - "vulcangov_restore_2*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+    - index_patterns:
+        - "vulcangov_no_restore_1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:admin/create"
+    - index_patterns:
+        - "vulcangov_no_restore_2"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:admin/create"
+    - index_patterns:
+        - "vulcangov_no_restore_3"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+    - index_patterns:
+        - "vulcangov_no_restore_4"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/create"
+  tenant_permissions: []
+baz:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "ALL"
+  index_permissions:
+    - index_patterns:
+        - "foo*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+        - "foo"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+kibana4:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/nodes/info"
+    - "cluster:monitor/health"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/search-"
+        - "indices:data/read/msearch"
+        - "indices:admin/get"
+        - "indices:admin/validate/query"
+        - "indices:admin/mappings/fields/get"
+    - index_patterns:
+        - "?kibana"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:data/write/delete"
+        - "indices:data/write/update"
+        - "indices:admin/mapping/put"
+        - "indices:data/read/get"
+        - "indices:admin/refresh"
+        - "indices:admin/validate/query"
+        - "indices:data/read/search"
+        - "indices:admin/mappings/fields/get"
+        - "indices:admin/exists"
+        - "indices:data/read/mget"
+  tenant_permissions: []
+dlsnoinvest:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "ALL"
+  index_permissions:
+    - index_patterns:
+        - "article"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+    - index_patterns:
+        - "investment"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+    - index_patterns:
+        - "company"
+      dls: "{\"term\" : {\"category_code\" : \"software\"}}"
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+remote_ccs:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/shards/search_shards"
+  tenant_permissions: []
+zdummy_all:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions:
+    - tenant_patterns:
+        - "admin_1"
+      allowed_actions:
+        - "kibana_all_write"
+    - tenant_patterns:
+        - "abcdef_2_2"
+      allowed_actions:
+        - "kibana_all_read"
+multiget:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "indices:data/read/mget"
+  index_permissions:
+    - index_patterns:
+        - "mindex1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+        - "mindex2"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+public:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/main"
+  index_permissions:
+    - index_patterns:
+        - ".notexistingindexcvnjl9809991"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+ccsresolv1:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "?abc*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/*"
+    - index_patterns:
+        - "xyz"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/*"
+    - index_patterns:
+        - "*noexist"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/*"
+  tenant_permissions: []
+role01_role02:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "role01_role02"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+kibana4_server:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/nodes/info"
+    - "cluster:monitor/health"
+  index_permissions:
+    - index_patterns:
+        - "?kibana"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:data/write/delete"
+        - "indices:data/write/update"
+        - "indices:admin/mapping/put"
+        - "indices:data/read/get"
+        - "indices:admin/refresh"
+        - "indices:admin/validate/query"
+        - "indices:data/read/search"
+        - "indices:admin/mappings/fields/get"
+        - "indices:admin/create"
+        - "indices:admin/exists"
+        - "indices:data/read/mget"
+  tenant_permissions: []
+557:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "/\\S*/"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+role_starfleet:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor*"
+    - "indices:data/read/scroll"
+  index_permissions:
+    - index_patterns:
+        - "sf"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+        - "indices:*"
+    - index_patterns:
+        - "pub*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+opendistro_security_own_index:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "${user_name}"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+aliastest:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "?kibana"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/*"
+        - "indices:data/read/*"
+    - index_patterns:
+        - "calias-1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/*"
+        - "indices:data/read/*"
+  tenant_permissions: []
+admin:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_ALL"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+ua:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "indexa*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+    - index_patterns:
+        - "permitnotexistentindex*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/field_caps"
+  tenant_permissions: []
+flsdls:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: "{\"term\" : {\"_type\" : \"legends\"}}"
+      fls:
+        - "fieldx"
+        - "field2.b"
+        - "field3.m.*"
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+ub:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "indexb"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+uc:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "indexc"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+    - index_patterns:
+        - "beats-*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/*"
+        - "indices:data/read/*"
+        - "OPENDISTRO_SECURITY_CREATE_INDEX"
+  tenant_permissions: []
+dummy:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "cluster:monitor/health"
+  index_permissions: []
+  tenant_permissions: []
+attr:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "${attr_internal_c2}"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/*"
+  tenant_permissions: []
+mindex3:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "mindex_3"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write*"
+  tenant_permissions: []
+role.with.dot:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "index.with.dot"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+mindex2:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "mindex_2"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/search"
+  tenant_permissions: []
+mindex1:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "mindex_1"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/search"
+  tenant_permissions: []
+role_klingons1:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/shards/search_shards"
+    - index_patterns:
+        - "klingonempire"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions:
+    - tenant_patterns:
+        - "kltentrw"
+      allowed_actions:
+        - "kibana_all_write"
+    - tenant_patterns:
+        - "kltentro"
+      allowed_actions:
+        - "kibana_all_read"
+snapres:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_MANAGE_SNAPSHOTS"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/index"
+        - "indices:admin/create"
+  tenant_permissions: []
+role_klingons2:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "klingonempire"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions:
+    - tenant_patterns:
+        - "praxisrw"
+      allowed_actions:
+        - "kibana_all_write"
+    - tenant_patterns:
+        - "praxisro"
+      allowed_actions:
+        - "kibana_all_read"
+theindex_admin:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS"
+  index_permissions:
+    - index_patterns:
+        - "theindex"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+power_user:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_MONITOR"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+remote_marvel_agent:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "indices:admin/template/put"
+    - "indices:admin/template/get"
+  index_permissions:
+    - index_patterns:
+        - "?marvel-es-*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+opendistro_security_kibana_server:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_MONITOR"
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS"
+    - "indices:admin/template*"
+    - "indices:data/read/scroll*"
+  index_permissions:
+    - index_patterns:
+        - "?kibana"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_INDICES_ALL"
+    - index_patterns:
+        - "?kibana-6"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_INDICES_ALL"
+    - index_patterns:
+        - "?kibana_*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_INDICES_ALL"
+    - index_patterns:
+        - "?tasks"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_INDICES_ALL"
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:admin/aliases*"
+  tenant_permissions: []
+opendistro_security_all_access:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+    - index_patterns:
+        - ".notexistingindexcvnjl9809991"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "ALL"
+  tenant_permissions: []
+marvel_user:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "?marvel-es-*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+    - index_patterns:
+        - "?kibana"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/read/get"
+        - "indices:admin/validate/query"
+        - "indices:data/read/search"
+        - "indices:admin/mappings/fields/get"
+        - "indices:admin/exists"
+        - "indices:data/read/mget"
+  tenant_permissions: []
+writer:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "indices:data/write/bulk*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_CREATE_INDEX"
+        - "OPENDISTRO_SECURITY_WRITE"
+  tenant_permissions: []
+opendistro_security_logstash:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "indices:admin/template/get"
+    - "indices:admin/template/put"
+    - "indices:data/write*"
+  index_permissions:
+    - index_patterns:
+        - "logstash-*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "indices:data/write/*"
+        - "indices:data/read/*"
+        - "OPENDISTRO_SECURITY_CREATE_INDEX"
+  tenant_permissions: []
+user:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "*"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions: []
+twitter:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+env_test:
+  cluster_permissions:
+    - '*'
+  index_permissions:
+    - index_patterns:
+        - '${env.INDEXNAME1:-index1}'
+        - '${env.INDEXNAME2:-index2}'
+        - '${user_name}'
+        - '${env.INDEXNAME3}'
+      allowed_actions:
+        - "*"
+xyz_impsr:
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      allowed_actions:
+        - "ALL"
+role_foo_index:
+  cluster_permissions:
+    - '*'
+  index_permissions:
+    - index_patterns:
+        - foo-index
+      allowed_actions:
+        - indices:data/read/*
+        - indices:admin/*
+        - indices:monitor/*
+role_foo_all:
+  cluster_permissions:
+    - '*'
+  index_permissions:
+    - index_patterns:
+        - 'foo-*'
+      allowed_actions:
+        - indices:data/read/*
+        - indices:admin/*
+        - indices:monitor/*
+
+xyz_sr:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+
+# This role is hidden in rolesmapping
+xyz_sr_hidden:
+  reserved: false
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+
+xyz_sr_reserved:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+    - index_patterns:
+        - "twitter"
+        - "analytics"
+      dls: null
+      fls: null
+      masked_fields: null
+      allowed_actions:
+        - "*"
+  tenant_permissions: []
+
+default_role:
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      allowed_actions:
+        - "*"
+

--- a/src/test/resources/security_passive/roles_mapping.yml
+++ b/src/test/resources/security_passive/roles_mapping.yml
@@ -1,0 +1,396 @@
+---
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+opendistro_security_own_index:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "spock"
+    - "kirk"
+  and_backend_roles: []
+  description: "Migrated from v6"
+unittest_1:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "CN=spock,OU=client,O=client,L=Test,C=DE"
+  and_backend_roles: []
+  description: "Migrated from v6"
+rexclude:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "rexclude"
+  and_backend_roles: []
+  description: "Migrated from v6"
+underscore:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "underscore"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_vulcans_admin:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "vulcanadmin"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+shakespeare:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "picard"
+  and_backend_roles: []
+  description: "Migrated from v6"
+aliastest:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "aliastest"
+    - "dummy"
+  and_backend_roles: []
+  description: "Migrated from v6"
+user1:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "worf"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_vulcans:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "vulcangov"
+  hosts: []
+  users:
+    - "kirk"
+  and_backend_roles: []
+  description: "Migrated from v6"
+flsdls:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "sarek"
+  and_backend_roles: []
+  description: "Migrated from v6"
+ccsresolv:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "ccsresolv"
+  and_backend_roles: []
+  description: "Migrated from v6"
+user2:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "picard"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_starfleet_captains:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "captains"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+restore:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "restoreuser"
+  and_backend_roles: []
+  description: "Migrated from v6"
+attr:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "custattr"
+  and_backend_roles: []
+  description: "Migrated from v6"
+mindex3:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "mindex12"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_starfleet_library:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "starfleet*"
+    - "ambassador"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+baz:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "baz"
+  and_backend_roles: []
+  description: "Migrated from v6"
+mindex2:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "mindex12"
+  and_backend_roles: []
+  description: "Migrated from v6"
+mindex1:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "mindex12"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_klingons1:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+snapres:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "snapresuser"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_klingons2:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "klingon"
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+kibana4:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "bug108"
+  and_backend_roles: []
+  description: "Migrated from v6"
+dlsnoinvest:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "dlsnoinvest"
+  and_backend_roles: []
+  description: "Migrated from v6"
+theindex_admin:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "theindexadmin"
+  and_backend_roles: []
+  description: "Migrated from v6"
+remote_ccs:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "crusherw"
+  and_backend_roles: []
+  description: "Migrated from v6"
+zdummy_all:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "bug108"
+  and_backend_roles: []
+  description: "Migrated from v6"
+multiget:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "picard"
+  and_backend_roles: []
+  description: "Migrated from v6"
+opendistro_security_kibana_server:
+  reserved: true
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "kibanaserver"
+  and_backend_roles: []
+  description: "Migrated from v6"
+opendistro_security_all_access:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "nagilum"
+  and_backend_roles: []
+  description: "Migrated from v6"
+public:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "*"
+  and_backend_roles: []
+  description: "Migrated from v6"
+writer:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "writer"
+  and_backend_roles: []
+  description: "Migrated from v6"
+opendistro_security_logstash:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "opendistro_security_logstash"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role01_role02:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users: []
+  and_backend_roles:
+    - "role01"
+    - "role02"
+  description: "Migrated from v6"
+role_starfleet:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - "starfleet"
+    - "captains"
+    - "defectors"
+  hosts:
+    - "*.starfleetintranet.com"
+  users:
+    - "nagilum"
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_host1:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts:
+    - "127.0.0.1"
+    - "localhost"
+  users: []
+  and_backend_roles: []
+  description: "Migrated from v6"
+role_host2:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "host_127.0.0.1"
+    - "host_localhost"
+  and_backend_roles: []
+  description: "Migrated from v6"
+twitter:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "twitter"
+  and_backend_roles: []
+  description: "Migrated from v6"
+env_test:
+  users:
+    - env.replace@example.comp.com
+ODS_ALL_ACCESS:
+  users:
+    - static_role_user
+role_foo_index:
+  users:
+    - foo_index
+role_foo_all:
+  users:
+    - foo_all
+xyz_sr_hidden:
+  reserved: false
+  hidden: true
+  backend_roles: []
+  hosts: []
+  users:
+    - "test_user"
+  and_backend_roles: []
+  description: "Migrated from v6"
+bulk_test_user_role:
+  users:
+    - "bulk_test_user"
+default_role:
+  users:
+    - "*"
+admin:
+  users:
+    - "admin"

--- a/src/test/resources/security_passive/tenants.yml
+++ b/src/test/resources/security_passive/tenants.yml
@@ -1,0 +1,11 @@
+---
+_meta:
+  type: "tenants"
+  config_version: 2
+
+# Define your tenants here
+
+## Demo tenants
+admin_tenant:
+  reserved: false
+  description: "Demo tenant for admin user"

--- a/src/test/resources/security_passive/whitelist.yml
+++ b/src/test/resources/security_passive/whitelist.yml
@@ -1,0 +1,69 @@
+---
+_meta:
+  type: "whitelist"
+  config_version: 2
+
+# Description:
+# enabled - feature flag.
+# if enabled is false, the whitelisting feature is removed.
+# This is like removing the check that checks if an API is whitelisted.
+# This is equivalent to continuing with the usual access control checks, and removing all the code that implements whitelisting.
+# if enabled is true, then all users except SuperAdmin can access only the APIs in requests
+# SuperAdmin can access all APIs.
+# SuperAdmin is defined by the SuperAdmin certificate, which is configured in the elasticsearch.yml setting: opendistro_security.authcz.admin_dn:
+# Refer to the example setting in elasticsearch.yml.example, and the opendistro documentation to know more about configuring SuperAdmin.
+#
+# requests - map of whitelisted endpoints, and the whitelisted HTTP requests for those endpoints
+
+# Examples showing how to configure this yml file (make sure the _meta data from above is also there):
+# Example 1:
+# To enable whitelisting and whitelist GET /_cluster/settings
+#
+#config:
+#  enabled: true
+#  requests:
+#    /_cluster/settings:
+#      - GET
+#
+# Example 2:
+# If you want to whitelist multiple request methods for /_cluster/settings (GET,PUT):
+#
+#config:
+#  enabled: true
+#  requests:
+#    /_cluster/settings:
+#      - GET
+#      - PUT
+#
+# Example 3:
+# If you want to whitelist other APIs as well, for example GET /_cat/nodes, and GET /_cat/shards:
+#
+#config:
+#  enabled: true
+#  requests:
+#    /_cluster/settings:
+#      - GET
+#      - PUT
+#    /_cat/nodes:
+#      - GET
+#    /_cat/shards:
+#      - GET
+#
+# Example 4:
+# If you want to disable the whitelisting feature, set enabled to false.
+#  enabled: false
+#  requests:
+#    /_cluster/settings:
+#      - GET
+#
+#At this point, all APIs become whitelisted because the feature to whitelist is off, so requests is irrelevant.
+
+
+#this name must be config
+config:
+  enabled: false
+  requests:
+    /_cluster/settings:
+      - GET
+    /_cat/nodes:
+      - GET


### PR DESCRIPTION
…etween nodes with adv sec enabled and nodes without adv sec enabled.

Changes to ssl_dual_mode_enabled to support the same.


##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ New feature
 

 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__ Introducing opendistro security dynamic config feature flag "passive_intertransport_auth".
 Additionally, making changes to ssl_dual_node behaviour.
The changes allow transport communication between nodes with advanced security enabled and nodes without advanced security enabled (ssl only or plugin disabled).
The feature flag should be used transiently to facilitate migration of cluster to using advanced security.



 4. __Why these changes are required?__ 
Currently, migrating to advanced security requires a full cluster restart as any other kind of migration process causes transport communication to break between old and newer nodes. These changes will allow a cluster to be migrated to use advanced security without any downtime, by allowing old and new nodes to successfully communicate at the transport layer.
NOTE: There is an existing feature `disable_intertransport_auth` that if enabled will cause transport level authorization to be skipped. However, the side affect of this is that any non-super admin user will be able to update opendistro_security during migration. 
`passive_intertransport_auth` does not skip authorization, instead it injects a default user, which you can map to the permissions you want to give during this transient phase of migration.

 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Old Behaviour: Transport communication from old node to a new node fails at the new nodes with the error: `No user found for...`
New Behaviour: Transport communication from old node to a new node succeeds. When a user is not found and this feature flag is set to true, we inject a default user. Note that this user should have all index and cluster permissions.


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 Extensive UTs to cover all cases.

```
__With passive_intertransport_auth disabled:__
dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode)> curl "https://localhost:9200/_cat/nodes" -k
192.168.240.3 18 22 44 2.01 1.88 1.04 dimr * elasticsearch1
192.168.240.2 55 20 49 2.01 1.88 1.04 dir  - elasticsearch2
dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode)> curl -X PUT "https://localhost:9200/test5?pretty" -H 'Content-Type: application/json' -d'
                                                                   {
                                                                       "settings": {
                                                                           "index": {
                                                                             "number_of_shards": 1,
                                                                             "auto_expand_replicas": "0-all",
                                                                             "routing.allocation.exclude._name": "elasticsearch1"
                                                                           }
                                                                       }
                                                                   }' -k
{
  "acknowledged" : true,
  "shards_acknowledged" : true,
  "index" : "test5"
}
dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode)> curl -XPOST "https://localhost:9200/test5/_doc/1" -k -H 'Content-Type: application/json' -d'{}' -k
{"error":{"root_cause":[{"type":"security_exception","reason":"No user found for indices:admin/mapping/auto_put"}],"type":"security_exception","reason":"No user found for indices:admin/mapping/auto_put"},"status":500}⏎


__With passive_intertransport_auth enabled:__

dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode) [60]> curl "https://localhost:9200/_cat/nodes" -k
192.168.240.3 17 21 48 2.84 1.97 0.95 dimr * elasticsearch1
192.168.240.2 26 21 49 2.84 1.97 0.95 dir  - elasticsearch2
dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode)> curl -X PUT "https://localhost:9200/test4?pretty" -H 'Content-Type: application/json' -d'
                                                                   {
                                                                       "settings": {
                                                                           "index": {
                                                                             "number_of_shards": 1,
                                                                             "auto_expand_replicas": "0-all",
                                                                             "routing.allocation.exclude._name": "elasticsearch1"
                                                                           }
                                                                       }
                                                                   }' -k
{
  "acknowledged" : true,
  "shards_acknowledged" : true,
  "index" : "test4"
}
dhireshj@f45c899db61b ~/w/d/dhi_security (transport_passive_mode) [52]> curl -XPOST "https://localhost:9200/test4/_doc/1" -k -H 'Content-Type: application/json' -d'{}' -k
{"_index":"test4","_type":"_doc","_id":"1","_version":1,"result":"created","_shards":{"total":1,"successful":1,"failed":0},"_seq_no":0,"_primary_term":1}⏎
```



By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).