### PR TITLE
Remove java17 from 1.3 build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        jdk: [8, 11, 14, 17]
+        jdk: [8, 11, 14]
 
     steps:
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -30,7 +30,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
 import org.opensearch.common.settings.Settings;
 
 import org.apache.http.HttpHeaders;
@@ -42,24 +41,12 @@ import org.mockito.internal.util.reflection.FieldSetter;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 import com.google.common.io.BaseEncoding;
-
-import static org.junit.Assume.assumeFalse;
-
 public class HTTPJwtAuthenticatorTest {
 
     final static byte[] secretKey = new byte[1024];
 
     static {
         new SecureRandom().nextBytes(secretKey);
-    }
-
-    /*
-    This test fails during Java 17 build due to a known bug: https://bugs.openjdk.java.net/browse/JDK-8251547
-    TODO: This method should be removed once a fix is implemented
-    */
-    @Before
-    public void isJavaVersionBelow17(){
-        assumeFalse(System.getProperty("java.version").startsWith("17"));
     }
 
     @Test


### PR DESCRIPTION
### Description
Removes Java-17 support from CI matrix as the expected behavior is that 1.3 will fail for Java-17. Refer this discussion more details: https://github.com/opensearch-project/job-scheduler/pull/130


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).