### PR TITLE
Switch gradle to info logging for improved test debugging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       uses: github/codeql-action/analyze@v1
 
     - name: Test
-      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test
+      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test -i
 
     - name: Coverage
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
### Description
Switch gradle to info logging for improved test debugging

### Issues Resolved
- Originally included in https://github.com/opensearch-project/security/pull/1632

### Testing
- [X] After the CI checks have passed on this pull request, the logs should increase in size and include the test details.  Verified in CI run, [5336510839](https://github.com/opensearch-project/security/runs/5336510839?check_suite_focus=true).

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).