### PR TITLE
Remove netty-tcnative dependency to unblock security plugin build on ARM64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,8 +121,6 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka_2.13:2.8.1'
     testImplementation 'org.apache.kafka:kafka_2.13:2.8.1:test'
     testImplementation 'org.apache.kafka:kafka-clients:2.8.1:test'
-    compileOnly "io.netty:netty-tcnative:2.0.25.Final:${osdetector.classifier}"
-    testImplementation "io.netty:netty-tcnative:2.0.25.Final:${osdetector.classifier}"
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 }
 


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required? `netty-tcnative-2.0.25.Final` does not support ARM64.
* What is the old behavior before changes and new behavior after changes? No behavior changes

### Issues Resolved
#1647

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Compile and UTs

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).