### PR TITLE
Security plugin qualifier support default to alpha1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,9 +55,19 @@ repositories {
 }
 
 ext {
-    default_opensearch_version = property("opensearch-core.version") + "-SNAPSHOT"
-    opensearch_version = System.getProperty("opensearch.version", default_opensearch_version)
-    buildVersionQualifier = System.getProperty("build.version_qualifier")
+    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
+    opensearch_version = System.getProperty("opensearch.version", "2.0.0-alpha1-SNAPSHOT")
+    buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+    // 2.0.0-alpha1-SNAPSHOT -> 2.0.0.0-alpha1-SNAPSHOT
+    version_tokens = opensearch_version.tokenize('-')
+    opensearch_build = version_tokens[0] + '.0'
+    if (buildVersionQualifier) {
+        opensearch_build += "-${buildVersionQualifier}"
+        opensearch_build_nosnapshot = opensearch_build
+    }
+    if (isSnapshot) {
+        opensearch_build += "-SNAPSHOT"
+    }
 }
 
 configurations.all {
@@ -124,19 +134,8 @@ dependencies {
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 }
 
-ext {
-    securityPluginVersion = property('security-plugin.version')
-    isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-}
-
 group = 'org.opensearch'
-version = securityPluginVersion
-if (buildVersionQualifier) {
-    version += "-${buildVersionQualifier}"
-}
-if (isSnapshot) {
-    version += "-SNAPSHOT"
-}
+version = opensearch_build
 
 description = 'OpenSearch Security'
 
@@ -326,16 +325,13 @@ task bundleSecurityAdminStandaloneTarGz(dependsOn: jar, type: Tar) {
 }
 
 task createPluginDescriptor() {
-    if (opensearch_version.contains("-SNAPSHOT")) {
-        opensearch_version=opensearch_version.substring(0, opensearch_version.length() - 9)
-    }
     List<String> descriptorProperties = [
         "description=Provide access control related features for OpenSearch",
         "version=${version}",
         "name=opensearch-security",
         "classname=org.opensearch.security.OpenSearchSecurityPlugin",
         "java.version=${java.targetCompatibility}",
-        "opensearch.version=${opensearch_version}",
+        "opensearch.version=${opensearch_build_nosnapshot}",
     ]
 
     new File("plugin-descriptor.properties").text = descriptorProperties.join ("\n")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,0 @@
-# Sets the version of the Security plugin
-security-plugin.version=2.0.0.0
-# Sets the version of OpenSearch this plugin should be built with
-opensearch-core.version=1.4.0


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Security plugin qualifier support default to alpha1

### Issues Resolved
#1676

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
