### PR TITLE
JWT: validate issuer and audience (#1780, #1781)

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -61,6 +61,8 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String subjectKey;
+    private final String requireAudience;
+    private final String requireIssuer;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
         super();
@@ -109,6 +111,17 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         isDefaultAuthHeader = HttpHeaders.AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
+        requireAudience = settings.get("required_audience");
+        requireIssuer = settings.get("required_issuer");
+
+        if (requireAudience != null) {
+            _jwtParser.requireAudience(requireAudience);
+        }
+
+        if (requireIssuer != null) {
+            _jwtParser.requireIssuer(requireIssuer);
+        }
+
         jwtParser = _jwtParser;
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -26,6 +26,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.crypto.SecretKey;
+
 import org.apache.http.HttpHeaders;
 import org.junit.Assert;
 import org.junit.Test;
@@ -37,6 +39,7 @@ import org.opensearch.security.util.FakeRestRequest;
 
 import com.google.common.io.BaseEncoding;
 
+import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
@@ -44,83 +47,61 @@ import io.jsonwebtoken.security.Keys;
 
 public class HTTPJwtAuthenticatorTest {
 
-    final static byte[] secretKey = new byte[1024];
-
+    final static byte[] secretKeyBytes = new byte[1024];
+    final static SecretKey secretKey;
+    
     static {
-        new SecureRandom().nextBytes(secretKey);
+        new SecureRandom().nextBytes(secretKeyBytes);
+        secretKey = Keys.hmacShaKeyFor(secretKeyBytes);
     }
 
     @Test
     public void testNoKey() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder(),
+        		Jwts.builder().setSubject("Leonard McCoy"));
 
-
-        Settings settings = Settings.builder().build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth =new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer "+jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testEmptyKey() throws Exception {
+    	
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", ""),
+        		Jwts.builder().setSubject("Leonard McCoy"));
 
-
-
-        Settings settings = Settings.builder().put("signing_key", "").build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer "+jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        Assert.assertNull(credentials); 
     }
 
     @Test
     public void testBadKey() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(new byte[]{1,3,3,4,3,6,7,8,3,10})),
+        		Jwts.builder().setSubject("Leonard McCoy"));
 
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(new byte[]{1,3,3,4,3,6,7,8,3,10})).build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer "+jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testTokenMissing() throws Exception {
 
-
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
 
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        AuthCredentials credentials = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testInvalid() throws Exception {
 
-
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
 
         String jwsToken = "123invalidtoken..";
 
@@ -128,69 +109,49 @@ public class HTTPJwtAuthenticatorTest {
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", "Bearer "+jwsToken);
 
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        AuthCredentials credentials = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testBearer() throws Exception {
 
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
 
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").setAudience("myaud").signWith(SignatureAlgorithm.HS512, secretKey).compact();
+        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").setAudience("myaud").signWith(secretKey, SignatureAlgorithm.HS512).compact();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", "Bearer "+jwsToken);
 
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(2, creds.getAttributes().size());
+        AuthCredentials credentials = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        Assert.assertEquals(2, credentials.getAttributes().size());
     }
 
     @Test
     public void testBearerWrongPosition() throws Exception {
 
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
 
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.HS512, secretKey).compact();
+        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(secretKey, SignatureAlgorithm.HS512).compact();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", jwsToken + "Bearer " + " 123");
 
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        AuthCredentials credentials = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+
+        Assert.assertNull(credentials);
     }
 
-    @Test
-    public void testNonBearer() throws Exception {
-
-
-
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-    }
 
     @Test
     public void testBasicAuthHeader() throws Exception {
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).build();
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         JwtParser jwtParser = Mockito.spy(JwtParser.class);
         FieldSetter.setField(jwtAuth, HTTPJwtAuthenticator.class.getDeclaredField("jwtParser"), jwtParser);
@@ -198,253 +159,131 @@ public class HTTPJwtAuthenticatorTest {
         String basicAuth = BaseEncoding.base64().encode("user:password".getBytes(StandardCharsets.UTF_8));
         Map<String, String> headers = Collections.singletonMap(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth);
 
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, Collections.emptyMap()), null);
-        Assert.assertNull(creds);
+        AuthCredentials credentials = jwtAuth.extractCredentials(new FakeRestRequest(headers, Collections.emptyMap()), null);
+        Assert.assertNull(credentials);
         Mockito.verifyZeroInteractions(jwtParser);
     }
 
     @Test
     public void testRoles() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+        		Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2"));
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_key", "roles")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .claim("roles", "role1,role2")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(2, creds.getBackendRoles().size());
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(2, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testNullClaim() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+        		Jwts.builder().setSubject("Leonard McCoy").claim("roles", null));
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_key", "roles")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .claim("roles", null)
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testNonStringClaim() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+        		Jwts.builder().setSubject("Leonard McCoy").claim("roles", 123L));
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_key", "roles")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .claim("roles", 123L)
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(1, creds.getBackendRoles().size());
-        Assert.assertTrue( creds.getBackendRoles().contains("123"));
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(1, credentials.getBackendRoles().size());
+        Assert.assertTrue( credentials.getBackendRoles().contains("123"));
     }
 
     @Test
     public void testRolesMissing() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+        		Jwts.builder().setSubject("Leonard McCoy"));  
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_key", "roles")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testWrongSubjectKey() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "missing"),
+        		Jwts.builder().claim("roles", "role1,role2").claim("asub", "Dr. Who"));   
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("subject_key", "missing")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .claim("roles", "role1,role2")
-                .claim("asub", "Dr. Who")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testAlternativeSubject() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "asub"),
+        		Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2").claim("asub", "Dr. Who"));                  
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("subject_key", "asub")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .claim("roles", "role1,role2")
-                .claim("asub", "Dr. Who")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Dr. Who", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Dr. Who", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testNonStringAlternativeSubject() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "asub"),
+        		Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2").claim("asub", false));                  
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("subject_key", "asub")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .claim("roles", "role1,role2")
-                .claim("asub", false)
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("false", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("false", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testUrlParam() throws Exception {
 
+        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("jwt_url_parameter", "abc").build();
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("jwt_url_parameter", "abc")
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Leonard McCoy")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(secretKey, SignatureAlgorithm.HS512).compact();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
         FakeRestRequest req = new FakeRestRequest(headers, new HashMap<String, String>());
         req.params().put("abc", jwsToken);
 
-        AuthCredentials creds = jwtAuth.extractCredentials(req, null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        AuthCredentials credentials = jwtAuth.extractCredentials(req, null);
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
     }
 
     @Test
     public void testExp() throws Exception {
 
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)),
+        		Jwts.builder().setSubject("Expired").setExpiration(new Date(100)));         
 
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Expired")
-                .setExpiration(new Date(100))
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        Assert.assertNull(credentials);
     }
 
     @Test
     public void testNbf() throws Exception {
 
-
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .build();
-
-        String jwsToken = Jwts.builder()
-                .setSubject("Expired")
-                .setNotBefore(new Date(System.currentTimeMillis()+(1000*36000)))
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNull(creds);
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)),
+        		Jwts.builder().setSubject("Expired").setNotBefore(new Date(System.currentTimeMillis()+(1000*36000))));        
+        
+        Assert.assertNull(credentials);
     }
 
     @Test
@@ -456,7 +295,7 @@ public class HTTPJwtAuthenticatorTest {
         PrivateKey priv = pair.getPrivate();
         PublicKey pub = pair.getPublic();
 
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.RS256, priv).compact();
+        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.RS256).compact();
         Settings settings = Settings.builder().put("signing_key", "-----BEGIN PUBLIC KEY-----\n"+BaseEncoding.base64().encode(pub.getEncoded())+"-----END PUBLIC KEY-----").build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
@@ -464,6 +303,7 @@ public class HTTPJwtAuthenticatorTest {
         headers.put("Authorization", "Bearer "+jwsToken);
 
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+
         Assert.assertNotNull(creds);
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
         Assert.assertEquals(0, creds.getBackendRoles().size());
@@ -477,97 +317,93 @@ public class HTTPJwtAuthenticatorTest {
         KeyPair pair = keyGen.generateKeyPair();
         PrivateKey priv = pair.getPrivate();
         PublicKey pub = pair.getPublic();
-
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(SignatureAlgorithm.ES512, priv).compact();
+        
         Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(pub.getEncoded())).build();
-
+        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.ES512).compact();
+        
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer "+jwsToken);
+        headers.put("Authorization", jwsToken);
 
         AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
+
         Assert.assertNotNull(creds);
         Assert.assertEquals("Leonard McCoy", creds.getUsername());
         Assert.assertEquals(0, creds.getBackendRoles().size());
     }
 
     @Test
-    public void rolesArray() throws Exception {
+    public void testRolesArray() throws Exception {
 
-
-
-        Settings settings = Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKey))
-                .put("roles_key", "roles")
-                .build();
-
-        String jwsToken = Jwts.builder()
+        JwtBuilder builder = Jwts.builder()
                 .setPayload("{"+
                     "\"sub\": \"John Doe\","+
                     "\"roles\": [\"a\",\"b\",\"3rd\"]"+
-                  "}")
-                .signWith(SignatureAlgorithm.HS512, secretKey).compact();
+                  "}");
 
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer "+jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("John Doe", creds.getUsername());
-        Assert.assertEquals(3, creds.getBackendRoles().size());
-        Assert.assertTrue(creds.getBackendRoles().contains("a"));
-        Assert.assertTrue(creds.getBackendRoles().contains("b"));
-        Assert.assertTrue(creds.getBackendRoles().contains("3rd"));
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+        		builder);
+        
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("John Doe", credentials.getUsername());
+        Assert.assertEquals(3, credentials.getBackendRoles().size());
+        Assert.assertTrue(credentials.getBackendRoles().contains("a"));
+        Assert.assertTrue(credentials.getBackendRoles().contains("b"));
+        Assert.assertTrue(credentials.getBackendRoles().contains("3rd"));
     }
 
     @Test
-    public void testRequiredAudience() {
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).put("required_audience", "test_audience")
-                .build();
+    public void testRequiredAudienceWithCorrectAudience() {
 
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").setAudience("test_audience")
-                .signWith(Keys.hmacShaKeyFor(secretKey), SignatureAlgorithm.HS512).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-
-        jwsToken = Jwts.builder().setSubject("Leonard McCoy").setAudience("wrong_audience")
-                .signWith(Keys.hmacShaKeyFor(secretKey), SignatureAlgorithm.HS512).compact();
-        headers.put("Authorization", jwsToken);
-
-        creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()), null);
-
-        Assert.assertNull(creds);
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_audience", "test_audience"),
+        		Jwts.builder().setSubject("Leonard McCoy").setAudience("test_audience"));
+        
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
     }
 
     @Test
-    public void testRequiredIssuer() {
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKey)).put("required_issuer", "test_issuer")
-                .build();
+    public void testRequiredAudienceWithIncorrectAudience() {
 
-        String jwsToken = Jwts.builder().setSubject("Leonard McCoy").setIssuer("test_issuer")
-                .signWith(Keys.hmacShaKeyFor(secretKey), SignatureAlgorithm.HS512).compact();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()), null);
-        Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-
-        jwsToken = Jwts.builder().setSubject("Leonard McCoy").setIssuer("wrong_issuer")
-                .signWith(Keys.hmacShaKeyFor(secretKey), SignatureAlgorithm.HS512).compact();
-        headers.put("Authorization", jwsToken);
-
-        creds = jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()), null);
-
-        Assert.assertNull(creds);
+    	final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+    			Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_audience", "test_audience"),
+    			Jwts.builder().setSubject("Leonard McCoy").setAudience("wrong_audience"));
+    	
+        Assert.assertNull(credentials);
     }
+
+    @Test
+    public void testRequiredIssuerWithCorrectAudience() {
+    	    			
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+        		Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_issuer", "test_issuer"),
+        		Jwts.builder().setSubject("Leonard McCoy").setIssuer("test_issuer"));
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+    }
+
+    @Test
+    public void testRequiredIssuerWithIncorrectAudience() {
+    	    	
+    	final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+    			Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_issuer", "test_issuer"),
+    			Jwts.builder().setSubject("Leonard McCoy").setIssuer("wrong_issuer"));
+    	
+        Assert.assertNull(credentials);
+    }
+
+    /** extracts a default user credential from a request header */
+    private AuthCredentials extractCredentialsFromJwtHeader(
+            final Settings.Builder settingsBuilder,
+            final JwtBuilder jwtBuilder) {
+        final Settings settings = settingsBuilder.build();
+        final String jwsToken = jwtBuilder.signWith(secretKey, SignatureAlgorithm.HS512).compact();
+        final HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        final Map<String, String> headers = Map.of("Authorization", jwsToken);
+        return jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<>()), null);
+    }
+
 }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -28,22 +28,21 @@ import java.util.Map;
 
 import javax.crypto.SecretKey;
 
-import org.apache.http.HttpHeaders;
-import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.internal.util.reflection.FieldSetter;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.security.user.AuthCredentials;
-import org.opensearch.security.util.FakeRestRequest;
-
 import com.google.common.io.BaseEncoding;
-
 import io.jsonwebtoken.JwtBuilder;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import org.apache.http.HttpHeaders;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.internal.util.reflection.FieldSetter;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.user.AuthCredentials;
+import org.opensearch.security.util.FakeRestRequest;
 
 public class HTTPJwtAuthenticatorTest {
 


### PR DESCRIPTION
This PR adds an option to validate the issuer and/or audience claim
in a JWT per JWT authentication domain

Signed-off-by: Jochen Kressin <jkressin@floragunn.com>

### Description
The audience and issuer claim in a JWT is currently not validated by the JWT authentication domain. This PR adds a configuration option to enforce this validation per JWT authentication domain.

### Issues Resolved
* Resolves #1780
* Resolves #1781

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
New unit tests added to HTTPJwtAuthenticatorTest

### Check List
- [ x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
