### PR TITLE
Exclude velocity 1.7 from OpenSAML dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,17 @@
                     <groupId>commons-collections</groupId>
                     <artifactId>commons-collections</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.velocity</groupId>
+                    <artifactId>velocity</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Bringing back commons-lang as it is expected by opensaml-saml-impl but it was being brought by now excluded velocity -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Excluding velocity from dependencies as it is not used and it has security vulnerabilities (see #1605)
* Category: Maintenance
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
Fixes #1605 

### Testing
Build locally. Will make sure all ITs pass.

### Check List
- N/A New functionality includes testing
- N/A New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).