### PR TITLE
Updates the test retry-count to give flaky tests more chances to pass

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -632,8 +632,8 @@
 
                 <configuration>
                     <argLine>-Xmx3072m</argLine>
-                    <rerunFailingTestsCount>3</rerunFailingTestsCount>
-                    <forkCount>3</forkCount>
+                    <rerunFailingTestsCount>5</rerunFailingTestsCount>
+                    <forkCount>5</forkCount>
                     <reuseForks>true</reuseForks>
                     <!--
                     <parallel>methods</parallel>


### PR DESCRIPTION
### Description
This PR changes the number of retries maven should do if a test fails. It is done so in order to give flaky tests more runs to pass, and hence to improves chances of CI pipeline to not fail because of these flaky tests.
* Refactoring
* Allows flaky tests to have better chance of passing
* The retry-count changes from `3` to `5`


### Check List
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).