### PR TITLE
Make Git ignore out/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test.sh
 *.iml
 IML
 .vscode/
+out/
 
 # gradle
 build/


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required? 
IntelliJ compilation outputs `out/` directory that is not needed for version control.

### Testing
UTs

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
