### PR TITLE
Add suppression for all removal warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,6 +379,12 @@ tasks.withType(Checkstyle) {
     }
 }
 
+tasks.withType(JavaCompile) {
+    configure(options) {
+        options.compilerArgs << '-Xlint:removal' << '-Werror'
+    }
+}
+
 spotless {
   java {
     // note: you can use an empty string for all the imports you didn't specify explicitly, and '\\#` prefix for static imports

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -78,6 +78,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     }
 
     @Override
+    @SuppressWarnings("removal")
     public AuthCredentials extractCredentials(RestRequest request, ThreadContext context)
             throws OpenSearchSecurityException {
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -114,6 +114,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
 
     @Override
+    @SuppressWarnings("removal")
     public AuthCredentials extractCredentials(RestRequest request, ThreadContext context) throws OpenSearchSecurityException {
         final SecurityManager sm = System.getSecurityManager();
 

--- a/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -70,6 +70,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
     private Set<String> acceptorPrincipal;
     private Path acceptorKeyTabPath;
 
+    @SuppressWarnings("removal")
     public HTTPSpnegoAuthenticator(final Settings settings, final Path configPath) {
         super();
         try {
@@ -165,6 +166,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
+    @SuppressWarnings("removal")
     public AuthCredentials extractCredentials(final RestRequest request, ThreadContext threadContext) {
         final SecurityManager sm = System.getSecurityManager();
 

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -125,6 +125,7 @@ class AuthTokenProcessorHandler {
 
     }
 
+    @SuppressWarnings("removal")
     boolean handle(RestRequest restRequest, RestChannel restChannel) throws Exception {
         try {
             final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -258,6 +258,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
         }
     }
 
+    @SuppressWarnings("removal")
     static void ensureOpenSamlInitialization() {
         if (openSamlInitialized) {
             return;
@@ -299,6 +300,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
         }
     }
 
+    @SuppressWarnings("removal")
     private MetadataResolver createMetadataResolver(final Settings settings, final Path configPath)
             throws Exception {
         final AbstractMetadataResolver metadataResolver;

--- a/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
@@ -67,6 +67,7 @@ public class Saml2SettingsProvider {
         this.spSignaturePrivateKey = spSignaturePrivateKey;
     }
 
+    @SuppressWarnings("removal")
     Saml2Settings get() throws SamlConfigException {
         try {
             HashMap<String, Object> configProperties = new HashMap<>();

--- a/src/main/java/com/amazon/dlic/auth/http/saml/SamlFilesystemMetadataResolver.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/SamlFilesystemMetadataResolver.java
@@ -34,6 +34,7 @@ public class SamlFilesystemMetadataResolver extends FilesystemMetadataResolver {
     }
 
     @Override
+    @SuppressWarnings("removal")
     protected byte[] fetchMetadata() throws ResolverException {
         try {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<byte[]>() {

--- a/src/main/java/com/amazon/dlic/auth/http/saml/SamlHTTPMetadataResolver.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/SamlHTTPMetadataResolver.java
@@ -41,6 +41,7 @@ public class SamlHTTPMetadataResolver extends HTTPMetadataResolver {
     }
 
     @Override
+    @SuppressWarnings("removal")
     protected byte[] fetchMetadata() throws ResolverException {
         try {
             return AccessController.doPrivileged(new PrivilegedExceptionAction<byte[]>() {
@@ -64,6 +65,7 @@ public class SamlHTTPMetadataResolver extends HTTPMetadataResolver {
         return new SettingsBasedSSLConfigurator(settings, configPath, "idp").buildSSLConfig();
     }
 
+    @SuppressWarnings("removal")
     private static HttpClient createHttpClient(Settings settings, Path configPath) throws Exception {
         try {
             final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -117,6 +117,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         this.userBaseSettings = LDAPAuthenticationBackend.getUserBaseSettings(settings);
     }
 
+    @SuppressWarnings("removal")
     public static void checkConnection(final ConnectionConfig connectionConfig, String bindDn, byte[] password) throws Exception {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -146,6 +147,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
     }
 
+    @SuppressWarnings("removal")
     public static Connection getConnection(final Settings settings, final Path configPath) throws Exception {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -201,7 +203,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         return Collections.singletonList(result.entrySet().iterator().next());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings("removal")
     private static void checkConnection0(final ConnectionConfig connectionConfig, String bindDn, byte[] password, final ClassLoader cl,
                                          final boolean needRestore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException,
                                          FileNotFoundException, IOException, LdapException {
@@ -244,7 +246,6 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private static Connection getConnection0(final Settings settings, final Path configPath, final ClassLoader cl,
             final boolean needRestore) throws KeyStoreException, NoSuchAlgorithmException, CertificateException,
             FileNotFoundException, IOException, LdapException {
@@ -477,6 +478,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         };
     }
 
+    @SuppressWarnings("removal")
     private static void restoreClassLoader0(final ClassLoader cl) {
         try {
             AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
@@ -43,6 +43,7 @@ import org.opensearch.SpecialPermission;
 public class LdapHelper {
 
     private static SearchFilter ALL = new SearchFilter("(objectClass=*)");
+    @SuppressWarnings("removal")
     public static List<LdapEntry> search(final Connection conn, final String unescapedDn, SearchFilter filter,
             final SearchScope searchScope) throws LdapException {
 

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/Utils.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/Utils.java
@@ -41,6 +41,7 @@ public final class Utils {
 
     }
 
+    @SuppressWarnings("removal")
     public static void unbindAndCloseSilently(final Connection connection) {
         if (connection == null) {
             return;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -85,6 +85,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
     }
 
     @Override
+    @SuppressWarnings("removal")
     public User authenticate(final AuthCredentials credentials) throws OpenSearchSecurityException {
         final SecurityManager sm = System.getSecurityManager();
 
@@ -184,6 +185,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
         return "ldap";
     }
 
+    @SuppressWarnings("removal")
     @Override
     public boolean exists(final User user) {
         final SecurityManager sm = System.getSecurityManager();
@@ -230,6 +232,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
         }
     }
 
+    @SuppressWarnings("removal")
     private void authenticateByLdapServer(final Connection connection, final String dn, byte[] password)
             throws LdapException {
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -120,6 +120,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         return Collections.singletonList(result.entrySet().iterator().next());
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void fillRoles(final User user, final AuthCredentials optionalAuthCreds)
             throws OpenSearchSecurityException {

--- a/src/main/java/com/amazon/dlic/auth/ldap2/MakeJava9Happy.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/MakeJava9Happy.java
@@ -29,6 +29,7 @@ public class MakeJava9Happy {
     private static ClassLoader classLoader;
     private static boolean isJava9OrHigher = PlatformDependent.javaVersion() >= 9;;
 
+    @SuppressWarnings("removal")
     static ClassLoader getClassLoader() {
         if (!isJava9OrHigher) {
             return null;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/PrivilegedProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/PrivilegedProvider.java
@@ -85,6 +85,7 @@ public class PrivilegedProvider implements Provider<JndiProviderConfig> {
         }
 
         @Override
+        @SuppressWarnings("removal")
         public ProviderConnection create() throws LdapException {
             final SecurityManager sm = System.getSecurityManager();
 
@@ -121,6 +122,7 @@ public class PrivilegedProvider implements Provider<JndiProviderConfig> {
             this.jndiProviderConfig = jndiProviderConfig;
         }
 
+        @SuppressWarnings("removal")
         public Response<Void> bind(BindRequest request) throws LdapException {
             final SecurityManager sm = System.getSecurityManager();
 

--- a/src/main/java/org/opensearch/security/DefaultObjectMapper.java
+++ b/src/main/java/org/opensearch/security/DefaultObjectMapper.java
@@ -100,6 +100,7 @@ public class DefaultObjectMapper {
         return value != null ? value : defaultValue;
     }
 
+    @SuppressWarnings("removal")
     public static <T> T readTree(JsonNode node, Class<T> clazz) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -120,6 +121,7 @@ public class DefaultObjectMapper {
         }
     }
     
+    @SuppressWarnings("removal")
     public static <T> T readValue(String string, Class<T> clazz) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -140,6 +142,7 @@ public class DefaultObjectMapper {
         }
     }
     
+    @SuppressWarnings("removal")
     public static JsonNode readTree(String string) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -160,6 +163,7 @@ public class DefaultObjectMapper {
         }
     }
 
+    @SuppressWarnings("removal")
     public static String writeValueAsString(Object value, boolean omitDefaults) throws JsonProcessingException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -181,6 +185,7 @@ public class DefaultObjectMapper {
 
     }
 
+    @SuppressWarnings("removal")
     public static <T> T readValue(String string, TypeReference<T> tr) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -202,6 +207,7 @@ public class DefaultObjectMapper {
 
     }
 
+    @SuppressWarnings("removal")
     public static <T> T readValue(String string, JavaType jt) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
+++ b/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
@@ -59,6 +59,7 @@ public class NonValidatingObjectMapper {
         nonValidatingObjectMapper.setInjectableValues(injectableValues);
     }
 
+    @SuppressWarnings("removal")
     public static <T> T readValue(String string, JavaType jt) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -258,6 +258,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
         return settings.getAsBoolean(ConfigConstants.SECURITY_SSL_CERT_RELOAD_ENABLED, false);
     }
 
+    @SuppressWarnings("removal")
     public OpenSearchSecurityPlugin(final Settings settings, final Path configPath) {
         super(settings, configPath, isDisabled(settings));
 

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -79,6 +79,7 @@ import org.opensearch.transport.TransportRequest;
 
 import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
+
 public abstract class AbstractAuditLog implements AuditLog {
     protected final Logger log = LogManager.getLogger(this.getClass());
 
@@ -508,6 +509,7 @@ public abstract class AbstractAuditLog implements AuditLog {
         save(msg);
     }
 
+    @SuppressWarnings("removal")
     protected void logExternalConfig() {
 
         final ComplianceConfig complianceConfig = getComplianceConfig();

--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditLogImpl.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditLogImpl.java
@@ -59,6 +59,7 @@ public final class AuditLogImpl extends AbstractAuditLog {
 		this(settings, configPath, clientProvider, threadPool, resolver, clusterService, null);
 	}
 
+    @SuppressWarnings("removal")
 	public AuditLogImpl(final Settings settings,
 						final Path configPath,
 						final Client clientProvider,
@@ -103,6 +104,7 @@ public final class AuditLogImpl extends AbstractAuditLog {
     }
 
     @Override
+    @SuppressWarnings("removal")
     public void close() throws IOException {
 
         log.info("Closing {}", getClass().getSimpleName());

--- a/src/main/java/org/opensearch/security/auditlog/sink/KafkaSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/KafkaSink.java
@@ -41,6 +41,7 @@ public class KafkaSink extends AuditLogSink {
 	private Producer<Long, String> producer;
 	private String topicName;
 
+    @SuppressWarnings("removal")
 	public KafkaSink(final String name, final Settings settings, final String settingsPrefix, AuditLogSink fallbackSink) {
 		super(name, settings, settingsPrefix, fallbackSink);
 

--- a/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
@@ -102,6 +102,7 @@ public class WebhookSink extends AuditLogSink {
 	}
 
 	@Override
+    @SuppressWarnings("removal")
 	public boolean doStore(AuditMessage msg) {
 		if (Strings.isEmpty(webhookUrl)) {
 			log.debug("Webhook URL is null");
@@ -299,6 +300,7 @@ public class WebhookSink extends AuditLogSink {
 		}
 	}
 
+    @SuppressWarnings("removal")
 	private KeyStore getEffectiveKeyStore(final Path configPath) {
 
 		return AccessController.doPrivileged(new PrivilegedAction<KeyStore>() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -562,6 +562,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
         }
 
+        @SuppressWarnings("removal")
         private static <T> Field getField(Class<T> cls, String name) {
             SpecialPermission.check();
             return AccessController.doPrivileged((PrivilegedAction<Field>) () -> getFieldPrivileged(cls, name));

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -137,6 +137,7 @@ public class Utils {
 
     }
 
+    @SuppressWarnings("removal")
     public static byte[] jsonMapToByteArray(Map<String, Object> jsonAsMap) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();
@@ -163,6 +164,7 @@ public class Utils {
         }
     }
 
+    @SuppressWarnings("removal")
     public static Map<String, Object> byteArrayToMutableJsonMap(byte[] jsonBytes) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -738,6 +738,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
     }
 
+    @SuppressWarnings("removal")
     private void initEnabledSSLCiphers() {
 
         final List<String> secureHttpSSLCiphers = SSLConfigConstants.getSecureSSLCiphers(settings, true);
@@ -898,6 +899,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
     }
 
+    @SuppressWarnings("removal")
     private SslContext buildSSLContext0(final SslContextBuilder sslContextBuilder) throws SSLException {
 
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -109,6 +109,7 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
 //        this(settings, configPath, false);
 //    }
 
+    @SuppressWarnings("removal")
     protected OpenSearchSecuritySSLPlugin(final Settings settings, final Path configPath, boolean disabled) {
 
         if(disabled) {

--- a/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/DefaultPrincipalExtractor.java
@@ -40,6 +40,7 @@ public class DefaultPrincipalExtractor implements PrincipalExtractor {
     protected final Logger log = LogManager.getLogger(this.getClass());
     
     @Override
+    @SuppressWarnings("removal")
     public String extractPrincipal(final X509Certificate x509Certificate, final Type type) {
         if (x509Certificate == null) {
             return null;

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
@@ -210,6 +210,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
         private final DiscoveryNode node;
         private SSLConnectionTestResult connectionTestResult;
 
+        @SuppressWarnings("removal")
         public SSLClientChannelInitializer(DiscoveryNode node) {
             this.node = node;
             hostnameVerificationEnabled = settings.getAsBoolean(

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -102,6 +102,7 @@ public class SSLRequestHelper {
 
     }
 
+    @SuppressWarnings("removal")
     public static SSLInfo getSSLInfo(final Settings settings, final Path configPath, final RestRequest request, PrincipalExtractor principalExtractor) throws SSLPeerUnverifiedException {
         
         if(request == null || request.getHttpChannel() == null || !(request.getHttpChannel() instanceof Netty4HttpChannel)) {

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -107,6 +107,7 @@ public class Base64Helper {
 
         private static final boolean useSafeObjectOutputStream = checkSubstitutionPermission();
 
+        @SuppressWarnings("removal")
         private static boolean checkSubstitutionPermission() {
             SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
@@ -135,6 +136,7 @@ public class Base64Helper {
             }
         }
 
+        @SuppressWarnings("removal")
         private SafeObjectOutputStream(OutputStream out) throws IOException {
             super(out);
 

--- a/src/main/java/org/opensearch/security/support/ReflectiveAttributeAccessors.java
+++ b/src/main/java/org/opensearch/security/support/ReflectiveAttributeAccessors.java
@@ -52,6 +52,7 @@ public class ReflectiveAttributeAccessors {
             this.type = type;
         }
 
+        @SuppressWarnings("removal")
         @Override
         public R apply(O object) {
             final SecurityManager sm = System.getSecurityManager();
@@ -89,6 +90,7 @@ public class ReflectiveAttributeAccessors {
             this.type = type;
         }
 
+        @SuppressWarnings("removal")
         @Override
         public R apply(O object) {
             final SecurityManager sm = System.getSecurityManager();
@@ -128,6 +130,7 @@ public class ReflectiveAttributeAccessors {
             this.type = type;
         }
 
+        @SuppressWarnings("removal")
         @Override
         public Void apply(O object, R value) {
             final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
+++ b/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
@@ -91,6 +91,7 @@ public class SnapshotRestoreHelper {
         return snapshotInfo;
     }
     
+    @SuppressWarnings("removal")
     private static void setCurrentThreadName(final String name) {
         final SecurityManager sm = System.getSecurityManager();
 


### PR DESCRIPTION
### Description

Use of the SecurityManager and AccessController have been deprecated and
will be removed in java versions after 17.  While this is an issue its
also one that will take a concerted effort to resolve.  These warning
messages making discovering build errors and other warnings more
difficult; hence adding this supression logic.

For tracking the effort to replace these components look into https://github.com/opensearch-project/OpenSearch/issues/1687

### Issues Resolved
* Related to https://github.com/opensearch-project/OpenSearch/issues/1687

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
