### PR TITLE
Update `org.apache.zookeeper:zookeeper` to `3.7.1`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ dependencies {
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.8'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
-    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.6.3'
+    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.7.1'
     testRuntimeOnly 'org.apache.kafka:kafka-metadata:3.0.1'
     testRuntimeOnly 'org.apache.kafka:kafka-storage:3.0.1'
 


### PR DESCRIPTION
### Description
Update `org.apache.zookeeper:zookeeper` to `3.7.1`
   
Fixes CVE-2021-4104, CVE-2020-9488, and more from dependency on log4j-1.2.17.jar

### Issues Resolved
* Resolves #1904
* Resolves #1905
* Resolves #1906
* Resolves #1907
* Resolves #1908
* Resolves #1909
* Resolves #1910

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
