### PR TITLE
Remove '-SNAPSHOT' from opensearch.version in plugin descriptor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,9 @@ task bundleSecurityAdminStandaloneTarGz(dependsOn: jar, type: Tar) {
 }
 
 task createPluginDescriptor() {
+    if (opensearch_version.contains("-SNAPSHOT")) {
+        opensearch_version=opensearch_version.substring(0, opensearch_version.length() - 9)
+    }
     List<String> descriptorProperties = [
         "description=Provide access control related features for OpenSearch",
         "version=${version}",


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required? 
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[#1633]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

- Built security plugin 1.3.0.0
- Installed security plugin 1.3.0.0 on OpenSearch 1.3.0

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).