### PR TITLE
Remove artifact step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,3 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/jacoco/test/jacocoTestReport.xml
-
-    - name: Upload Artifacts
-      uses: actions/upload-artifact@v1
-      with:
-        name: artifacts
-        path: build/distributions/


### PR DESCRIPTION
### Description
Removed artifacts step as they were never used and the martix of jdk
release would override them (saves couple minutes from check runtime)

### Issues Resolved
- Originally included in https://github.com/opensearch-project/security/pull/1632

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).