### PR TITLE
Upgrade jackson databind to 2.13.2.2 to match core's version.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ configurations.all {
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
-        force "org.springframework:spring-core:5.3.14"
+        force "org.springframework:spring-core:5.3.20"
         force "com.google.guava:guava:30.0-jre"
     }
 }
@@ -81,7 +81,7 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'org.slf4j:slf4j-api:1.7.32'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
@@ -91,7 +91,7 @@ dependencies {
     }
     implementation 'com.github.wnameless:json-flattener:0.5.0'
     implementation 'com.flipkart.zjsonpatch:zjsonpatch:0.4.4'
-    implementation 'org.apache.kafka:kafka-clients:2.8.1'
+    implementation 'org.apache.kafka:kafka-clients:3.0.1'
     implementation 'com.onelogin:java-saml:2.5.0'
     implementation ('org.opensaml:opensaml-saml-impl:3.4.5') {
         exclude(group: 'org.apache.velocity', module: 'velocity')
@@ -114,13 +114,13 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
     testImplementation 'org.mockito:mockito-core:2.23.0'
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.7.9'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:2.8.6'
     testImplementation 'javax.servlet:servlet-api:2.5'
     testImplementation 'com.unboundid:unboundid-ldapsdk:4.0.9'
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1:test'
-    testImplementation 'org.apache.kafka:kafka-clients:2.8.1:test'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.0.1'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.0.1:test'
+    testImplementation 'org.apache.kafka:kafka-clients:3.0.1:test'
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 }
 


### PR DESCRIPTION
### Description

Upgrade of jackson-databind to address CVE-2020-36518. The version now matches the version in core's `version.properties`. This should be backported to 1.3.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
