### PR TITLE
Add default roles for Notifications plugin

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -33,6 +33,7 @@ alerting_full_access:
     - 'cluster_monitor'
     - 'cluster:admin/opendistro/alerting/*'
     - 'cluster:admin/opensearch/alerting/*'
+    - 'cluster:admin/opensearch/notifications/feature/publish'
   index_permissions:
     - index_patterns:
         - '*'
@@ -155,6 +156,7 @@ index_management_full_access:
     - "cluster:admin/opendistro/ism/*"
     - "cluster:admin/opendistro/rollup/*"
     - "cluster:admin/opendistro/transform/*"
+    - "cluster:admin/opensearch/notifications/feature/publish"
   index_permissions:
     - index_patterns:
         - '*'
@@ -211,3 +213,17 @@ ml_full_access:
         - '*'
       allowed_actions:
         - 'indices_monitor'
+
+# Allows users to use all Notifications functionality
+notifications_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/notifications/*'
+
+# Allows users to read Notifications config/channels
+notifications_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/notifications/configs/get'
+    - 'cluster:admin/opensearch/notifications/features'
+    - 'cluster:admin/opensearch/notifications/channels/get'


### PR DESCRIPTION
Signed-off-by: Mohammad Qureshi <47198598+qreshi@users.noreply.github.com>

### Description
[Describe what this change achieves]
Adding new full access and read-only roles for the Notifications plugin launching in 2.0.

There is also a `"cluster:admin/opensearch/notifications/feature/publish"` permission which is for the legacy Notification publish which only Alerting and ISM use as a fallback to their legacy behavior. This permission has been added to the Alerting and IM full access roles to ensure no disruption in functionality in the fallback case.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #
This PR isn't a backport but it should be backported to the `2.0` branch, I don't have permissions to add the label myself to trigger the workflow

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
