### PR TITLE
Modifying UTs and CI to add support for Java 8, 11 and 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,17 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        jdk: [8, 11, 14]
 
     steps:
 
-    - name: Set up JDK 14
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 14.0.x
+        java-version: ${{ matrix.jdk }}
 
     - name: Checkout security
       uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
         <dependency.locations.enabled>false</dependency.locations.enabled>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.release>8</maven.compiler.release>
 
         <opensearch.version>1.3.0-SNAPSHOT</opensearch.version>
 
@@ -555,8 +554,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.11,)</version>
-                                    <message>Java 11 or later required to build the plugin</message>
+                                    <version>[1.8,)</version>
+                                    <message>Java 8 or later required to build the plugin</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -283,7 +283,7 @@ public class LdapBackendTest {
                 .put(ConfigConstants.LDAPS_ENABLE_SSL, true)
                 .put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH, FileHelper.getAbsoluteFilePathFromClassPath("ldap/truststore.jks"))
                 .put("verify_hostnames", false)
-                .putList("enabled_ssl_protocols", "TLSv1")
+                .putList("enabled_ssl_protocols", "TLSv1.2")
                 .putList("enabled_ssl_ciphers", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA")
                 .put("path.home",".")
                 .build();

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -257,7 +257,7 @@ public class LdapBackendTestNewStyleConfig {
                 .put("users.u1.search", "(uid={0})").put(ConfigConstants.LDAPS_ENABLE_SSL, true)
                 .put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
                         FileHelper.getAbsoluteFilePathFromClassPath("ldap/truststore.jks"))
-                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1")
+                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1.2")
                 .putList("enabled_ssl_ciphers", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA").put("path.home", ".").build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend(settings, null)

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -291,7 +291,7 @@ public class LdapBackendTestNewStyleConfig2 {
                 .put("users.u1.search", "(uid={0})").put(ConfigConstants.LDAPS_ENABLE_SSL, true)
                 .put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
                         FileHelper.getAbsoluteFilePathFromClassPath("ldap/truststore.jks"))
-                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1")
+                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1.2")
                 .putList("enabled_ssl_ciphers", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA").put("path.home", ".").build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend2(settings, null)

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
@@ -339,7 +339,7 @@ public class LdapBackendTestOldStyleConfig2 {
                 .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})").put(ConfigConstants.LDAPS_ENABLE_SSL, true)
                 .put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
                         FileHelper.getAbsoluteFilePathFromClassPath("ldap/truststore.jks"))
-                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1")
+                .put("verify_hostnames", false).putList("enabled_ssl_protocols", "TLSv1.2")
                 .putList("enabled_ssl_ciphers", "TLS_DHE_RSA_WITH_AES_128_CBC_SHA").put("path.home", ".").build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend2(settings, null)

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -246,9 +246,9 @@ public class OpenSSLTest extends SSLTest {
     }
 
     @Test
-    public void testTLSv1() throws Exception {
+    public void testTLSv12() throws Exception {
         Assume.assumeTrue(OpenSearchSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable());
-        super.testTLSv1();
+        super.testTLSv12();
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -854,7 +854,7 @@ public class SSLTest extends SingleClusterTest {
     }
     
     @Test
-    public void testTLSv1() throws Exception {
+    public void testTLSv12() throws Exception {
 
         final Settings settings = Settings.builder().put("plugins.security.ssl.transport.enabled", true)
                 .put(ConfigConstants.SECURITY_SSL_ONLY, true)
@@ -867,7 +867,7 @@ public class SSLTest extends SingleClusterTest {
                 .put("plugins.security.ssl.http.truststore_filepath", FileHelper. getAbsoluteFilePathFromClassPath("ssl/truststore.jks"))
                 .put("plugins.security.ssl.transport.enforce_hostname_verification", false)
                 .put("plugins.security.ssl.transport.resolve_hostname", false)
-                .put(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, "TLSv1")
+                .put(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, "TLSv1.2")
                 .put(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED, true)
                 .build();
 


### PR DESCRIPTION
Signed-off-by: Nidhi Sridhar <srnidhi@amazon.com>

### Description
Adds 8, 11 and 14 to the CI matrix
Modifies UTs to drop TLSv1 and add TLSv1.2 instead
* Category: Maintenance
* Why these changes are required? Because opensearch claims compatibility for 8, 11 and 14
* What is the old behavior before changes and new behavior after changes? N/A

### Issues Resolved
#1502 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manually tested all the changes on my fork.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).