### PR TITLE
Delay the security index initial bootstrap when the index is red

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -132,6 +132,8 @@ public class ConfigurationRepository {
                                     threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
 
                                     final boolean isSecurityIndexCreated = createSecurityIndexIfAbsent();
+                                    waitForSecurityIndexToBeAtLeastYellow();
+
                                     if (isSecurityIndexCreated) {
                                         ConfigHelper.uploadFile(client, cd+"config.yml", securityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
                                         ConfigHelper.uploadFile(client, cd+"roles.yml", securityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
@@ -157,34 +159,8 @@ public class ConfigurationRepository {
                                 LOGGER.error("{} does not exist", confFile.getAbsolutePath());
                             }
                         } catch (Exception e) {
-                            LOGGER.debug("Cannot apply default config (this is maybe not an error!) due to {}", e.getMessage());
+                            LOGGER.error("Cannot apply default config (this is maybe not an error!) due to {}", e);
                         }
-                    }
-
-                    LOGGER.debug("Node started, try to initialize it. Wait for at least yellow cluster state....");
-                    ClusterHealthResponse response = null;
-                    try {
-                        response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex)
-                                .waitForActiveShards(1)
-                                .waitForYellowStatus()).actionGet();
-                    } catch (Exception e1) {
-                        LOGGER.debug("Catched a {} but we just try again ...", e1.toString());
-                    }
-
-                    while(response == null || response.isTimedOut() || response.getStatus() == ClusterHealthStatus.RED) {
-                        LOGGER.debug("index '{}' not healthy yet, we try again ... (Reason: {})", securityIndex, response==null?"no response":(response.isTimedOut()?"timeout":"other, maybe red cluster"));
-                        try {
-                            Thread.sleep(500);
-                        } catch (InterruptedException e1) {
-                            //ignore
-                            Thread.currentThread().interrupt();
-                        }
-                        try {
-                            response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex).waitForYellowStatus()).actionGet();
-                        } catch (Exception e1) {
-                            LOGGER.debug("Catched again a {} but we just try again ...", e1.toString());
-                        }
-                        continue;
                     }
 
                     while(!dynamicConfigFactory.isInitialized()) {
@@ -247,6 +223,33 @@ public class ConfigurationRepository {
         } catch (ResourceAlreadyExistsException resourceAlreadyExistsException) {
             LOGGER.info("Index {} already exists", securityIndex);
             return false;
+        }
+    }
+
+    private void waitForSecurityIndexToBeAtLeastYellow() {
+        LOGGER.info("Node started, try to initialize it. Wait for at least yellow cluster state....");
+        ClusterHealthResponse response = null;
+        try {
+            response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex)
+                    .waitForActiveShards(1)
+                    .waitForYellowStatus()).actionGet();
+        } catch (Exception e1) {
+            LOGGER.debug("Caught a {} but we just try again ...", e1.toString());
+        }
+
+        while(response == null || response.isTimedOut() || response.getStatus() == ClusterHealthStatus.RED) {
+            LOGGER.debug("index '{}' not healthy yet, we try again ... (Reason: {})", securityIndex, response==null?"no response":(response.isTimedOut()?"timeout":"other, maybe red cluster"));
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e1) {
+                //ignore
+                Thread.currentThread().interrupt();
+            }
+            try {
+                response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex).waitForYellowStatus()).actionGet();
+            } catch (Exception e1) {
+                LOGGER.debug("Caught again a {} but we just try again ...", e1.toString());
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -159,7 +159,7 @@ public class ConfigurationRepository {
                                 LOGGER.error("{} does not exist", confFile.getAbsolutePath());
                             }
                         } catch (Exception e) {
-                            LOGGER.error("Cannot apply default config (this is maybe not an error!) due to {}", e);
+                            LOGGER.error("Cannot apply default config (this is maybe not an error!)", e);
                         }
                     }
 
@@ -241,14 +241,14 @@ public class ConfigurationRepository {
             LOGGER.debug("index '{}' not healthy yet, we try again ... (Reason: {})", securityIndex, response==null?"no response":(response.isTimedOut()?"timeout":"other, maybe red cluster"));
             try {
                 Thread.sleep(500);
-            } catch (InterruptedException e1) {
+            } catch (InterruptedException e) {
                 //ignore
                 Thread.currentThread().interrupt();
             }
             try {
                 response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex).waitForYellowStatus()).actionGet();
-            } catch (Exception e1) {
-                LOGGER.debug("Caught again a {} but we just try again ...", e1.toString());
+            } catch (Exception e) {
+                LOGGER.debug("Caught again a {} but we just try again ...", e.toString());
             }
         }
     }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -233,8 +233,8 @@ public class ConfigurationRepository {
             response = client.admin().cluster().health(new ClusterHealthRequest(securityIndex)
                     .waitForActiveShards(1)
                     .waitForYellowStatus()).actionGet();
-        } catch (Exception e1) {
-            LOGGER.debug("Caught a {} but we just try again ...", e1.toString());
+        } catch (Exception e) {
+            LOGGER.debug("Caught a {} but we just try again ...", e.toString());
         }
 
         while(response == null || response.isTimedOut() || response.getStatus() == ClusterHealthStatus.RED) {

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -170,6 +170,7 @@ public class SlowIntegrationTests extends SingleClusterTest {
                 .build();
         try {
             setup(Settings.EMPTY, null, settings, false);
+            Assert.fail("Expected IOException here due to red cluster state");
         } catch (IOException e) {
             // Index request has a default timeout of 1 minute, adding buffer between nodes initialization and cluster health check
             Thread.sleep(1000*80);

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -174,8 +174,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
         } catch (IOException e) {
             // Index request has a default timeout of 1 minute, adding buffer between nodes initialization and cluster health check
             Thread.sleep(1000*80);
+            // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved IP address
             clusterHelper.nodeClient().admin().cluster().updateSettings(
-                    new ClusterUpdateSettingsRequest().transientSettings(Settings.builder().put("cluster.routing.allocation.exclude._ip", "1.2.3.4").build()));
+                    new ClusterUpdateSettingsRequest().transientSettings(Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()));
             this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10),3);
         }
         RestHelper rh = nonSslRestHelper();

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -30,20 +30,25 @@
 
 package org.opensearch.security;
 
+import org.apache.http.HttpStatus;
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.transport.Netty4Plugin;
 import org.junit.Assert;
 import org.junit.Test;
+import java.io.IOException;
 
 public class SlowIntegrationTests extends SingleClusterTest {
 
@@ -155,6 +160,26 @@ public class SlowIntegrationTests extends SingleClusterTest {
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
+    }
+
+    @Test
+    public void testDelayInSecurityIndexInitialization() throws Exception {
+        final Settings settings = Settings.builder()
+                .put(ConfigConstants.OPENDISTRO_SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
+                .put("cluster.routing.allocation.exclude._ip", "127.0.0.1")
+                .build();
+        try {
+            setup(Settings.EMPTY, null, settings, false);
+        } catch (IOException e) {
+            // Index request has a default timeout of 1 minute, adding buffer between nodes initialization and cluster health check
+            Thread.sleep(1000*80);
+            clusterHelper.nodeClient().admin().cluster().updateSettings(
+                    new ClusterUpdateSettingsRequest().transientSettings(Settings.builder().put("cluster.routing.allocation.exclude._ip", "1.2.3.4").build()));
+            this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10),3);
+        }
+        RestHelper rh = nonSslRestHelper();
+        Thread.sleep(10000);
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
     }
 
 }


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

__NOTE__: This commit has been moved from opendistro repo to opensearch. The manual test was done using docker in opendistro. Docker testing is currently unavailable in opensearch so did not perform a manual test here yet.
 
 1. __Category:__ Bug fix
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__ In the plugin bootstrap logic, when the security index is being populated (if empty) from the static files, currently the health check on the index is done after populating the data - and if the index is red, the population of data fails and the plugin perpetually fails all the non-super admin rest requests unless a manual intervention is done. This usually involves fixing the reason for index going red, deleting the index (else population of initial data will not happen), and restarting plugin on one of the nodes. 
This change introduces the health check on this index before populating it. This way, we wait for the index to be at least yellow before populating it. Now, to fix issues where the security index is red and plugin is stuck in bootstrap, we need to only get the index to yellow state and there's no need to delete the index and restart the plugin on any node.



 4. __Why these changes are required?__ This fixes issues for clusters where certain cluster allocation settings might cause the newly created security index to go red and causes the security plugin to perpetually fail. With these changes, to fix the issue we need to only remove the cluster allocation setting causing the red index, and plugin starts working almost immediately.



 5. __What is the old behavior before changes and new behavior after changes?__ 
Old Behaviour: 
* Security plugin is enabled on cluster.
* Security Index is created but in RED state during plugin bootstrap.
* All the rest requests fail with `Open Distro Security not initialized.`
* After a few minutes, security index is YELLOW/GREEN, rest requests continue failing with `Open Distro Security not initialized.`.

New Behaviour:
* Security plugin is enabled on cluster.
* Security Index is created but in RED state during plugin bootstrap.
* All the rest requests fail with `Open Distro Security not initialized.`
* After a few minutes, security index is YELLOW/GREEN, rest requests now succeed.


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
  __Old Behaviour:__ 
```
elasticsearch1    | [2021-03-30T17:11:15,803][INFO ][c.a.o.s.c.ConfigurationRepository] [elasticsearch1] Index .opendistro_security created?: true
elasticsearch1    | [2021-03-30T17:11:15,807][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Will update 'config' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch2    | [2021-03-30T17:13:22,347][ERROR][c.a.o.s.a.BackendRegistry] [elasticsearch2] Not yet initialized (you may need to run securityadmin)

[root@127f1f7718f3 config]# curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
index                shard prirep state      docs store ip node
.opendistro_security 0     p      UNASSIGNED
.opendistro_security 0     r      UNASSIGNED

[root@127f1f7718f3 elasticsearch]# curl "https://localhost:9200/_cat/shards?v" -k -u admin:admin
Open Distro Security not initialized.

[root@127f1f7718f3 config]# curl -s "https://localhost:9200/_cluster/settings?flat_settings&include_defaults&pretty" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem |grep cluster.routing.allocation.exclude
    "cluster.routing.allocation.exclude._name" : "elasticsearch1, elasticsearch2",

[root@127f1f7718f3 config]# curl -XPUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
> {
>    "transient" : {
>      "cluster.routing.allocation.exclude._name": "old_elasticsearch"
>    }
>  }'  -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
{"acknowledged":true,"persistent":{},"transient":{"cluster":{"routing":{"allocation":{"exclude":{"_name":"old_elasticsearch"}}}}}}

elasticsearch1    | [2021-03-30T17:15:30,734][INFO ][o.e.c.r.a.AllocationService] [elasticsearch1] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[.opendistro_security][0]]]).
elasticsearch2    | [2021-03-30T17:15:30,943][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch2    | [2021-03-30T17:15:30,944][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch2    | [2021-03-30T17:15:30,946][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for config while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch2    | [2021-03-30T17:15:30,947][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch2    | [2021-03-30T17:15:30,950][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch2    | [2021-03-30T17:15:30,951][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch2] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,973][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for internalusers while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,974][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for actiongroups while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,974][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for config while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,975][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for roles while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,975][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for rolesmapping while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)
elasticsearch1    | [2021-03-30T17:15:30,976][WARN ][c.a.o.s.c.ConfigurationLoaderSecurity7] [elasticsearch1] No data for tenants while retrieving configuration for [INTERNALUSERS, ACTIONGROUPS, CONFIG, ROLES, ROLESMAPPING, TENANTS, NODESDN, WHITELIST, AUDIT]  (index=.opendistro_security and type=null)

[root@127f1f7718f3 config]# curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
index                shard prirep state   docs store ip         node
.opendistro_security 0     p      STARTED    0  208b 172.24.0.2 elasticsearch2
.opendistro_security 0     r      STARTED    0  208b 172.24.0.3 elasticsearch1

[root@127f1f7718f3 config]# curl "https://localhost:9200/_cat/shards?v" -k -u admin:admin
Open Distro Security not initialized.
```

  __New Behaviour:__ 
 ```
[root@b9cebd673fd8 config]# curl https://localhost:9200/_cat/shards?v --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
index                shard prirep state      docs store ip node
.opendistro_security 0     p      UNASSIGNED
.opendistro_security 0     r      UNASSIGNED

[root@b9cebd673fd8 elasticsearch]# curl https://localhost:9200/_cat/shards?v -k -u "admin:admin"
Open Distro Security not initialized.

elasticsearch1    | [2021-03-30T16:58:23,087][INFO ][c.a.o.s.c.ConfigurationRepository] [elasticsearch1] Index .opendistro_security created?: true
elasticsearch1    | [2021-03-30T16:58:23,089][INFO ][c.a.o.s.c.ConfigurationRepository] [elasticsearch1] Node started, try to initialize it. Wait for at least yellow cluster state....
elasticsearch2    | [2021-03-30T17:00:17,556][ERROR][c.a.o.s.a.BackendRegistry] [elasticsearch2] Not yet initialized (you may need to run securityadmin)

[root@c3d1eb212467 config]# curl "https://localhost:9200/_cat/shards?v" -u "admin:admin" -k
Open Distro Security not initialized.
curl "https://localhost:9200/_cat/shards?v"  -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
index                shard prirep state      docs store ip node
.opendistro_security 0     p      UNASSIGNED
.opendistro_security 0     r      UNASSIGNED

[root@c3d1eb212467 config]# curl -XPUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
{
  "transient" : {
    "cluster.routing.allocation.exclude._name": "old_elasticsearch"
  }
}'  -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
{"acknowledged":true,"persistent":{},"transient":{"cluster":{"routing":{"allocation":{"exclude":{"_name":"old_elasticsearch"}}}}}}[root@c3d1eb212467 config]#

elasticsearch1    | [2021-03-30T17:01:33,473][INFO ][o.e.c.r.a.AllocationService] [elasticsearch1] Cluster health status changed from [RED] to [YELLOW] (reason: [shards started [[.opendistro_security][0]]]).
elasticsearch1    | [2021-03-30T17:01:33,600][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Will update 'config' with /usr/share/elasticsearch/plugins/opendistro_security/securityconfig/config.yml and populate it with empty doc if file missing and populateEmptyIfFileMissing=false
elasticsearch1    | [2021-03-30T17:01:34,435][INFO ][o.e.c.m.MetadataMappingService] [elasticsearch1] [.opendistro_security/xkQ2_YoRQKW_Djyz6nzY_w] create_mapping [_doc]
elasticsearch1    | [2021-03-30T17:01:34,701][INFO ][o.e.c.m.MetadataMappingService] [elasticsearch1] [.opendistro_security/xkQ2_YoRQKW_Djyz6nzY_w] update_mapping [_doc]
elasticsearch1    | [2021-03-30T17:01:34,932][INFO ][c.a.o.s.s.ConfigHelper   ] [elasticsearch1] Doc with id 'config' and version 2 is updated in .opendistro_security index.

[root@c3d1eb212467 config]# curl "https://localhost:9200/_cat/shards?v"  -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
index                shard prirep state   docs  store ip         node
.opendistro_security 0     p      STARTED    6 36.6kb 172.23.0.2 elasticsearch2
.opendistro_security 0     r      STARTED    6 30.8kb 172.23.0.3 elasticsearch1

[root@c3d1eb212467 config]# curl "https://localhost:9200/_cat/shards?v" -u "admin:admin" -k
index                shard prirep state   docs  store ip         node
.opendistro_security 0     p      STARTED    9 36.6kb 172.23.0.2 elasticsearch2
.opendistro_security 0     r      STARTED    9 30.8kb 172.23.0.3 elasticsearch1
```
 
 7. __Setup Instructions__

 -> Checkout https://github.com/opendistro-for-elasticsearch/opendistro-build
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Create directory build/elasticsearch/plugins/
-> Create file build/elasticsearch/plugins/plugins.list
-> Pull changes of this PR locally
-> cd into plugin directory
-> To simulate security index being red: Add index setting `index.routing.allocation.exclude._name: "{elasticsearch_conatiner_1_name},{elasticsearch_conatiner_1_name}"` here https://github.com/opendistro-for-elasticsearch/security/blob/main/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java#L236
-> Build the plugin: mvn clean package -Padvanced -DskipTests
-> Copy artifact target/releases/*.zip to ../opendistro-build/elasticsearch/docker/build/elasticsearch/plugins/
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Add the artifact name to the plugins.list file
-> run make-build [TIP: Remove knn dependencies from Dockerfile to speed up build. We do no require knn anyway)
-> run make-cluster
-> Once the cluster is up with two nodes, verify requests fail with Open Distro Security not initialized. Verify that the security index is RED
-> Fix the security index by updating cluster settings inside one of the docker containers:
`curl -XPUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
  {
     "transient" : {
       "index.routing.allocation.exclude._name": null
     }
   }'  -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem`
-> Verify security index is not RED anymore
-> Cluster should be up and requests to it should succeed now
-> Without the plugin changes, the previous step would still fail even though security index is not RED anymore





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).