### PR TITLE
Remove advanced_modules_enabled from example

### DIFF
--- a/securityconfig/opensearch.yml.example
+++ b/securityconfig/opensearch.yml.example
@@ -7,11 +7,6 @@
 
 ############## Common configuration settings ##############
 
-# Enable or disable the OpenSearch Security advanced modules
-# By default advanced modules are enabled, you can switch
-# all advanced features off by setting the following key to false
-plugins.security.advanced_modules_enabled: true
-
 # Specify a list of DNs which denote the other nodes in the cluster.
 # This settings support wildcards and regular expressions
 # The list of DNs are also read from security index **in addition** to the yml configuration if


### PR DESCRIPTION
Since #1001, the `plugins.security.advanced_modules_enabled` configuration setting has been deprecated, so this PR removes this setting from the example configuration to avoid confusion and deprecation warnings.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.