### PR TITLE
Made PR template easier to fill in

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,17 @@
 ### Description
 [Describe what this change achieves]
-* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
-* Why these changes are required?
-* What is the old behavior before changes and new behavior after changes?
+
+### Category
+[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]
+
+### Why these changes are required?
+
+
+### What is the old behavior before changes and new behavior after changes?
+
 
 ### Issues Resolved
-[List any issues this PR will resolve]
-
-Is this a backport? If so, please add backport PR # and/or commits #
+[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]
 
 ### Testing
 [Please provide details of testing done: unit testing, integration testing and manual testing]


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Updated PR template so that it is easier to fill in. Mostly just formatting changes.

### Category
Maintenance

### Why these changes are required?
Save a few clicks/keystrokes when filling in PRs.

### What is the old behavior before changes and new behavior after changes?
No behavior changes introduced.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).