### PR TITLE
Updates guava dependency to latest stable version suggested by whitesource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <bc.version>1.67</bc.version>
         <log4j.version>2.17.1</log4j.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <guava.version>25.1-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
         <jackson-databind.version>2.12.6</jackson-databind.version>
         <jjwt.version>0.10.8</jjwt.version>


### PR DESCRIPTION
Signed-off-by: Darshit Chanpura <dchanp@amazon.com>

### Description
Updates outdated guava dependency. This issue was opened by whitesource as part of version compatibility/vulnerability check. But the version suggested by whitesource was an android toolkit, and hence this PR was opened to update to it to Java toolkit `30.1.1-jre`.
* Enhancement
* White-source suggested

### Issues Resolved
https://github.com/opensearch-project/security/issues/1565

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual testing

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).