### PR TITLE
Change _opendistro/_security/saml/acs to /_plugins/_security/saml/acs

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/Saml2SettingsProvider.java
@@ -214,9 +214,9 @@ public class Saml2SettingsProvider {
     private String buildAssertionConsumerEndpoint(String dashboardsRoot) {
 
         if (dashboardsRoot.endsWith("/")) {
-            return dashboardsRoot + "_opendistro/_security/saml/acs";
+            return dashboardsRoot + "_plugins/_security/saml/acs";
         } else {
-            return dashboardsRoot + "/_opendistro/_security/saml/acs";
+            return dashboardsRoot + "/_plugins/_security/saml/acs";
         }
     }
 


### PR DESCRIPTION
### Description
Change _opendistro/_security/saml/acs to /_plugins/_security/saml/acs
* Category (Bug fix, Test fix, Refactoring, Maintenance)
* Why these changes are required?
Project opensearch-project/security-dashboards-plugin in version 2.1.0 changed SAML2 authentication endpoint to _plugins/_security/saml/acs while opensearch-project/security use old /_opendistro/_security/saml/acs
This creates clash as users need modify this place by hand to get SAML working.
* What is the old behavior before changes and new behavior after changes?
Before this change users will need to change endpoint  by hand back to _opendistro/  in /usr/share/opensearch-dashboards/plugins/securityDashboards/server/auth/types/saml/routes.js after installing or upgrading to opensearch-dashboards.

### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/security/issues/1941


### Testing
I just build recent security project and used it with opensearch 2.1.0 using SAML with /_plugins/ endpoint and it worked .

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
