### PR TITLE
Upgrade jackson-databind from 2.11.2 to 2.13.3 and add jackson-core a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         <log4j.version>2.11.1</log4j.version>
         <guava.version>25.1-jre</guava.version>
         <commons.cli.version>1.3.1</commons.cli.version>
-        <jackson-databind.version>2.11.2</jackson-databind.version>
+        <jackson.version>2.13.3</jackson.version>
         <jjwt.version>0.10.5</jjwt.version>
         <ldaptive.version>1.2.3</ldaptive.version>
         <http.commons.version>4.5.3</http.commons.version>
@@ -207,8 +207,15 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
+            <version>${jackson.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>jackson-core</artifactId>


### PR DESCRIPTION
…s a provided dependency

Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Upgrades jackson-databind to resolve CVE-2020-36518. This adds jackson-core as a provided dependency to build with the same version of jackon-core, but ultimately have jackson-core provided by core. (version 2.10.4)

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
