### PR TITLE
Bump plugin version to 1.3.1.0 and OpenSearch dependency version to 1.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ repositories {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch.version", "1.3.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "1.3.1-SNAPSHOT")
 }
 
 configurations.all {
@@ -125,7 +125,7 @@ dependencies {
 }
 
 ext {
-    securityPluginVersion = '1.3.0.0'
+    securityPluginVersion = '1.3.1.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance

### Testing

- UTs
- Manual Testing:

1. Install security plugin 1.4.0.0 on OpenSearch 1.4.0-SNAPSHOT
2. Start OpenSearch cluster
3. Cat indices:
```
HTTP/1.1 200 OK
Warning: 299 OpenSearch-1.3.1-SNAPSHOT-01c99f761603dc8a63795c17d132a9cdbaedb5a8 "this request accesses system indices: [.opendistro_security], but in a future major version, direct access to system indices will be prevented by default"
content-type: text/plain; charset=UTF-8
content-length: 77

green open .opendistro_security QaZBpKzWRI-T73ul2rS8FA 1 0 9 0 60.1kb 60.1kb
```

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).