### PR TITLE
Revert build breaking change from Lucene upgrade to 9.3.0

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -965,7 +965,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader  {
                     }
 
                     @Override
-                    public int docValueCount() {
+                    public long docValueCount() {
                         return sortedSetDocValues.docValueCount();
                     }
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Reverts https://github.com/opensearch-project/security/pull/1990. Core is reverting the Lucene upgrade for a future release and we will re-apply this change in tandem.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
