### PR TITLE
Delegate all methods to the original RestHandler while wrapping REST API requests in SecurityRestFilter instead of relying on the default RestHandler interface implementation.

### DIFF
--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -115,8 +115,7 @@ public class SecurityRestFilter {
      * SuperAdmin is identified by credentials, which can be passed in the curl request.
      */
     public RestHandler wrap(RestHandler original, AdminDNs adminDNs) {
-        return new RestHandler() {
-            
+        return new RestHandler.Wrapper(original) {
             @Override
             public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
                 org.apache.logging.log4j.ThreadContext.clearAll();
@@ -126,6 +125,14 @@ public class SecurityRestFilter {
                         original.handleRequest(request, channel, client);
                     }
                 }
+            }
+
+            @Override
+            public boolean allowsUnsafeBuffers() {
+                // this RestHandler does not allow unsafe buffers in RestRequest as it access RestRequest content after
+                // sending response during audit logging
+                // TODO: see if unsafe buffers can be supported by chaning how audit logging is done
+                return false;
             }
         };
     }


### PR DESCRIPTION
##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 bug fix
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
Fix for incorrect delegation in the SecurityRestFilter.wrap()


 4. __Why these changes are required?__ 
It is necessary to delegate all methods and not only `handleRequest()` method to the original `RestHandler`. The current implementation relies on the wrong assumption that only `handleRequest()` method is called on the wrapped handler. It is not the case for the `allowSystemIndexAccessByDefault()` method and may change for other methods as well in the future.


 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
Will help with https://github.com/opensearch-project/OpenSearch/issues/1108


 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).