### PR TITLE
Keep jackson-databind in alignment with OpenSearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'


### PR DESCRIPTION
### Description
While addressing CVE-2020-36518 the security team updated to the latest
minor version of jackson-databind, whereas the OpenSearch team took the
CVE specific update.  Aligning with OpenSearch's version.

### Issues Resolved
* Resolves the build break associated with https://github.com/opensearch-project/OpenSearch/issues/2597

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
