### PR TITLE
Remove support for JDK14

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
 
-    - name: Set up JDK 14
+    - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 14.0.x
+        java-version: 11
 
     - name: Checkout security
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        jdk: [11, 14, 17]
+        jdk: [11, 17]
 
     steps:
 
     - name: Set up JDK for build and test
-      if: matrix.jdk != 17 
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         distribution: temurin # Temurin is a distribution of adoptium
         java-version: ${{ matrix.jdk }}


### PR DESCRIPTION
### Description
Remove support for JDK14

### Issues Resolved
* Resolves https://github.com/opensearch-project/security/issues/1718

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
