### PR TITLE
Force netty-transport-native-unix-common version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -224,6 +224,7 @@ configurations.all {
         force "io.netty:netty-common:${versions.netty}"
         force "io.netty:netty-handler:${versions.netty}"
         force "io.netty:netty-transport:${versions.netty}"
+        force "io.netty:netty-transport-native-unix-common:${versions.netty}"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

After the upgrade of Netty from 4.1.73.Final -> 4.1.79.Final, we added another netty jar for `netty-transport-native-unix-common` in core's `module/transport-netty4` which is a new transitive dependency on `netty-handler`. 

We are experiencing build issues for 2.1.1 since other dependencies that depend on netty may resolve to another version of the jar. This PR adds a resolution strategy to determine which version of the jar to ultimately use.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

* Why these changes are required?

Our build system needs to know how to resolve version conflicts in dependencies.

* What is the old behavior before changes and new behavior after changes?

### Issues Resolved

This resolves build issues uncovered in this PR [#1939](https://github.com/opensearch-project/security/pull/1939)

Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
