### PR TITLE
Point in time security changes

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -149,6 +149,23 @@ asynchronous_search_read_access:
   cluster_permissions:
     - 'cluster:admin/opendistro/asynchronous_search/get'
 
+# Allows users to use all point in time search functionality
+point_in_time_search_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'indices:data/read/point_in_time/*'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:data/read/search*'
+
+# Allows users to read all active point in time search contexts
+point_in_time_search_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'indices:data/read/point_in_time/read*'
+
 # Allows user to use all index_management actions - ism policies, rollups, transforms
 index_management_full_access:
   reserved: true

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -149,23 +149,6 @@ asynchronous_search_read_access:
   cluster_permissions:
     - 'cluster:admin/opendistro/asynchronous_search/get'
 
-# Allows users to use all point in time search functionality
-point_in_time_search_full_access:
-  reserved: true
-  cluster_permissions:
-    - 'indices:data/read/point_in_time/*'
-  index_permissions:
-    - index_patterns:
-        - '*'
-      allowed_actions:
-        - 'indices:data/read/search*'
-
-# Allows users to read all active point in time search contexts
-point_in_time_search_read_access:
-  reserved: true
-  cluster_permissions:
-    - 'indices:data/read/point_in_time/read*'
-
 # Allows user to use all index_management actions - ism policies, rollups, transforms
 index_management_full_access:
   reserved: true

--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -130,6 +130,7 @@ cluster_composite_ops_ro:
   - "indices:admin/aliases/get*"
   - "indices:data/read/scroll"
   - "indices:admin/resolve/index"
+  - "indices:data/read/point_in_time/read*"
   type: "cluster"
   description: "Allow readonly bulk and m* operations"
 get:

--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -116,6 +116,7 @@ cluster_composite_ops:
   - "indices:admin/aliases*"
   - "indices:data/write/reindex"
   - "cluster_composite_ops_ro"
+  - "indices:data/read/point_in_time/delete"
   type: "cluster"
   description: "Allow read/write bulk and m* operations"
 cluster_composite_ops_ro:
@@ -131,6 +132,7 @@ cluster_composite_ops_ro:
   - "indices:data/read/scroll"
   - "indices:admin/resolve/index"
   - "indices:data/read/point_in_time/read*"
+  - "indices:data/read/point_in_time/create"
   type: "cluster"
   description: "Allow readonly bulk and m* operations"
 get:

--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -87,6 +87,7 @@ kibana_server:
   - "cluster_composite_ops"
   - "indices:admin/template*"
   - "indices:data/read/scroll*"
+  - "indices:data/read/point_in_time*"
   index_permissions:
   - index_patterns:
     - ".kibana"


### PR DESCRIPTION
### Description
This adds point in time permissions to default action groups.
Point in time has 3 apis:
1. Create PIT
2. List all PITs
3. Delete PIT

The permission model is similar to scroll which is a similar pagination feature

Cluster_composite_ops_ro:
Adding 'create pit' and 'list all pits' API permission to cluster composite ops read only action group.

Cluster_composite_ops:
Adding 'delete' API permission + above permissions to cluster composite ops action group.

Kibana_server:
Kibana server has access to all operations.

API changes links : 
https://github.com/opensearch-project/OpenSearch/pull/4064 - create pit and delete pit api
https://github.com/opensearch-project/OpenSearch/pull/4016 - list all

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
New feature - Point in time feature
* Why these changes are required?
These changes are required for access of various point in time APIs
* What is the old behavior before changes and new behavior after changes?
This is a new feature

### Issues Resolved

Meta issue - https://github.com/opensearch-project/OpenSearch/issues/3959


Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
