### PR TITLE
Use ReplacedRoute instead of Route in rest APIs to mark the old route…

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -18,7 +18,6 @@ package org.opensearch.security.dlic.rest.api;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.AccountValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -55,6 +54,7 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.security.dlic.rest.support.Utils.hash;
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
 
 /**
  * Rest API action to fetch or update account details of the signed-in user.
@@ -62,7 +62,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.hash;
  */
 public class AccountApiAction extends AbstractApiAction {
     private static final String RESOURCE_NAME = "account";
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/account"),
             new Route(Method.PUT, "/account")
     ));

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -86,10 +86,6 @@ public class AccountApiAction extends AbstractApiAction {
         this.threadContext = threadPool.getThreadContext();
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -62,7 +62,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  */
 public class AccountApiAction extends AbstractApiAction {
     private static final String RESOURCE_NAME = "account";
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(Method.GET, "/account"),
             new Route(Method.PUT, "/account")
     ));
@@ -88,7 +88,12 @@ public class AccountApiAction extends AbstractApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -18,6 +18,7 @@ package org.opensearch.security.dlic.rest.api;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.AccountValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -54,7 +55,6 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.security.dlic.rest.support.Utils.hash;
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 /**
  * Rest API action to fetch or update account details of the signed-in user.
@@ -62,7 +62,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  */
 public class AccountApiAction extends AbstractApiAction {
     private static final String RESOURCE_NAME = "account";
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/account"),
             new Route(Method.PUT, "/account")
     ));

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -86,7 +86,6 @@ public class AccountApiAction extends AbstractApiAction {
         this.threadContext = threadPool.getThreadContext();
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -72,14 +72,10 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+		return replacedRoutes;
 	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(final RestRequest request, BytesReference ref, Object... param) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -29,7 +29,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.ActionGroupValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -39,9 +38,11 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.security.securityconf.impl.CType;
 import com.google.common.collect.ImmutableList;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
 			// legacy mapping for backwards compatibility
 			// TODO: remove in next version
 			new Route(Method.GET, "/actiongroup/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -72,7 +72,6 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -29,6 +29,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.ActionGroupValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -38,11 +39,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.security.securityconf.impl.CType;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
 			// legacy mapping for backwards compatibility
 			// TODO: remove in next version
 			new Route(Method.GET, "/actiongroup/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -42,7 +42,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
-	private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
 			// legacy mapping for backwards compatibility
 			// TODO: remove in next version
 			new Route(Method.GET, "/actiongroup/{name}"),
@@ -74,8 +74,13 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected AbstractConfigurationValidator getValidator(final RestRequest request, BytesReference ref, Object... param) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -47,6 +47,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 /**
  * Rest handler for fetching and updating audit configuration.
  * Supported REST endpoints
@@ -125,7 +127,7 @@ import java.util.Map;
  * [{"op": "replace", "path": "/config/compliance/internal_config", "value": "true"}]
  */
 public class AuditApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/audit/"),
             new Route(RestRequest.Method.PUT, "/audit/{name}"),
             new Route(RestRequest.Method.PATCH, "/audit/")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -47,8 +47,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 /**
  * Rest handler for fetching and updating audit configuration.
  * Supported REST endpoints
@@ -127,7 +125,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * [{"op": "replace", "path": "/config/compliance/internal_config", "value": "true"}]
  */
 public class AuditApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/audit/"),
             new Route(RestRequest.Method.PUT, "/audit/{name}"),
             new Route(RestRequest.Method.PATCH, "/audit/")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -168,10 +168,6 @@ public class AuditApiAction extends PatchableResourceApiAction {
         }
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -168,7 +168,6 @@ public class AuditApiAction extends PatchableResourceApiAction {
         }
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -127,7 +127,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * [{"op": "replace", "path": "/config/compliance/internal_config", "value": "true"}]
  */
 public class AuditApiAction extends PatchableResourceApiAction {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/audit/"),
             new Route(RestRequest.Method.PUT, "/audit/{name}"),
             new Route(RestRequest.Method.PATCH, "/audit/")
@@ -170,7 +170,12 @@ public class AuditApiAction extends PatchableResourceApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -58,14 +58,10 @@ public class AuthTokenProcessorAction extends AbstractApiAction {
 				auditLog);
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+	    return replacedRoutes;
 	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
 
 	@Override
 	protected void handlePost(RestChannel channel, final RestRequest request, final Client client, final JsonNode content) throws IOException {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -43,8 +42,10 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class AuthTokenProcessorAction extends AbstractApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(Collections.singletonList(
 			new Route(Method.POST, "/authtoken")
 	));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -42,10 +43,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class AuthTokenProcessorAction extends AbstractApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
 			new Route(Method.POST, "/authtoken")
 	));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -58,7 +58,6 @@ public class AuthTokenProcessorAction extends AbstractApiAction {
 				auditLog);
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -15,7 +15,6 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import com.google.common.collect.ImmutableList;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -59,7 +59,7 @@ public class AuthTokenProcessorAction extends AbstractApiAction {
 
 	@Override
 	public List<ReplacedRoute> replacedRoutes() {
-	    return replacedRoutes;
+		return replacedRoutes;
 	}
 
 	@Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuthTokenProcessorAction.java
@@ -15,6 +15,7 @@
 
 package org.opensearch.security.dlic.rest.api;
 
+import com.google.common.collect.ImmutableList;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
@@ -44,7 +45,7 @@ import java.util.List;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class AuthTokenProcessorAction extends AbstractApiAction {
-	private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
 			new Route(Method.POST, "/authtoken")
 	));
 
@@ -59,8 +60,13 @@ public class AuthTokenProcessorAction extends AbstractApiAction {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected void handlePost(RestChannel channel, final RestRequest request, final Client client, final JsonNode content) throws IOException {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -35,7 +35,6 @@ import org.opensearch.security.action.configupdate.ConfigUpdateResponse;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -46,9 +45,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.opensearch.security.securityconf.impl.CType;
 import com.google.common.collect.ImmutableList;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
 
 public class FlushCacheApiAction extends AbstractApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
 			new Route(Method.DELETE, "/cache"),
 			new Route(Method.GET, "/cache"),
 			new Route(Method.PUT, "/cache"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.RepositoryCleanupInProgress;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.inject.Inject;
@@ -48,7 +49,7 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class FlushCacheApiAction extends AbstractApiAction {
-	private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
 			new Route(Method.DELETE, "/cache"),
 			new Route(Method.GET, "/cache"),
 			new Route(Method.PUT, "/cache"),
@@ -64,8 +65,13 @@ public class FlushCacheApiAction extends AbstractApiAction {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected Endpoint getEndpoint() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -62,14 +62,10 @@ public class FlushCacheApiAction extends AbstractApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
-	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+		return replacedRoutes;
+    	}
 
 	@Override
 	protected Endpoint getEndpoint() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import org.opensearch.action.ActionListener;
 import org.opensearch.client.Client;
-import org.opensearch.cluster.RepositoryCleanupInProgress;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.inject.Inject;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -62,7 +62,6 @@ public class FlushCacheApiAction extends AbstractApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -35,6 +35,7 @@ import org.opensearch.security.action.configupdate.ConfigUpdateResponse;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -48,7 +49,7 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class FlushCacheApiAction extends AbstractApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
 			new Route(Method.DELETE, "/cache"),
 			new Route(Method.GET, "/cache"),
 			new Route(Method.PUT, "/cache"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -46,7 +46,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.opensearch.security.securityconf.impl.CType;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class FlushCacheApiAction extends AbstractApiAction {
 	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -52,7 +52,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.hash;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class InternalUsersApiAction extends PatchableResourceApiAction {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(Method.GET, "/user/{name}"),
             new Route(Method.GET, "/user/"),
             new Route(Method.DELETE, "/user/{name}"),
@@ -78,7 +78,12 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -19,6 +19,7 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.InternalUsersValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -49,10 +50,9 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.security.dlic.rest.support.Utils.hash;
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class InternalUsersApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/user/{name}"),
             new Route(Method.GET, "/user/"),
             new Route(Method.DELETE, "/user/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -76,7 +76,6 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
                 auditLog);
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -19,7 +19,6 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.InternalUsersValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -50,9 +49,10 @@ import java.util.List;
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.security.dlic.rest.support.Utils.hash;
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
 
 public class InternalUsersApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/user/{name}"),
             new Route(Method.GET, "/user/"),
             new Route(Method.DELETE, "/user/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -76,10 +76,6 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
                 auditLog);
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -87,10 +87,6 @@ public class MigrateApiAction extends AbstractApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -87,7 +87,6 @@ public class MigrateApiAction extends AbstractApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -48,7 +48,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -74,8 +73,10 @@ import org.opensearch.security.securityconf.impl.v7.TenantV7;
 
 import com.google.common.collect.ImmutableList;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class MigrateApiAction extends AbstractApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(Collections.singletonList(
             new Route(Method.POST, "/migrate")
     ));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -76,7 +76,7 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class MigrateApiAction extends AbstractApiAction {
-    private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
             new Route(Method.POST, "/migrate")
     ));
 
@@ -89,7 +89,12 @@ public class MigrateApiAction extends AbstractApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -48,6 +48,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -73,10 +74,8 @@ import org.opensearch.security.securityconf.impl.v7.TenantV7;
 
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class MigrateApiAction extends AbstractApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
             new Route(Method.POST, "/migrate")
     ));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -18,6 +18,7 @@ package org.opensearch.security.dlic.rest.api;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NodesDnValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -45,8 +46,6 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 /**
  * This class implements CRUD operations to manage dynamic NodesDn. The primary usecase is targeted at cross-cluster where
  * in node restart can be avoided by populating the coordinating cluster's nodes_dn values.
@@ -64,7 +63,7 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
     public static final String STATIC_OPENSEARCH_YML_NODES_DN = "STATIC_OPENSEARCH_YML_NODES_DN";
     private final List<String> staticNodesDnFromEsYml;
 
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/nodesdn/{name}"),
             new Route(Method.GET, "/nodesdn/"),
             new Route(Method.DELETE, "/nodesdn/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -18,7 +18,6 @@ package org.opensearch.security.dlic.rest.api;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NodesDnValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -46,6 +45,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 /**
  * This class implements CRUD operations to manage dynamic NodesDn. The primary usecase is targeted at cross-cluster where
  * in node restart can be avoided by populating the coordinating cluster's nodes_dn values.
@@ -63,7 +64,7 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
     public static final String STATIC_OPENSEARCH_YML_NODES_DN = "STATIC_OPENSEARCH_YML_NODES_DN";
     private final List<String> staticNodesDnFromEsYml;
 
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/nodesdn/{name}"),
             new Route(Method.GET, "/nodesdn/"),
             new Route(Method.DELETE, "/nodesdn/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -64,7 +64,7 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
     public static final String STATIC_OPENSEARCH_YML_NODES_DN = "STATIC_OPENSEARCH_YML_NODES_DN";
     private final List<String> staticNodesDnFromEsYml;
 
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(Method.GET, "/nodesdn/{name}"),
             new Route(Method.GET, "/nodesdn/"),
             new Route(Method.DELETE, "/nodesdn/{name}"),
@@ -82,9 +82,12 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
     }
 
     @Override
-    public List<Route> routes() {
+    public List<Route> routes() { return ImmutableList.of(); }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
         if (settings.getAsBoolean(ConfigConstants.SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false)) {
-            return routes;
+            return replacedRoutes;
         }
         return Collections.emptyList();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -81,8 +81,6 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
         this.staticNodesDnFromEsYml = settings.getAsList(ConfigConstants.SECURITY_NODES_DN, Collections.emptyList());
     }
 
-    public List<Route> routes() { return ImmutableList.of(); }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         if (settings.getAsBoolean(ConfigConstants.SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false)) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -81,7 +81,6 @@ public class NodesDnApiAction extends PatchableResourceApiAction {
         this.staticNodesDnFromEsYml = settings.getAsList(ConfigConstants.SECURITY_NODES_DN, Collections.emptyList());
     }
 
-    @Override
     public List<Route> routes() { return ImmutableList.of(); }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -78,7 +78,7 @@ public class PermissionsInfoAction extends BaseRestHandler {
 
 	@Override
 	public List<ReplacedRoute> replacedRoutes() {
-	    return replacedRoutes;
+		return replacedRoutes;
 	}
 
 	@Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -40,18 +40,19 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 /**
  * Provides the evaluated REST API permissions for the currently logged in user
  */
 public class PermissionsInfoAction extends BaseRestHandler {
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(Collections.singletonList(
 			new Route(Method.GET, "/permissionsinfo")
 	));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -52,7 +52,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * Provides the evaluated REST API permissions for the currently logged in user
  */
 public class PermissionsInfoAction extends BaseRestHandler {
-	private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
 			new Route(Method.GET, "/permissionsinfo")
 	));
 
@@ -78,8 +78,13 @@ public class PermissionsInfoAction extends BaseRestHandler {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -76,7 +76,6 @@ public class PermissionsInfoAction extends BaseRestHandler {
 		return getClass().getSimpleName();
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -40,19 +40,18 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 /**
  * Provides the evaluated REST API permissions for the currently logged in user
  */
 public class PermissionsInfoAction extends BaseRestHandler {
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
 			new Route(Method.GET, "/permissionsinfo")
 	));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PermissionsInfoAction.java
@@ -76,14 +76,10 @@ public class PermissionsInfoAction extends BaseRestHandler {
 		return getClass().getSimpleName();
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+	    return replacedRoutes;
 	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
 
 	@Override
 	protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -57,7 +57,6 @@ public class RolesApiAction extends PatchableResourceApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -56,14 +56,10 @@ public class RolesApiAction extends PatchableResourceApiAction {
 		super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+	    return replacedRoutes;
 	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
 
 	@Override
 	protected Endpoint getEndpoint() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -29,6 +29,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.RolesValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -39,10 +40,8 @@ import org.opensearch.security.securityconf.impl.CType;
 
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class RolesApiAction extends PatchableResourceApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
 			new Route(Method.GET, "/roles/"),
 			new Route(Method.GET, "/roles/{name}"),
 			new Route(Method.DELETE, "/roles/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -58,7 +58,7 @@ public class RolesApiAction extends PatchableResourceApiAction {
 
 	@Override
 	public List<ReplacedRoute> replacedRoutes() {
-	    return replacedRoutes;
+		return replacedRoutes;
 	}
 
 	@Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -42,7 +42,7 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class RolesApiAction extends PatchableResourceApiAction {
-	private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
 			new Route(Method.GET, "/roles/"),
 			new Route(Method.GET, "/roles/{name}"),
 			new Route(Method.DELETE, "/roles/{name}"),
@@ -59,8 +59,13 @@ public class RolesApiAction extends PatchableResourceApiAction {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected Endpoint getEndpoint() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -29,7 +29,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.RolesValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -37,11 +36,12 @@ import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.threadpool.ThreadPool;
 
 import org.opensearch.security.securityconf.impl.CType;
-
 import com.google.common.collect.ImmutableList;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class RolesApiAction extends PatchableResourceApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
 			new Route(Method.GET, "/roles/"),
 			new Route(Method.GET, "/roles/{name}"),
 			new Route(Method.DELETE, "/roles/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -93,7 +93,6 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 		});
 	}
 
-	@Override
 	public List<Route> routes() {
 		return ImmutableList.of();
 	}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -36,6 +36,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.RolesMappingValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -44,10 +45,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import org.opensearch.security.securityconf.impl.CType;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class RolesMappingApiAction extends PatchableResourceApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
 			new Route(Method.GET, "/rolesmapping/"),
 			new Route(Method.GET, "/rolesmapping/{name}"),
 			new Route(Method.DELETE, "/rolesmapping/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -93,14 +93,10 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 		});
 	}
 
-	public List<Route> routes() {
-		return ImmutableList.of();
-	}
-
-    @Override
-    public List<ReplacedRoute> replacedRoutes() {
-        return replacedRoutes;
-    }
+	@Override
+	public List<ReplacedRoute> replacedRoutes() {
+        	return replacedRoutes;
+    	}
 
 	@Override
 	protected Endpoint getEndpoint() {
@@ -119,7 +115,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Override
     protected CType getConfigName() {
-        return CType.ROLESMAPPING;
+        	return CType.ROLESMAPPING;
 	}
 
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -36,7 +36,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.RolesMappingValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -45,8 +44,10 @@ import org.opensearch.threadpool.ThreadPool;
 
 import org.opensearch.security.securityconf.impl.CType;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class RolesMappingApiAction extends PatchableResourceApiAction {
-	private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
 			new Route(Method.GET, "/rolesmapping/"),
 			new Route(Method.GET, "/rolesmapping/{name}"),
 			new Route(Method.DELETE, "/rolesmapping/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -115,7 +115,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Override
     protected CType getConfigName() {
-        	return CType.ROLESMAPPING;
+	    return CType.ROLESMAPPING;
 	}
 
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -47,7 +47,7 @@ import org.opensearch.security.securityconf.impl.CType;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class RolesMappingApiAction extends PatchableResourceApiAction {
-	private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+	private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
 			new Route(Method.GET, "/rolesmapping/"),
 			new Route(Method.GET, "/rolesmapping/{name}"),
 			new Route(Method.DELETE, "/rolesmapping/{name}"),
@@ -95,8 +95,13 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 
 	@Override
 	public List<Route> routes() {
-		return routes;
+		return ImmutableList.of();
 	}
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
+    }
 
 	@Override
 	protected Endpoint getEndpoint() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -74,10 +74,6 @@ public class SecurityConfigAction extends PatchableResourceApiAction {
         allowPutOrPatch = settings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false);
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return allowPutOrPatch ? allRoutes : getRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -45,9 +45,11 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class SecurityConfigAction extends PatchableResourceApiAction {
 
-    private static final List<ReplacedRoute> getRoutes = Utils.replaceRoutes(Collections.singletonList(
+    private static final List<ReplacedRoute> getRoutes = replaceRoutes(Collections.singletonList(
             new Route(Method.GET, "/securityconfig/")
     ));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -48,11 +48,11 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityConfigAction extends PatchableResourceApiAction {
 
-    private static final List<Route> getRoutes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> getRoutes = addRoutesPrefix(Collections.singletonList(
             new Route(Method.GET, "/securityconfig/")
     ));
 
-    private static final List<Route> allRoutes = new ImmutableList.Builder<Route>()
+    private static final List<ReplacedRoute> allRoutes = new ImmutableList.Builder<ReplacedRoute>()
             .addAll(getRoutes)
             .addAll(addRoutesPrefix(
                 ImmutableList.of(
@@ -75,6 +75,11 @@ public class SecurityConfigAction extends PatchableResourceApiAction {
 
     @Override
     public List<Route> routes() {
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
         return allowPutOrPatch ? allRoutes : getRoutes;
     }
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -36,6 +36,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
@@ -44,17 +45,15 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class SecurityConfigAction extends PatchableResourceApiAction {
 
-    private static final List<ReplacedRoute> getRoutes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> getRoutes = Utils.replaceRoutes(Collections.singletonList(
             new Route(Method.GET, "/securityconfig/")
     ));
 
     private static final List<ReplacedRoute> allRoutes = new ImmutableList.Builder<ReplacedRoute>()
             .addAll(getRoutes)
-            .addAll(addRoutesPrefix(
+            .addAll(Utils.replaceRoutes(
                 ImmutableList.of(
                     new Route(Method.PUT, "/securityconfig/{name}"),
                     new Route(Method.PATCH, "/securityconfig/")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -36,7 +36,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
@@ -55,7 +54,7 @@ public class SecurityConfigAction extends PatchableResourceApiAction {
 
     private static final List<ReplacedRoute> allRoutes = new ImmutableList.Builder<ReplacedRoute>()
             .addAll(getRoutes)
-            .addAll(Utils.replaceRoutes(
+            .addAll(replaceRoutes(
                 ImmutableList.of(
                     new Route(Method.PUT, "/securityconfig/{name}"),
                     new Route(Method.PATCH, "/securityconfig/")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigAction.java
@@ -73,7 +73,6 @@ public class SecurityConfigAction extends PatchableResourceApiAction {
         allowPutOrPatch = settings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false);
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -73,7 +73,6 @@ public class TenantsApiAction extends PatchableResourceApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -46,7 +46,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.TenantValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -55,8 +54,10 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class TenantsApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/tenants/{name}"),
             new Route(Method.GET, "/tenants/"),
             new Route(Method.DELETE, "/tenants/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -46,6 +46,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.TenantValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -54,10 +55,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class TenantsApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(Method.GET, "/tenants/{name}"),
             new Route(Method.GET, "/tenants/"),
             new Route(Method.DELETE, "/tenants/{name}"),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -57,7 +57,7 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class TenantsApiAction extends PatchableResourceApiAction {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(Method.GET, "/tenants/{name}"),
             new Route(Method.GET, "/tenants/"),
             new Route(Method.DELETE, "/tenants/{name}"),
@@ -75,7 +75,12 @@ public class TenantsApiAction extends PatchableResourceApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -73,10 +73,6 @@ public class TenantsApiAction extends PatchableResourceApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -72,7 +72,6 @@ public class ValidateApiAction extends AbstractApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -15,6 +15,7 @@
 
 package org.opensearch.security.dlic.rest.api;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -60,7 +61,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 
 public class ValidateApiAction extends AbstractApiAction {
-    private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
             new Route(Method.GET, "/validate")
     ));
 
@@ -73,7 +74,12 @@ public class ValidateApiAction extends AbstractApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -35,7 +35,6 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -58,8 +57,10 @@ import org.opensearch.security.securityconf.impl.v7.RoleMappingsV7;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.securityconf.impl.v7.TenantV7;
 
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
+
 public class ValidateApiAction extends AbstractApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(Collections.singletonList(
             new Route(Method.GET, "/validate")
     ));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -71,10 +71,6 @@ public class ValidateApiAction extends AbstractApiAction {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, evaluator, threadPool, auditLog);
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -35,6 +35,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.NoOpValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -57,11 +58,8 @@ import org.opensearch.security.securityconf.impl.v7.RoleMappingsV7;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.securityconf.impl.v7.TenantV7;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
-
 public class ValidateApiAction extends AbstractApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(Collections.singletonList(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(Collections.singletonList(
             new Route(Method.GET, "/validate")
     ));
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
@@ -88,7 +88,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * <p>
  */
 public class WhitelistApiAction extends PatchableResourceApiAction {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/whitelist"),
             new Route(RestRequest.Method.PUT, "/whitelist"),
             new Route(RestRequest.Method.PATCH, "/whitelist")
@@ -155,7 +155,12 @@ public class WhitelistApiAction extends PatchableResourceApiAction {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
@@ -153,7 +153,6 @@ public class WhitelistApiAction extends PatchableResourceApiAction {
     }
 
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
@@ -20,7 +20,6 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.WhitelistValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -45,6 +44,8 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+
+import static org.opensearch.security.dlic.rest.support.Utils.replaceRoutes;
 
 /**
  * This class implements GET and PUT operations to manage dynamic WhitelistingSettings.
@@ -87,7 +88,7 @@ import java.util.List;
  * <p>
  */
 public class WhitelistApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = replaceRoutes(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/whitelist"),
             new Route(RestRequest.Method.PUT, "/whitelist"),
             new Route(RestRequest.Method.PATCH, "/whitelist")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
@@ -20,6 +20,7 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator;
 import org.opensearch.security.dlic.rest.validation.WhitelistValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -44,8 +45,6 @@ import org.opensearch.threadpool.ThreadPool;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 /**
  * This class implements GET and PUT operations to manage dynamic WhitelistingSettings.
@@ -88,7 +87,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * <p>
  */
 public class WhitelistApiAction extends PatchableResourceApiAction {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = Utils.replaceRoutes(ImmutableList.of(
             new Route(RestRequest.Method.GET, "/whitelist"),
             new Route(RestRequest.Method.PUT, "/whitelist"),
             new Route(RestRequest.Method.PATCH, "/whitelist")

--- a/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/WhitelistApiAction.java
@@ -152,11 +152,6 @@ public class WhitelistApiAction extends PatchableResourceApiAction {
         });
     }
 
-
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -221,8 +221,7 @@ public class Utils {
     /**
      * Add prefixes(_opendistro... and _plugins...) to rest API routes
      * @param routes routes
-     * @return new list of API routes prefixed with _opendistro... and _plugins...
-     *Total number of routes is expanded as twice as the number of routes passed in
+     * @return a list of replaced routes
      */
     public static List<ReplacedRoute> replaceRoutes(List<Route> routes){
         return RestHandler.replaceRoutes(routes, "/_plugins/_security/api", "/_opendistro/_security/api");

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -49,15 +49,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.security.DefaultObjectMapper;
 
-<<<<<<< HEAD
-import com.google.common.collect.ImmutableList;
-
 import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
-=======
-import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
-
->>>>>>> e41d82d7... Use replaceRoutes() method from RestHandler instead of addRoutesPrefix()
 public class Utils {
 
     private static final ObjectMapper internalMapper = new ObjectMapper();

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -40,6 +40,7 @@ import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.rest.RestHandler.Route;
+import org.opensearch.rest.RestHandler.ReplacedRoute;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -224,22 +225,22 @@ public class Utils {
      * @return new list of API routes prefixed with _opendistro... and _plugins...
      *Total number of routes is expanded as twice as the number of routes passed in
      */
-    public static List<Route> addRoutesPrefix(List<Route> routes){
-        return addRoutesPrefix(routes, "/_opendistro/_security/api", "/_plugins/_security/api");
+    public static List<ReplacedRoute> addRoutesPrefix(List<Route> routes){
+        return addRoutesPrefix(routes, "/_plugins/_security/api", "/_opendistro/_security/api");
     }
 
     /**
      * Add customized prefix(_opendistro... and _plugins...)to API rest routes
      * @param routes routes
-     * @param prefixes all api prefix
+     * @param newPrefix new prefix
+     * @param oldPrefix old prefix
      * @return new list of API routes prefixed with the strings listed in prefixes
      * Total number of routes will be expanded len(prefixes) as much comparing to the list passed in
      */
-    public static List<Route> addRoutesPrefix(List<Route> routes, final String... prefixes){
+    public static List<ReplacedRoute> addRoutesPrefix(List<Route> routes, final String newPrefix, final String oldPrefix){
         return routes.stream()
-             .flatMap(
-                r -> Arrays.stream(prefixes)
-                   .map(p -> new Route(r.getMethod(), p + r.getPath())))
-             .collect(ImmutableList.toImmutableList());
+                     .map(p -> new ReplacedRoute(p.getMethod(), newPrefix + p.getPath(),
+                        p.getMethod(), oldPrefix + p.getPath()))
+                .collect(ImmutableList.toImmutableList());
     }
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -39,6 +39,7 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentParser;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestHandler.Route;
 import org.opensearch.rest.RestHandler.ReplacedRoute;
 
@@ -48,10 +49,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.opensearch.security.DefaultObjectMapper;
 
+<<<<<<< HEAD
 import com.google.common.collect.ImmutableList;
 
 import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
+=======
+import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
+
+>>>>>>> e41d82d7... Use replaceRoutes() method from RestHandler instead of addRoutesPrefix()
 public class Utils {
 
     private static final ObjectMapper internalMapper = new ObjectMapper();
@@ -225,22 +231,7 @@ public class Utils {
      * @return new list of API routes prefixed with _opendistro... and _plugins...
      *Total number of routes is expanded as twice as the number of routes passed in
      */
-    public static List<ReplacedRoute> addRoutesPrefix(List<Route> routes){
-        return addRoutesPrefix(routes, "/_plugins/_security/api", "/_opendistro/_security/api");
-    }
-
-    /**
-     * Add customized prefix(_opendistro... and _plugins...)to API rest routes
-     * @param routes routes
-     * @param newPrefix new prefix
-     * @param oldPrefix old prefix
-     * @return new list of API routes prefixed with the strings listed in prefixes
-     * Total number of routes will be expanded len(prefixes) as much comparing to the list passed in
-     */
-    public static List<ReplacedRoute> addRoutesPrefix(List<Route> routes, final String newPrefix, final String oldPrefix){
-        return routes.stream()
-                     .map(p -> new ReplacedRoute(p.getMethod(), newPrefix + p.getPath(),
-                        p.getMethod(), oldPrefix + p.getPath()))
-                .collect(ImmutableList.toImmutableList());
+    public static List<ReplacedRoute> replaceRoutes(List<Route> routes){
+        return RestHandler.replaceRoutes(routes, "/_plugins/_security/api", "/_opendistro/_security/api");
     }
 }

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -58,19 +58,19 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class DashboardsInfoAction extends BaseRestHandler {
 
-    private static final List<Route> routes = ImmutableList.<Route>builder()
+    private static final List<ReplacedRoute> replacedRoutes = ImmutableList.<ReplacedRoute>builder()
         .addAll(addRoutesPrefix(
             ImmutableList.of(
                 new Route(GET, "/dashboardsinfo"),
                 new Route(POST, "/dashboardsinfo")
             ),
-            "/_plugins/_security"))
+            "/_plugins/_security", ""))
         .addAll(addRoutesPrefix(
             ImmutableList.of(
                 new Route(GET, "/kibanainfo"),
                 new Route(POST, "/kibanainfo")
             ),
-            "/_opendistro/_security"))
+            "/_opendistro/_security", ""))
         .build();
 
     private final Logger log = LogManager.getLogger(this.getClass());
@@ -85,7 +85,12 @@ public class DashboardsInfoAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -73,7 +73,6 @@ public class DashboardsInfoAction extends BaseRestHandler {
         this.evaluator = evaluator;
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -54,8 +54,6 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.security.user.User;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class DashboardsInfoAction extends BaseRestHandler {
 
     private static final List<ReplacedRoute> replacedRoutes = ImmutableList.of(

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -71,10 +71,6 @@ public class DashboardsInfoAction extends BaseRestHandler {
         this.evaluator = evaluator;
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -58,20 +58,10 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class DashboardsInfoAction extends BaseRestHandler {
 
-    private static final List<ReplacedRoute> replacedRoutes = ImmutableList.<ReplacedRoute>builder()
-        .addAll(addRoutesPrefix(
-            ImmutableList.of(
-                new Route(GET, "/dashboardsinfo"),
-                new Route(POST, "/dashboardsinfo")
-            ),
-            "/_plugins/_security", ""))
-        .addAll(addRoutesPrefix(
-            ImmutableList.of(
-                new Route(GET, "/kibanainfo"),
-                new Route(POST, "/kibanainfo")
-            ),
-            "/_opendistro/_security", ""))
-        .build();
+    private static final List<ReplacedRoute> replacedRoutes = ImmutableList.of(
+            new ReplacedRoute(GET, "/_plugins/_security/dashboardsinfo", GET,"/_opendistro/_security/kibanainfo"),
+            new ReplacedRoute(POST, "/_plugins/_security/dashboardsinfo", POST, "/_opendistro/_security/kibanainfo")
+    );
 
     private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -48,6 +48,7 @@ import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
@@ -57,8 +58,8 @@ import com.google.common.collect.ImmutableList;
 public class DashboardsInfoAction extends BaseRestHandler {
 
     private static final List<ReplacedRoute> replacedRoutes = ImmutableList.of(
-            new ReplacedRoute(GET, "/_plugins/_security/dashboardsinfo", GET,"/_opendistro/_security/kibanainfo"),
-            new ReplacedRoute(POST, "/_plugins/_security/dashboardsinfo", POST, "/_opendistro/_security/kibanainfo")
+            new RestHandler.ReplacedRoute(GET, "/_plugins/_security/dashboardsinfo", GET,"/_opendistro/_security/kibanainfo"),
+            new RestHandler.ReplacedRoute(POST, "/_plugins/_security/dashboardsinfo", POST, "/_opendistro/_security/kibanainfo")
     );
 
     private final Logger log = LogManager.getLogger(this.getClass());

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -43,16 +43,15 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 
 import org.opensearch.security.auth.BackendRegistry;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class SecurityHealthAction extends BaseRestHandler {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(ImmutableList.of(
             new Route(GET, "/health"),
             new Route(POST, "/health")
     ), "/_plugins/_security", "/_opendistro/_security");

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -64,7 +64,6 @@ public class SecurityHealthAction extends BaseRestHandler {
         this.registry = registry;
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -63,10 +63,6 @@ public class SecurityHealthAction extends BaseRestHandler {
         this.registry = registry;
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -52,10 +52,10 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityHealthAction extends BaseRestHandler {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(GET, "/health"),
             new Route(POST, "/health")
-    ), "/_opendistro/_security", "/_plugins/_security");
+    ), "/_plugins/_security", "/_opendistro/_security");
 
     private final BackendRegistry registry;
 
@@ -66,7 +66,12 @@ public class SecurityHealthAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -78,10 +78,6 @@ public class SecurityInfoAction extends BaseRestHandler {
         this.evaluator = evaluator;
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -64,10 +64,10 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityInfoAction extends BaseRestHandler {
-    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
             new Route(GET, "/authinfo"),
             new Route(POST, "/authinfo")
-    ),"/_opendistro/_security", "/_plugins/_security");
+    ),"/_plugins/_security", "/_opendistro/_security");
 
     private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;
@@ -81,7 +81,12 @@ public class SecurityInfoAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -79,7 +79,6 @@ public class SecurityInfoAction extends BaseRestHandler {
         this.evaluator = evaluator;
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -52,6 +52,7 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -61,10 +62,8 @@ import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class SecurityInfoAction extends BaseRestHandler {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(ImmutableList.of(
+    private static final List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(ImmutableList.of(
             new Route(GET, "/authinfo"),
             new Route(POST, "/authinfo")
     ),"/_plugins/_security", "/_opendistro/_security");

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -39,7 +39,6 @@ import java.util.List;
 import java.util.SortedMap;
 import com.google.common.base.Strings;
 
-import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.SortedMap;
 import com.google.common.base.Strings;
 
+import org.opensearch.cluster.metadata.RepositoriesMetadata;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
@@ -68,12 +69,12 @@ import com.google.common.collect.ImmutableList;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class TenantInfoAction extends BaseRestHandler {
-    private static final List<Route> routes = addRoutesPrefix(
+    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(
             ImmutableList.of(
                 new Route(GET, "/tenantinfo"),
                 new Route(POST, "/tenantinfo")
             ),
-            "/_opendistro/_security", "/_plugins/_security");
+            "/_plugins/_security", "/_opendistro/_security");
 
     private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;
@@ -95,7 +96,12 @@ public class TenantInfoAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return routes;
+        return ImmutableList.of();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return replacedRoutes;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -56,6 +56,7 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.security.configuration.AdminDNs;
@@ -65,10 +66,8 @@ import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 import com.google.common.collect.ImmutableList;
 
-import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-
 public class TenantInfoAction extends BaseRestHandler {
-    private static final List<ReplacedRoute> replacedRoutes = addRoutesPrefix(
+    private static final List<ReplacedRoute> replacedRoutes = RestHandler.replaceRoutes(
             ImmutableList.of(
                 new Route(GET, "/tenantinfo"),
                 new Route(POST, "/tenantinfo")

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -92,10 +92,6 @@ public class TenantInfoAction extends BaseRestHandler {
         this.configurationRepository = configurationRepository;
     }
 
-    public List<Route> routes() {
-        return ImmutableList.of();
-    }
-
     @Override
     public List<ReplacedRoute> replacedRoutes() {
         return replacedRoutes;

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -93,7 +93,6 @@ public class TenantInfoAction extends BaseRestHandler {
         this.configurationRepository = configurationRepository;
     }
 
-    @Override
     public List<Route> routes() {
         return ImmutableList.of();
     }


### PR DESCRIPTION
…s deprecated


##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Enhancement
 
 
 2. __Github Issue # or road-map entry, if available:__
This PR is to address a comment from @saratvemulapalli on PR #1172 regarding replacing an existing route with a new route and mark the old one deprecated.
https://github.com/opensearch-project/opensearch-plugins/blob/main/UPGRADING.md#naming-conventions


 3. __Description of changes:__
 In the current implementation, we support both RestAPIs with old route prefix (`_opendistro`) and new route prefix (`_plugins`), however the older ones are not deprecated. In the new implementation, we use a cleaner way to replace an existing route with a new route and mark the old one deprecated. OpenSearch automatically notifies the user with a warning message when the older route is used. 

 4. __Why these changes are required?__ 
The changes are required so we can deprecate the old routes and the user will be notified as well.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
In the olde behavior, we support both RestAPIs with old route prefix (`_opendistro`) and new route prefix (`_plugins`), however the older ones are not deprecated.


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 Unit testing
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).