### PR TITLE
List out test failures in CI log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -394,3 +394,28 @@ buildDeb {
     arch = 'all'
     archiveName "${packageName}-${version}.deb"
 }
+
+allprojects {
+    // add a collection to track failedTests
+    ext.failedTests = []
+
+    // add a testlistener to all tasks of type Test
+    tasks.withType(Test) {
+        afterTest { TestDescriptor descriptor, TestResult result ->
+            if(result.resultType == org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE){
+                failedTests << ["${descriptor.className}::${descriptor.name}"]
+            }
+        }
+    }
+
+    // print out tracked failed tests when the build has finished
+    gradle.buildFinished {
+        if(!failedTests.empty){
+            println "Failed tests for ${project.name}:"
+            failedTests.each { failedTest ->
+                println failedTest
+            }
+            println ""
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required? 
Currently, CI log only gives a number of failing tests, but there is no easy way to find out what tests actually failed.
With this change, CI log summarizes a list of all failing tests, which facilitates test failure investigation.
* What is the old behavior before changes and new behavior after changes?

Old behavior:
```
2022-04-01T07:19:55.2791783Z 1133 tests completed, 13 failed, 46 skipped
```

New bahavior:
```
2022-04-01T06:09:12.2380647Z Failed tests for opensearch-security:
2022-04-01T06:09:12.2381069Z [org.opensearch.security.HttpIntegrationTests::testTenantInfo]
2022-04-01T06:09:12.2381586Z [org.opensearch.security.SecurityAdminMigrationTests::testSecurityMigrate]
2022-04-01T06:09:12.2571025Z [org.opensearch.security.SecurityAdminMigrationTests::testSecurityMigrate2]
2022-04-01T06:09:12.2572007Z [org.opensearch.security.auditlog.integration.BasicAuditlogTest::testRestMethod]
2022-04-01T06:09:12.2572879Z [org.opensearch.security.auditlog.integration.BasicAuditlogTest::testRestMethod]
2022-04-01T06:09:12.2573500Z [org.opensearch.security.dlic.dlsfls.DlsTest::testDlsWithMinDocCountZeroAggregations]
2022-04-01T06:09:12.2574262Z [org.opensearch.security.dlic.rest.api.ActionGroupsApiTest::testActionGroupsApi[0]]
2022-04-01T06:09:12.2574916Z [org.opensearch.security.dlic.rest.api.ActionGroupsApiTest::testActionGroupsApi[1]]
2022-04-01T06:09:12.2575545Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrate[0]]
2022-04-01T06:09:12.2576207Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityValidateWithInvalidConfig[0]]
2022-04-01T06:09:12.2576865Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityValidate[0]]
2022-04-01T06:09:12.2577523Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrateWithEmptyPassword[0]]
2022-04-01T06:09:12.2578192Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrateInvalid[0]]
2022-04-01T06:09:12.2578798Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrate[1]]
2022-04-01T06:09:12.2579460Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityValidateWithInvalidConfig[1]]
2022-04-01T06:09:12.2580115Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityValidate[1]]
2022-04-01T06:09:12.2580773Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrateWithEmptyPassword[1]]
2022-04-01T06:09:12.2581439Z [org.opensearch.security.dlic.rest.api.MigrationTests::testSecurityMigrateInvalid[1]]
...
...
```

### Testing
UTs

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
