### PR TITLE
[Backport 2.x] Adds default roles for Snapshot Management plugin (#1897)

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -227,3 +227,22 @@ notifications_read_access:
     - 'cluster:admin/opensearch/notifications/configs/get'
     - 'cluster:admin/opensearch/notifications/features'
     - 'cluster:admin/opensearch/notifications/channels/get'
+
+# Allows users to use all snapshot management functionality
+snapshot_management_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/snapshot_management/*'
+    - 'cluster:admin/opensearch/notifications/feature/publish'
+    - 'cluster:admin/repository/*'
+    - 'cluster:admin/snapshot/*'
+
+# Allows users to see snapshots, repositories, and snapshot management policies
+snapshot_management_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/snapshot_management/policy/get'
+    - 'cluster:admin/opensearch/snapshot_management/policy/search'
+    - 'cluster:admin/opensearch/snapshot_management/policy/explain'
+    - 'cluster:admin/repository/get'
+    - 'cluster:admin/snapshot/get'


### PR DESCRIPTION
Signed-off-by: Clay Downs <downsrob@amazon.com>
(cherry picked from commit 7f5ca536da4599e4ad2d22ba05af0e33bf107fee)

Backport 7f5ca536da4599e4ad2d22ba05af0e33bf107fee from #1897 



### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
