### PR TITLE
Delay the security index initial bootstrap when the index is red (#1153)

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java
@@ -132,6 +132,8 @@ public class ConfigurationRepository {
                                     threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
 
                                     final boolean isSecurityIndexCreated = createSecurityIndexIfAbsent();
+                                    waitForSecurityIndexToBeAtLeastYellow();
+
                                     if (isSecurityIndexCreated) {
                                         ConfigHelper.uploadFile(client, cd+"config.yml", opendistrosecurityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
                                         ConfigHelper.uploadFile(client, cd+"roles.yml", opendistrosecurityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
@@ -157,34 +159,8 @@ public class ConfigurationRepository {
                                 LOGGER.error("{} does not exist", confFile.getAbsolutePath());
                             }
                         } catch (Exception e) {
-                            LOGGER.debug("Cannot apply default config (this is maybe not an error!) due to {}", e.getMessage());
+                            LOGGER.error("Cannot apply default config (this is maybe not an error!)", e);
                         }
-                    }
-
-                    LOGGER.debug("Node started, try to initialize it. Wait for at least yellow cluster state....");
-                    ClusterHealthResponse response = null;
-                    try {
-                        response = client.admin().cluster().health(new ClusterHealthRequest(opendistrosecurityIndex)
-                                .waitForActiveShards(1)
-                                .waitForYellowStatus()).actionGet();
-                    } catch (Exception e1) {
-                        LOGGER.debug("Catched a {} but we just try again ...", e1.toString());
-                    }
-
-                    while(response == null || response.isTimedOut() || response.getStatus() == ClusterHealthStatus.RED) {
-                        LOGGER.debug("index '{}' not healthy yet, we try again ... (Reason: {})", opendistrosecurityIndex, response==null?"no response":(response.isTimedOut()?"timeout":"other, maybe red cluster"));
-                        try {
-                            Thread.sleep(500);
-                        } catch (InterruptedException e1) {
-                            //ignore
-                            Thread.currentThread().interrupt();
-                        }
-                        try {
-                            response = client.admin().cluster().health(new ClusterHealthRequest(opendistrosecurityIndex).waitForYellowStatus()).actionGet();
-                        } catch (Exception e1) {
-                            LOGGER.debug("Catched again a {} but we just try again ...", e1.toString());
-                        }
-                        continue;
                     }
 
                     while(!dynamicConfigFactory.isInitialized()) {
@@ -247,6 +223,33 @@ public class ConfigurationRepository {
         } catch (ResourceAlreadyExistsException resourceAlreadyExistsException) {
             LOGGER.info("Index {} already exists", opendistrosecurityIndex);
             return false;
+        }
+    }
+
+    private void waitForSecurityIndexToBeAtLeastYellow() {
+        LOGGER.info("Node started, try to initialize it. Wait for at least yellow cluster state....");
+        ClusterHealthResponse response = null;
+        try {
+            response = client.admin().cluster().health(new ClusterHealthRequest(opendistrosecurityIndex)
+                    .waitForActiveShards(1)
+                    .waitForYellowStatus()).actionGet();
+        } catch (Exception e) {
+            LOGGER.debug("Caught a {} but we just try again ...", e.toString());
+        }
+
+        while(response == null || response.isTimedOut() || response.getStatus() == ClusterHealthStatus.RED) {
+            LOGGER.debug("index '{}' not healthy yet, we try again ... (Reason: {})", opendistrosecurityIndex, response==null?"no response":(response.isTimedOut()?"timeout":"other, maybe red cluster"));
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                //ignore
+                Thread.currentThread().interrupt();
+            }
+            try {
+                response = client.admin().cluster().health(new ClusterHealthRequest(opendistrosecurityIndex).waitForYellowStatus()).actionGet();
+            } catch (Exception e) {
+                LOGGER.debug("Caught again a {} but we just try again ...", e.toString());
+            }
         }
     }
 


### PR DESCRIPTION
##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
In the plugin bootstrap logic, when the security index is being populated (if empty) from the static files, currently the health check on the index is done after populating the data - and if the index is red, the population of data fails and the plugin perpetually fails all the non-super admin rest requests unless a manual intervention is done. This usually involves fixing the reason for index going red, deleting the index (else population of initial data will not happen), and restarting plugin on one of the nodes.
This change introduces the health check on this index before populating it. This way, we wait for the index to be at least yellow before populating it. Now, to fix issues where the security index is red and plugin is stuck in bootstrap, we need to only get the index to yellow state and there's no need to delete the index and restart the plugin on any node.


 4. __Why these changes are required?__ 
This fixes issues for clusters where certain cluster allocation settings might cause the newly created security index to go red and causes the security plugin to perpetually fail. With these changes, to fix the issue we need to only remove the cluster allocation setting causing the red index, and plugin starts working almost immediately.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
    Old Behaviour:

        Security plugin is enabled on cluster.
        Security Index is created but in RED state during plugin bootstrap.
        All the rest requests fail with Open Distro Security not initialized.
        After a few minutes, security index is YELLOW/GREEN, rest requests continue failing with Open Distro Security not initialized..

    New Behaviour:

        Security plugin is enabled on cluster.
        Security Index is created but in RED state during plugin bootstrap.
        All the rest requests fail with Open Distro Security not initialized.
        After a few minutes, security index is YELLOW/GREEN, rest requests now succeed.



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
  __Old Behaviour__
  
      (21-05-26 10:32:43) <0> [~/elasticsearch-7.10.2]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      Open Distro Security not initialized.%
      
      (21-05-26 10:33:40) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      index                shard prirep state      docs store ip node
      .opendistro_security 0     p      UNASSIGNED
      .opendistro_security 0     r      UNASSIGNED
      
      (21-05-26 10:34:22) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl -X PUT "https://localhost:9200/.opendistro_security/_settings?pretty" -H 'Content-Type: application/json' -d'
      quote> {
      quote>   "index.routing.allocation.exclude._name": null
      quote> }' -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      {
        "acknowledged" : true
      }
      
      (21-05-26 10:34:43) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      index                shard prirep state   docs store ip            node
      .opendistro_security 0     p      STARTED    0  208b 172.16.59.101 smoketestnode
      
      (21-05-26 10:35:22) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k -u admin:admin
      Open Distro Security not initialized.%


__New Behaviour__

      (21-05-26 11:10:51) <1> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      index                shard prirep state      docs store ip node
      .opendistro_security 0     p      UNASSIGNED
      .opendistro_security 0     r      UNASSIGNED
      
      (21-05-26 11:11:34) <77> [~/elasticsearch-7.10.2]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k -u admin:admin
      Open Distro Security not initialized.%
      
      (21-05-26 11:12:58) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl -X PUT "https://localhost:9200/.opendistro_security/_settings?pretty" -H 'Content-Type: application/json' -d'
      {
        "index.routing.allocation.exclude._name": null
      }' -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      {
        "acknowledged" : true
      }
      
      (21-05-26 11:13:02) <0> [~/elasticsearch-7.10.2/config]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
      index                shard prirep state   docs  store ip            node
      .opendistro_security 0     p      STARTED    9 57.6kb 172.16.59.101 smoketestnode
      
      (21-05-26 11:14:03) <0> [~/elasticsearch-7.10.2]
      dev-dsk-niravpi-2c-050374fd % curl "https://localhost:9200/_cat/shards?v" -k -u admin:admin
      index                shard prirep state   docs  store ip            node
      .opendistro_security 0     p      STARTED    9 57.6kb 172.16.59.101 smoketestnode






 
 7. __Setup Instructions 
-> Checkout https://github.com/opendistro-for-elasticsearch/opendistro-build
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Create directory build/elasticsearch/plugins/
-> Create file build/elasticsearch/plugins/plugins.list
-> Pull changes of this PR locally
-> cd into plugin directory
-> To simulate security index being red: Add index setting index.routing.allocation.exclude._name: "{elasticsearch_conatiner_1_name},{elasticsearch_conatiner_1_name}" here https://github.com/opendistro-for-elasticsearch/security/blob/main/src/main/java/com/amazon/opendistroforelasticsearch/security/configuration/ConfigurationRepository.java#L236
-> Build the plugin: mvn clean package -Padvanced -DskipTests
-> Copy artifact target/releases/*.zip to ../opendistro-build/elasticsearch/docker/build/elasticsearch/plugins/
-> cd into {$PATH}/opendistro-build/elasticsearch/docker
-> Add the artifact name to the plugins.list file
-> run make-build [TIP: Remove knn dependencies from Dockerfile to speed up build. We do no require knn anyway)
-> run make-cluster
-> Once the cluster is up with two nodes, verify requests fail with Open Distro Security not initialized. Verify that the security index is RED
-> Fix the security index by updating cluster settings inside one of the docker containers:
curl -XPUT "https://localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d' { "transient" : { "index.routing.allocation.exclude._name": null } }' -k --cacert root-ca.pem --cert ./kirk.pem --key kirk-key.pem
-> Verify security index is not RED anymore
-> Cluster should be up and requests to it should succeed now
-> Without the plugin changes, the previous step would still fail even though security index is not RED anymore





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).