### PR TITLE
Remove standalone admin tools zip file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,39 +273,6 @@ task bundle(dependsOn: jar, type: Zip) {
     }
 }
 
-task bundleSecurityAdminStandalone(dependsOn: jar, type: Zip) {
-    archiveClassifier = 'securityadmin-standalone'
-    from(configurations.runtimeClasspath) {
-        into 'deps/'
-    }
-    from(project.jar) {
-        into 'deps/'
-    }
-    from('tools') {
-        into 'tools/'
-    }
-    from('securityconfig') {
-        into 'deps/securityconfig'
-    }
-}
-task bundleSecurityAdminStandaloneTarGz(dependsOn: jar, type: Tar) {
-    archiveClassifier = 'securityadmin-standalone'
-    archiveExtension = 'tar.gz'
-    compression = Compression.GZIP
-    from(configurations.runtimeClasspath) {
-        into 'deps/'
-    }
-    from(project.jar) {
-        into 'deps/'
-    }
-    from('tools') {
-        into 'tools/'
-    }
-    from('securityconfig') {
-        into 'deps/securityconfig'
-    }
-}
-
 task createPluginDescriptor() {
     List<String> descriptorProperties = [
         "description=Provide access control related features for OpenSearch",
@@ -324,8 +291,6 @@ bundle.doLast() {
 
 tasks.assemble.dependsOn(bundle)
 tasks.bundle.dependsOn(createPluginDescriptor)
-tasks.assemble.dependsOn(bundleSecurityAdminStandalone)
-tasks.assemble.dependsOn(bundleSecurityAdminStandaloneTarGz)
 
 clean {
     delete 'data/'

--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,39 @@ task bundle(dependsOn: jar, type: Zip) {
     }
 }
 
+task bundleSecurityAdminStandalone(dependsOn: jar, type: Zip) {
+    archiveClassifier = 'securityadmin-standalone'
+    from(configurations.runtimeClasspath) {
+        into 'deps/'
+    }
+    from(project.jar) {
+        into 'deps/'
+    }
+    from('tools') {
+        into 'tools/'
+    }
+    from('securityconfig') {
+        into 'deps/securityconfig'
+    }
+}
+task bundleSecurityAdminStandaloneTarGz(dependsOn: jar, type: Tar) {
+    archiveClassifier = 'securityadmin-standalone'
+    archiveExtension = 'tar.gz'
+    compression = Compression.GZIP
+    from(configurations.runtimeClasspath) {
+        into 'deps/'
+    }
+    from(project.jar) {
+        into 'deps/'
+    }
+    from('tools') {
+        into 'tools/'
+    }
+    from('securityconfig') {
+        into 'deps/securityconfig'
+    }
+}
+
 task createPluginDescriptor() {
     List<String> descriptorProperties = [
         "description=Provide access control related features for OpenSearch",


### PR DESCRIPTION
### Description
There is a copy of the admin tools that are produced on build but are
not consumed or distributed as part of this project.  Until we have
documentation and/or tooling that uses this we should remove it from the
project.

By removing this file the security plugin to remove its custom build logic from OpenSearch-build, [see]( https://github.com/opensearch-project/opensearch-build/issues/1631#issuecomment-1042471356).

### Testing
Searched through opensearch.org, this repository, and the security-dashboards-plugin repo for references to these stand alone tools.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).