### PR TITLE
Fix the settings of roles_seperator

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -95,7 +95,8 @@ class AuthTokenProcessorHandler {
 
         this.samlRolesKey = settings.get("roles_key");
         this.samlSubjectKey = settings.get("subject_key");
-        String samlRolesSeparator = settings.get("roles_seperator");
+        // Originally release with a typo, prioritize correct spelling over typo'ed version
+        String samlRolesSeparator = settings.get("roles_separator", settings.get("roles_seperator"));
         this.kibanaRootUrl = settings.get("kibana_url");
         if (samlRolesSeparator != null) {
             this.samlRolesSeparatorPattern = Pattern.compile(samlRolesSeparator);

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -567,20 +567,30 @@ public class HTTPSamlAuthenticatorTest {
         Assert.assertEquals("horst", jwt.getClaim("sub"));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void commaSeparatedRolesTest() throws Exception {
+        final Settings.Builder settingsBuilder = Settings.builder().put("roles_seperator", ";").put("roles_separator", ",");
+        commaSeparatedRoles("a,b", settingsBuilder);
+    }
+
+    @Test
+    public void legacyCommaSeparatedRolesTest() throws Exception {
+        final Settings.Builder settingsBuilder = Settings.builder().put("roles_seperator", ";");
+        commaSeparatedRoles("a;b", settingsBuilder);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void commaSeparatedRoles(final String rolesAsString, final Settings.Builder settingsBuilder) throws Exception {
         mockSamlIdpServer.setAuthenticateUser("horst");
         mockSamlIdpServer.setSignResponses(true);
         mockSamlIdpServer.loadSigningKeys("saml/kirk-keystore.jks", "kirk");
-        mockSamlIdpServer.setAuthenticateUserRoles(Arrays.asList("a,b"));
+        mockSamlIdpServer.setAuthenticateUserRoles(Arrays.asList(rolesAsString));
         mockSamlIdpServer.setEndpointQueryString(null);
 
-        Settings settings = Settings.builder().put(IDP_METADATA_URL, mockSamlIdpServer.getMetadataUri())
+        Settings settings = settingsBuilder.put(IDP_METADATA_URL, mockSamlIdpServer.getMetadataUri())
                 .put("kibana_url", "http://wherever").put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
-                .put("exchange_key", "abc").put("roles_key", "roles").put("roles_seperator", ",").put("path.home", ".")
+                .put("exchange_key", "abc").put("roles_key", "roles").put("path.home", ".")
                 .build();
-
         HTTPSamlAuthenticator samlAuthenticator = new HTTPSamlAuthenticator(settings, null);
 
         AuthenticateHeaders authenticateHeaders = getAutenticateHeaders(samlAuthenticator);

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -580,7 +580,7 @@ public class HTTPSamlAuthenticatorTest {
     }
 
     @SuppressWarnings("unchecked")
-    public void commaSeparatedRoles(final String rolesAsString, final Settings.Builder settingsBuilder) throws Exception {
+    private void commaSeparatedRoles(final String rolesAsString, final Settings.Builder settingsBuilder) throws Exception {
         mockSamlIdpServer.setAuthenticateUser("horst");
         mockSamlIdpServer.setSignResponses(true);
         mockSamlIdpServer.loadSigningKeys("saml/kirk-keystore.jks", "kirk");


### PR DESCRIPTION
### Description
1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
Bug fix

2. __Why these changes are required?__ 
This is how to set a different separator for the roles attribute that comes on the SAML assertion.

3. __What is the old behavior before changes and new behavior after changes?__
Now if the setting is spelled correctly according to the documentation it will be picked up, if there is a conflicting typo'ed spelling it will be only used if the correctly spelled setting is not present.

Built off of the changes by @cliu123 in #1024 

### Issues Resolved
- Resolves #969 

### Testing
Added unit tests to cover correct setting, and legacy setting

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~ Was already documented without the typo
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).