### PR TITLE
Disable checkstyle until rules are enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
 
-
-    - name: Checkstyle
-      run: ./gradlew clean checkstyleMain checkstyleTest
-
     - name: Package
       run: ./gradlew clean build -Dbuild.snapshot=false -x test
 


### PR DESCRIPTION
### Description
With the current checkstyle settings the build is done, but it doesn't
prevent changes from being merged that contain checkstyle violations.
We need to revisit these as a whole, **saving 3 minutes of build time** per
leg until this work has been done.

### Issues Resolved
See https://github.com/opensearch-project/security/issues/1659

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).