### PR TITLE
Bumping jjwt version to fix dependency vulnerability created by jjwt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <guava.version>25.1-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
         <jackson-databind.version>2.12.6</jackson-databind.version>
-        <jjwt.version>0.10.5</jjwt.version>
+        <jjwt.version>0.10.8</jjwt.version>
         <ldaptive.version>1.2.3</ldaptive.version>
         <http.commons.version>4.5.13</http.commons.version>
         <cxf.version>3.4.5</cxf.version>


### PR DESCRIPTION
Signed-off-by: Darshit Chanpura <dchanp@amazon.com>

### Description
[Describe what this change achieves]
* Maintenance
* To fix the security vulnerability introduced by jjwt version 0.10.5 as desribed in this [issue](https://github.com/opensearch-project/security/issues/1587)

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).