### PR TITLE
Fix 'openserach' typo in roles.yml

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -192,7 +192,7 @@ cross_cluster_replication_follower_full_access:
 ml_read_access:
   reserved: true
   cluster_permissions:
-    - 'cluster:admin/opensearch/ml/stats'
+    - 'cluster:admin/opensearch/ml/stats/nodes'
     - 'cluster:admin/opensearch/ml/models/get'
     - 'cluster:admin/opensearch/ml/models/search'
     - 'cluster:admin/opensearch/ml/tasks/get'

--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -192,7 +192,7 @@ cross_cluster_replication_follower_full_access:
 ml_read_access:
   reserved: true
   cluster_permissions:
-    - 'cluster:admin/openserach/ml/stats'
+    - 'cluster:admin/opensearch/ml/stats'
     - 'cluster:admin/opensearch/ml/models/get'
     - 'cluster:admin/opensearch/ml/models/search'
     - 'cluster:admin/opensearch/ml/tasks/get'


### PR DESCRIPTION
Signed-off-by: Cam McKenzie <camAtGitHub@users.noreply.github.com>

### Description
Fix 'openserach' typo. 
This commit has not been tested, however I scanned 'security', 'security-dashboard-plugins, and 'opensearch' repos.
security and its dashboards are the only two occurrences of the word.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
