### PR TITLE
[Backport 1.3] Switch to log4j logger (#1751)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6'
-    implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -26,8 +26,10 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
 import org.apache.http.HttpHeaders;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.Strings;
@@ -46,7 +48,7 @@ import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.user.AuthCredentials;
 
 public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator {
-    private final static Logger log = LoggerFactory.getLogger(AbstractHTTPJwtAuthenticator.class);
+    private final static Logger log = LogManager.getLogger(AbstractHTTPJwtAuthenticator.class);
 
     private static final String BEARER = "bearer ";
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -29,8 +29,8 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import org.apache.http.HttpHeaders;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -51,7 +51,7 @@ import io.jsonwebtoken.security.WeakKeyException;
 
 public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
@@ -24,7 +24,7 @@ import com.amazon.dlic.util.SettingsBasedSSLConfigurator;
 
 public class HTTPJwtKeyByOpenIdConnectAuthenticator extends AbstractHTTPJwtAuthenticator {
 
-	//private final static Logger log = LoggerFactory.getLogger(HTTPJwtKeyByOpenIdConnectAuthenticator.class);
+	//private final static Logger log = LogManager.getLogger(HTTPJwtKeyByOpenIdConnectAuthenticator.class);
 
 	public HTTPJwtKeyByOpenIdConnectAuthenticator(Settings settings, Path configPath) {
 		super(settings, configPath);

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -27,14 +27,14 @@ import org.apache.cxf.rs.security.jose.jwt.JwtException;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
 import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.google.common.base.Strings;
 
 public class JwtVerifier {
 
-	private final static Logger log = LoggerFactory.getLogger(JwtVerifier.class);
+	private final static Logger log = LogManager.getLogger(JwtVerifier.class);
 
 	private final KeyProvider keyProvider;
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -33,15 +33,15 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.client.cache.BasicHttpCacheStorage;
 import org.apache.http.impl.client.cache.CacheConfig;
 import org.apache.http.impl.client.cache.CachingHttpClients;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.amazon.dlic.auth.http.jwt.oidc.json.OpenIdProviderConfiguration;
 import com.amazon.dlic.util.SettingsBasedSSLConfigurator.SSLConfig;
 
 
 public class KeySetRetriever implements KeySetProvider {
-	private final static Logger log = LoggerFactory.getLogger(KeySetRetriever.class);
+	private final static Logger log = LogManager.getLogger(KeySetRetriever.class);
 	private static final long CACHE_STATUS_LOG_INTERVAL_MS = 60L * 60L * 1000L;
 
 	private String openIdConnectEndpoint;

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java
@@ -24,13 +24,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.google.common.base.Strings;
 
 public class SelfRefreshingKeySet implements KeyProvider {
-	private static final Logger log = LoggerFactory.getLogger(SelfRefreshingKeySet.class);
+	private static final Logger log = LogManager.getLogger(SelfRefreshingKeySet.class);
 
 	private final KeySetProvider keySetProvider;
 	private final ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(1, 10, 1000, TimeUnit.MILLISECONDS,

--- a/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -33,8 +33,8 @@ import java.util.Set;
 import javax.security.auth.Subject;
 import javax.security.auth.login.LoginException;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -65,7 +65,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
     private static final String EMPTY_STRING = "";
     private static final Oid[] KRB_OIDS = new Oid[] {KrbConstants.SPNEGO, KrbConstants.KRB5MECH};
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private boolean stripRealmFromPrincipalName;
     private Set<String> acceptorPrincipal;

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -40,8 +40,8 @@ import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
 import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
 import org.apache.cxf.rs.security.jose.jwt.JwtToken;
 import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.bytes.BytesReference;
@@ -68,8 +68,8 @@ import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.util.Util;
 
 class AuthTokenProcessorHandler {
-    private static final Logger log = LoggerFactory.getLogger(AuthTokenProcessorHandler.class);
-    private static final Logger token_log = LoggerFactory.getLogger("com.amazon.dlic.auth.http.saml.Token");
+    private static final Logger log = LogManager.getLogger(AuthTokenProcessorHandler.class);
+    private static final Logger token_log = LogManager.getLogger("com.amazon.dlic.auth.http.saml.Token");
     private static final Pattern EXPIRY_SETTINGS_PATTERN = Pattern.compile("\\s*(\\w+)\\s*(?:\\+\\s*(\\w+))?\\s*");
 
     private Saml2SettingsProvider saml2SettingsProvider;

--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -26,8 +26,8 @@ import com.google.common.annotations.VisibleForTesting;
 import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -73,7 +73,7 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 
 public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
-    protected final static Logger log = LoggerFactory.getLogger(HTTPSamlAuthenticator.class);
+    protected final static Logger log = LogManager.getLogger(HTTPSamlAuthenticator.class);
 
     public static final String IDP_METADATA_URL = "idp.metadata_url";
     public static final String IDP_METADATA_FILE = "idp.metadata_file";

--- a/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
@@ -26,8 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -52,7 +52,7 @@ import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
 import net.shibboleth.utilities.java.support.resolver.ResolverException;
 
 public class Saml2SettingsProvider {
-    protected final static Logger log = LoggerFactory.getLogger(Saml2SettingsProvider.class);
+    protected final static Logger log = LogManager.getLogger(Saml2SettingsProvider.class);
 
     private final Settings opensearchSettings;
     private final MetadataResolver metadataResolver;

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -27,8 +27,8 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 
@@ -53,7 +53,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
     static final String DEFAULT_USERBASE = "";
     static final String DEFAULT_USERSEARCH_PATTERN = "(sAMAccountName={0})";
 
-    protected static final Logger log = LoggerFactory.getLogger(LDAPAuthenticationBackend.class);
+    protected static final Logger log = LogManager.getLogger(LDAPAuthenticationBackend.class);
 
     private final Settings settings;
     private final Path configPath;

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -43,8 +43,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.Strings;
@@ -99,7 +99,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
     static final String DEFAULT_ROLENAME = "name";
     static final String DEFAULT_USERROLENAME = "memberOf";
 
-    protected static final Logger log = LoggerFactory.getLogger(LDAPAuthorizationBackend.class);
+    protected static final Logger log = LogManager.getLogger(LDAPAuthorizationBackend.class);
     private final Settings settings;
     private final WildcardMatcher skipUsersMatcher;
     private final WildcardMatcher nestedRoleMatcher;

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/Utils.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/Utils.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.ldaptive.Connection;
@@ -34,7 +34,7 @@ import org.ldaptive.LdapAttribute;
 
 public final class Utils {
 
-    private static final Logger log = LoggerFactory.getLogger(Utils.class);
+    private static final Logger log = LogManager.getLogger(Utils.class);
 
     private Utils() {
 

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -25,8 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.UUID;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -51,7 +51,7 @@ import org.opensearch.security.support.WildcardMatcher;
 
 public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destroyable {
 
-    protected static final Logger log = LoggerFactory.getLogger(LDAPAuthenticationBackend2.class);
+    protected static final Logger log = LogManager.getLogger(LDAPAuthenticationBackend2.class);
 
     private final Settings settings;
 

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -31,8 +31,8 @@ import java.util.Set;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.Strings;
@@ -68,7 +68,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
     static final String DEFAULT_ROLENAME = "name";
     static final String DEFAULT_USERROLENAME = "memberOf";
 
-    protected static final Logger log = LoggerFactory.getLogger(LDAPAuthorizationBackend2.class);
+    protected static final Logger log = LogManager.getLogger(LDAPAuthorizationBackend2.class);
     private final Settings settings;
     private final WildcardMatcher skipUsersMatcher;
     private final WildcardMatcher nestedRoleMatcher;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
@@ -22,8 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.ldaptive.ActivePassiveConnectionStrategy;
 import org.ldaptive.BindConnectionInitializer;
@@ -67,7 +67,7 @@ import com.amazon.dlic.util.SettingsBasedSSLConfigurator.SSLConfigException;
 
 public class LDAPConnectionFactoryFactory {
 
-    private static final Logger log = LoggerFactory.getLogger(LDAPConnectionFactoryFactory.class);
+    private static final Logger log = LogManager.getLogger(LDAPConnectionFactoryFactory.class);
 
     private final Settings settings;
     private final SettingsBasedSSLConfigurator.SSLConfig sslConfig;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.ldaptive.Connection;
 import org.ldaptive.LdapEntry;
@@ -36,7 +36,7 @@ import com.amazon.dlic.auth.ldap.util.LdapHelper;
 import com.amazon.dlic.auth.ldap.util.Utils;
 
 public class LDAPUserSearcher {
-    protected static final Logger log = LoggerFactory.getLogger(LDAPUserSearcher.class);
+    protected static final Logger log = LogManager.getLogger(LDAPUserSearcher.class);
 
     private static final int ZERO_PLACEHOLDER = 0;
     private static final String DEFAULT_USERBASE = "";

--- a/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfigurator.java
+++ b/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfigurator.java
@@ -45,8 +45,8 @@ import org.apache.http.ssl.PrivateKeyDetails;
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 
 import org.opensearch.security.ssl.util.SSLConfigConstants;
@@ -54,7 +54,7 @@ import org.opensearch.security.support.PemKeyReader;
 import com.google.common.collect.ImmutableList;
 
 public class SettingsBasedSSLConfigurator {
-    private static final Logger log = LoggerFactory.getLogger(SettingsBasedSSLConfigurator.class);
+    private static final Logger log = LogManager.getLogger(SettingsBasedSSLConfigurator.class);
 
     public static final String CERT_ALIAS = "cert_alias";
     public static final String CA_ALIAS = "ca_alias";

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -65,8 +65,8 @@ import org.opensearch.security.transport.SecurityInterceptor;
 import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.setting.TransportPassiveAuthSetting;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -180,7 +180,7 @@ import com.google.common.collect.Lists;
 public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin implements ClusterPlugin, MapperPlugin {
 
     private static final String KEYWORD = ".keyword";
-    private static final Logger actionTrace = LoggerFactory.getLogger("opendistro_security_action_trace");
+    private static final Logger actionTrace = LogManager.getLogger("opendistro_security_action_trace");
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(OpenSearchSecurityPlugin.class);
 
     public static final String LEGACY_OPENDISTRO_PREFIX = "_opendistro/_security";

--- a/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
@@ -33,8 +33,8 @@ package org.opensearch.security.action.configupdate;
 import java.io.IOException;
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.nodes.BaseNodeRequest;
@@ -57,7 +57,7 @@ public class TransportConfigUpdateAction
 extends
 TransportNodesAction<ConfigUpdateRequest, ConfigUpdateResponse, TransportConfigUpdateAction.NodeConfigUpdateRequest, ConfigUpdateNodeResponse> {
 
-    protected Logger logger = LoggerFactory.getLogger(getClass());
+    protected Logger logger = LogManager.getLogger(getClass());
     private final Provider<BackendRegistry> backendRegistry;
     private final ConfigurationRepository configurationRepository;
     private DynamicConfigFactory dynamicConfigFactory;

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -31,7 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 
 import java.util.Collections;

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -34,8 +34,8 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.config.AuditConfig;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.SpecialPermission;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkShardRequest;
@@ -80,7 +80,7 @@ import com.google.common.io.BaseEncoding;
 import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
 public abstract class AbstractAuditLog implements AuditLog {
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private final ThreadPool threadPool;
     private final IndexNameExpressionResolver resolver;

--- a/src/main/java/org/opensearch/security/auditlog/impl/RequestResolver.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/RequestResolver.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
@@ -65,7 +65,7 @@ import org.opensearch.security.support.WildcardMatcher;
 
 public final class RequestResolver {
 
-    private static final Logger log = LoggerFactory.getLogger(RequestResolver.class);
+    private static final Logger log = LogManager.getLogger(RequestResolver.class);
 
     public static List<AuditMessage> resolve(
             final AuditCategory category,

--- a/src/main/java/org/opensearch/security/auditlog/routing/AsyncStoragePool.java
+++ b/src/main/java/org/opensearch/security/auditlog/routing/AsyncStoragePool.java
@@ -21,14 +21,14 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.opensearch.security.auditlog.config.ThreadPoolConfig;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.auditlog.sink.AuditLogSink;
 
 public class AsyncStoragePool {
-	private static final Logger log = LoggerFactory.getLogger(AsyncStoragePool.class);
+	private static final Logger log = LogManager.getLogger(AsyncStoragePool.class);
 	private final ExecutorService pool;
 	private final ThreadPoolConfig threadPoolConfig;
 

--- a/src/main/java/org/opensearch/security/auditlog/routing/AuditMessageRouter.java
+++ b/src/main/java/org/opensearch/security/auditlog/routing/AuditMessageRouter.java
@@ -24,8 +24,8 @@ import java.util.Map;
 import org.opensearch.security.auditlog.config.ThreadPoolConfig;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
@@ -41,7 +41,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 public class AuditMessageRouter {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     final AuditLogSink defaultSink;
     volatile Map<AuditCategory, List<AuditLogSink>> categorySinks;
     final SinkProvider sinkProvider;

--- a/src/main/java/org/opensearch/security/auditlog/sink/AuditLogSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/AuditLogSink.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -32,7 +32,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 
 public abstract class AuditLogSink {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     protected final Settings settings;
     protected final String settingsPrefix;
     private final String name;

--- a/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
@@ -16,8 +16,8 @@
 package org.opensearch.security.auditlog.sink;
 
 import org.apache.logging.log4j.Level;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 
 import org.opensearch.security.auditlog.impl.AuditMessage;
@@ -32,7 +32,7 @@ public final class Log4JSink extends AuditLogSink {
     public Log4JSink(final String name, final Settings settings, final String settingsPrefix, AuditLogSink fallbackSink) {
         super(name, settings, settingsPrefix, fallbackSink);
         loggerName = settings.get( settingsPrefix + ".log4j.logger_name","sgaudit");
-        auditLogger = LoggerFactory.getLogger(loggerName);
+        auditLogger = LogManager.getLogger(loggerName);
         logLevel = Level.toLevel(settings.get(settingsPrefix + ".log4j.level","INFO").toUpperCase());
         enabled = isLogLevelEnabled(auditLogger, logLevel);
     }

--- a/src/main/java/org/opensearch/security/auditlog/sink/SinkProvider.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/SinkProvider.java
@@ -20,8 +20,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
@@ -31,7 +31,7 @@ import org.opensearch.security.support.ConfigConstants;
 
 public class SinkProvider {
 
-	protected final Logger log = LoggerFactory.getLogger(this.getClass());
+	protected final Logger log = LogManager.getLogger(this.getClass());
 	private static final String FALLBACKSINK_NAME = "fallback";
 	private static final String DEFAULTSINK_NAME = "default";
 	private final Client clientProvider;

--- a/src/main/java/org/opensearch/security/auth/AuthenticationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/AuthenticationBackend.java
@@ -47,7 +47,7 @@ import org.opensearch.security.user.User;
  * The constructor should not throw any exception in case of an initialization problem.
  * Instead catch all exceptions and log a appropriate error message. A logger can be instantiated like:
  * <p/>
- * {@code private final Logger log = LoggerFactory.getLogger(this.getClass());}
+ * {@code private final Logger log = LogManager.getLogger(this.getClass());}
  * 
  * <p/>
  */

--- a/src/main/java/org/opensearch/security/auth/AuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/AuthorizationBackend.java
@@ -47,7 +47,7 @@ import org.opensearch.security.user.User;
  * The constructor should not throw any exception in case of an initialization problem.
  * Instead catch all exceptions and log a appropriate error message. A logger can be instantiated like:
  * <p/>
- * {@code private final Logger log = LoggerFactory.getLogger(this.getClass());}
+ * {@code private final Logger log = LogManager.getLogger(this.getClass());}
  *
  * <p/>
  */

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -46,8 +46,8 @@ import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
@@ -81,7 +81,7 @@ import com.google.common.collect.Multimap;
 
 public class BackendRegistry {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private SortedSet<AuthDomain> restAuthDomains;
     private Set<AuthorizationBackend> restAuthorizers;
     private SortedSet<AuthDomain> transportAuthDomains;

--- a/src/main/java/org/opensearch/security/auth/HTTPAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/HTTPAuthenticator.java
@@ -50,7 +50,7 @@ import org.opensearch.security.user.AuthCredentials;
  * The constructor should not throw any exception in case of an initialization problem.
  * Instead catch all exceptions and log a appropriate error message. A logger can be instantiated like:
  * <p/>
- * {@code private final Logger log = LoggerFactory.getLogger(this.getClass());}
+ * {@code private final Logger log = LogManager.getLogger(this.getClass());}
  * <p/>
  */
 public interface HTTPAuthenticator {

--- a/src/main/java/org/opensearch/security/auth/RolesInjector.java
+++ b/src/main/java/org/opensearch/security/auth/RolesInjector.java
@@ -20,8 +20,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportRequest;
@@ -37,7 +37,7 @@ import java.util.Set;
  * User name is ignored. And roles are opendistro-roles.
  */
 final public class RolesInjector {
-    protected final Logger log = LoggerFactory.getLogger(RolesInjector.class);
+    protected final Logger log = LogManager.getLogger(RolesInjector.class);
     private final AuditLog auditLog;
 
     public RolesInjector(AuditLog auditLog) {

--- a/src/main/java/org/opensearch/security/auth/UserInjector.java
+++ b/src/main/java/org/opensearch/security/auth/UserInjector.java
@@ -36,8 +36,8 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Map;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.rest.RestRequest;
@@ -52,7 +52,7 @@ import com.google.common.base.Strings;
 
 public class UserInjector {
 
-    protected final Logger log = LoggerFactory.getLogger(UserInjector.class);
+    protected final Logger log = LogManager.getLogger(UserInjector.class);
 
     private final ThreadPool threadPool;
     private final AuditLog auditLog;

--- a/src/main/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/blocking/HeapBasedClientBlockRegistry.java
@@ -19,8 +19,8 @@ package org.opensearch.security.auth.blocking;
 
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -29,7 +29,7 @@ import com.google.common.cache.RemovalNotification;
 
 public class HeapBasedClientBlockRegistry<ClientIdType> implements ClientBlockRegistry<ClientIdType> {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
 
     private final Cache<ClientIdType, Long> cache;
     private final Class<ClientIdType> clientIdType;

--- a/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
@@ -47,8 +47,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.joda.time.DateTime;
@@ -76,7 +76,7 @@ import static org.opensearch.security.DefaultObjectMapper.getOrDefault;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ComplianceConfig {
 
-    private static final Logger log = LoggerFactory.getLogger(ComplianceConfig.class);
+    private static final Logger log = LogManager.getLogger(ComplianceConfig.class);
     public static final ComplianceConfig DEFAULT = ComplianceConfig.from(Settings.EMPTY);
     private static final int CACHE_SIZE = 1000;
     private static final String INTERNAL_OPENSEARCH = "internal_opensearch";

--- a/src/main/java/org/opensearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceIndexingOperationListenerImpl.java
@@ -17,8 +17,8 @@ package org.opensearch.security.compliance;
 
 import java.util.Objects;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.engine.Engine.Delete;
@@ -33,7 +33,7 @@ import org.opensearch.security.auditlog.AuditLog;
 
 public final class ComplianceIndexingOperationListenerImpl extends ComplianceIndexingOperationListener {
 
-    private static final Logger log = LoggerFactory.getLogger(ComplianceIndexingOperationListenerImpl.class);
+    private static final Logger log = LogManager.getLogger(ComplianceIndexingOperationListenerImpl.class);
     private final AuditLog auditlog;
     private volatile IndexService is;
 

--- a/src/main/java/org/opensearch/security/compliance/FieldReadCallback.java
+++ b/src/main/java/org/opensearch/security/compliance/FieldReadCallback.java
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.index.FieldInfo;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -49,7 +49,7 @@ import com.github.wnameless.json.flattener.JsonFlattener;
 
 public final class FieldReadCallback {
 
-    private static final Logger log = LoggerFactory.getLogger(FieldReadCallback.class);
+    private static final Logger log = LogManager.getLogger(FieldReadCallback.class);
     //private final ThreadContext threadContext;
     //private final ClusterService clusterService;
     private final Index index;

--- a/src/main/java/org/opensearch/security/configuration/AdminDNs.java
+++ b/src/main/java/org/opensearch/security/configuration/AdminDNs.java
@@ -41,8 +41,8 @@ import java.util.function.Function;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 
 import org.opensearch.security.support.ConfigConstants;
@@ -53,7 +53,7 @@ import com.google.common.collect.ImmutableMap;
 
 public class AdminDNs {
 
-    protected final Logger log = LoggerFactory.getLogger(AdminDNs.class);
+    protected final Logger log = LogManager.getLogger(AdminDNs.class);
     private final Set<LdapName> adminDn = new HashSet<LdapName>();
     private final Set<String> adminUsernames = new HashSet<String>();
     private final Map<LdapName, WildcardMatcher> allowedDnsImpersonations;

--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -33,8 +33,8 @@ package org.opensearch.security.configuration;
 import java.util.Iterator;
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
@@ -46,7 +46,7 @@ import org.opensearch.index.Index;
 
 public class ClusterInfoHolder implements ClusterStateListener {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile Boolean has6xNodes = null;
     private volatile Boolean has6xIndices = null;
     private volatile DiscoveryNodes nodes = null;

--- a/src/main/java/org/opensearch/security/configuration/CompatConfig.java
+++ b/src/main/java/org/opensearch/security/configuration/CompatConfig.java
@@ -31,8 +31,8 @@
 package org.opensearch.security.configuration;
 
 import org.opensearch.security.setting.OpensearchDynamicSetting;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.greenrobot.eventbus.Subscribe;
@@ -44,7 +44,7 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORT
 
 public class CompatConfig {
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final Logger log = LogManager.getLogger(getClass());
     private final Settings staticSettings;
     private DynamicConfigModel dcm;
     private final OpensearchDynamicSetting<Boolean> transportPassiveAuthSetting;

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -42,8 +42,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.support.ConfigHelper;
 import org.opensearch.security.support.SecurityUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetResponse;
@@ -71,7 +71,7 @@ import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTE
 
 public class ConfigurationLoaderSecurity7 {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final Client client;
     private final String securityIndex;
     private final ClusterService cs;

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -49,8 +49,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.support.SecurityUtils;
 import com.google.common.collect.ImmutableMap;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.ResourceAlreadyExistsException;
@@ -80,7 +80,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 public class ConfigurationRepository {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationRepository.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConfigurationRepository.class);
 
     private final String securityIndex;
     private final Client client;

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -24,8 +24,8 @@ import org.opensearch.search.aggregations.InternalAggregation;
 import org.opensearch.search.aggregations.InternalAggregations;
 import org.opensearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.opensearch.security.support.SecurityUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.BytesRef;
 
 import java.lang.reflect.Field;
@@ -68,7 +68,7 @@ import org.opensearch.security.support.HeaderHelper;
 import com.google.common.collect.ImmutableList;
 
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
-    private static final Logger log = LoggerFactory.getLogger(DlsFlsValveImpl.class);
+    private static final Logger log = LogManager.getLogger(DlsFlsValveImpl.class);
 
     /**
      *

--- a/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -18,8 +18,8 @@ package org.opensearch.security.configuration;
 import java.util.Map;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteRequest;
@@ -65,7 +65,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
             IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1"
     );
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     public PrivilegesInterceptorImpl(IndexNameExpressionResolver resolver, ClusterService clusterService, Client client, ThreadPool threadPool) {
         super(resolver, clusterService, client, threadPool);

--- a/src/main/java/org/opensearch/security/configuration/Salt.java
+++ b/src/main/java/org/opensearch/security/configuration/Salt.java
@@ -17,8 +17,8 @@ package org.opensearch.security.configuration;
 
 import org.opensearch.security.support.ConfigConstants;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class Salt {
 
-    private static final Logger log = LoggerFactory.getLogger(Salt.class);
+    private static final Logger log = LogManager.getLogger(Salt.class);
 
     @VisibleForTesting
     static final int SALT_SIZE = 16;

--- a/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
@@ -36,8 +36,8 @@ import java.util.Set;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.securityconf.ConfigModel;
 import org.opensearch.security.support.WildcardMatcher;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.index.DirectoryReader;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.settings.Settings;
@@ -53,7 +53,7 @@ import org.opensearch.security.user.User;
 
 public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException>  {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadContext threadContext;
     protected final Index index;
     protected final String securityIndex;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -22,8 +22,8 @@ import java.util.Collections;
 import java.util.Objects;
 
 import org.opensearch.security.DefaultObjectMapper;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.index.IndexRequest;
@@ -72,7 +72,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 
 public abstract class AbstractApiAction extends BaseRestHandler {
 
-	protected final Logger log = LoggerFactory.getLogger(this.getClass());
+	protected final Logger log = LogManager.getLogger(this.getClass());
 
 	protected final ConfigurationRepository cl;
 	protected final ClusterService cs;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -21,8 +21,8 @@ import java.nio.file.Path;
 import java.util.Iterator;
 
 import org.opensearch.security.DefaultObjectMapper;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
@@ -53,7 +53,7 @@ import com.flipkart.zjsonpatch.JsonPatchApplicationException;
 
 public abstract class PatchableResourceApiAction extends AbstractApiAction {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     public PatchableResourceApiAction(Settings settings, Path configPath, RestController controller, Client client,
                                       AdminDNs adminDNs, ConfigurationRepository cl, ClusterService cs,

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RestApiPrivilegesEvaluator.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.rest.RestRequest;
@@ -47,7 +47,7 @@ import org.opensearch.threadpool.ThreadPool;
 // TODO: Make Singleton?
 public class RestApiPrivilegesEvaluator {
 
-	protected final Logger logger = LoggerFactory.getLogger(this.getClass());
+	protected final Logger logger = LogManager.getLogger(this.getClass());
 
 	private final AdminDNs adminDNs;
 	private final PrivilegesEvaluator privilegesEvaluator;

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
@@ -25,8 +25,8 @@ import java.util.Set;
 
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.DefaultObjectMapper;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -57,7 +57,7 @@ public abstract class AbstractConfigurationValidator {
     /* public for testing */
     public final static String MISSING_MANDATORY_OR_KEYS_KEY = "specify_one_of";
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     /** Define the various keys for this validator */
     protected final Map<String, DataType> allowedKeys = new HashMap<>();

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -41,8 +41,8 @@ import org.opensearch.security.support.WildcardMatcher;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import org.opensearch.security.auth.BackendRegistry;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
@@ -104,7 +104,7 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.traceAction;
 
 public class SecurityFilter implements ActionFilter {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evalp;
     private final AdminDNs adminDns;
     private DlsFlsRequestValve dlsFlsValve;

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -37,8 +37,8 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.dlic.rest.api.WhitelistApiAction;
 import org.opensearch.security.securityconf.impl.WhitelistingSettings;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
@@ -71,7 +71,7 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class SecurityRestFilter {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final BackendRegistry registry;
     private final AuditLog auditLog;
     private final ThreadContext threadContext;

--- a/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
@@ -32,8 +32,8 @@ package org.opensearch.security.http;
 
 import java.nio.file.Path;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.BytesRestResponse;
@@ -48,7 +48,7 @@ import org.opensearch.security.user.AuthCredentials;
 //TODO FUTURE allow only if protocol==https
 public class HTTPBasicAuthenticator implements HTTPAuthenticator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     public HTTPBasicAuthenticator(final Settings settings, final Path configPath) {
     

--- a/src/main/java/org/opensearch/security/http/HTTPClientCertAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPClientCertAuthenticator.java
@@ -39,8 +39,8 @@ import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -53,7 +53,7 @@ import org.opensearch.security.user.AuthCredentials;
 
 public class HTTPClientCertAuthenticator implements HTTPAuthenticator {
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     protected final Settings settings;
 
     public HTTPClientCertAuthenticator(final Settings settings, final Path configPath) {

--- a/src/main/java/org/opensearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPProxyAuthenticator.java
@@ -33,8 +33,8 @@ package org.opensearch.security.http;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
@@ -49,7 +49,7 @@ import com.google.common.base.Predicates;
 
 public class HTTPProxyAuthenticator implements HTTPAuthenticator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile Settings settings;
     private final Pattern rolesSeparator;
 

--- a/src/main/java/org/opensearch/security/http/RemoteIpDetector.java
+++ b/src/main/java/org/opensearch/security/http/RemoteIpDetector.java
@@ -52,8 +52,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.RestRequest;
 
@@ -69,7 +69,7 @@ final class RemoteIpDetector {
     /**
      * Logger
      */
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     /**
      * Convert a given comma delimited String into an array of String

--- a/src/main/java/org/opensearch/security/http/XFFResolver.java
+++ b/src/main/java/org/opensearch/security/http/XFFResolver.java
@@ -32,8 +32,8 @@ package org.opensearch.security.http;
 
 import java.net.InetSocketAddress;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -46,7 +46,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 public class XFFResolver {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile boolean enabled;
     private volatile RemoteIpDetector detector;
     private final ThreadContext threadContext;

--- a/src/main/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
@@ -34,8 +34,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -50,7 +50,7 @@ public class HTTPExtendedProxyAuthenticator extends HTTPProxyAuthenticator{
 
     private static final String ATTR_PROXY = "attr.proxy.";
     private static final String ATTR_PROXY_USERNAME = "attr.proxy.username";
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile Settings settings;
 
     public HTTPExtendedProxyAuthenticator(Settings settings, final Path configPath) {

--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -46,8 +46,8 @@ import org.apache.http.ssl.PrivateKeyDetails;
 import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
@@ -129,7 +129,7 @@ public class HttpClient implements Closeable {
     }
 
     private final KeyStore trustStore;
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private RestHighLevelClient rclient;
     private String basicCredentials;
     private KeyStore keystore;

--- a/src/main/java/org/opensearch/security/privileges/DlsFlsEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/DlsFlsEvaluator.java
@@ -58,7 +58,7 @@ import com.google.common.collect.ImmutableMap;
 
 public class DlsFlsEvaluator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private final ThreadPool threadPool;
 

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -42,8 +42,8 @@ import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableSet;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.IndicesRequest;
@@ -114,7 +114,7 @@ public class PrivilegesEvaluator {
 
     private static final IndicesOptions ALLOW_EMPTY = IndicesOptions.fromOptions(true, true, false, false);
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final ClusterService clusterService;
 
     private final IndexNameExpressionResolver resolver;

--- a/src/main/java/org/opensearch/security/privileges/ProtectedIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ProtectedIndexAccessEvaluator.java
@@ -23,8 +23,8 @@ import org.opensearch.security.resolver.IndexResolverReplacer;
 import org.opensearch.security.securityconf.SecurityRoles;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.search.SearchRequest;
@@ -33,7 +33,7 @@ import org.opensearch.tasks.Task;
 
 public class ProtectedIndexAccessEvaluator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private final AuditLog auditLog;
     private final WildcardMatcher indexMatcher;

--- a/src/main/java/org/opensearch/security/privileges/SecurityIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/SecurityIndexAccessEvaluator.java
@@ -35,8 +35,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.search.SearchRequest;
@@ -51,7 +51,7 @@ import org.opensearch.security.support.WildcardMatcher;
 
 public class SecurityIndexAccessEvaluator {
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     
     private final String securityIndex;
     private final AuditLog auditLog;

--- a/src/main/java/org/opensearch/security/privileges/SnapshotRestoreEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/SnapshotRestoreEvaluator.java
@@ -32,8 +32,8 @@ package org.opensearch.security.privileges;
 
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.common.settings.Settings;
@@ -46,7 +46,7 @@ import org.opensearch.security.support.SnapshotRestoreHelper;
 
 public class SnapshotRestoreEvaluator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final boolean enableSnapshotRestorePrivilege;
     private final String securityIndex;
     private final AuditLog auditLog;

--- a/src/main/java/org/opensearch/security/privileges/TermsAggregationEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/TermsAggregationEvaluator.java
@@ -32,8 +32,8 @@ package org.opensearch.security.privileges;
 
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -50,7 +50,7 @@ import org.opensearch.security.user.User;
 
 public class TermsAggregationEvaluator {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     private static final String[] READ_ACTIONS = new String[]{
             "indices:data/read/msearch",

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -47,8 +47,8 @@ import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.apache.commons.collections.keyvalue.MultiKey;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.IndicesRequest;
@@ -104,7 +104,7 @@ import static org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS;
 public class IndexResolverReplacer {
 
     private static final Set<String> NULL_SET = new HashSet<>(Collections.singleton(null));
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final IndexNameExpressionResolver resolver;
     private final ClusterService clusterService;
     private final ClusterInfoHolder clusterInfoHolder;

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -36,8 +36,8 @@ import static org.opensearch.rest.RestRequest.Method.POST;
 import java.io.IOException;
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -73,7 +73,7 @@ public class DashboardsInfoAction extends BaseRestHandler {
             "/_opendistro/_security"))
         .build();
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;
     private final ThreadContext threadContext;
 

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -40,8 +40,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Set;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.util.RamUsageEstimator;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
@@ -69,7 +69,7 @@ public class SecurityInfoAction extends BaseRestHandler {
             new Route(POST, "/authinfo")
     ),"/_opendistro/_security", "/_plugins/_security");
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;
     private final ThreadContext threadContext;
 

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -44,8 +44,8 @@ import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.RoleMappings;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.service.ClusterService;
@@ -75,7 +75,7 @@ public class TenantInfoAction extends BaseRestHandler {
             ),
             "/_opendistro/_security", "/_plugins/_security");
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final PrivilegesEvaluator evaluator;
     private final ThreadContext threadContext;
     private final ClusterService clusterService;

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
@@ -35,8 +35,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -67,7 +67,7 @@ import static org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS;
 
 public class ConfigModelV6 extends ConfigModel {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private ConfigConstants.RolesMappingResolution rolesMappingResolution;
     private ActionGroupResolver agr = null;
     private SecurityRoles securityRoles = null;
@@ -299,7 +299,7 @@ public class ConfigModelV6 extends ConfigModel {
 
     public static class SecurityRoles implements org.opensearch.security.securityconf.SecurityRoles {
 
-        protected final Logger log = LoggerFactory.getLogger(this.getClass());
+        protected final Logger log = LogManager.getLogger(this.getClass());
 
         final Set<SecurityRole> roles;
 
@@ -937,7 +937,7 @@ public class ConfigModelV6 extends ConfigModel {
     }
 
     private static final class IndexMatcherAndTypePermissions {
-        private static final Logger log = LoggerFactory.getLogger(IndexMatcherAndTypePermissions.class);
+        private static final Logger log = LogManager.getLogger(IndexMatcherAndTypePermissions.class);
 
         private final WildcardMatcher matcher;
         private final Set<TypePerm> typePerms;

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -35,8 +35,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -67,7 +67,7 @@ import static org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS;
 
 public class ConfigModelV7 extends ConfigModel {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private ConfigConstants.RolesMappingResolution rolesMappingResolution;
     private ActionGroupResolver agr = null;
     private SecurityRoles securityRoles = null;
@@ -285,7 +285,7 @@ public class ConfigModelV7 extends ConfigModel {
 
     public static class SecurityRoles implements org.opensearch.security.securityconf.SecurityRoles {
 
-        protected final Logger log = LoggerFactory.getLogger(this.getClass());
+        protected final Logger log = LogManager.getLogger(this.getClass());
 
         final Set<SecurityRole> roles;
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -44,8 +44,8 @@ import org.opensearch.security.securityconf.impl.NodesDn;
 import org.opensearch.security.securityconf.impl.WhitelistingSettings;
 import org.opensearch.security.support.WildcardMatcher;
 import com.google.common.collect.ImmutableList;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
@@ -120,7 +120,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         return original;
     }
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final ConfigurationRepository cr;
     private final AtomicBoolean initialized = new AtomicBoolean();
     private final EventBus eventBus = EVENT_BUS_BUILDER.build();

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModel.java
@@ -38,8 +38,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.security.auth.AuthDomain;
 import org.opensearch.security.auth.AuthFailureListener;
@@ -58,7 +58,7 @@ import com.google.common.collect.Multimap;
 
 public abstract class DynamicConfigModel {
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     public abstract SortedSet<AuthDomain> getRestAuthDomains();
     public abstract Set<AuthorizationBackend> getRestAuthorizers();
     public abstract SortedSet<AuthDomain> getTransportAuthDomains();

--- a/src/main/java/org/opensearch/security/setting/OpensearchDynamicSetting.java
+++ b/src/main/java/org/opensearch/security/setting/OpensearchDynamicSetting.java
@@ -15,8 +15,8 @@
 
 package org.opensearch.security.setting;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 
@@ -30,7 +30,7 @@ public abstract class OpensearchDynamicSetting<T> {
     private final Setting<T> dynamicSetting;
     private volatile T dynamicSettingValue;
 
-    private final Logger logger = LoggerFactory.getLogger(getClass());
+    private final Logger logger = LogManager.getLogger(getClass());
 
     public OpensearchDynamicSetting(Setting<T> dynamicSetting, T dynamicSettingValue) {
         this.dynamicSetting = dynamicSetting;

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -66,8 +66,8 @@ import org.opensearch.security.ssl.util.KeystoreProps;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 
 import io.netty.util.internal.PlatformDependent;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.bouncycastle.asn1.ASN1InputStream;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -100,7 +100,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
     }
 
     private final Settings settings;
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     public final SslProvider sslHTTPProvider;
     public final SslProvider sslTransportServerProvider;
     public final SslProvider sslTransportClientProvider;

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -39,8 +39,8 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.Version;
@@ -92,7 +92,7 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
 
     private static boolean USE_NETTY_DEFAULT_ALLOCATOR = Booleans.parseBoolean(System.getProperty("opensearch.unsafe.use_netty_default_allocator"), false);
     public static final boolean OPENSSL_SUPPORTED = (PlatformDependent.javaVersion() < 12) && USE_NETTY_DEFAULT_ALLOCATOR;
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     protected static final String CLIENT_TYPE = "client.type";
     protected final boolean client;
     protected final boolean httpSSLEnabled;

--- a/src/main/java/org/opensearch/security/ssl/http/netty/SecuritySSLNettyHttpServerTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/SecuritySSLNettyHttpServerTransport.java
@@ -17,8 +17,8 @@
 
 package org.opensearch.security.ssl.http.netty;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.network.NetworkService;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
@@ -39,7 +39,7 @@ import io.netty.handler.ssl.SslHandler;
 
 public class SecuritySSLNettyHttpServerTransport extends Netty4HttpServerTransport {
 
-    private static final Logger logger = LoggerFactory.getLogger(SecuritySSLNettyHttpServerTransport.class);
+    private static final Logger logger = LogManager.getLogger(SecuritySSLNettyHttpServerTransport.class);
     private final SecurityKeyStore sks;
     private final SslExceptionHandler errorHandler;
     

--- a/src/main/java/org/opensearch/security/ssl/http/netty/ValidatingDispatcher.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/ValidatingDispatcher.java
@@ -21,8 +21,8 @@ import java.nio.file.Path;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.ExceptionsHelper;
@@ -39,7 +39,7 @@ import org.opensearch.security.ssl.util.SSLRequestHelper;
 
 public class ValidatingDispatcher implements Dispatcher {
 
-    private static final Logger logger = LoggerFactory.getLogger(ValidatingDispatcher.class);
+    private static final Logger logger = LogManager.getLogger(ValidatingDispatcher.class);
 
     private final ThreadContext threadContext;
     private final Dispatcher originalDispatcher;

--- a/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLCertsInfoAction.java
+++ b/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLCertsInfoAction.java
@@ -20,8 +20,8 @@ import org.opensearch.security.ssl.SecurityKeyStore;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import com.google.common.collect.ImmutableMap;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -55,7 +55,7 @@ public class SecuritySSLCertsInfoAction extends BaseRestHandler {
             new Route(Method.GET, "/_opendistro/_security/api/ssl/certs")
     );
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private Settings settings;
     private SecurityKeyStore odsks;
     private AdminDNs adminDns;

--- a/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLInfoAction.java
+++ b/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLInfoAction.java
@@ -27,8 +27,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -50,7 +50,7 @@ public class SecuritySSLInfoAction extends BaseRestHandler {
             new Route(Method.GET, "/_opendistro/_security/sslinfo")
     );
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final SecurityKeyStore sks;
     final PrincipalExtractor principalExtractor;
     private final Path configPath;

--- a/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
@@ -30,13 +30,13 @@ import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.security.auth.x500.X500Principal;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.SpecialPermission;
 
 public class DefaultPrincipalExtractor implements PrincipalExtractor {
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     
     @Override
     public String extractPrincipal(final X509Certificate x509Certificate, final Type type) {

--- a/src/main/java/org/opensearch/security/ssl/transport/DualModeSSLHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/DualModeSSLHandler.java
@@ -27,8 +27,8 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.ssl.SslHandler;
 import java.nio.charset.StandardCharsets;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.net.ssl.SSLException;
 import java.util.List;
@@ -38,7 +38,7 @@ import java.util.List;
  */
 public class DualModeSSLHandler extends ByteToMessageDecoder {
 
-    private static final Logger logger = LoggerFactory.getLogger(DualModeSSLHandler.class);
+    private static final Logger logger = LogManager.getLogger(DualModeSSLHandler.class);
     private final SecurityKeyStore securityKeyStore;
 
     private final SslHandler providedSSLHandler;

--- a/src/main/java/org/opensearch/security/ssl/transport/SSLConfig.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SSLConfig.java
@@ -16,8 +16,8 @@
 package org.opensearch.security.ssl.transport;
 
 import org.opensearch.security.support.ConfigConstants;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Setting;
 import org.opensearch.common.settings.Settings;
@@ -25,7 +25,7 @@ import org.opensearch.security.support.SecuritySettings;
 
 public class SSLConfig {
 
-    private static final Logger logger = LoggerFactory.getLogger(SSLConfig.class);
+    private static final Logger logger = LogManager.getLogger(SSLConfig.class);
 
     private final boolean sslOnly;
     private volatile boolean dualModeEnabled;

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
@@ -42,8 +42,8 @@ import java.security.PrivilegedAction;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -71,7 +71,7 @@ import io.netty.handler.ssl.SslHandler;
 
 public class SecuritySSLNettyTransport extends Netty4Transport {
 
-    private static final Logger logger = LoggerFactory.getLogger(SecuritySSLNettyTransport.class);
+    private static final Logger logger = LogManager.getLogger(SecuritySSLNettyTransport.class);
     private final SecurityKeyStore ossks;
     private final SslExceptionHandler errorHandler;
     private final SSLConfig SSLConfig;
@@ -147,7 +147,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
     }
 
     protected static class ClientSSLHandler extends ChannelOutboundHandlerAdapter {
-        private final Logger log = LoggerFactory.getLogger(this.getClass());
+        private final Logger log = LogManager.getLogger(this.getClass());
         private final SecurityKeyStore sks;
         private final boolean hostnameVerificationEnabled;
         private final boolean hostnameVerificationResovleHostName;

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -25,8 +25,8 @@ import java.util.Arrays;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import org.opensearch.security.support.ConfigConstants;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -52,7 +52,7 @@ implements TransportRequestHandler<T> {
     private final String action;
     private final TransportRequestHandler<T> actualHandler;
     private final ThreadPool threadPool;
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     private final PrincipalExtractor principalExtractor;
     private final SslExceptionHandler errorHandler;
     private final SSLConfig SSLConfig;

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLTransportInterceptor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLTransportInterceptor.java
@@ -17,8 +17,8 @@
 
 package org.opensearch.security.ssl.transport;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportInterceptor;
@@ -29,7 +29,7 @@ import org.opensearch.security.ssl.SslExceptionHandler;
 
 public final class SecuritySSLTransportInterceptor implements TransportInterceptor {
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadPool threadPool;
     protected final PrincipalExtractor principalExtractor;
     protected final SslExceptionHandler errorHandler;

--- a/src/main/java/org/opensearch/security/ssl/util/SSLCertificateHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLCertificateHelper.java
@@ -31,13 +31,13 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.Strings;
 
 public class SSLCertificateHelper {
 
-    private static final Logger log = LoggerFactory.getLogger(SSLCertificateHelper.class);
+    private static final Logger log = LogManager.getLogger(SSLCertificateHelper.class);
     private static boolean stripRootFromChain = true; //TODO check
     
     public static X509Certificate[] exportRootCertificates(final KeyStore ks, final String alias) throws KeyStoreException {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
@@ -23,8 +23,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Utility class to test if the server supports SSL connections.
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
  */
 public class SSLConnectionTestUtil {
 
-    private static final Logger logger = LoggerFactory.getLogger(SSLConnectionTestUtil.class);
+    private static final Logger logger = LogManager.getLogger(SSLConnectionTestUtil.class);
     public static final byte[] OPENSEARCH_PING_MSG = new byte[]{(byte) 'E', (byte) 'S', (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
     public static final String DUAL_MODE_CLIENT_HELLO_MSG = "DUALCM";
     public static final String DUAL_MODE_SERVER_HELLO_MSG = "DUALSM";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -38,8 +38,8 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
@@ -53,7 +53,7 @@ import org.opensearch.security.ssl.transport.PrincipalExtractor.Type;
 
 public class SSLRequestHelper {
 
-    private static final Logger log = LoggerFactory.getLogger(SSLRequestHelper.class);
+    private static final Logger log = LogManager.getLogger(SSLRequestHelper.class);
     
     public static class SSLInfo {
         private final X509Certificate[] x509Certs;

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -76,7 +76,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.BaseEncoding;
 
 public class Base64Helper {
-    private static final Logger logger = LoggerFactory.getLogger(Base64Helper.class);
+    private static final Logger logger = LogManager.getLogger(Base64Helper.class);
 
     private static final String ODFE_PACKAGE = "com.amazon.opendistroforelasticsearch";
     private static final String OS_PACKAGE = "org.opensearch";

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -37,8 +37,8 @@ import java.io.Reader;
 import java.io.StringReader;
 
 import org.opensearch.security.securityconf.impl.Meta;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
@@ -59,7 +59,7 @@ import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTE
 
 public class ConfigHelper {
     
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConfigHelper.class);
 
     public static void uploadFile(Client tc, String filepath, String index, CType cType, int configVersion) throws Exception {
         uploadFile(tc, filepath, index, cType, configVersion, false);

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -35,7 +35,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.rest.RestRequest;
 
 import org.opensearch.security.user.AuthCredentials;

--- a/src/main/java/org/opensearch/security/support/PemKeyReader.java
+++ b/src/main/java/org/opensearch/security/support/PemKeyReader.java
@@ -67,8 +67,8 @@ import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.bouncycastle.util.encoders.Base64;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
@@ -77,7 +77,7 @@ import org.opensearch.env.Environment;
 public final class PemKeyReader {
     
     //private static final String[] EMPTY_STRING_ARRAY = new String[0];
-    protected static final Logger log = LoggerFactory.getLogger(PemKeyReader.class);
+    protected static final Logger log = LogManager.getLogger(PemKeyReader.class);
     static final String JKS = "JKS";
     static final String PKCS12 = "PKCS12";
     

--- a/src/main/java/org/opensearch/security/support/ReflectionHelper.java
+++ b/src/main/java/org/opensearch/security/support/ReflectionHelper.java
@@ -39,8 +39,8 @@ import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 
@@ -51,7 +51,7 @@ import org.opensearch.security.transport.InterClusterRequestEvaluator;
 
 public class ReflectionHelper {
 
-    protected static final Logger log = LoggerFactory.getLogger(ReflectionHelper.class);
+    protected static final Logger log = LogManager.getLogger(ReflectionHelper.class);
 
     private static Set<ModuleInfo> modulesLoaded = new HashSet<>();
 

--- a/src/main/java/org/opensearch/security/support/SecurityUtils.java
+++ b/src/main/java/org/opensearch/security/support/SecurityUtils.java
@@ -41,15 +41,15 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.settings.Settings;
 
 import org.opensearch.security.tools.Hasher;
 
 public final class SecurityUtils {
     
-    protected final static Logger log = LoggerFactory.getLogger(SecurityUtils.class);
+    protected final static Logger log = LogManager.getLogger(SecurityUtils.class);
     private static final Pattern ENV_PATTERN = Pattern.compile("\\$\\{env\\.([\\w]+)((\\:\\-)?[\\w]*)\\}");
     private static final Pattern ENVBC_PATTERN = Pattern.compile("\\$\\{envbc\\.([\\w]+)((\\:\\-)?[\\w]*)\\}");
     private static final Pattern ENVBASE64_PATTERN = Pattern.compile("\\$\\{envbase64\\.([\\w]+)((\\:\\-)?[\\w]*)\\}");

--- a/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
+++ b/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
@@ -36,8 +36,8 @@ import java.util.List;
 import java.util.Objects;
 
 import org.opensearch.security.OpenSearchSecurityPlugin;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.SpecialPermission;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.support.PlainActionFuture;
@@ -50,7 +50,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 public class SnapshotRestoreHelper {
 
-    protected static final Logger log = LoggerFactory.getLogger(SnapshotRestoreHelper.class);
+    protected static final Logger log = LogManager.getLogger(SnapshotRestoreHelper.class);
     
     public static List<String> resolveOriginalIndices(RestoreSnapshotRequest restoreRequest) {
         final SnapshotInfo snapshotInfo = getSnapshotInfo(restoreRequest);

--- a/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
+++ b/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
@@ -41,8 +41,8 @@ import java.util.Map;
 
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.NodesDnModel;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.transport.TransportRequest;
@@ -53,7 +53,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 public final class DefaultInterClusterRequestEvaluator implements InterClusterRequestEvaluator {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
     private final String certOid;
     private final WildcardMatcher staticNodesDnFromEsYml;
     private boolean dynamicNodesDnConfigEnabled;

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -39,8 +39,8 @@ import java.util.stream.Collectors;
 
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.apache.commons.lang.StringUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.get.GetRequest;
@@ -82,7 +82,7 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.isActionTraceEnab
 
 public class SecurityInterceptor {
 
-    protected final Logger log = LoggerFactory.getLogger(getClass());
+    protected final Logger log = LogManager.getLogger(getClass());
     private BackendRegistry backendRegistry;
     private AuditLog auditLog;
     private final ThreadPool threadPool;

--- a/src/main/java/org/opensearch/security/util/ratetracking/HeapBasedRateTracker.java
+++ b/src/main/java/org/opensearch/security/util/ratetracking/HeapBasedRateTracker.java
@@ -21,8 +21,8 @@ import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -31,7 +31,7 @@ import com.google.common.cache.RemovalNotification;
 
 public class HeapBasedRateTracker<ClientIdType> implements RateTracker<ClientIdType> {
 
-    private final Logger log = LoggerFactory.getLogger(this.getClass());
+    private final Logger log = LogManager.getLogger(this.getClass());
 
     private final Cache<ClientIdType, ClientRecord> cache;
     private final long timeWindowMs;

--- a/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
@@ -29,9 +29,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.network.SocketUtils;
 import com.google.common.io.CharStreams;
@@ -48,7 +47,7 @@ import com.unboundid.util.ssl.SSLUtil;
 import com.unboundid.util.ssl.TrustStoreTrustManager;
 
 final class LdapServer {
-    private final static Logger LOG = LoggerFactory.getLogger(LdapServer.class);
+    private final static Logger LOG = LogManager.getLogger(LdapServer.class);
 
     private static final int LOCK_TIMEOUT = 60;
     private static final TimeUnit TIME_UNIT = TimeUnit.SECONDS;
@@ -217,7 +216,7 @@ final class LdapServer {
     }
 
     /* private static class DebugHandler extends Handler {
-        private final static Logger LOG = LoggerFactory.getLogger(DebugHandler.class);
+        private final static Logger LOG = LogManager.getLogger(DebugHandler.class);
 
         @Override
         public void publish(LogRecord logRecord) {

--- a/src/test/java/org/opensearch/security/ResolveAPITests.java
+++ b/src/test/java/org/opensearch/security/ResolveAPITests.java
@@ -16,8 +16,8 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -34,7 +34,7 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 
 public class ResolveAPITests extends SingleClusterTest {
     
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     @Test
     public void testResolveDnfofFalse() throws Exception {

--- a/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
@@ -30,8 +30,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.ExceptionsHelper;
 import org.junit.Assert;
 import org.junit.Test;
@@ -43,7 +43,7 @@ import org.opensearch.security.test.helper.file.FileHelper;
 public class CertificateValidatorTest {
     
     public static final Date CRL_DATE = new Date(1525546426000L);
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     
     @Test
     public void testStaticCRL() throws Exception {

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -44,8 +44,8 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.get.GetRequest;
@@ -96,7 +96,7 @@ public abstract class AbstractSecurityUnitTest {
         //System.setProperty("security.display_lic_none","true");
     }
 
-    protected final Logger log = LoggerFactory.getLogger(this.getClass());
+    protected final Logger log = LogManager.getLogger(this.getClass());
     public static final ThreadPool MOCK_POOL = new ThreadPool(Settings.builder().put("node.name",  "mock").build());
 
     //TODO Test Matrix

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -43,8 +43,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.OpenSearchTimeoutException;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.node.info.NodeInfo;
@@ -75,7 +75,7 @@ public final class ClusterHelper {
         System.setProperty("security.default_init.dir", new File("./securityconfig").getAbsolutePath());
     }
 
-    protected final Logger log = LoggerFactory.getLogger(ClusterHelper.class);
+    protected final Logger log = LogManager.getLogger(ClusterHelper.class);
 
     protected final List<PluginAwareNode> opensearchNodes = new LinkedList<>();
 

--- a/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
@@ -47,8 +47,8 @@ import java.nio.file.Paths;
 import java.security.KeyStore;
 
 import org.apache.commons.io.IOUtils;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
 import org.opensearch.common.xcontent.XContentBuilder;
@@ -60,7 +60,7 @@ import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTE
 
 public class FileHelper {
 
-	protected final static Logger log = LoggerFactory.getLogger(FileHelper.class);
+	protected final static Logger log = LogManager.getLogger(FileHelper.class);
 
 	public static KeyStore getKeystoreFromClassPath(final String fileNameFromClasspath, String password) throws Exception {
 	    Path path = getAbsoluteFilePathFromClassPath(fileNameFromClasspath);

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -68,15 +68,15 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
-import org.slf4j.LoggerFactory;
-import org.slf4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.file.FileHelper;
 
 public class RestHelper {
 
-	protected final Logger log = LoggerFactory.getLogger(RestHelper.class);
+	protected final Logger log = LogManager.getLogger(RestHelper.class);
 	
 	public boolean enableHTTPClientSSL = true;
 	public boolean enableHTTPClientSSLv3Only = false;


### PR DESCRIPTION
### Description

In OpenSearch 1.3.0 we removed an explicit dependency on log4j
https://github.com/opensearch-project/security/pull/1563 this caused the
log4j-slf4j-impl-X.XX.X.jar file no longer to be included in the plugin.
When the plugin started up the default no-op logger was used instead.
This prevented the security plugin from logging anything, yikes.

When looking at the other opensearch plugins, none of them use slf4.
Rather than continue using a seperate logging process, moving to the
standard log4j Logger/LogManager.

Tested this change on 2.0.0-alpha distribution and logging works as
expected.

Signed-off-by: Peter Nied <petern@amazon.com>
(cherry picked from commit 54a920b20bd520f25aef328c1bb4997b325f46ce)


* Category : Refactoring

### Issues Resolved
* Resolves #1790 

Backport PR #1751

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
