### PR TITLE
Fix gradle build issue after upgrade to Lucene 9.3.0

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -965,7 +965,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader  {
                     }
 
                     @Override
-                    public long docValueCount() {
+                    public int docValueCount() {
                         return sortedSetDocValues.docValueCount();
                     }
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The recent upgrade to Lucene 9.3.0 in core caused a build failure when an abstract method signature changed inside of `SortedSetDocValues`. See [here](https://build.ci.opensearch.org/job/distribution-build-opensearch/5849/execution/node/263/log/) for the build failure: 

Before Lucene 9.3.0: `public abstract long docValueCount();`
https://github.com/apache/lucene/blob/branch_9_2/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java#L51

Lucene 9.3.0: `public abstract long docValueCount();`
https://github.com/apache/lucene/blob/branch_9_3/lucene/core/src/java/org/apache/lucene/index/SortedSetDocValues.java#L61

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
