### PR TITLE
Add support for -Dbuild.snapshot=true/false and default to building snapshot.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
     - name: Build OpenSearch
       working-directory: ./OpenSearch
-      run: ./gradlew publishToMavenLocal -Dbuild.snapshot=false
+      run: ./gradlew publishToMavenLocal
 
     - name: Checkstyle
       run: mvn -B checkstyle:checkstyle

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildDir = 'gradle-build'
 
 ext {
     securityPluginVersion = '1.1.0.0'
+    opensearchVersion = System.getProperty("opensearch.version", "1.1.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -67,7 +68,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
 
-    requires('opensearch-oss', "1.1.0", EQUAL)
+    requires('opensearch-oss', opensearchVersion - '-SNAPSHOT', EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for OpenSearch 1.0.0
 #
 # 'version': plugin's version
-version=1.1.0.0-SNAPSHOT
+version=1.1.0.0
 #
 # 'name': the plugin name
 name=opensearch-security

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.opensearch</groupId>
     <artifactId>opensearch-security</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0.0-SNAPSHOT</version>
+    <version>${version}</version>
     <name>OpenSearch Security</name>
     <description>OpenSearch Security</description>
     <url>https://github.com/opensearch-project/security</url>
@@ -69,6 +69,7 @@
         <maven.compiler.release>8</maven.compiler.release>
 
         <opensearch.version>1.1.0</opensearch.version>
+        <version>1.1.0.0</version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>
@@ -831,6 +832,18 @@
         </resources>
     </build>
     <profiles>
+        <profile>
+            <activation>
+                <property>
+                    <name>build.snapshot</name>
+                    <value>!false</value>
+                </property>
+            </activation>
+            <properties>
+                <version>1.1.0.0-SNAPSHOT</version>
+                <opensearch.version>1.1.0.0-SNAPSHOT</opensearch.version>
+            </properties>
+        </profile>
         <profile>
             <id>advanced</id>
             <build>


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_
 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 
 Maintenance
 
 2. __Github Issue # or road-map entry, if available:__

https://github.com/opensearch-project/security/issues/1403

 3. __Description of changes:__

- Default to building a -SNAPSHOT version of this plugin.
- Adds support for passing `-Dbuild.snapshot=false` to not build a snapshot. 

The downside is that the pom.xml is incorrect for -SNAPSHOT build (contains non-snapshot version because pom.xml doesn't know anything about profiles).

 4. __Why these changes are required?__ 

Building the end-to-end bundle needs the artifacts to be able to build snapshot vs. not snapshot.

 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)

The build could only produce a snapshot version vs. non-snapshot.

 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)

#### Snapshot (default)

```
mvn -B clean package -Padvanced -DskipTests

[INFO] -----------------< org.opensearch:opensearch-security >-----------------
[INFO] Building OpenSearch Security 1.1.0.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------

...

[INFO] --- maven-jar-plugin:3.1.1:jar (default-jar) @ opensearch-security ---
[INFO] Building jar: /home/ubuntu/source/opensearch-project/security/dblock-security/target/opensearch-security-1.1.0.0-SNAPSHOT.jar
[INFO]
[INFO] --- git-commit-id-plugin:2.2.6:validateRevision (validate-the-git-infos) @ opensearch-security ---
[INFO]
[INFO] --- maven-jar-plugin:3.1.1:test-jar (default) @ opensearch-security ---
[INFO] Building jar: /home/ubuntu/source/opensearch-project/security/dblock-security/target/opensearch-security-1.1.0.0-SNAPSHOT-tests.jar
[INFO]
[INFO] --- maven-assembly-plugin:3.1.1:single (plugin) @ opensearch-security ---
[INFO] Reading assembly descriptor: /home/ubuntu/source/opensearch-project/security/dblock-security/src/main/assemblies/plugin.xml
[INFO] Building zip: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0-SNAPSHOT.zip
[INFO] 
[INFO] --- maven-assembly-plugin:3.1.1:single (securityadmin) @ opensearch-security ---
[INFO] Reading assembly descriptor: /home/ubuntu/source/opensearch-project/security/dblock-security/src/main/assemblies/securityadmin-standalone.xml
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.opensearch:dlic*'

[INFO] Building zip: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0-SNAPSHOT-securityadmin-standalone.zip
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.opensearch:dlic*'

[INFO] Building tar: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0-SNAPSHOT-securityadmin-standalone.tar.gz
[INFO] 
[INFO] --- checksum-maven-plugin:1.7.1:files (default) @ opensearch-security ---
[INFO] opensearch-security-1.1.0.0-SNAPSHOT.zip - SHA-512 : e9f9434e058ddfeb3be9468889afcc46cf031c9591b79317fd0cb60cc16e6a5eda5951bfb86a5a1c1551af2b29b1e37f7bff1976c918521bdd987f888bbe73ab
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

$ unzip -p target/opensearch-security-1.1.0.0-SNAPSHOT.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Created-By: Apache Maven 3.6.3
Build-Jdk: 14.0.2
Implementation-Title: OpenSearch Security
Implementation-Version: 1.1.0.0-SNAPSHOT <-------------------------------------------
Implementation-Vendor-Id: org.opensearch
Implementation-URL: https://github.com/opensearch-project/security
Build-Time: 2021-08-30T22:05:33Z
Built-By: Amazon OpenDistro ElasticSearch Security Parent
git-sha1: 7d3518f77f7e614e7bec8523b2c867b34f1b67d6

```

#### Not Snapshot

```
mvn -B clean package -Padvanced -DskipTests -Dbuild.snapshot=false

[INFO] -----------------< org.opensearch:opensearch-security >-----------------
[INFO] Building OpenSearch Security 1.1.0.0
[INFO] --------------------------------[ jar ]---------------------------------

...

[INFO] --- maven-jar-plugin:3.1.1:test-jar (default) @ opensearch-security ---
[INFO] Building jar: /home/ubuntu/source/opensearch-project/security/dblock-security/target/opensearch-security-1.1.0.0-tests.jar
[INFO] 
[INFO] --- maven-assembly-plugin:3.1.1:single (plugin) @ opensearch-security ---
[INFO] Reading assembly descriptor: /home/ubuntu/source/opensearch-project/security/dblock-security/src/main/assemblies/plugin.xml
[INFO] Building zip: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0.zip
[INFO] 
[INFO] --- maven-assembly-plugin:3.1.1:single (securityadmin) @ opensearch-security ---
[INFO] Reading assembly descriptor: /home/ubuntu/source/opensearch-project/security/dblock-security/src/main/assemblies/securityadmin-standalone.xml
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.opensearch:dlic*'

[INFO] Building zip: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0-securityadmin-standalone.zip
[WARNING] The following patterns were never triggered in this artifact exclusion filter:
o  'org.opensearch:dlic*'

[INFO] Building tar: /home/ubuntu/source/opensearch-project/security/dblock-security/target/releases/opensearch-security-1.1.0.0-securityadmin-standalone.tar.gz
[INFO] 
[INFO] --- checksum-maven-plugin:1.7.1:files (default) @ opensearch-security ---
[INFO] opensearch-security-1.1.0.0.zip - SHA-512 : 57fa1109843795d12f0c56b51e3352b1e50aa9bdaf4dbf05bb17517019c46f6f95774f0e3d020a422a9b7692dc2e4cb9e19d561101dbe0a383f226701dc4ada0
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------

$ unzip -p target/opensearch-security-1.1.0.0.jar META-INF/MANIFEST.MF
Manifest-Version: 1.0
Created-By: Apache Maven 3.6.3
Build-Jdk: 14.0.2
Implementation-Title: OpenSearch Security
Implementation-Version: 1.1.0.0 <------------------------------------------
Implementation-Vendor-Id: org.opensearch
Implementation-URL: https://github.com/opensearch-project/security
Build-Time: 2021-08-30T22:02:25Z
Built-By: Amazon OpenDistro ElasticSearch Security Parent
git-sha1: 7d3518f77f7e614e7bec8523b2c867b34f1b67d6

```


In a previous iteration of this PR, installed `opensearch-security` plugin on OpenSearch 1.1.0, and started the cluster.
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)

Use the profile to depend on OpenSearch 1.1.0-SNAPSHOT as well.

 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)

No


By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).