### PR TITLE
Update SAML Endpoint

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
@@ -212,11 +212,10 @@ public class Saml2SettingsProvider {
     }
 
     private String buildAssertionConsumerEndpoint(String dashboardsRoot) {
-
         if (dashboardsRoot.endsWith("/")) {
-            return dashboardsRoot + "_opendistro/_security/saml/acs";
+            return dashboardsRoot + "_plugins/_security/saml/acs";
         } else {
-            return dashboardsRoot + "/_opendistro/_security/saml/acs";
+            return dashboardsRoot + "/_plugins/_security/saml/acs";
         }
     }
 


### PR DESCRIPTION
I am setting up v2.1 cluster with saml authentication, all the configuration seems to be correct however when i try to login and found out that saml authrequest still builds ACS URL with _opendistro/_security/saml/acs instead of /_plugin/_security/saml/acs.
Below is what we extracted from the saml tracer plugin.

<samlp:AuthnRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
                    ID="ONELOGIN_XYZ"
                    Version="2.0"
                    IssueInstant="2022-07-13T08:55:10Z"
                    Destination="https://domain/trust/saml2/http-redirect/sso/<uuid>"
                    ProtocolBinding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
                    AssertionConsumerServiceURL="https://domain/_opendistro/_security/saml/acs"
                    >
    <saml:Issuer>opensearch-saml</saml:Issuer>
    <samlp:NameIDPolicy Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
                        AllowCreate="true"
                        />
</samlp:AuthnRequest>

Seems like after version 2.1.0 both enpoints: /_opendistro/_security/saml/acs and /_plugins/_security/saml/acs not working.
If using first-one as IDP acs URL getting: {"statusCode":404,"error":"Not Found","message":"Not Found"} - probbably expected after https://github.com/opensearch-project/security-dashboards-plugin/pull/895
But if switching to 2nd one /_plugins/_security/saml/acs getting {"statusCode":500,"error":"Internal Server Error","message":"Internal Error"}

Rolling back Kibana to version 2.0.1 but leaving Opensearch version: 2.1.0 helps the issue a bit as /_opendistro/_security/saml/acs starts to work again

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Bug Fix
* Why these changes are required?
*  Login Dashboard v2.1 with SAML authentication
* What is the old behavior before changes and new behavior after changes?
*  Old behaviour doesnt allow dashboard v2.1 to login with saml authentication 

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
