### PR TITLE
Add archive of reports for test/coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,18 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/jacoco/test/jacocoTestReport.xml
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ matrix.jdk }}-reports
+        path: |
+          ./build/reports/
+
+    - name: check archive for debugging
+      if: always()
+      run: echo "Check the artifact ${{ matrix.jdk }}-reports.zip for detailed test results"
 
   backward-compatibility:
     runs-on: ubuntu-latest

--- a/build.gradle
+++ b/build.gradle
@@ -356,7 +356,7 @@ tasks.assemble.finalizedBy(createChecksums)
 
 
 jacoco {
-    reportsDirectory = file("$buildDir/jacoco")
+    reportsDirectory = file("$buildDir/reports/jacoco")
 }
 jacocoTestReport {
     reports {


### PR DESCRIPTION
### Description
This provides a more digestible version of the test results for
debugging/troubleshooting failures that occur in CI.

I moved the jacoco report to use the same location

See how this output looks from this GHA workflow summary https://github.com/opensearch-project/security/actions/runs/2204140083
![image](https://user-images.githubusercontent.com/2754967/164759467-63611b8a-8d1e-41b5-878a-23a4bd61a17c.png)

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
