### PR TITLE
Add 'opens' for java.io libraries to unblock build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,9 @@ testsJar {
 test {
     maxParallelForks = 3
     jvmArgs += "-Xmx3072m"
-    jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    }
     retry {
         failOnPassedAfterRetry = false
         maxFailures = 30

--- a/build.gradle
+++ b/build.gradle
@@ -218,7 +218,8 @@ testsJar {
 
 test {
     maxParallelForks = 3
-    jvmArgs "-Xmx3072m"
+    jvmArgs += "-Xmx3072m"
+    jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
     retry {
         failOnPassedAfterRetry = false
         maxFailures = 30


### PR DESCRIPTION
### Description
Add 'opens' for java.io libraries to unblock build

----

Background on JDK visibility changes over time, and why this is needed

> If you cannot obtain or deploy newer versions of tools and libraries, then there are two command-line options that enable you to grant access to specific internal APIs for older versions of tools and libraries:
> 
> [--add-exports](https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-2F61F3A9-0979-46A4-8B49-325BA0EE8B66): If you have an older tool or library that needs to use an internal API that has been strongly encapsulated, then use the --add-exports runtime option. You can also use --add-exports at compile time to access the internal APIs.
> [--add-opens](https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-12F945EB-71D6-46AF-8C3D-D354FD0B1781): If you have an older tool or library that needs to access non-public fields and methods of java.* APIs by reflection, then use the --add-opens option.

From https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).