### PR TITLE
Rename cluster settings following new 2.x convention

### DIFF
--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -366,7 +366,7 @@ public final class ClusterHelper {
                 .put("path.logs", "./target/data/"+clustername+"/logs")
                 .put("node.max_local_storage_nodes", nodeCount)
                 //.put("discovery.zen.minimum_master_nodes", minMasterNodes(masterTcpPorts.size()))
-                .putList("cluster.initial_master_nodes", masterTcpPorts.stream().map(s->"127.0.0.1:"+s).collect(Collectors.toList()))
+                .putList("cluster.initial_cluster_manager_nodes", masterTcpPorts.stream().map(s->"127.0.0.1:"+s).collect(Collectors.toList()))
                 //.put("discovery.zen.no_master_block", "all")
                 //.put("discovery.zen.fd.ping_timeout", "5s")
                 .put("discovery.initial_state_timeout","8s")

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -382,7 +382,7 @@ else
 	if [ "$cluster_mode" == 1 ]; then
         echo "network.host: 0.0.0.0" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
         echo "node.name: smoketestnode" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
-        echo "cluster.initial_master_nodes: smoketestnode" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
+        echo "cluster.initial_cluster_manager_nodes: smoketestnode" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
     fi
 fi
 


### PR DESCRIPTION
### Description
Previously the setting was `cluster.initial_master_nodes` and has since
changed to `cluster.initial_cluster_manager_nodes`.  This was causing
issues due to a bug in the fallback method that has been fixed in
OpenSearch, but getting ahead of this change before its needed.

### Issues
See related https://github.com/opensearch-project/OpenSearch/pull/2779

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
