### PR TITLE
Add Alerting getFindings cluster permission

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -18,6 +18,7 @@ alerting_read_access:
     - 'cluster:admin/opendistro/alerting/destination/get'
     - 'cluster:admin/opendistro/alerting/monitor/get'
     - 'cluster:admin/opendistro/alerting/monitor/search'
+    - 'cluster:admin/opensearch/alerting/findings/get'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:
@@ -31,6 +32,7 @@ alerting_full_access:
   cluster_permissions:
     - 'cluster_monitor'
     - 'cluster:admin/opendistro/alerting/*'
+    - 'cluster:admin/opensearch/alerting/*'
   index_permissions:
     - index_patterns:
         - '*'


### PR DESCRIPTION
Signed-off-by: Ashish Agrawal <ashisagr@amazon.com>

### Description
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
  * Enhancement
* Why these changes are required?
  * The Alerting plugin created a new api called getFindings and need to add its cluster permission, cluster:admin/opensearch/alerting/findings/get, as part of the default roles.
* What is the old behavior before changes and new behavior after changes?
  * The default `alerting_read_access` and `alerting_full_access` now has the cluster permission for getFindings
### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #
N/A
### Testing
Builds fine

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
