### PR TITLE
Add checkstyle for non-inclusive terms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -372,11 +372,9 @@ checkstyle {
 }
 
 tasks.withType(Checkstyle) {
+    showViolations true
     reports {
-        showViolations false
-        ignoreFailures = true
-        xml.required = true
-        html.required = true
+        ignoreFailures = false
     }
 }
 

--- a/config/checkstyle/sun_checks.xml
+++ b/config/checkstyle/sun_checks.xml
@@ -27,7 +27,7 @@
       https://checkstyle.org/config.html#Checker
       <property name="basedir" value="${basedir}"/>
   -->
-  <property name="severity" value="error"/>
+  <property name="severity" value="ignore"/>
 
   <property name="fileExtensions" value="java, properties, xml"/>
 
@@ -181,6 +181,20 @@
       <property name="optional" value="true"/>
     </module>
 
+  </module>
+
+  <module name="RegexpSingleline">
+    <property name="format" value="whitelist"/>
+    <property name="ignoreCase" value="true"/>
+    <property name="message" value="Usage should be switched to an allow* based pattern" />
+    <property name="severity" value="warning"/>
+  </module>
+
+  <module name="RegexpSingleline">
+    <property name="format" value="master"/>
+    <property name="ignoreCase" value="true"/>
+    <property name="message" value="Usage should be switched to cluster manager" />
+    <property name="severity" value="warning"/>
   </module>
 
 </module>


### PR DESCRIPTION
### Description
To aid in detection and removal of non-inclusive terms, adding a
checkstyle error when they are detected.  When we are ready to remove
all these terms from the codebase we will set these checks to error
level.

### Issues Resolved
* Related to https://github.com/opensearch-project/security/issues/1664

### Updated build output
Since all errors are ignored by default, now the checkstyle output is much easier to parse, here is an example of the output with this change.

```
...
[ant:checkstyle] [WARN] /local/home/petern/git/security/src/main/java/org/opensearch/security/tools/SecurityAdmin.java:1267: Usage should be switched to an allow* based pattern [RegexpSingleline]
[ant:checkstyle] [WARN] /local/home/petern/git/security/src/main/java/org/opensearch/security/tools/SecurityAdmin.java:1268: Usage should be switched to an allow* based pattern [RegexpSingleline]
[ant:checkstyle] [WARN] /local/home/petern/git/security/src/main/java/org/opensearch/security/tools/SecurityAdmin.java:1278: Usage should be switched to an allow* based pattern [RegexpSingleline]
Checkstyle rule violations were found. See the report at: file:///local/home/petern/git/security/build/reports/checkstyle/main.html
Checkstyle files with violations: 22
Checkstyle violations by severity: [warning:123]
...
```

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
