### PR TITLE
fix wrong stats permission of ml-commons

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -192,7 +192,7 @@ cross_cluster_replication_follower_full_access:
 ml_read_access:
   reserved: true
   cluster_permissions:
-    - 'cluster:admin/openserach/ml/stats'
+    - 'cluster:admin/opensearch/ml/stats/nodes'
     - 'cluster:admin/opensearch/ml/models/get'
     - 'cluster:admin/opensearch/ml/models/search'
     - 'cluster:admin/opensearch/ml/tasks/get'


### PR DESCRIPTION
Signed-off-by: Yaliang Wu <ylwu@amazon.com>

### Description
Fix the wrong stats permission name of `ml-commons` plugin. This is to replace this PR https://github.com/opensearch-project/security/pull/1770 
* Category: bug fix

* Why these changes are required?

User with ml-commons read only access can't use stats API.

* What is the old behavior before changes and new behavior after changes?

After this bug fix, read only user can access stats API of `ml-commons` plugin.



Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Test locally

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
