### PR TITLE
Centralize version settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,3 +68,34 @@ jobs:
         cp -r build/ ./bwc-test/
         cd bwc-test/
         ./gradlew bwcTestSuite -Dtests.security.manager=false
+
+  build-artifact-names:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - id: security-plugin-version
+      uses: madhead/read-java-properties@66cc8c88f5c6f6069ebfb42586024dd6ffe2e451
+      with:
+         file: gradle.properties
+         property: security-plugin.version
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - run: ./gradlew clean assemble
+    - run: test -s ./build/opensearch-security-${{ steps.security-plugin-version.outputs.value }}-SNAPSHOT.jar
+
+    - run: ./gradlew clean assemble -Dbuild.snapshot=false
+    - run: test -s ./build/opensearch-security-${{ steps.security-plugin-version.outputs.value }}.jar
+
+    - run: ./gradlew clean assemble -Dbuild.snapshot=false -Dbuild.version_qualifier=alpha1
+    - run: test -s ./build/opensearch-security-${{ steps.security-plugin-version.outputs.value }}-alpha1.jar
+
+    - run: ./gradlew clean assemble -Dbuild.version_qualifier=alpha1
+    - run: test -s ./build/opensearch-security-${{ steps.security-plugin-version.outputs.value }}-alpha1-SNAPSHOT.jar
+
+    - name: List files in the build directory if there was an error
+      run: ls -al ./build/
+      if: failure()

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -2,9 +2,6 @@ name: Plugin Install
 
 on: [push, pull_request, workflow_dispatch]
 
-env:
-  OPENSEARCH_VERSION: "1.4.0"
-
 jobs:
   plugin_install:
     name: Plugin Install
@@ -15,25 +12,36 @@ jobs:
         jdk: [8, 11, 14]
 
     steps:
+    - uses: actions/checkout@v2
+
+    - id: opensearch-version
+      uses: madhead/read-java-properties@66cc8c88f5c6f6069ebfb42586024dd6ffe2e451
+      with:
+         file: gradle.properties
+         property: opensearch-core.version
+
+    - id: security-plugin-version
+      uses: madhead/read-java-properties@66cc8c88f5c6f6069ebfb42586024dd6ffe2e451
+      with:
+         file: gradle.properties
+         property: security-plugin.version
+
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.jdk }}
-
-    - name: Checkout security
-      uses: actions/checkout@v2
 
     - name: Build
       run: ./gradlew clean assemble -Dbuild.snapshot=false
 
     - name: Download OpenSearch Core
       run: |
-        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{env.OPENSEARCH_VERSION}}/latest/linux/x64/builds/opensearch/dist/opensearch-min-${{env.OPENSEARCH_VERSION}}-linux-x64.tar.gz
+        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-version.outputs.value }}/latest/linux/x64/builds/opensearch/dist/opensearch-min-${{ steps.opensearch-version.outputs.value }}-linux-x64.tar.gz
         tar -xzf opensearch-*.tar.gz
         rm -f opensearch-*.tar.gz
 
     - name: Move and rename security plugin for installation
-      run: mv build/distributions/opensearch-security-*.0.zip opensearch-security.zip
+      run: mv build/distributions/opensearch-security-${{ steps.security-plugin-version.outputs.value }}.zip opensearch-security.zip
 
     - name: Run OpenSearch with plugin
       run: |

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -20,12 +20,6 @@ jobs:
          file: gradle.properties
          property: opensearch-core.version
 
-    - id: security-plugin-version
-      uses: madhead/read-java-properties@66cc8c88f5c6f6069ebfb42586024dd6ffe2e451
-      with:
-         file: gradle.properties
-         property: security-plugin.version
-
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
@@ -41,7 +35,7 @@ jobs:
         rm -f opensearch-*.tar.gz
 
     - name: Move and rename security plugin for installation
-      run: mv build/distributions/opensearch-security-${{ steps.security-plugin-version.outputs.value }}.zip opensearch-security.zip
+      run: mv build/distributions/opensearch-security-*.zip opensearch-security.zip
 
     - name: Run OpenSearch with plugin
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ import org.gradle.crypto.checksum.Checksum
 
 import java.text.SimpleDateFormat
 
-
 repositories {
     mavenLocal()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
@@ -56,7 +55,9 @@ repositories {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch.version", "1.4.0-SNAPSHOT")
+    default_opensearch_version = property("opensearch-core.version") + "-SNAPSHOT"
+    opensearch_version = System.getProperty("opensearch.version", default_opensearch_version)
+    buildVersionQualifier = System.getProperty("build.version_qualifier")
 }
 
 configurations.all {
@@ -125,12 +126,19 @@ dependencies {
 }
 
 ext {
-    securityPluginVersion = '2.0.0.0'
+    securityPluginVersion = property('security-plugin.version')
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
 group = 'org.opensearch'
-version = "${securityPluginVersion}" + (isSnapshot ? "-SNAPSHOT" : "")
+version = opensearch_version.tokenize('-')[0] + '.0'
+if (buildVersionQualifier) {
+    version += "-${buildVersionQualifier}"
+}
+if (isSnapshot) {
+    version += "-SNAPSHOT"
+}
+
 description = 'OpenSearch Security'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ ext {
 }
 
 group = 'org.opensearch'
-version = opensearch_version.tokenize('-')[0] + '.0'
+version = securityPluginVersion
 if (buildVersionQualifier) {
     version += "-${buildVersionQualifier}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+# Sets the version of the Security plugin
+security-plugin.version=2.0.0.0
+# Sets the version of OpenSearch this plugin should be built with
+opensearch-core.version=1.4.0


### PR DESCRIPTION
### Description
A single file is referenced and read for version settings, updated
the build scripts and test script to read from this file.

Added functionality and tests for build.version_qualifier parameter

### Issues Resolved
* Resolves https://github.com/opensearch-project/security/issues/1676

### Testing
Added a new job that verifies the built artifact name correspond to the parameters passed to gradle

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).