### PR TITLE
Tenant info action test

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -363,13 +363,13 @@ public class ConfigurationRepository {
                 } else {
                     LOGGER.debug("security index exists and was created with ES 7 (new layout)");
                 }
-                retVal.putAll(validate(cl.load(configTypes.toArray(new CType[0]), 5, TimeUnit.SECONDS, acceptInvalid), configTypes.size()));
+                retVal.putAll(validate(cl.load(configTypes.toArray(new CType[0]), 10, TimeUnit.SECONDS, acceptInvalid), configTypes.size()));
 
 
             } else {
                 //wait (and use new layout)
                 LOGGER.debug("security index not exists (yet)");
-                retVal.putAll(validate(cl.load(configTypes.toArray(new CType[0]), 5, TimeUnit.SECONDS, acceptInvalid), configTypes.size()));
+                retVal.putAll(validate(cl.load(configTypes.toArray(new CType[0]), 10, TimeUnit.SECONDS, acceptInvalid), configTypes.size()));
             }
 
         } catch (Exception e) {

--- a/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
@@ -74,18 +74,6 @@ public class RolesInjectorIntegTest extends SingleClusterTest {
         }
     }
 
-    //Wait for the security plugin to load roles.
-    private void waitForInit(Client client) throws Exception {
-        try {
-            client.admin().cluster().health(new ClusterHealthRequest()).actionGet();
-        } catch (OpenSearchSecurityException ex) {
-            if(ex.getMessage().contains("OpenSearch Security not initialized")) {
-                Thread.sleep(500);
-                waitForInit(client);
-            }
-        }
-    }
-
     @Test
     public void testRolesInject() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles("roles.yml"), Settings.EMPTY);

--- a/src/test/java/org/opensearch/security/RolesValidationIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesValidationIntegTest.java
@@ -20,7 +20,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
-import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
@@ -68,18 +67,6 @@ public class RolesValidationIntegTest extends SingleClusterTest {
                 threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION, rolesValidation);
             }
             return new ArrayList<>();
-        }
-    }
-
-    //Wait for the security plugin to load roles.
-    private void waitForInit(Client client) throws Exception {
-        try {
-            client.admin().cluster().health(new ClusterHealthRequest()).actionGet();
-        } catch (OpenSearchSecurityException ex) {
-            if(ex.getMessage().contains("OpenSearch Security not initialized")) {
-                Thread.sleep(500);
-                waitForInit(client);
-            }
         }
     }
 

--- a/src/test/java/org/opensearch/security/TransportUserInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/TransportUserInjectorIntegTest.java
@@ -20,7 +20,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
-import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.client.Client;
@@ -64,18 +63,6 @@ public class TransportUserInjectorIntegTest extends SingleClusterTest {
             if(injectedUser != null)
                 threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, injectedUser);
             return new ArrayList<>();
-        }
-    }
-
-    //Wait for the security plugin to load roles.
-    private void waitForInit(Client client) throws Exception {
-        try {
-            client.admin().cluster().health(new ClusterHealthRequest()).actionGet();
-        } catch (OpenSearchSecurityException ex) {
-            if(ex.getMessage().contains("OpenSearch Security not initialized")) {
-                Thread.sleep(500);
-                waitForInit(client);
-            }
         }
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/integration/TestAuditlogImpl.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/TestAuditlogImpl.java
@@ -74,7 +74,7 @@ public class TestAuditlogImpl extends AuditLogSink {
                 throw new MessagesNotFoundException(expectedCount, messages);
             }
             if (messages.size() != expectedCount) {
-                throw new RuntimeException("Unexpected number of messages, was expecting " + expectedCount + ", recieved " + messages.size());
+                throw new RuntimeException("Unexpected number of messages, was expecting " + expectedCount + ", received " + messages.size());
             }
         } catch (final InterruptedException e) {
             throw new RuntimeException("Unexpected exception", e);
@@ -119,7 +119,7 @@ public class TestAuditlogImpl extends AuditLogSink {
 
         private static String createDetailMessage(final int expectedCount, final List<AuditMessage> foundMessages) {
             return new StringBuilder()
-                .append("Did not recieve all " + expectedCount + " audit messages after a short wait. ")
+                .append("Did not receive all " + expectedCount + " audit messages after a short wait. ")
                 .append("Missing " + (expectedCount - foundMessages.size()) + " messages.")
                 .append("Messages found during this time: \n\n")
                 .append(foundMessages.stream()

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -982,24 +982,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         assertThat(ccs.getBody(), containsString("cross_cluster_two:twitter"));
     }
 
-    //Wait for the security plugin to load roles.
-    private void waitOrThrow(Client client) throws Exception {
-        int failures = 0;
-        while(failures < 5) {
-            try {
-                client.admin().cluster().health(new ClusterHealthRequest()).actionGet();
-                break;
-            } catch (OpenSearchSecurityException ex) {
-                if (ex.getMessage().contains("OpenSearch Security not initialized")) {
-                    Thread.sleep(500);
-                    failures++;
-                } else {
-                    throw ex;
-                }
-            }
-        }
-    }
-
     @Test
     public void testCcsWithRoleInjection() throws Exception {
         setupCcs(new DynamicSecurityConfig().setSecurityRoles("roles.yml"));
@@ -1041,7 +1023,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "invalid_user|invalid_role";
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class,
                 OpenSearchSecurityPlugin.class, RolesInjectorIntegTest.RolesInjectorPlugin.class).start()) {
-            waitOrThrow(node.client());
+            waitForInit(node.client());
             Client remoteClient = node.client().getRemoteClusterClient("cross_cluster_two");
             GetRequest getReq = new GetRequest("twitter", "0");
             getReq.realtime(true);
@@ -1061,7 +1043,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "valid_user|opendistro_security_all_access";
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class,
                 OpenSearchSecurityPlugin.class, RolesInjectorIntegTest.RolesInjectorPlugin.class).start()) {
-            waitOrThrow(node.client());
+            waitForInit(node.client());
             Client remoteClient = node.client().getRemoteClusterClient("cross_cluster_two");
             GetRequest getReq = new GetRequest("twitter", "0");
             getReq.realtime(true);

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
@@ -156,6 +156,12 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         }
     }
 
+    //Wait for the security plugin to load roles.
+    private void waitOrThrow(Client client, String index) throws Exception {
+        waitForInit(client);
+        client.execute(MockReplicationAction.INSTANCE, new MockReplicationRequest(index)).actionGet();
+    }
+
     void populateData(Client tc) {
         tc.index(new IndexRequest("hr-dls").id("0").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
             .source("{\"User\": \"testuser\",\"Date\":\"2021-01-18T17:27:20Z\",\"Designation\":\"HR\"}", XContentType.JSON)).actionGet();
@@ -194,8 +200,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         // Set roles for the user
         MockReplicationPlugin.injectedRoles = "ccr_user|opendistro_security_human_resources_trainee";
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
-            waitForInit(node.client());
-            node.client().execute(MockReplicationAction.INSTANCE, new MockReplicationRequest("hr-dls")).actionGet();
+            waitOrThrow(node.client(), "hr-dls");
             Assert.fail("Expecting exception");
         } catch (OpenSearchSecurityException ex) {
             log.warn(ex.getMessage());
@@ -205,8 +210,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
-            waitForInit(node.client());
-            node.client().execute(MockReplicationAction.INSTANCE, new MockReplicationRequest("hr-fls")).actionGet();
+            waitOrThrow(node.client(), "hr-fls");
             Assert.fail("Expecting exception");
         } catch (OpenSearchSecurityException ex) {
             log.warn(ex.getMessage());
@@ -216,8 +220,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
-            waitForInit(node.client());
-            node.client().execute(MockReplicationAction.INSTANCE, new MockReplicationRequest("hr-masking")).actionGet();
+            waitOrThrow(node.client(), "hr-masking");
             Assert.fail("Expecting exception");
         } catch (OpenSearchSecurityException ex) {
             log.warn(ex.getMessage());
@@ -227,8 +230,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         }
 
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class, OpenSearchSecurityPlugin.class, MockReplicationPlugin.class).start()) {
-            waitForInit(node.client());
-            node.client().execute(MockReplicationAction.INSTANCE, new MockReplicationRequest("hr-normal")).actionGet();
+            waitOrThrow(node.client(), "hr-normal");
             AcknowledgedResponse res = node.client().execute(MockReplicationAction.INSTANCE, new MockReplicationRequest("hr-normal")).actionGet();
             Assert.assertTrue(res.isAcknowledged());
         }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -60,6 +60,7 @@ public class TenantInfoActionTest extends AbstractRestApiUnitTest {
     public void testTenantInfoAPIUpdate() throws Exception {
         Settings settings = Settings.builder().put(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build();
         setup(settings);
+        
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendHTTPClientCredentials = true;
         rh.sendAdminCertificate = true;


### PR DESCRIPTION
### Description

`waitForInit` was copied in few different tests classes. This PR abstracts it into `SingleClusterTests` and changes it from being recursive to iterative with a `maxRetries` of 3. (i.e. waiting a max of 1.5 seconds for security plugin initialization).

While abstracting the function I noticed that some of the tests its applied to correctly identify that the plugin is initialized, but swallow an error that the user making the health request does not have the correct permissions. This PR keeps the same behavior.

This also adds `waitForInit` inside of tests in `TenantInfoActionTest`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance, Test Reliability

* Why these changes are required?

Reduce code duplication and improve reliability

* What is the old behavior before changes and new behavior after changes?

### Issues Resolved

[Test reliability is impacting CI workflows #1917](https://github.com/opensearch-project/security/issues/1917)

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
