### PR TITLE
Add depreciation notice to security tools

### DIFF
--- a/tools/audit_config_migrater.bat
+++ b/tools/audit_config_migrater.bat
@@ -1,6 +1,11 @@
 @echo off
 set SCRIPT_DIR=%~dp0
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 rem comparing to empty string makes this equivalent to bash -v check on env var
 if not "%OPENSEARCH_JAVA_HOME%" == "" (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"

--- a/tools/audit_config_migrater.sh
+++ b/tools/audit_config_migrater.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then

--- a/tools/hash.bat
+++ b/tools/hash.bat
@@ -1,6 +1,11 @@
 @echo off
 set SCRIPT_DIR=%~dp0
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 rem comparing to empty string makes this equivalent to bash -v check on env var
 if not "%OPENSEARCH_JAVA_HOME%" == "" (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"

--- a/tools/hash.sh
+++ b/tools/hash.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 #install_demo_configuration.sh [-y]
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then
@@ -16,6 +21,7 @@ else
     DIR="$( cd "$( dirname "$(realpath "$SCRIPT_PATH")" )" && pwd -P)"
 fi
 
+exit 
 echo "OpenSearch Security Demo Installer"
 echo " ** Warning: Do not use on production or public reachable systems **"
 

--- a/tools/securityadmin.bat
+++ b/tools/securityadmin.bat
@@ -1,6 +1,11 @@
 @echo off
 set SCRIPT_DIR=%~dp0
 
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 rem comparing to empty string makes this equivalent to bash -v check on env var
 if not "%OPENSEARCH_JAVA_HOME%" == "" (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"

--- a/tools/securityadmin.sh
+++ b/tools/securityadmin.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+echo "**************************************************************************"
+echo "** This tool will be deprecated in the next major release of OpenSearch **"
+echo "** https://github.com/opensearch-project/security/issues/1755           **"
+echo "**************************************************************************"
+
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then


### PR DESCRIPTION
### Description
In order to remove or replace the security tools location we are creating a depreciation notice as part of the tools.  There is a link in the tools that link will be pointed to a [GitHub issue](https://github.com/opensearch-project/security/issues/1755) that will acknowledge the depreciation and also describe the migration path.

### Issues Resolved
- Related https://github.com/opensearch-project/security/issues/1673

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
