### PR TITLE
Revert jackson-databind back to 2.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <log4j.version>2.11.1</log4j.version>
         <guava.version>25.1-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
-        <jackson.version>2.13.3</jackson.version>
+        <jackson-databind.version>2.11.2</jackson-databind.version>
         <jjwt.version>0.10.5</jjwt.version>
         <ldaptive.version>1.2.3</ldaptive.version>
         <http.commons.version>4.5.3</http.commons.version>
@@ -207,14 +207,8 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-databind.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jackson-core</artifactId>

--- a/release-notes/opendistro-for-elasticsearch-security.release-notes-1.13.1.1.md
+++ b/release-notes/opendistro-for-elasticsearch-security.release-notes-1.13.1.1.md
@@ -28,7 +28,7 @@ Compatible with Elasticsearch 7.10.2
 
 ### Maintenance
 
-* Upgrade CXF and jackson-binding ([#1943](https://github.com/opensearch-project/security/pull/1943))
+* Upgrade CXF ([#1943](https://github.com/opensearch-project/security/pull/1943))
 * [backport] Upgrade json-smart from 2.4.2 to 2.4.7 ([#1299](https://github.com/opensearch-project/security/pull/1299)) ([#1503](https://github.com/opensearch-project/security/pull/1503))
 * [Backport] Extended role injection support for cross cluster requests ([#1195](https://github.com/opensearch-project/security/pull/1195)) ([#1441](https://github.com/opensearch-project/security/pull/1441))
 * [Backport] Handled DLS/FLS/Field masking for Cross cluster replication ([#1436](https://github.com/opensearch-project/security/pull/1436))


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Fixes a plugin installation issue with conflicting versions of jackson-core causing jar hell.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* 
Bug fix

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
