### PR TITLE
Adds default roles for Snapshot Management plugin

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -227,3 +227,22 @@ notifications_read_access:
     - 'cluster:admin/opensearch/notifications/configs/get'
     - 'cluster:admin/opensearch/notifications/features'
     - 'cluster:admin/opensearch/notifications/channels/get'
+
+# Allows users to use all snapshot management functionality
+snapshot_management_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/snapshot_management/*'
+    - 'cluster:admin/opensearch/notifications/feature/publish'
+    - 'cluster:admin/repository/*'
+    - 'cluster:admin/snapshot/*'
+
+# Allows users to see snapshots, repositories, and snapshot management policies
+snapshot_management_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/snapshot_management/policy/get'
+    - 'cluster:admin/opensearch/snapshot_management/policy/search'
+    - 'cluster:admin/opensearch/snapshot_management/policy/explain'
+    - 'cluster:admin/repository/get'
+    - 'cluster:admin/snapshot/get'


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>

### Description
Adds new full access and read-only roles for the Snapshot Management plugin launching in 2.1.

### Issues Resolved
Depending on the security plugin's branching strategy, this PR may need to be ported to the 2.x branch so it may be included in the 2.1 branch once that is cut. 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
