### PR TITLE
Use standard opensearch.version property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch_version", "1.3.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
 }
 
 configurations.all {


### PR DESCRIPTION
### Description
After migrating from maven to gradle, the build script for security in OpenSearch-build was broken.  We could not use the default script and had to make modifications, see https://github.com/opensearch-project/opensearch-build/pull/1631

### Testing
Built locally with opensearch-build 1.3.0 manifest, see https://github.com/opensearch-project/opensearch-build#building-from-source

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).