### PR TITLE
Reduce heap size usage during unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -631,7 +631,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
 
                 <configuration>
-                    <argLine>-Xmx3072m</argLine>
+                    <argLine>-Xmx768m</argLine>
                     <rerunFailingTestsCount>5</rerunFailingTestsCount>
                     <forkCount>3</forkCount>
                     <reuseForks>true</reuseForks>
@@ -641,6 +641,7 @@
                      -->
                     <systemPropertyVariables>
                         <forkno>fork_${surefire.forkNumber}</forkno>
+                        <opensearch.use_unpooled_allocator>true</opensearch.use_unpooled_allocator>
                     </systemPropertyVariables>
 
                     <includes>


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

Coming from #1368, fixing merge conflicts here to save @vrozov the trouble.

#### Category:
Maintenance

#### Description of changes:
Change fork heap size and use unpooled netty byte buffer allocator

#### Why these changes are required?
Lower heap usage during CI to free up more memory for direct buffers

### Check List
- N/A New functionality includes testing
- N/A New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).