### PR TITLE
Version bump to 1.3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ plugins {
 buildDir = 'gradle-build'
 
 ext {
-    securityPluginVersion = '1.2.2.0'
+    securityPluginVersion = '1.3.0.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -67,7 +67,7 @@ ospackage {
     user 'root'
     permissionGroup 'root'
 
-    requires('opensearch-oss', "1.2.2", EQUAL)
+    requires('opensearch-oss', "1.3.0", EQUAL)
     packager = 'Amazon'
     vendor = 'Amazon'
     os = 'LINUX'

--- a/plugin-descriptor.properties
+++ b/plugin-descriptor.properties
@@ -3,7 +3,7 @@
 description=Provide access control related features for OpenSearch 1.0.0
 #
 # 'version': plugin's version
-version=1.2.2.0-SNAPSHOT
+version=1.3.0.0-SNAPSHOT
 #
 # 'name': the plugin name
 name=opensearch-security
@@ -24,4 +24,4 @@ java.version=1.8
 # OpenSearch release. This version is checked when the plugin
 # is loaded so OpenSearch will refuse to start in the presence of
 # plugins with the incorrect opensearch.version.
-opensearch.version=1.2.2
+opensearch.version=1.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <groupId>org.opensearch</groupId>
     <artifactId>opensearch-security</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.2.0-SNAPSHOT</version>
+    <version>1.3.0.0-SNAPSHOT</version>
     <name>OpenSearch Security</name>
     <description>OpenSearch Security</description>
     <url>https://github.com/opensearch-project/security</url>
@@ -68,7 +68,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <opensearch.version>1.2.2-SNAPSHOT</opensearch.version>
+        <opensearch.version>1.3.0-SNAPSHOT</opensearch.version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>
@@ -103,7 +103,7 @@
         <url>https://github.com/opensearch-project/security</url>
         <connection>scm:git:git@github.com:opensearch-project/security.git</connection>
         <developerConnection>scm:git:git@github.com:opensearch-project/security.git</developerConnection>
-        <tag>1.2.2.0</tag>
+        <tag>1.3.0.0</tag>
     </scm>
 
     <repositories>


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>


##  opensearch-security pull request intake form
Version bump to 1.3.0.0

 
 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance
