### PR TITLE
Bump version to 2.1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
         cp -r build/ ./bwc-test/
         mkdir ./bwc-test/src/test/resources/security_plugin_version_no_snapshot
         cp build/distributions/opensearch-security-${security_plugin_version_no_snapshot}.zip ./bwc-test/src/test/resources/${security_plugin_version_no_snapshot}
-        mkdir bwc-test/src/test/resources/1.3.0.0
-        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/latest/linux/x64/builds/opensearch/plugins/opensearch-security-1.3.0.0.zip
-        mv opensearch-security-1.3.0.0.zip bwc-test/src/test/resources/1.3.0.0/
+        mkdir bwc-test/src/test/resources/2.0.0.0
+        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.0.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.0.0.0.zip
+        mv opensearch-security-2.0.0.0.zip bwc-test/src/test/resources/2.0.0.0/
         cd bwc-test/
         ./gradlew bwcTestSuite -Dtests.security.manager=false
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -47,7 +47,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
     repositories {
@@ -76,13 +76,13 @@ dependencies {
 String bwcVersion = "1.3.0.0";
 String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
-String projectVersion = "2.0.0.0"
+String projectVersion = "2.1.0.0"
 
 2.times {i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-        versions = ["1.3.0","2.0.0"]
+        versions = ["1.3.0","2.1.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 
-String bwcVersion = "1.3.0.0";
+String bwcVersion = "2.0.0.0";
 String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
 String projectVersion = "2.1.0.0"
@@ -82,7 +82,7 @@ String projectVersion = "2.1.0.0"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-        versions = ["1.3.0","2.1.0"]
+        versions = ["2.0.0","2.1.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/bwc-test/gradle/wrapper/gradle-wrapper.properties
+++ b/bwc-test/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Bump security plugin version to 2.1.0.0 and OpenSearch core version to 2.1.0.
* Upgrading Gradle to [the version that OpenSearch core uses.](https://github.com/opensearch-project/OpenSearch/blob/main/gradle/wrapper/gradle-wrapper.properties#L14)
```
* What went wrong:
A problem occurred evaluating root project 'bwc-test'.
> Failed to apply plugin class 'org.opensearch.gradle.info.GlobalBuildInfoPlugin'.
   > Gradle 7.4.1+ is required
```

### Testing
UTs

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
