### PR TITLE
Prevent recursive action groups

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -41,7 +41,6 @@ import org.opensearch.security.dlic.rest.validation.ActionGroupValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
-import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.threadpool.ThreadPool;
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -15,9 +15,11 @@
 
 package org.opensearch.security.dlic.rest.api;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import org.opensearch.client.Client;
@@ -25,9 +27,11 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.bytes.BytesReference;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
@@ -35,6 +39,8 @@ import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidat
 import org.opensearch.security.dlic.rest.validation.ActionGroupValidator;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -97,4 +103,35 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		request.param("name");
 	}
 
+	@Override
+	protected void handlePut(RestChannel channel, RestRequest request, Client client, JsonNode content) throws IOException {
+		final String name = request.param("name");
+
+		if (name == null || name.length() == 0) {
+			badRequestResponse(channel, "No " + getResourceName() + " specified.");
+			return;
+		}
+
+		// Prevent the case where action group and role share a same name.
+		SecurityDynamicConfiguration<?> existingRoles = load(CType.ROLES, false);
+		for (String role : existingRoles.getCEntries().keySet()) {
+			if (role.equals(name)) {
+				badRequestResponse(channel, name + " is an existing role. A action group cannot be named with an existing role name.");
+				return;
+			}
+		}
+
+		// Prevent the case where action group references to itself in the allowed_actions.
+		final SecurityDynamicConfiguration<?> existingActionGroups = load(getConfigName(), false);
+		existingActionGroups.putCObject(name, DefaultObjectMapper.readTree(content, existingActionGroups.getImplementingClass()));
+
+		for (String allowed_action : ((ActionGroupsV7) existingActionGroups.getCEntry(name)).getAllowed_actions()) {
+			if (allowed_action.equals(name)) {
+				badRequestResponse(channel, name + " cannot be an allowed_action of itself");
+				return;
+			}
+		}
+
+		super.handlePut(channel, request, client, content);
+	}
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -125,7 +125,7 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		final SecurityDynamicConfiguration<?> existingActionGroupsConfig = load(getConfigName(), false);
 		existingActionGroupsConfig.putCObject(name, DefaultObjectMapper.readTree(content, existingActionGroupsConfig.getImplementingClass()));
 		List<String> allowedActions = ((ActionGroupsV7) existingActionGroupsConfig.getCEntry(name)).getAllowed_actions();
-		if (allowedActions.contains(name)) {
+		if (hasActionGroupSelfReference(existingActionGroupsConfig, name)) {
 			badRequestResponse(channel, name + " cannot be an allowed_action of itself");
 			return;
 		}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -124,7 +124,6 @@ public class ActionGroupsApiAction extends PatchableResourceApiAction {
 		// Prevent the case where action group references to itself in the allowed_actions.
 		final SecurityDynamicConfiguration<?> existingActionGroupsConfig = load(getConfigName(), false);
 		existingActionGroupsConfig.putCObject(name, DefaultObjectMapper.readTree(content, existingActionGroupsConfig.getImplementingClass()));
-		List<String> allowedActions = ((ActionGroupsV7) existingActionGroupsConfig.getCEntry(name)).getAllowed_actions();
 		if (hasActionGroupSelfReference(existingActionGroupsConfig, name)) {
 			badRequestResponse(channel, name + " cannot be an allowed_action of itself");
 			return;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -281,7 +281,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
     }
 
     // Prevent the case where action group references to itself in the allowed_actions.
-    private Boolean hasActionGroupSelfReference(SecurityDynamicConfiguration<?> mdc, String name) {
+    protected Boolean hasActionGroupSelfReference(SecurityDynamicConfiguration<?> mdc, String name) {
         List<String> allowedActions = ((ActionGroupsV7) mdc.getCEntry(name)).getAllowed_actions();
         return allowedActions.contains(name);
     }


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Bug fix

* Prevent the following 3 cases that cause recursive action groups and result in `StackOverflowException` when resolving the security configurations in runtime:

1. Prevent creating an action group with a role name.
2. Prevent creating an action group with itself as an allowed_actions.
3. Prevent patching an action group with itself as an allowed_actions.

### Issues Resolved
https://github.com/opensearch-project/security/issues/1389

### Testing
UTs

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
