### PR TITLE
Delegate to NettyAllocator.getAllocator() for ByteBufAllocator instead of hard-coding PooledByteBufAllocator.

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -78,6 +78,7 @@ import org.opensearch.security.ssl.util.CertFromTruststore;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.KeystoreProps;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.transport.NettyAllocator;
 
 public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
@@ -653,21 +654,21 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
     }
 
     public SSLEngine createHTTPSSLEngine() throws SSLException {
-        final SSLEngine engine = httpSslContext.newEngine(PooledByteBufAllocator.DEFAULT);
+        final SSLEngine engine = httpSslContext.newEngine(NettyAllocator.getAllocator());
         engine.setEnabledProtocols(getEnabledSSLProtocols(this.sslHTTPProvider, true));
         return engine;
 
     }
 
     public SSLEngine createServerTransportSSLEngine() throws SSLException {
-        final SSLEngine engine = transportServerSslContext.newEngine(PooledByteBufAllocator.DEFAULT);
+        final SSLEngine engine = transportServerSslContext.newEngine(NettyAllocator.getAllocator());
         engine.setEnabledProtocols(getEnabledSSLProtocols(this.sslTransportServerProvider, false));
         return engine;
     }
 
     public SSLEngine createClientTransportSSLEngine(final String peerHost, final int peerPort) throws SSLException {
         if (peerHost != null) {
-            final SSLEngine engine = transportClientSslContext.newEngine(PooledByteBufAllocator.DEFAULT, peerHost,
+            final SSLEngine engine = transportClientSslContext.newEngine(NettyAllocator.getAllocator(), peerHost,
                 peerPort);
 
             final SSLParameters sslParams = new SSLParameters();
@@ -676,7 +677,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
             engine.setEnabledProtocols(getEnabledSSLProtocols(this.sslTransportClientProvider, false));
             return engine;
         } else {
-            final SSLEngine engine = transportClientSslContext.newEngine(PooledByteBufAllocator.DEFAULT);
+            final SSLEngine engine = transportClientSslContext.newEngine(NettyAllocator.getAllocator());
             engine.setEnabledProtocols(getEnabledSSLProtocols(this.sslTransportClientProvider, false));
             return engine;
         }

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -49,7 +49,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLParameters;
 
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.OpenSsl;

--- a/src/test/java/org/opensearch/security/ssl/transport/DualModeSSLHandlerTests.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/DualModeSSLHandlerTests.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -38,6 +37,7 @@ public class DualModeSSLHandlerTests {
 
     public static final int TLS_MAJOR_VERSION = 3;
     public static final int TLS_MINOR_VERSION = 0;
+    private static final ByteBufAllocator ALLOCATOR = getAllocator();
 
     private SecurityKeyStore securityKeyStore;
     private ChannelPipeline pipeline;
@@ -58,8 +58,7 @@ public class DualModeSSLHandlerTests {
     public void testInvalidMessage() throws Exception {
         DualModeSSLHandler handler = new DualModeSSLHandler(securityKeyStore);
 
-        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-        handler.decode(ctx, alloc.directBuffer(4), null);
+        handler.decode(ctx, ALLOCATOR.buffer(4), null);
         // ensure pipeline is not fetched and manipulated
         Mockito.verify(ctx, Mockito.times(0)).pipeline();
     }
@@ -68,8 +67,7 @@ public class DualModeSSLHandlerTests {
     public void testValidTLSMessage() throws Exception {
         DualModeSSLHandler handler = new DualModeSSLHandler(securityKeyStore, sslHandler);
 
-        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-        ByteBuf buffer = alloc.directBuffer(6);
+        ByteBuf buffer = ALLOCATOR.buffer(6);
         buffer.writeByte(20);
         buffer.writeByte(TLS_MAJOR_VERSION);
         buffer.writeByte(TLS_MINOR_VERSION);
@@ -90,8 +88,7 @@ public class DualModeSSLHandlerTests {
     public void testNonTLSMessage() throws Exception {
         DualModeSSLHandler handler = new DualModeSSLHandler(securityKeyStore, sslHandler);
 
-        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-        ByteBuf buffer = alloc.directBuffer(6);
+        ByteBuf buffer = ALLOCATOR.buffer(6);
 
         for (int i = 0; i < 6; i++) {
             buffer.writeByte(1);
@@ -112,8 +109,7 @@ public class DualModeSSLHandlerTests {
         Mockito.when(ctx.writeAndFlush(Mockito.any())).thenReturn(channelFuture);
         Mockito.when(channelFuture.addListener(Mockito.any())).thenReturn(channelFuture);
 
-        ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-        ByteBuf buffer = alloc.directBuffer(6);
+        ByteBuf buffer = ALLOCATOR.buffer(6);
         buffer.writeCharSequence(SSLConnectionTestUtil.DUAL_MODE_CLIENT_HELLO_MSG, StandardCharsets.UTF_8);
 
         DualModeSSLHandler handler = new DualModeSSLHandler(securityKeyStore, sslHandler);

--- a/src/test/java/org/opensearch/security/ssl/transport/DualModeSSLHandlerTests.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/DualModeSSLHandlerTests.java
@@ -33,6 +33,8 @@ import org.mockito.Mockito;
 import org.opensearch.security.ssl.SecurityKeyStore;
 import org.opensearch.security.ssl.util.SSLConnectionTestUtil;
 
+import static org.opensearch.transport.NettyAllocator.getAllocator;
+
 public class DualModeSSLHandlerTests {
 
     public static final int TLS_MAJOR_VERSION = 3;

--- a/src/test/java/org/opensearch/security/ssl/util/TLSUtilTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/TLSUtilTests.java
@@ -16,15 +16,17 @@ package org.opensearch.security.ssl.util;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.buffer.PooledByteBufAllocator;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.opensearch.transport.NettyAllocator.getAllocator;
 
 public class TLSUtilTests {
 
     public static final int TLS_MAJOR_VERSION = 3;
     public static final int TLS_MINOR_VERSION = 0;
+    private static final ByteBufAllocator ALLOCATOR = getAllocator();
 
     @Before
     public void setup() {
@@ -35,8 +37,7 @@ public class TLSUtilTests {
     public void testSSLUtilSuccess() {
         // byte 20 to 24 are ssl headers
         for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
-            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-            ByteBuf buffer = alloc.directBuffer(5);
+            ByteBuf buffer = ALLOCATOR.buffer(5);
             buffer.writeByte(byteToSend);
             buffer.writeByte(TLS_MAJOR_VERSION);
             buffer.writeByte(TLS_MINOR_VERSION);
@@ -50,8 +51,7 @@ public class TLSUtilTests {
     public void testSSLUtilWrongTLSVersion() {
         // byte 20 to 24 are ssl headers
         for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
-            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-            ByteBuf buffer = alloc.directBuffer(5);
+            ByteBuf buffer = ALLOCATOR.buffer(5);
             buffer.writeByte(byteToSend);
             //setting invalid TLS version 100
             buffer.writeByte(100);
@@ -66,8 +66,7 @@ public class TLSUtilTests {
     public void testSSLUtilInvalidContentLength() {
         // byte 20 to 24 are ssl headers
         for (int byteToSend = 20; byteToSend <= 24; byteToSend++) {
-            ByteBufAllocator alloc = PooledByteBufAllocator.DEFAULT;
-            ByteBuf buffer = alloc.directBuffer(5);
+            ByteBuf buffer = ALLOCATOR.buffer(5);
             buffer.writeByte(byteToSend);
             buffer.writeByte(TLS_MAJOR_VERSION);
             buffer.writeByte(TLS_MINOR_VERSION);


### PR DESCRIPTION
##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Enhancement
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
security plugin should rely on `NettyAllocator.getAllocator()` to get `ByteBufAllocator` based on configured settings and parameters. Hard-coding `DEFAULT` `PooledByteBufAllocator` may cause unexpected allocator to be used.


 4. __Why these changes are required?__ 



 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).