### PR TITLE
Move to version 2.0.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ dependencies {
 }
 
 ext {
-    securityPluginVersion = '1.3.0.0'
+    securityPluginVersion = '2.0.0.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 


### PR DESCRIPTION
### Description
Move to version 2.0.0.0

Keeping the default OpenSearch build version to 1.3.0 until we have
resolved the breaking changes from core.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).