### PR TITLE
Add rolespath to JWT authentication

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -40,7 +40,7 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 
-import com.amazon.dlic.util.Roles;
+import com.amazon.dlic.util.RolesUtil;
 import com.amazon.opendistroforelasticsearch.security.auth.HTTPAuthenticator;
 import com.amazon.opendistroforelasticsearch.security.user.AuthCredentials;
 import com.jayway.jsonpath.Configuration;
@@ -68,7 +68,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String jsonRolesPath;
-    private Configuration jsonPathConfig;
+    private final Configuration jsonPathConfig;
     private final String subjectKey;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
@@ -123,7 +123,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
         // throw exception when settings provided both roles_key and roles_path
         if (rolesKey != null && jsonRolesPath != null) {
-            throw new IllegalStateException("Both roles_key and roles_path have simultaneously provided." +
+            throw new IllegalStateException("Both roles_key and roles_path are simultaneously provided." +
                     " Please provide only one combination.");
         }
         jsonPathConfig = Configuration.defaultConfiguration().addOptions(Option.ALWAYS_RETURN_LIST);
@@ -254,7 +254,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     	// get roles from roles_path if roles_path is specified
     	if (jsonRolesPath != null){
     	    try {
-                return Roles.split(JsonPath.using(jsonPathConfig).parse(claims).read(jsonRolesPath));
+                return RolesUtil.split(JsonPath.using(jsonPathConfig).parse(claims).read(jsonRolesPath));
             } catch (PathNotFoundException e) {
                 log.error("The provided JSON path {} could not be found ", jsonRolesPath);
                 return new String[0];
@@ -268,7 +268,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     		return new String[0];
     	}
 
-    	return Roles.split(rolesObject);
+    	return RolesUtil.split(rolesObject);
     }
 
     private static PublicKey getPublicKey(final byte[] keyBytes, final String algo) throws NoSuchAlgorithmException, InvalidKeySpecException {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -16,7 +16,12 @@
 package com.amazon.dlic.auth.http.jwt;
 
 import java.nio.file.Path;
-import java.security.*;
+import java.security.AccessController;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedAction;
+import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Collection;
@@ -199,7 +204,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         } catch (WeakKeyException e) {
             log.error("Cannot authenticate user with JWT because of ", e);
             return null;
-        } catch (ElasticsearchSecurityException e){
+        } catch (IllegalArgumentException e){
             throw e;
         } catch (Exception e) {
             if(log.isDebugEnabled()) {

--- a/src/main/java/com/amazon/dlic/util/Roles.java
+++ b/src/main/java/com/amazon/dlic/util/Roles.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package com.amazon.dlic.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Roles {
+    private static final Logger log = LogManager.getLogger(Roles.class);
+
+    public static String[] split(Object rolesObject) {
+        if (rolesObject == null) {
+            return new String[0];
+        } else if (rolesObject instanceof Collection) {
+            List<String> roles = new ArrayList<>();
+            for (Object object : (Collection<?>) rolesObject) {
+                if (object instanceof Collection) {
+                    for (Object subObject : (Collection<?>) object) {
+                        roles.addAll(Arrays.asList(splitString(String.valueOf(subObject))));
+                    }
+                } else {
+                    if (!(object instanceof String)) {
+                        // We expect a String or Collection. If we find something else, convert to
+                        // String but issue a warning
+                        log.warn(
+                                "Expected type String or Collection for roles in the JWT for roles_key {}, but value was '{}' ({}). Will convert this value to String.",
+                                object, object.getClass());
+                    }
+                    roles.addAll(Arrays.asList(splitString(String.valueOf(object))));
+                }
+            }
+
+            return roles.toArray(new String[roles.size()]);
+        } else {
+            if (!(rolesObject instanceof String)) {
+                // We expect a String or Collection. If we find something else, convert to
+                // String but issue a warning
+                log.warn(
+                        "Expected type String or Collection for roles in the JWT for roles_key {}, but value was '{}' ({}). Will convert this value to String.",
+                        rolesObject, rolesObject.getClass());
+            }
+
+            return splitString(String.valueOf(rolesObject));
+        }
+    }
+
+    public static String[] splitString(String string) {
+        String[] result = string.split(",");
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = result[i].trim();
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/amazon/dlic/util/RolesUtil.java
+++ b/src/main/java/com/amazon/dlic/util/RolesUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License").
  *  You may not use this file except in compliance with the License.
@@ -23,9 +23,34 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-public class Roles {
-    private static final Logger log = LogManager.getLogger(Roles.class);
+public class RolesUtil {
+    private static final Logger log = LogManager.getLogger(RolesUtil.class);
 
+    /*
+     * Split the given rolesObject to one or several roles
+     * rolesObject should be a String if given by roles_key
+     * rolesObject should always be net.minidev.json.JSONArray if given by roles_path (jayway config set to ALWAYS_RETURN_LIST)
+     *
+     * Here are some examples:
+     *
+     *   JWT paylaoad contains:
+     *     "access": {
+     *       "roles": [
+     *         "readall, testrole",
+     *         "admin",
+     *         "kibanauser"
+     *       ]
+     *     }
+     *  if contains a Json array, it will convert all elements to String and split by comma to get roles.
+     *    roles_path = $["access"]["roles"]
+     *    the result should be ("readall", "testrole", "admin", "kibanauser")
+     *  if contains a String, it will split by comma to get roles.
+     *    roles_path = $["access"]["roles"][0]
+     *    the result should be ("readall", "testrole")
+     *  if contains neither Json array nor String, e.g. Json Object, it will convert the value to String and split by comma to get roles
+     *    roles_path = $["access"]
+     *    the result should be ("{roles=[readall", "testrole", "admin", "kinanauser]}")
+     */
     public static String[] split(Object rolesObject) {
         if (rolesObject == null) {
             return new String[0];

--- a/src/main/java/com/amazon/dlic/util/RolesUtil.java
+++ b/src/main/java/com/amazon/dlic/util/RolesUtil.java
@@ -20,8 +20,6 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchSecurityException;
-import org.elasticsearch.rest.RestStatus;
 
 public class RolesUtil {
     private static final Logger log = LogManager.getLogger(RolesUtil.class);
@@ -65,10 +63,7 @@ public class RolesUtil {
         } else if (rolesObject instanceof String) {
             return splitString(String.valueOf(rolesObject));
         }
-        log.error("=================================");
-        throw new ElasticsearchSecurityException(
-                "Expected type String or JSON array in the JWT for roles_key/roles_path",
-                RestStatus.BAD_REQUEST);
+        throw new IllegalArgumentException("Expected type String or JSON array in the JWT for roles_key/roles_path");
     }
     public static String[] splitString(String string) {
         String[] result = string.split(",");

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -227,6 +227,38 @@ public class HTTPJwtAuthenticatorTest {
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
         Assert.assertEquals(2, creds.getBackendRoles().size());
     }
+    @Test
+    public void testRolesPath() throws Exception {
+
+
+
+        Settings settings = Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKey))
+                .put("roles_path", "$[\"access\"][\"roles\"]")
+                .build();
+
+        String jwsToken = Jwts.builder()
+                .setPayload("{"+
+                        "\"sub\": \"Leonard McCoy\","+
+                        "\"access\": {"+
+                        "\"roles\": [\"a, b\",\"c\",\"3rd\"]"+
+                        "}"+
+                        "}")
+                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", jwsToken);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+        Assert.assertNotNull(creds);
+        Assert.assertEquals("Leonard McCoy", creds.getUsername());
+        Assert.assertEquals(4, creds.getBackendRoles().size());
+        Assert.assertTrue(creds.getBackendRoles().contains("a"));
+        Assert.assertTrue(creds.getBackendRoles().contains("b"));
+        Assert.assertTrue(creds.getBackendRoles().contains("c"));
+        Assert.assertTrue(creds.getBackendRoles().contains("3rd"));
+    }
 
     @Test
     public void testNullClaim() throws Exception {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -438,7 +438,7 @@ public class HTTPJwtAuthenticatorTest {
         Assert.assertEquals(0, creds.getBackendRoles().size());
     }
 
-    @Test(expected = ElasticsearchSecurityException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testNonStringClaim() throws Exception {
         Settings settings = Settings.builder()
                 .put("signing_key", BaseEncoding.base64().encode(secretKey))


### PR DESCRIPTION
Category: (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

Github Issue # or road-map entry, if available:
#1003

Description of changes:
Introduce roles_path to JWT authentication so that users can use JSON path expression to the payload to get user's roles.

Why these changes are required?

What is the old behavior before changes and new behavior after changes? (Please add any example/logs/screen-shot if available)
Before: roles_key only accepts a single string.
After: you can give a JSON path to roles_path such as $["access"]["roles"]. roles_path accepts string or Json array. You can only specify one of roles_key and roles_path.

Testing done: (Please provide details of testing done: Unit testing, integration testing and manual testing)
Unit tests to cover different cases of roles_path.

TO-DOs, if any: (Please describe pending items and provide Github issues# for each of them)

Is it backport from main branch? (If yes, please add backport PR # and commits #)

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
have the right to submit it under the open source license
indicated in the file; or

(b) The contribution is based upon previous work that, to the best
of my knowledge, is covered under an appropriate open source
license and I have the right under that license to submit that
work with modifications, whether created in whole or in part
by me, under the same open source license (unless I am
permitted to submit under a different license), as indicated
in the file; or

(c) The contribution was provided directly to me by some other
person who certified (a), (b) or (c) and I have not modified
it.

(d) I understand and agree that this project and the contribution
are public and that a record of the contribution (including all
personal information I submit with it, including my sign-off) is
maintained indefinitely and may be redistributed consistent with
this project or the open source license(s) involved.