### PR TITLE
Use Collections.synchronizedSet and Collections.synchronizedMap for r…

### DIFF
--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -62,10 +62,10 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     /**
      * roles == backend_roles
      */
-    private final Set<String> roles = new HashSet<String>();
-    private final Set<String> securityRoles = new HashSet<String>();
+    private final Set<String> roles = Collections.synchronizedSet(new HashSet<String>());
+    private final Set<String> securityRoles = Collections.synchronizedSet(new HashSet<String>());
     private String requestedTenant;
-    private Map<String, String> attributes = new HashMap<>();
+    private Map<String, String> attributes = Collections.synchronizedMap(new HashMap<>());
     private boolean isInjected = false;
 
     public User(final StreamInput in) throws IOException {
@@ -73,7 +73,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         name = in.readString();
         roles.addAll(in.readList(StreamInput::readString));
         requestedTenant = in.readString();
-        attributes = in.readMap(StreamInput::readString, StreamInput::readString);
+        attributes = Collections.synchronizedMap(in.readMap(StreamInput::readString, StreamInput::readString));
         securityRoles.addAll(in.readList(StreamInput::readString));
     }
     
@@ -250,7 +250,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
      */
     public synchronized final Map<String, String> getCustomAttributesMap() {
         if(attributes == null) {
-            attributes = new HashMap<>();
+            attributes = Collections.synchronizedMap(new HashMap<>());
         }
         return attributes;
     }
@@ -262,6 +262,6 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     }
     
     public final Set<String> getSecurityRoles() {
-        return this.securityRoles == null ? Collections.emptySet() : Collections.unmodifiableSet(this.securityRoles);
+        return this.securityRoles == null ? Collections.synchronizedSet(Collections.emptySet()) : Collections.unmodifiableSet(this.securityRoles);
     }
 }


### PR DESCRIPTION
…oles, securityRoles and attributes in User

Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Creating a draft PR to solicit feedback on a potential fix for https://github.com/opensearch-project/security/issues/1961 and https://github.com/opensearch-project/security/issues/1927.

Users are reporting that when the security cache expires that an intermittent `java.io.OptionalDataException` occurs. 

The error is thrown while trying to `readObject()` from a `SafeObjectInputStream` while deserializing `getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER)`. 

I got the idea for this fix from [here](https://stackoverflow.com/questions/44229340/optionaldataexception-with-no-apparent-reason/44348839#44348839) and [here](https://issues.apache.org/jira/browse/AMQ-2083). Since the error was occurring on deserialization of the User object, I turned the `HashSet` and `HashMap` members of `User` into their corresponding `Collections.synchronizedSet` and `Collections.synchronizedMap` respectively.

Automated tests for this issue are being written.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug Fix

* What is the old behavior before changes and new behavior after changes?

Old behavior: `java.io.OptionalDataException` exception is intermittently thrown on expiry of `plugins.security.cache.ttl_minutes`

New behavior: No exceptions thrown, bulk api does not throw exception at the expiration of the security cache

### Issues Resolved

- https://github.com/opensearch-project/security/issues/1961
- https://github.com/opensearch-project/security/issues/1927

### Testing

Testing was performed by following the steps outlined here: https://github.com/opensearch-project/security/issues/1961#issuecomment-1194311479

Before the change: Cluster would throw the exception within a minute

After the change: Cluster is stable and running without runtime exception for a long time

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
