### PR TITLE
Fixed rest status for the replication action failure with DLS/FLS

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -49,6 +49,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.search.DocValueFormat;
 import org.opensearch.search.aggregations.AggregationBuilder;
 import org.opensearch.search.aggregations.BucketOrder;
@@ -255,7 +256,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         }
 
         if(action.contains("plugins/replication")) {
-            listener.onFailure(new OpenSearchSecurityException("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated"));
+            listener.onFailure(new OpenSearchSecurityException("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated",
+                    RestStatus.FORBIDDEN));
             return false;
         }
         

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
@@ -59,6 +59,7 @@ import org.opensearch.node.PluginAwareNode;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.rest.RestStatus;
 import org.opensearch.script.ScriptService;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.support.ConfigConstants;
@@ -221,6 +222,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             log.warn(ex.getMessage());
             Assert.assertNotNull(ex);
             Assert.assertTrue(ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated"));
+            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
@@ -230,6 +232,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             log.warn(ex.getMessage());
             Assert.assertNotNull(ex);
             Assert.assertTrue(ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated"));
+            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
@@ -239,6 +242,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             log.warn(ex.getMessage());
             Assert.assertNotNull(ex);
             Assert.assertTrue(ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated"));
+            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {


### PR DESCRIPTION
Fixed rest status for the replication action failure with DLS/FLS
and updated test cases to capture status code

Signed-off-by: Sai Kumar <karanas@amazon.com>

### Description
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Bug fix
* Why these changes are required? Latest commit changed the status in https://github.com/opensearch-project/security/pull/1541
* What is the old behavior before changes and new behavior after changes? Error code was `403` instead of `500`

### Issues Resolved
https://github.com/opensearch-project/cross-cluster-replication/issues/340

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
unit testing

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).