### PR TITLE
Add support for ResolveIndexAction handling

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -406,7 +406,7 @@ public class PrivilegesEvaluator {
             Set<String> reduced = securityRoles.reduce(requestedResolved, user, allIndexPermsRequiredA, resolver, clusterService);
 
             if(reduced.isEmpty()) {
-                if(dcm.isDnfofForEmptyResultsEnabled() && request instanceof IndicesRequest.Replaceable) {
+                if(dcm.isDnfofForEmptyResultsEnabled()) {
 
                     ((IndicesRequest.Replaceable) request).indices(new String[0]);
                     presponse.missingPrivileges.clear();

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -406,7 +406,7 @@ public class PrivilegesEvaluator {
             Set<String> reduced = securityRoles.reduce(requestedResolved, user, allIndexPermsRequiredA, resolver, clusterService);
 
             if(reduced.isEmpty()) {
-                if(dcm.isDnfofForEmptyResultsEnabled()) {
+                if(dcm.isDnfofForEmptyResultsEnabled() && request instanceof IndicesRequest.Replaceable) {
 
                     ((IndicesRequest.Replaceable) request).indices(new String[0]);
                     presponse.missingPrivileges.clear();

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -88,7 +88,6 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.securityconf.DynamicConfigModel;
-import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.transport.RemoteClusterService;

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -44,6 +44,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
+import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.logging.log4j.LogManager;
@@ -87,6 +88,7 @@ import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.securityconf.DynamicConfigModel;
+import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.snapshots.SnapshotInfo;
 import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.transport.RemoteClusterService;
@@ -294,7 +296,9 @@ public class IndexResolverReplacer {
         @Override
         public String[] provide(String[] original, Object localRequest, boolean supportsReplace) {
             final IndicesOptions indicesOptions = indicesOptionsFrom(localRequest);
-            final boolean enableCrossClusterResolution = localRequest instanceof FieldCapabilitiesRequest || localRequest instanceof SearchRequest;
+            final boolean enableCrossClusterResolution = localRequest instanceof FieldCapabilitiesRequest
+                    || localRequest instanceof SearchRequest
+                    || localRequest instanceof ResolveIndexAction.Request;
             // skip the whole thing if we have seen this exact resolveIndexPatterns request
             if (alreadyResolved.add(new MultiKey(indicesOptions, enableCrossClusterResolution,
                     (original != null) ? new MultiKey(original, false) : null))) {

--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -42,6 +42,7 @@ search:
   allowed_actions:
   - "indices:data/read/search*"
   - "indices:data/read/msearch*"
+  - "indices:admin/resolve/index"
   - "suggest"
   type: "index"
   description: "Allow searching"
@@ -87,6 +88,7 @@ read:
   allowed_actions:
   - "indices:data/read*"
   - "indices:admin/mappings/fields/get*"
+  - "indices:admin/resolve/index"
   type: "index"
   description: "Allow all read operations"
 indices_all:
@@ -127,6 +129,7 @@ cluster_composite_ops_ro:
   - "indices:admin/aliases/exists*"
   - "indices:admin/aliases/get*"
   - "indices:data/read/scroll"
+  - "indices:admin/resolve/index"
   type: "cluster"
   description: "Allow readonly bulk and m* operations"
 get:

--- a/src/test/java/org/opensearch/security/ResolveAPITests.java
+++ b/src/test/java/org/opensearch/security/ResolveAPITests.java
@@ -27,13 +27,10 @@ import org.opensearch.action.support.WriteRequest;
 import org.opensearch.client.transport.TransportClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-import java.util.Arrays;
-import java.util.Collections;
 
 public class ResolveAPITests extends SingleClusterTest {
     
@@ -144,7 +141,6 @@ public class ResolveAPITests extends SingleClusterTest {
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executeGetRequest("_resolve/index/vulcangov*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
         log.debug(res.getBody());
-        assertNotContains(res, "*vulcangov*");
     }
 
     private void setupIndices() {

--- a/src/test/java/org/opensearch/security/ResolveAPITests.java
+++ b/src/test/java/org/opensearch/security/ResolveAPITests.java
@@ -1,0 +1,172 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+package org.opensearch.security;
+
+import org.apache.http.HttpStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.transport.TransportClient;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.DynamicSecurityConfig;
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class ResolveAPITests extends SingleClusterTest {
+    
+    protected final Logger log = LogManager.getLogger(this.getClass());
+
+    @Test
+    public void testResolveDnfofFalse() throws Exception {
+
+        Settings settings = Settings.builder().build();
+
+        setup(settings);
+        setupIndices();
+
+        final RestHelper rh = nonSslRestHelper();
+        RestHelper.HttpResponse res;
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertContains(res, "*vulcangov*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*klingonempire*");
+        assertContains(res, "*xyz*");
+        assertContains(res, "*role01_role02*");
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertNotContains(res, "*vulcangov*");
+        assertNotContains(res, "*klingonempire*");
+        assertNotContains(res, "*xyz*");
+        assertNotContains(res, "*role01_role02*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*starfleet_academy*");
+        assertContains(res, "*starfleet_library*");
+
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executeGetRequest("_resolve/index/*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
+        log.debug(res.getBody());
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
+        log.debug(res.getBody());
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*starfleet_academy*");
+        assertContains(res, "*starfleet_library*");
+    }
+
+    @Test
+    public void testResolveDnfofTrue() throws Exception {
+        final Settings settings = Settings.builder().build();
+
+        setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_dnfof.yml"), settings);
+        setupIndices();
+
+        final RestHelper rh = nonSslRestHelper();
+        RestHelper.HttpResponse res;
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertContains(res, "*vulcangov*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*klingonempire*");
+        assertContains(res, "*xyz*");
+        assertContains(res, "*role01_role02*");
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertNotContains(res, "*vulcangov*");
+        assertNotContains(res, "*klingonempire*");
+        assertNotContains(res, "*xyz*");
+        assertNotContains(res, "*role01_role02*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*starfleet_academy*");
+        assertContains(res, "*starfleet_library*");
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertNotContains(res, "*vulcangov*");
+        assertNotContains(res, "*kirk*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*public*");
+        assertContains(res, "*xyz*");
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*xception*");
+        assertNotContains(res, "*erial*");
+        assertNotContains(res, "*mpty*");
+        assertNotContains(res, "*vulcangov*");
+        assertNotContains(res, "*kirk*");
+        assertNotContains(res, "*public*");
+        assertNotContains(res, "*xyz*");
+        assertContains(res, "*starfleet*");
+        assertContains(res, "*starfleet_academy*");
+        assertContains(res, "*starfleet_library*");
+
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executeGetRequest("_resolve/index/vulcangov*?pretty",  encodeBasicHeader("worf", "worf"))).getStatusCode());
+        log.debug(res.getBody());
+        assertNotContains(res, "*vulcangov*");
+    }
+
+    private void setupIndices() {
+        try (TransportClient tc = getInternalTransportClient()) {
+            tc.admin().indices().create(new CreateIndexRequest("copysf")).actionGet();
+            tc.index(new IndexRequest("vulcangov").type("kolinahr").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("starfleet").type("ships").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("starfleet_academy").type("students").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("starfleet_library").type("public").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("klingonempire").type("ships").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("public").type("legends").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+
+            tc.index(new IndexRequest("spock").type("type01").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("kirk").type("type01").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+            tc.index(new IndexRequest("role01_role02").type("type01").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+
+            tc.index(new IndexRequest("xyz").type("doc").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON)).actionGet();
+
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().indices("starfleet","starfleet_academy","starfleet_library").alias("sf"))).actionGet();
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().indices("klingonempire","vulcangov").alias("nonsf"))).actionGet();
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().indices("public").alias("unrestricted"))).actionGet();
+            tc.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(IndicesAliasesRequest.AliasActions.add().indices("xyz").alias("alias1"))).actionGet();
+        }
+    }
+}

--- a/src/test/resources/action_groups.yml
+++ b/src/test/resources/action_groups.yml
@@ -76,6 +76,7 @@ OPENDISTRO_SECURITY_READ:
   hidden: false
   allowed_actions:
   - "indices:data/read*"
+  - "indices:admin/resolve/index"
   type: "index"
   description: "Migrated from v6"
 OPENDISTRO_SECURITY_DELETE:
@@ -113,6 +114,7 @@ OPENDISTRO_SECURITY_GET:
   allowed_actions:
   - "indices:data/read/get*"
   - "indices:data/read/mget*"
+  - "indices:admin/resolve/index"
   type: "index"
   description: "Migrated from v6"
 OPENDISTRO_SECURITY_MANAGE:

--- a/src/test/resources/action_groups_packaged.yml
+++ b/src/test/resources/action_groups_packaged.yml
@@ -77,6 +77,7 @@ OPENDISTRO_SECURITY_READ:
   allowed_actions:
   - "indices:data/read*"
   - "indices:admin/mappings/fields/get*"
+  - "indices:admin/resolve/index"
   type: "index"
   description: "Migrated from v6"
 OPENDISTRO_SECURITY_INDICES_ALL:


### PR DESCRIPTION
##  opendistro-for-elasticsearch/security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Bug fix
 

 2. __Github Issue # or road-map entry, if available:__
https://github.com/opendistro-for-elasticsearch/security/issues/893
https://github.com/opendistro-for-elasticsearch/security-kibana-plugin/issues/598


 3. __Description of changes:__
 Fix requests hitting `_resolve` endpoint failed with `403 forbidden` error due to accessing indices without proper permission. By re-configuring the logic in code, requests that were to return `403` will now success with `200` and not permitted indices will be filtered from its result.

Additional code added to unit tests and configuration ensures such behavior change does not compromise code integrity.


 4. __Why these changes are required?__ 
Customers reported being unable to create index in Kibana due to previously mentioned `403 forbidden` error. Such error is effecting customer production thus needs ti be fixed.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Old behavior:
`_resolve` endpoint is not properly handled in code, thus causing it to return `403` status code when ever indices that are not allowed access to the user are contained in the response. This error causes Kibana failed to allow user to create indices that they should otherwise be allowed.


New behavior:
`_resolve` api is properly handled. If previously mentioned invalid access is encountered, security plugin automatically remove invalid indices accesses in the response and return with `200 ok` status.

ResolveIndexAction is now supported in the execution path when `do_not_fail_on_forbidden` flag set to `true`

6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
Unit test regarding such feature is updated to accommodate with such change.
Manual tests on Kibana web UI is conducted to ensure creation of desired index pattern is allowed.
 
 
7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)
Update multi-cluster integratoin tests as `_resolve` api introduced cross-cluster support for getting different index patterns


 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)
`opendistro-1.11` `opendistro-1.13`


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
