### PR TITLE
Revert "Bump version to 2.1.0.0"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,9 +72,9 @@ jobs:
         cp -r build/ ./bwc-test/
         mkdir ./bwc-test/src/test/resources/security_plugin_version_no_snapshot
         cp build/distributions/opensearch-security-${security_plugin_version_no_snapshot}.zip ./bwc-test/src/test/resources/${security_plugin_version_no_snapshot}
-        mkdir bwc-test/src/test/resources/2.0.0.0
-        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.0.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.0.0.0.zip
-        mv opensearch-security-2.0.0.0.zip bwc-test/src/test/resources/2.0.0.0/
+        mkdir bwc-test/src/test/resources/1.3.0.0
+        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/latest/linux/x64/builds/opensearch/plugins/opensearch-security-1.3.0.0.zip
+        mv opensearch-security-1.3.0.0.zip bwc-test/src/test/resources/1.3.0.0/
         cd bwc-test/
         ./gradlew bwcTestSuite -Dtests.security.manager=false
 

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ repositories {
 
 ext {
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -47,7 +47,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.0.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
     repositories {
@@ -73,16 +73,16 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 
-String bwcVersion = "2.0.0.0";
+String bwcVersion = "1.3.0.0";
 String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
-String projectVersion = "2.1.0.0"
+String projectVersion = "2.0.0.0"
 
 2.times {i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-        versions = ["2.0.0","2.1.0"]
+        versions = ["1.3.0","2.0.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/bwc-test/gradle/wrapper/gradle-wrapper.properties
+++ b/bwc-test/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Reverts opensearch-project/security#1855

Seeing new build failures after this was merged, main CI failure: https://github.com/opensearch-project/security/runs/6615546106?check_suite_focus=true
```
* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find org.apache.lucene:lucene-core:9.2.0-snapshot-ba8c3a8.
     Searched in the following locations:
```