### PR TITLE
Remove explict dependency on jackson-databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'


### PR DESCRIPTION
### Description
Attempted workaround for a jar hell conflict in OpenSearch 2.0.0, confirming that tests can still run and pass as expected

### Issues Resolved
* Resolves https://github.com/opensearch-project/OpenSearch/issues/2590
* Resolves https://github.com/opensearch-project/security/issues/1687

### Testing
By running in the installation workflow, we can see if the security plugin load or create other unexpected issues.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
