### PR TITLE
Remove JDK8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        jdk: [8, 11, 14, 17]
+        jdk: [11, 14, 17]
 
     steps:
 

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        jdk: [8, 11, 14]
+        jdk: [11, 14, 17]
 
     steps:
     - name: Set up JDK

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        jdk: [11, 14, 17]
+        jdk: [11, 14]
 
     steps:
     - name: Set up JDK

--- a/build.gradle
+++ b/build.gradle
@@ -134,8 +134,8 @@ version = "${securityPluginVersion}" + (isSnapshot ? "-SNAPSHOT" : "")
 description = 'OpenSearch Security'
 
 
-java.sourceCompatibility = JavaVersion.VERSION_1_8
-java.targetCompatibility = JavaVersion.VERSION_1_8
+java.sourceCompatibility = JavaVersion.VERSION_11
+java.targetCompatibility = JavaVersion.VERSION_11
 
 tasks.register('testsJar', Jar) {
     archiveClassifier = 'tests'


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Enhancement
* Why these changes are required? OpenSearch 2.0.0 does not support JDK 8

### Issues Resolved
#1669

### Testing
UT

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).