### PR TITLE
Update to version 1.2.2 with log4j 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 buildDir = 'gradle-build'
 
 ext {
-    securityPluginVersion = '1.2.1.0'
+    securityPluginVersion = '1.2.2.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -67,7 +67,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
 
-    requires('opensearch-oss', "1.2.1", EQUAL)
+    requires('opensearch-oss', "1.2.2", EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for OpenSearch 1.0.0
 #
 # 'version': plugin's version
-version=1.2.1.0-SNAPSHOT
+version=1.2.2.0-SNAPSHOT
 #
 # 'name': the plugin name
 name=opensearch-security
@@ -24,4 +24,4 @@ java.version=1.8
 # OpenSearch release. This version is checked when the plugin
 # is loaded so OpenSearch will refuse to start in the presence of
 # plugins with the incorrect opensearch.version.
-opensearch.version=1.2.1
+opensearch.version=1.2.2

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.opensearch</groupId>
     <artifactId>opensearch-security</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.1.0-SNAPSHOT</version>
+    <version>1.2.2.0-SNAPSHOT</version>
     <name>OpenSearch Security</name>
     <description>OpenSearch Security</description>
     <url>https://github.com/opensearch-project/security</url>
@@ -68,12 +68,12 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <opensearch.version>1.2.1-SNAPSHOT</opensearch.version>
+        <opensearch.version>1.2.2-SNAPSHOT</opensearch.version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>
         <bc.version>1.67</bc.version>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
         <guava.version>25.1-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
         <jackson-databind.version>2.11.2</jackson-databind.version>
@@ -103,7 +103,7 @@
         <url>https://github.com/opensearch-project/security</url>
         <connection>scm:git:git@github.com:opensearch-project/security.git</connection>
         <developerConnection>scm:git:git@github.com:opensearch-project/security.git</developerConnection>
-        <tag>1.2.1.0</tag>
+        <tag>1.2.2.0</tag>
     </scm>
 
     <repositories>

--- a/release-notes/opensearch-security.release-notes-1.2.2.0.md
+++ b/release-notes/opensearch-security.release-notes-1.2.2.0.md
@@ -1,0 +1,7 @@
+## 2021-12-14 Version 1.2.2.0
+
+Compatible with OpenSearch 1.2.2
+
+### Maintenance
+
+* Bumping log4j to 2.16.0 ([#1525](https://github.com/opensearch-project/security/pull/1525))


### PR DESCRIPTION
I copied the changes that were done [here](https://github.com/opensearch-project/security/commit/fac75a8592c4f4a50284ef8ae392278ff03ee924) but incremented the plugin version to 1.2.2 and updated log4j to 2.16.0.

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).