### PR TITLE
Triple audit logging fix (#1995)

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
@@ -30,40 +30,17 @@ public final class Log4JSink extends AuditLogSink {
         loggerName = settings.get( settingsPrefix + ".log4j.logger_name","sgaudit");
         auditLogger = LogManager.getLogger(loggerName);
         logLevel = Level.toLevel(settings.get(settingsPrefix + ".log4j.level","INFO").toUpperCase());
-        enabled = isLogLevelEnabled(auditLogger, logLevel);
+        enabled = auditLogger.isEnabled(logLevel);
     }
 
     public boolean isHandlingBackpressure() {
         return !enabled; //no submit to thread pool if not enabled
     }
 
-
     public boolean doStore(final AuditMessage msg) {
         if(enabled) {
-            logAtLevel(auditLogger, logLevel, msg.toJson());
+            auditLogger.log(logLevel, msg.toJson());
         }
         return true;
-    }
-
-    private boolean isLogLevelEnabled(Logger logger, Level level) {
-        boolean isEnabled = false;
-        switch(level.toString()) {
-            case "TRACE": isEnabled = logger.isTraceEnabled();
-            case "DEBUG": isEnabled = logger.isDebugEnabled();
-            case "INFO": isEnabled = logger.isInfoEnabled();
-            case "WARN": isEnabled = logger.isWarnEnabled();
-            case "ERROR": isEnabled = logger.isErrorEnabled();
-        }
-        return isEnabled;
-    }
-
-    private void logAtLevel(Logger logger, Level level, String msg) {
-        switch(level.toString()) {
-            case "TRACE": logger.trace(msg);
-            case "DEBUG": logger.debug(msg);
-            case "INFO": logger.info(msg);
-            case "WARN": logger.warn(msg);
-            case "ERROR": logger.error(msg);
-        }
     }
 }


### PR DESCRIPTION
Revert some changes introduced by https://github.com/opensearch-project/security/pull/1563 to correct work with log4j.

Signed-off-by: Andrey Pustovetov <andrey.pustovetov@gmail.com>

### Description
[Describe what this change achieves]
* Category: Bug fix
* Why these changes are required?
When I execute `GET` request to `.opendistro_security` index, I see three audit messages in the logs instead of one.

### Issues Resolved
#1995

### Testing
I manually checked the changes by doing `GET` request to the index and checking the logs.

### Check List
- [ ] ~~New functionality includes testing~~
- [ ] ~~New functionality has been documented~~
- [ X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
