### PR TITLE
Set the mapped security roles of the user so these can be used by the…

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -236,6 +236,8 @@ public class PrivilegesEvaluator {
         final SecurityRoles securityRoles = getSecurityRoles(mappedRoles);
 
         setUserInfoInThreadContext(user, mappedRoles);
+        // Add the security roles for this user so that they can be used for DLS parameter substitution.
+        user.addSecurityRoles(mappedRoles);
 
         final boolean isDebugEnabled = log.isDebugEnabled();
         if (isDebugEnabled) {

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -907,6 +907,7 @@ public class ConfigModelV7 extends ConfigModel {
 
         orig = orig.replace("${user.name}", user.getName()).replace("${user_name}", user.getName());
         orig = replaceRoles(orig, user);
+        orig = replaceSecurityRoles(orig, user);
         for (Entry<String, String> entry : user.getCustomAttributesMap().entrySet()) {
             if (entry == null || entry.getKey() == null || entry.getValue() == null) {
                 continue;
@@ -922,6 +923,15 @@ public class ConfigModelV7 extends ConfigModel {
         if (orig.contains("${user.roles}") || orig.contains("${user_roles}")) {
             final String commaSeparatedRoles = toQuotedCommaSeparatedString(user.getRoles());
             retVal = orig.replace("${user.roles}", commaSeparatedRoles).replace("${user_roles}", commaSeparatedRoles);
+        }
+        return retVal;
+    }
+
+    private static String replaceSecurityRoles(final String orig, final User user) {
+        String retVal = orig;
+        if (orig.contains("${user.securityRoles}") || orig.contains("${user_securityRoles}")) {
+            final String commaSeparatedRoles = toQuotedCommaSeparatedString(user.getSecurityRoles());
+            retVal = orig.replace("${user.securityRoles}", commaSeparatedRoles).replace("${user_securityRoles}", commaSeparatedRoles);
         }
         return retVal;
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
@@ -40,7 +40,10 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest{
                 .source("{\"role\": \"prole2\", \"amount\": 4040}", XContentType.JSON)).actionGet();
         tc.index(new IndexRequest("prop2").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
                 .source("{\"role\": \"prole3\", \"amount\": 5050}", XContentType.JSON)).actionGet();
-
+        tc.index(new IndexRequest("prop-mapped").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{\"securityRole\": \"opendistro_security_mapped\", \"amount\": 6060}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest("prop-mapped").type("_doc").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{\"securityRole\": \"not_assigned\", \"amount\": 7070}", XContentType.JSON)).actionGet();
     }
 
 
@@ -58,5 +61,10 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest{
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password"))).getStatusCode());
         System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
+
+        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/prop-mapped/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password"))).getStatusCode());
+        System.out.println(res.getBody());
+        Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
+        Assert.assertTrue(res.getBody().contains("\"amount\" : 6060"));
     }
 }

--- a/src/test/resources/dlsfls/internal_users.yml
+++ b/src/test/resources/dlsfls/internal_users.yml
@@ -156,6 +156,7 @@ prop_replace:
   backend_roles:
   - "prole1"
   - "prole2"
+  - "prolemapped"
   attributes: {}
   description: "Migrated from v6"
 user_masked_custom:

--- a/src/test/resources/dlsfls/roles.yml
+++ b/src/test/resources/dlsfls/roles.yml
@@ -1385,6 +1385,13 @@ opendistro_security_prop_replace:
     masked_fields: null
     allowed_actions:
     - "OPENDISTRO_SECURITY_READ"
+  - index_patterns:
+    - "prop-mapped"
+    dls: "{\"terms\" : { \"securityRole\" : [${user.securityRoles}]}}"
+    fls: null
+    masked_fields: null
+    allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
   tenant_permissions: []
 opendistro_security_logstash:
   reserved: false

--- a/src/test/resources/dlsfls/roles_mapping.yml
+++ b/src/test/resources/dlsfls/roles_mapping.yml
@@ -234,3 +234,12 @@ opendistro_security_date_math:
 opendistro_security_fls_exists:
   users:
     - fls_exists
+opendistro_security_mapped:
+  reserved: false
+  hidden: false
+  backend_roles:
+    - prolemapped
+  hosts: []
+  users: []
+  and_backend_roles: []
+  description: "Security role mapping to backend role prolemapped"


### PR DESCRIPTION
… DLS privileges evaluator. Allow security roles to be used for DLS parameter substitution. Fixes opensearch-project/security/#1568

Signed-off-by: Caitlin Harper <caitlin.harper@defence.gov.au>

### Description
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug Fix /Enhancement

* Why these changes are required?
The changes are required so that we can map the backend roles to more appropriately named roles via the roles.mapping and these security roles can be used in the DLS privileges evaluation. 

* What is the old behavior before changes and new behavior after changes?
Old behaviour:
security roles were not added to the user object prior to the DLS privileges evaluation

New behaviour:
mapped roles are added to the user object for DLS  privileges evaluation
a new option for parameter substitution in the DLS query has been added. This is ${user.securityRoles} and is the mapped roles.

Note: there is no change to the existing ${user.roles} substitution. It remains the same.

### Issues Resolved
* Resolves #1568 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual test steps:
Testing was completed for both basic auth and OIDC/jwt auth. Note that both users had read access to the index.
1. Push 2 documents into the index, one with DLS required role = ROLE1 and the other with ROLE2.
example: 
```
curl https://localhost:9200/myindex/_doc?pretty -u admin:$PASS -XPOST -H "Content-Type: application/json" -d @doc1.json
```
doc1.json
```json
{
	"security": {
                        "exclusive": [
                            "ROLE1",
                        ],
                        "num_exclusive": 1
          },
	  "info":{
		"generalinfo": "this document should only be available to those with ROLE1"
	  }
}
```
2. Add the roles ROLE1, ROLE2 and the read to the roles.yml
example:
```yaml
ROLE1:
  reserved: false
  hidden: false
  cluster_permissions: []
  index_permissions: []
  tenant_permissions: []
  static: false

ROLE2:
  reserved: false
  hidden: false
  cluster_permissions: []
  index_permissions: []
  tenant_permissions: []
  static: false

myindex_read:
  reserved: false
  hidden: false
  cluster_permissions:
  - "indices:data/read/scroll/clear"
  - "indices:data/read/msearch"
  - "indices:data/write/bulk"
  - "indices:data/read/scroll"
  - "indices:data/read/mget"
  index_permissions:
  - index_patterns:
    - "myindex"
    dls: "{ \"bool\": { \"filter\": [\n   {\"terms_set\": {\"security.exclusive.keyword\": {\n\
      \ \"terms\": [${user.securityRoles}],\n \"minimum_should_match_field\": \"security.num_exclusive\"\
      \n }}}\n ]}}\n"
    fls: []
    masked_fields: []
    allowed_actions:
    - "read"
```
3. Add the role mappings to the backend roles in roles_mapping.yml
```yaml
ROLE1:
  hosts: []
  users: []
  reserved: false
  hidden: false
  backend_roles:
  - "client-id/role-1"
  and_backend_roles: []

ROLE2:
  hosts: []
  users: []
  reserved: false
  hidden: false
  backend_roles:
  - "client-id/role-2"
  and_backend_roles: []
```
4. Also add the following user for the internal/basic auth testing
```yaml
user1:
  hash: "<password-hash>"
  reserved: false
  backend_roles:
    - "client-id/role-1"
    - "myindex_read"
  description: "user1"
```
5. Note that we also have the test server set up to use keycloak and user2 has the following backend roles: "myindex_read", "client-id/role-1", "client-id/role-2".
6. Run the security config reload script
```
./plugins/opensearch-security/tools/securityadmin.sh" -cd "./plugins/opensearch-security/securityconfig" -icl -key "./config/kirk-key.pem" -cert "./config/kirk.pem" -cacert "./config/root-ca.pem" -nhnv
```
7. Test basic auth for user 1
```
curl https://localhost:9200/myindex/_search?pretty --insecure -u user1:user1
```
Expected result: This should return 1 document, doc1
8. Test jwt for user2
```
curl -H "Authorization: Bearer $TOKEN" https://localhost:9200/myindex/_search?pretty --insecure
```
Expected result: This should return 2 documents.
9. Also tested with another user that has neither ROLE1 or ROLE2 and confirm they have access to zero documents.

### Documentation
This will require an update to the DLS parameter substitution documentation to include the new ${user.securityRoles}.
The update to the documentation has been submitted here: https://github.com/opensearch-project/documentation-website/pull/420

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).