### PR TITLE
Upgrade netty to 4.1.77

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,10 +220,10 @@ configurations.all {
         force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
         force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
         force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-        force 'io.netty:netty-buffer:4.1.73.Final'
-        force 'io.netty:netty-common:4.1.73.Final'
-        force 'io.netty:netty-handler:4.1.73.Final'
-        force 'io.netty:netty-transport:4.1.73.Final'
+        force "io.netty:netty-buffer:${versions.netty}"
+        force "io.netty:netty-common:${versions.netty}"
+        force "io.netty:netty-handler:${versions.netty}"
+        force "io.netty:netty-transport:${versions.netty}"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

First PR! 🥇 This upgrades Netty to address a CVE in 4.1.73. This resolves [1831](https://github.com/opensearch-project/security/issues/1831)

* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved

- [1831](https://github.com/opensearch-project/security/issues/1831)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

This passes CI

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
