### PR TITLE
Add custom build script to ignore standalone admin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# The OpenSearch Contributors require contributions made to
+# this file be licensed under the Apache-2.0 license or a
+# compatible open source license.
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+mkdir -p $OUTPUT
+
+./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+
+zipPath=$(find . -path \*build/distributions/*.zip -not -name "*standalone.zip")
+
+echo "FIXING BUILD BREAK 1.3.2"
+echo "COPY ${zipPath}/*.zip"
+mkdir -p $OUTPUT/plugins
+cp $zipPath ./$OUTPUT/plugins 


### PR DESCRIPTION
### Description
Add custom build script to ignore standalone admin.  This script is largely from the deleted version of https://github.com/opensearch-project/opensearch-build/pull/1927.  The standalone-admin zip is generated as a part of the 1.X builds and is picked up by the default build script.

This change only applies to the the 1.x line as in 2.0.0 that tool has been removed.

### Issues Resolved
* Closes https://github.com/opensearch-project/security/issues/1809

### Testing
Built locally with a custom manifest for 1.3.2 pointing to this change
```
% ./build.sh manifests/1.3.2/opensearch-1.3.2.yml --component security
Installing dependencies in . ...
Installing dependencies from Pipfile.lock (d422cd)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 5/5 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Running ./src/run_build.py manifests/1.3.2/opensearch-1.3.2.yml --component security ...
2022-04-29 20:05:46 INFO     Building in /tmp/tmpsgjiquwj
2022-04-29 20:05:46 INFO     Building OpenSearch (x64) into /local/home/petern/git/opensearch-build/tar/builds/opensearch
2022-04-29 20:05:46 INFO     Skipping OpenSearch
2022-04-29 20:05:46 INFO     Skipping common-utils
2022-04-29 20:05:46 INFO     Skipping job-scheduler
2022-04-29 20:05:46 INFO     Skipping ml-commons
2022-04-29 20:05:46 INFO     Skipping alerting
2022-04-29 20:05:46 INFO     Skipping asynchronous-search
2022-04-29 20:05:46 INFO     Skipping index-management
2022-04-29 20:05:46 INFO     Building security
2022-04-29 20:05:46 INFO     Executing "git init" in /tmp/tmpsgjiquwj/security
2022-04-29 20:05:46 INFO     Executing "git remote add origin https://github.com/peternied/security.git" in /tmp/tmpsgjiquwj/security
2022-04-29 20:05:46 INFO     Executing "git fetch --depth 1 origin build-break-1.3.2" in /tmp/tmpsgjiquwj/security
2022-04-29 20:05:47 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpsgjiquwj/security
2022-04-29 20:05:47 INFO     Executing "git rev-parse HEAD" in /tmp/tmpsgjiquwj/security
2022-04-29 20:05:47 INFO     Checked out https://github.com/peternied/security.git@build-break-1.3.2 into /tmp/tmpsgjiquwj/security at 4d17d1ceddd714e017333e2463cdf8b44c0196eb
2022-04-29 20:05:47 INFO     Executing "bash /tmp/tmpsgjiquwj/security/build.sh -v 1.3.2 -p linux -a x64 -s false -o builds" in /tmp/tmpsgjiquwj/security
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ VERSION=1.3.2
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ PLATFORM=linux
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ ARCHITECTURE=x64
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ SNAPSHOT=false
+ getopts :h:v:q:s:o:p:a: arg
+ case $arg in
+ OUTPUT=builds
+ getopts :h:v:q:s:o:p:a: arg
+ '[' -z 1.3.2 ']'
+ [[ ! -z '' ]]
+ [[ false == \t\r\u\e ]]
+ '[' -z builds ']'
+ mkdir -p builds
+ ./gradlew assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=1.3.2 -Dbuild.snapshot=false -Dbuild.version_qualifier=
To honour the JVM settings for this build a single-use Daemon process will be forked. See https://docs.gradle.org/7.3/userguide/gradle_daemon.html#sec:disabling_the_daemon.
Daemon will be stopped at the end of the build 

> Task :compileJava
/tmp/tmpsgjiquwj/security/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java:178: warning: non-varargs call of varargs method with inexact argument type for last parameter;
            Method getInnerChannel = wrappedChannelCls.getMethod("getInnerChannel", null);
                                                                                    ^
  cast to Class for a varargs call
  cast to Class[] for a non-varargs call and to suppress this warning
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
1 warning

Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

See https://docs.gradle.org/7.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 27s
8 actionable tasks: 8 executed
++ find . -path '*build/distributions/*.zip' -not -name '*standalone.zip'
+ zipPath=./build/distributions/opensearch-security-1.3.2.0.zip
+ echo 'FIXING BUILD BREAK 1.3.2'
FIXING BUILD BREAK 1.3.2
+ echo 'COPY ./build/distributions/opensearch-security-1.3.2.0.zip/*.zip'
COPY ./build/distributions/opensearch-security-1.3.2.0.zip/*.zip
+ mkdir -p builds/plugins
+ cp ./build/distributions/opensearch-security-1.3.2.0.zip ./builds/plugins
2022-04-29 20:06:15 INFO     Recording plugins artifact for security: plugins/opensearch-security-1.3.2.0.zip (from /tmp/tmpsgjiquwj/security/builds/plugins/opensearch-security-1.3.2.0.zip)
2022-04-29 20:06:15 INFO     Checked /tmp/tmpsgjiquwj/security/builds/plugins/opensearch-security-1.3.2.0.zip (1.3.2.0)
2022-04-29 20:06:15 INFO     Skipping performance-analyzer
2022-04-29 20:06:15 INFO     Skipping cross-cluster-replication
2022-04-29 20:06:15 INFO     Skipping dashboards-reports
2022-04-29 20:06:15 INFO     Skipping opensearch-observability
2022-04-29 20:06:15 INFO     Created build manifest /local/home/petern/git/opensearch-build/tar/builds/opensearch/manifest.yml
2022-04-29 20:06:15 INFO     Done.
```


### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
