### PR TITLE
Fix data-stream name resolution for wild-cards

### DIFF
--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -224,6 +224,7 @@ public class IndexResolverReplacer {
 
             final Collection<String> matchingAliases;
             Collection<String> matchingAllIndices;
+            Collection<String> matchingDataStreams = null;
 
             if (isLocalAll(original)) {
                 if (isTraceEnabled) {
@@ -259,8 +260,11 @@ public class IndexResolverReplacer {
                 final boolean isDebugEnabled = log.isDebugEnabled();
                 try {
                     matchingAllIndices = Arrays.asList(resolver.concreteIndexNames(state, indicesOptions, localRequestedPatterns.toArray(new String[0])));
+                    matchingDataStreams = resolver.dataStreamNames(state, indicesOptions, localRequestedPatterns.toArray(new String[0]));
+
                     if (isDebugEnabled) {
-                        log.debug("Resolved pattern {} to {}", localRequestedPatterns, matchingAllIndices);
+                        log.debug("Resolved pattern {} to indices: {} and data-streams: {}",
+                                localRequestedPatterns, matchingAllIndices, matchingDataStreams);
                     }
                 } catch (IndexNotFoundException e1) {
                     if (isDebugEnabled) {
@@ -271,13 +275,16 @@ public class IndexResolverReplacer {
                 }
             }
 
-            if (isTraceEnabled) {
-                log.trace("Resolved patterns {} for {} ({}) to [aliases {}, allIndices {}, originalRequested{}, remote indices {}]",
-                        original, name, this.name, matchingAliases, matchingAllIndices, Arrays.toString(original), remoteIndices);
+            if (matchingDataStreams == null || matchingDataStreams.size() == 0) {
+                matchingDataStreams = Arrays.asList(NOOP);
             }
 
-            resolveTo(matchingAliases, matchingAllIndices, original, remoteIndices);
+            if (isTraceEnabled) {
+                log.trace("Resolved patterns {} for {} ({}) to [aliases {}, allIndices {}, dataStreams {}, originalRequested{}, remote indices {}]",
+                        original, name, this.name, matchingAliases, matchingAllIndices, matchingDataStreams, Arrays.toString(original), remoteIndices);
+            }
 
+            resolveTo(matchingAliases, matchingAllIndices, matchingDataStreams, original, remoteIndices);
         }
 
         private void resolveToLocalAll() {
@@ -286,9 +293,11 @@ public class IndexResolverReplacer {
             originalRequested.add(Resolved.ANY);
         }
 
-        private void resolveTo(Iterable<String> matchingAliases, Iterable<String> matchingAllIndices, String[] original, Iterable<String> remoteIndices) {
+        private void resolveTo(Iterable<String> matchingAliases, Iterable<String> matchingAllIndices,
+                               Iterable<String> matchingDataStreams, String[] original, Iterable<String> remoteIndices) {
             aliases.addAll(matchingAliases);
             allIndices.addAll(matchingAllIndices);
+            allIndices.addAll(matchingDataStreams);
             originalRequested.add(original);
             this.remoteIndices.addAll(remoteIndices);
         }

--- a/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
@@ -34,7 +34,9 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         rh.executePutRequest("/_index_template/my-data-stream-template", getIndexTemplateBody(), encodeBasicHeader("ds1", "nagilum"));
 
         rh.executePutRequest("/_data_stream/my-data-stream11", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
+        rh.executePutRequest("/_data_stream/my-data-stream21", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
         rh.executePutRequest("/_data_stream/my-data-stream22", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
+        rh.executePutRequest("/_data_stream/my-data-stream23", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
         rh.executePutRequest("/_data_stream/my-data-stream33", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
     }
 
@@ -89,6 +91,27 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream33", encodeBasicHeader("ds3", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
     @Test
@@ -103,18 +126,39 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds2", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-
-        response = rh.executeDeleteRequest("/_data_stream/my-data-stream22", encodeBasicHeader("ds1", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream33", encodeBasicHeader("ds3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds3", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
@@ -142,6 +186,27 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream33/_stats", encodeBasicHeader("ds3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22/_stats", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream2*/_stats", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22/_stats", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds3", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 }

--- a/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
@@ -209,4 +209,49 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds3", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
+
+    @Test
+    public void testBackingIndicesOfDataStream() throws Exception {
+
+        setup();
+        RestHelper rh = nonSslRestHelper();
+        createSampleDataStreams(rh);
+        HttpResponse response;
+
+        response = rh.executeGetRequest("my-data-stream11", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream11-000001", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream22-000001", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream21-000001,.ds-my-data-stream22-000001", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream2*", encodeBasicHeader("ds0", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest("my-data-stream11", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest("my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream11-000001", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream21-000001,.ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executeGetRequest(".ds-my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+    }
 }

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1080,6 +1080,17 @@ index_template_perm:
       allowed_actions:
         - "indices:admin/index_template/*"
 
+data_stream_0:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "*my-data-stream2*"
+      allowed_actions:
+        - "indices:admin/get"
+
 data_stream_1:
   reserved: true
   hidden: false
@@ -1105,6 +1116,7 @@ data_stream_2:
         - "indices:admin/data_stream/create"
         - "indices:monitor/data_stream/stats"
         - "indices:admin/data_stream/delete"
+        - "indices:admin/get"
 
 data_stream_3:
   reserved: true

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1091,7 +1091,6 @@ data_stream_1:
       allowed_actions:
         - "indices:admin/data_stream/get"
         - "indices:admin/data_stream/create"
-        - "indices:admin/data_stream/delete"
 
 data_stream_2:
   reserved: true
@@ -1105,6 +1104,7 @@ data_stream_2:
         - "indices:admin/data_stream/get"
         - "indices:admin/data_stream/create"
         - "indices:monitor/data_stream/stats"
+        - "indices:admin/data_stream/delete"
 
 data_stream_3:
   reserved: true

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -393,6 +393,11 @@ index_template_perm:
   hidden: false
   users:
     - "ds1"
+data_stream_0:
+  reserved: false
+  hidden: false
+  users:
+    - "ds0"
 data_stream_1:
   reserved: false
   hidden: false


### PR DESCRIPTION
Signed-off-by: Sandesh Kumar <sandeshkr419@gmail.com>

### Description
[Describe what this change achieves]
* Category: Bug fix
* Security plugin is not able to invalidate non-permitted data-stream (get/delete/stats) requests sent using wild-card expressions. 
This is because the list of 'allIndices' in 'ResolvedIndicesProvider' class does not has the resolved names of data streams. If the 'allIndices' variable when resolved, is empty -> leads the authorization to succeed as there are no eligible index patterns to block the request. 
In this change, we add the the names of resolved data streams to 'allIndices' so data stream names also can get resolved. 

* Additional Information: **This PR (code changes) was already reviewed and merged in 1.3 branch but was reverted back because 1.3 branch was finalized.**
Refer: https://github.com/opensearch-project/security/pull/1716

* What is the old behavior before changes and new behavior after changes?

Suppose the indices are as follows in a OS cluster.

```
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_cat/indices?v' --insecure -u 'admin:admin'
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_cat/indices?v' --insecure -u 'admin:admin'
health status index                        uuid                   pri rep docs.count docs.deleted store.size pri.store.size
yellow open   .ds-logs-nginx1-000001       3V1VOJ4NQ0KEqtrJ51el8g   1   1          0            0       208b           208b
yellow open   logs2                        AwHqtjeITBGumadYv5GNuQ   1   1          0            0       208b           208b
yellow open   .ds-logs-nginx11-000001      lnMe0uUPToKbQKJCrMUoSw   1   1          0            0       208b           208b
yellow open   logs1                        oR5D0gWFT_u5lbpvSi-SOA   1   1          0            0       208b           208b
yellow open   security-auditlog-2022.03.28 YknIcv-GQLGtdocWUA6-UA   1   1         31            0     94.8kb         94.8kb
yellow open   .ds-logs-nginx3-000001       E2fpfxHSSMarY84WMIjhhQ   1   1          0            0       208b           208b
green  open   .opendistro_security         h6L4aW-QR5KMrCui6BL12g   1   0          9            0     87.9kb         87.9kb
```

Assume the user ```sandesh``` to have the following data-streams related permissions:
```
kusandes@a483e789b681 ~ % curl -XPUT https://localhost:9200/_plugins/_security/api/roles/ds_all -u 'admin:admin' --insecure -H 'Content-Type: application/json' -d '
{
  "cluster_permissions": [ ],
  "index_permissions": [{
    "index_patterns": [
      "logs-nginx1*"
    ],
    "dls": "",
    "fls": [],
    "masked_fields": [],
    "allowed_actions": [
      "indices:admin/data_stream/get",
      "indices:admin/data_stream/delete",
      "indices:monitor/data_stream/stats"
    ]
  }],
  "tenant_permissions": [{
    "tenant_patterns": [
      "human_resources"
    ],
    "allowed_actions": [
    ]
  }]
}
'
```


The ideal (expected) behavior is that user ```sandesh``` should not be able to access data-streams other than logs-nginx1 & logs-nginx11.

*Old Behaviour:*

```
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_data_stream/logs-nginx*?pretty' --insecure -u 'sandesh:kumar'
{
  "data_streams" : [
    {
      "name" : "logs-nginx1",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx1-000001",
          "index_uuid" : "3V1VOJ4NQ0KEqtrJ51el8g"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    },
    {
      "name" : "logs-nginx11",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx11-000001",
          "index_uuid" : "lnMe0uUPToKbQKJCrMUoSw"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    },
    {
      "name" : "logs-nginx3",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx3-000001",
          "index_uuid" : "E2fpfxHSSMarY84WMIjhhQ"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    }
  ]
}
```


*New Behaviour:*

```
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_data_stream/logs-nginx*?pretty' --insecure -u 'sandesh:kumar'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "security_exception",
        "reason" : "no permissions for [indices:admin/data_stream/get] and User [name=sandesh, backend_roles=[], requestedTenant=null]"
      }
    ],
    "type" : "security_exception",
    "reason" : "no permissions for [indices:admin/data_stream/get] and User [name=sandesh, backend_roles=[], requestedTenant=null]"
  },
  "status" : 403
}
```


```
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_data_stream/logs-nginx1*?pretty' --insecure -u 'sandesh:kumar'
{
  "data_streams" : [
    {
      "name" : "logs-nginx1",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx1-000001",
          "index_uuid" : "3V1VOJ4NQ0KEqtrJ51el8g"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    },
    {
      "name" : "logs-nginx11",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx11-000001",
          "index_uuid" : "lnMe0uUPToKbQKJCrMUoSw"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    }
  ]
}
```

```kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_data_stream/logs-nginx1,logs-nginx2?pretty' --insecure -u 'sandesh:kumar'
{
  "error" : {
    "root_cause" : [
      {
        "type" : "security_exception",
        "reason" : "no permissions for [indices:admin/data_stream/get] and User [name=sandesh, backend_roles=[], requestedTenant=null]"
      }
    ],
    "type" : "security_exception",
    "reason" : "no permissions for [indices:admin/data_stream/get] and User [name=sandesh, backend_roles=[], requestedTenant=null]"
  },
  "status" : 403
}
```

```
kusandes@a483e789b681 ~ % curl -XGET 'https://localhost:9200/_data_stream/logs-nginx1,logs-nginx11?pretty' --insecure -u 'sandesh:kumar'
{
  "data_streams" : [
    {
      "name" : "logs-nginx1",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx1-000001",
          "index_uuid" : "3V1VOJ4NQ0KEqtrJ51el8g"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    },
    {
      "name" : "logs-nginx11",
      "timestamp_field" : {
        "name" : "@timestamp"
      },
      "indices" : [
        {
          "index_name" : ".ds-logs-nginx11-000001",
          "index_uuid" : "lnMe0uUPToKbQKJCrMUoSw"
        }
      ],
      "generation" : 1,
      "status" : "YELLOW",
      "template" : "logs-template"
    }
  ]
}
```




### Issues Resolved
https://github.com/opensearch-project/security/issues/1498


Is this a backport? If so, please add backport PR # and/or commits #

### Testing
* Tested the above behaviour/fix manually with get/delete/stats data stream api.
* Added integration tests for the same to verify.


### Check List
- [Y] New functionality includes testing
- [Y] New functionality has been documented
- [Y] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
