### PR TITLE
Remove sleep when waiting for node close

### DIFF
--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
@@ -247,10 +248,10 @@ public final class ClusterHelper {
 
     private void closeAllNodes() throws  Exception {
         //close non master nodes
-        opensearchNodes.stream().filter(n->!n.isMasterEligible()).forEach(node->closeNode(node));
+        opensearchNodes.stream().filter(n->!n.isMasterEligible()).forEach(ClusterHelper::closeNode);
 
         //close master nodes
-        opensearchNodes.stream().filter(n->n.isMasterEligible()).forEach(node->closeNode(node));
+        opensearchNodes.stream().filter(n->n.isMasterEligible()).forEach(ClusterHelper::closeNode);
         opensearchNodes.clear();
         clusterState = ClusterState.STOPPED;
     }
@@ -258,7 +259,7 @@ public final class ClusterHelper {
     private static void closeNode(Node node) {
         try {
             node.close();
-            Thread.sleep(250);
+            node.awaitClose(250, TimeUnit.MILLISECONDS);
         } catch (Throwable e) {
             //ignore
         }


### PR DESCRIPTION
### Description
For each node in the cluster we were removing and then sleeping for
250ms.  There is an API that we can wait on to be sure the node has
closed or at least take action if the closure wasn't successful.

For the usage, which is cleaning up all nodes, switching to a best
effort mode that could wait the same 250ms or return faster.

### Testing
~Tested in this PR's workflow, new runtime is 25 minutes down from 40, a 40% reduction in runtime.~
Tested in this PR's workflow, new runtime is 25 minutes, seeing this amount of time hit during other runs.  While it might not provide a giant boost, I still think its worthwhile to avoid unreasoned sleeps.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
