### PR TITLE
Introduce new API _plugins/_security/ssl/certs

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLCertsInfoAction.java
+++ b/src/main/java/org/opensearch/security/ssl/rest/SecuritySSLCertsInfoAction.java
@@ -18,11 +18,11 @@ package org.opensearch.security.ssl.rest;
 import java.io.IOException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -44,16 +44,18 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
 
 /**
  * Rest API action to get SSL certificate information related to http and transport encryption.
  * Only super admin users are allowed to access this API.
- * Currently this action serves GET request for _opendistro/_security/api/ssl/certs endpoint
+ * Currently this action serves GET request for _plugins/_security/api/ssl/certs endpoint
  */
 public class SecuritySSLCertsInfoAction extends BaseRestHandler {
-    private static final List<Route> routes = Collections.singletonList(
-            new Route(Method.GET, "/_opendistro/_security/api/ssl/certs")
-    );
+    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(
+            new Route(Method.GET, "/ssl/certs")
+    ));
 
     private final Logger log = LogManager.getLogger(this.getClass());
     private Settings settings;
@@ -82,7 +84,7 @@ public class SecuritySSLCertsInfoAction extends BaseRestHandler {
      * GET request to fetch transport certificate details
      *
      * Sample request:
-     * GET _opendistro/_security/api/ssl/certs
+     * GET _plugins/_security/api/ssl/certs
      *
      * Sample response:
      * {

--- a/src/test/java/org/opensearch/security/ssl/SecuritySSLCertsInfoActionTests.java
+++ b/src/test/java/org/opensearch/security/ssl/SecuritySSLCertsInfoActionTests.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableMap;
 import net.minidev.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
@@ -31,9 +33,24 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-public class SecuritySSLCertsInfoActionTests extends SingleClusterTest {
+import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
+import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
-    private final String ENDPOINT = "_opendistro/_security/api/ssl/certs";
+@RunWith(Parameterized.class)
+public class SecuritySSLCertsInfoActionTests extends SingleClusterTest {
+    private final String ENDPOINT;
+
+    public SecuritySSLCertsInfoActionTests(String endpoint){
+        ENDPOINT = endpoint;
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<String> endpoints() {
+        return ImmutableList.of(
+                LEGACY_OPENDISTRO_PREFIX +  "/api/ssl/certs",
+                PLUGINS_PREFIX +  "/api/ssl/certs"
+        );
+    }
 
     private final List<Map<String, String>> NODE_CERT_DETAILS = ImmutableList.of(
         ImmutableMap.of(


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
Introducing `_plugins/_security/ssl/certs` API path to be consistent with OpenSearch API path convention.
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Enhancement
* Why these changes are required? Apply consistent API path convention.

### Issues Resolved
#1827 

### Testing
UTs

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

### TO-DO
- [ ] Create an issue in [documentation-website repo](https://github.com/opensearch-project/documentation-website/issues) to update [documentaion](https://opensearch.org/docs/latest/security-plugin/access-control/api/#request-39) once this PR gets merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
