### PR TITLE
Make Git ignore plugin-descriptor.properties file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ deploy_all.sh
 *.log
 .externalToolBuilders
 maven-eclipse.xml
+plugin-descriptor.properties
 
 ## eclipse ignores (use 'mvn eclipse:eclipse' to build eclipse projects)
 ## The only configuration files which are not ignored are certain files in


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required? `plugin-descriptor.properties` is not needed in version contol.
* What is the old behavior before changes and new behavior after changes? No behavior changes

### Issues Resolved
#1650

Is this a backport? If so, please add backport PR # and/or commits #
Not a backport

### Testing

- Tested on local: `plugin-descriptor.properties` is not captured by Git.
- UTs

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).