### PR TITLE
Bump log4j-core to 2.17.0 and added 1.2.3.0 release notes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>
         <bc.version>1.67</bc.version>
-        <log4j.version>2.16.0</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
         <guava.version>25.1-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
         <jackson-databind.version>2.11.2</jackson-databind.version>

--- a/release-notes/opensearch-security.release-notes-1.2.3.0.md
+++ b/release-notes/opensearch-security.release-notes-1.2.3.0.md
@@ -1,0 +1,7 @@
+## 2021-12-20 Version 1.2.3.0
+
+Compatible with OpenSearch 1.2.3
+
+### Maintenance
+
+* Bump log4j-core from 2.16.0 to 2.17.0 ([#1535](https://github.com/opensearch-project/security/pull/1535))


### PR DESCRIPTION
Added release notes for 1.2.3 (cherry-picked from d8c3dcf)
Bump log4j-core from 2.16.0 to 2.17.0 (cherry-picked from 118e951)

Signed-off-by: Dave Lago <davelago@amazon.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>

 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
 Maintenance