### PR TITLE
Adding @cwperks to Security maintainers.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -14,6 +14,7 @@
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
 | Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
+| Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 
 ### Updating Practices
 To ensure common practices as maintainers, all practices are expected to be documented here or enforced through github actions.  There should be no expectations beyond what is documented in the repo [CONTRIBUTING.md](./CONTRIBUTING.md) and OpenSearch-Project [CONTRIBUTING.md](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md).  To modify an existing processes or create a new one, make a pull request on this MAINTAINERS.md for review and merge it after all maintainers approve of it.


### PR DESCRIPTION
### Description

Following the process in https://github.com/opensearch-project/.github/pull/59, I had nominated Craig Perkins (@cwperks) as a co-maintainer. The maintainers have voted and agreed to this nomination.

Craig has been participating in creating pull requests in both the back-end and front-end security repositories, answering questions and engaging with issue along with providing pull request feedback to keep standards high.

![image](https://user-images.githubusercontent.com/2754967/183511085-bf5dc19c-adf6-4134-a80e-61033ea65ddd.png)

![image](https://user-images.githubusercontent.com/2754967/183511035-88692bf4-9f7c-4844-b8ab-9c91e32ee759.png)

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
