### PR TITLE
Cluster permissions evaluation logic will now include `index_template` type action

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -592,7 +592,7 @@ public class PrivilegesEvaluator {
     public static boolean isClusterPerm(String action0) {
         return  (    action0.startsWith("cluster:")
                 || action0.startsWith("indices:admin/template/")
-
+                || action0.startsWith("indices:admin/index_template/")
             || action0.startsWith(SearchScrollAction.NAME)
             || (action0.equals(BulkAction.NAME))
             || (action0.equals(MultiGetAction.NAME))

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -57,6 +57,7 @@ import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
 import org.opensearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
+import org.opensearch.action.admin.indices.template.put.PutComponentTemplateAction;
 import org.opensearch.action.bulk.BulkRequest;
 import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.action.delete.DeleteRequest;
@@ -697,6 +698,8 @@ public class IndexResolverReplacer {
             //do nothing
         } else if (request instanceof SearchScrollRequest) {
             //do nothing
+        } else if (request instanceof PutComponentTemplateAction.Request) {
+            // do nothing
         } else {
             if (isDebugEnabled) {
                 log.debug(request.getClass() + " not supported (It is likely not a indices related request)");

--- a/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security;
+
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest{
+        private RestHelper rh;
+
+        final static String indexTemplateBody = "{ \"index_patterns\": [\"sem1234*\"], \"template\": { \"settings\": { \"number_of_shards\": 2, \"number_of_replicas\": 1 }, \"mappings\": { \"properties\": { \"timestamp\": { \"type\": \"date\", \"format\": \"yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis\" }, \"value\": { \"type\": \"double\" } } } } }";
+
+        private String getFailureResponseReason(String user) {
+            return "no permissions for [indices:admin/index_template/put] and User [name=" + user + ", backend_roles=[], requestedTenant=null]";
+        }
+
+        @Before
+        public void setupRestHelper() throws Exception{
+            setup();
+            rh = nonSslRestHelper();
+        }
+        @Test
+        public void testPutIndexTemplateByNonPrivilegedUser() throws Exception {
+            String expectedFailureResponse = getFailureResponseReason("ds3");
+
+            // should fail, as user `ds3` doesn't have correct permissions
+            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("ds3", "nagilum"));
+            Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+            Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
+        }
+
+        @Test
+        public void testPutIndexTemplateByPrivilegedUser() throws Exception {
+            // should pass, as user `sem-user` has correct permissions
+            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("sem-user", "nagilum"));
+            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        }
+
+        @Test
+        public void testPutIndexTemplateAsIndexLevelPermission() throws Exception {
+            String expectedFailureResponse = getFailureResponseReason("sem-user2");
+
+            // should fail, as user `sem-user2` is assigned `put-template` permission as index-level, not cluster-level
+            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("sem-user2", "nagilum"));
+            Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+            Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
+        }
+
+    }

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -350,3 +350,9 @@ hidden_test:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   opendistro_security_roles:
   - hidden_test
+sem-user:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+sem-user2:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1095,7 +1095,7 @@ data_stream_1:
   reserved: true
   hidden: false
   description: "Migrated from v6 (all types mapped)"
-  cluster_permissions: []
+  cluster_permissions: [ "indices:admin/index_template/put" ]
   index_permissions:
     - index_patterns:
         - "my-data-stream*"
@@ -1137,3 +1137,25 @@ hidden_test:
     - hidden_test_not_hidden
     allowed_actions:
     - "*"
+
+sem-role:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: [ "cluster_monitor", "indices:admin/index_template/put" ]
+  index_permissions:
+    - index_patterns:
+        - "sem*"
+      allowed_actions:
+        - "*"
+
+sem-role2:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: [ "cluster_monitor" ]
+  index_permissions:
+    - index_patterns:
+        - "sem*"
+      allowed_actions:
+        - "indices:admin/index_template/put"

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -413,3 +413,13 @@ data_stream_3:
   hidden: false
   users:
     - "ds3"
+sem-role:
+  reserved: false
+  hidden: false
+  users:
+    - "sem-user"
+sem-role2:
+  reserved: false
+  hidden: false
+  users:
+    - "sem-user2"


### PR DESCRIPTION
### Description
Title
* Category : Bug Fix

### Issues Resolved
* Resolves #1884 

### Testing
A test is written to evaluate this

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
