### PR TITLE
Fix to include hidden indices when resolving wildcards

### DIFF
--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -691,7 +691,7 @@ public class IndexResolverReplacer {
     private IndicesOptions indicesOptionsFrom(Object localRequest) {
         
         if(!respectRequestIndicesOptions) {
-            return IndicesOptions.fromOptions(false, true, true, false);
+            return IndicesOptions.fromOptions(false, true, true, false, true);
         }
 
         if (IndicesRequest.class.isInstance(localRequest)) {
@@ -701,7 +701,7 @@ public class IndexResolverReplacer {
             return ((RestoreSnapshotRequest) localRequest).indicesOptions();
         }
         else {
-            return IndicesOptions.fromOptions(false, true, true, false);
+            return IndicesOptions.fromOptions(false, true, true, false, true);
         }
     }
 

--- a/src/test/java/org/opensearch/security/PrivilegesEvaluationTest.java
+++ b/src/test/java/org/opensearch/security/PrivilegesEvaluationTest.java
@@ -1,0 +1,40 @@
+package org.opensearch.security;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.client.Client;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper;
+
+import com.google.common.collect.ImmutableMap;
+
+public class PrivilegesEvaluationTest extends SingleClusterTest {
+    @Test
+    public void resolveTestHidden() throws Exception {
+
+        setup();
+
+        try (Client client = getInternalTransportClient()) {
+
+            client.index(new IndexRequest("hidden_test_not_hidden").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source(XContentType.JSON, "index",
+                    "hidden_test_not_hidden", "b", "y", "date", "1985/01/01")).actionGet();
+
+            client.admin().indices().create(new CreateIndexRequest(".hidden_test_actually_hidden").settings(ImmutableMap.of("index.hidden", true)))
+                                       .actionGet();
+            client.index(new IndexRequest(".hidden_test_actually_hidden").id("test").source("a", "b").setRefreshPolicy(RefreshPolicy.IMMEDIATE))
+                    .actionGet();
+        }
+        RestHelper rh = nonSslRestHelper();
+        RestHelper.HttpResponse httpResponse = rh.executeGetRequest("/*hidden_test*/_search?expand_wildcards=all&pretty=true",
+                encodeBasicHeader("hidden_test", "nagilum"));
+        Assert.assertEquals(httpResponse.getBody(), 403, httpResponse.getStatusCode());
+
+        httpResponse = rh.executeGetRequest("/hidden_test_not_hidden?pretty=true",
+                encodeBasicHeader("hidden_test", "nagilum"));
+        Assert.assertEquals(httpResponse.getBody(), 200, httpResponse.getStatusCode());
+    }
+}

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -346,3 +346,8 @@ ds2:
 ds3:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum
+hidden_test:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  opendistro_security_roles:
+  - hidden_test
+

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1116,3 +1116,12 @@ data_stream_3:
         - "*"
       allowed_actions:
         - "DATASTREAM_ALL"
+
+hidden_test:
+  cluster_permissions:
+  - SGS_CLUSTER_COMPOSITE_OPS
+  index_permissions:
+  - index_patterns:
+    - hidden_test_not_hidden
+    allowed_actions:
+    - "*"


### PR DESCRIPTION
##  opensearch-security pull request intake form
_Please provide as much details as possible to get feedback/acceptance on your PR quickly_

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
Bug fix
 
 
 
 2. __Github Issue # or road-map entry, if available:__



 3. __Description of changes:__
 

- Modified class `IndexResolverReplacer` to expand to, and consider hidden indices as well when resolving wildcards.
- Added test `PrivilegesEvaluationTest` to verify that the issue is present, and to verify the fix



 4. __Why these changes are required?__ 
 
`index.hidden` indicates whether the index should be hidden by default. Hidden indices are not returned by default when using a wildcard expression. This behavior is controlled per request through the use of the `expand_wildcards` parameter. Possible values are true and false (default).

For proper authorization evaluation, it is necessary to determine the indices actions are operating on. This is done by the class `IndexResolverReplacer`. `IndexResolverReplacer` however failed to include hidden indices when resolving wildcards. So, for authorization evaluation, it looked like the particular action is not operating on the hidden indices; thus, these hidden indices were also not considered while checking for available index privileges.

Thus, a user could access the content of hidden indices by creating search requests with wildcards which match one index they are allowed to access plus any hidden index.




 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)



 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
 
 
 
 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)



 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)





By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).