### PR TITLE
Fixes broken test due to unsupported EC using JDK-17

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -30,7 +30,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
+
 import org.opensearch.common.settings.Settings;
 
 import org.apache.http.HttpHeaders;
@@ -43,23 +43,12 @@ import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 import com.google.common.io.BaseEncoding;
 
-import static org.junit.Assume.assumeFalse;
-
 public class HTTPJwtAuthenticatorTest {
 
     final static byte[] secretKey = new byte[1024];
 
     static {
         new SecureRandom().nextBytes(secretKey);
-    }
-
-    /*
-    This test fails during Java 17 build due to a known bug: https://bugs.openjdk.java.net/browse/JDK-8251547
-    TODO: This method should be removed once a fix is implemented
-    */
-    @Before
-    public void isJavaVersionBelow17(){
-        assumeFalse(System.getProperty("java.version").startsWith("17"));
     }
 
     @Test
@@ -485,7 +474,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testES512() throws Exception {
 
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC");
-        keyGen.initialize(571);
+        keyGen.initialize(521);
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
         PublicKey pub = pair.getPublic();


### PR DESCRIPTION
### Description
Fixes a broken test for testing EC algo which uses an unsupported curve in JDK 17

### Issues Resolved
* Resolves #1620 

### Testing
Gradle test script

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
