### PR TITLE
[Backport] Upgrade jackson-databind from 2.13.2 to 2.13.2.2 to match core's vers…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'
@@ -90,7 +90,7 @@ dependencies {
     }
     implementation 'com.github.wnameless:json-flattener:0.5.0'
     implementation 'com.flipkart.zjsonpatch:zjsonpatch:0.4.4'
-    implementation 'org.apache.kafka:kafka-clients:3.0.0'
+    implementation 'org.apache.kafka:kafka-clients:3.0.1'
     implementation 'com.onelogin:java-saml:2.5.0'
     implementation ('org.opensaml:opensaml-saml-impl:3.4.5') {
         exclude(group: 'org.apache.velocity', module: 'velocity')
@@ -117,9 +117,9 @@ dependencies {
     testImplementation 'javax.servlet:servlet-api:2.5'
     testImplementation 'com.unboundid:unboundid-ldapsdk:4.0.9'
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1'
-    testImplementation 'org.apache.kafka:kafka_2.13:2.8.1:test'
-    testImplementation 'org.apache.kafka:kafka-clients:2.8.1:test'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.0.1'
+    testImplementation 'org.apache.kafka:kafka_2.13:3.0.1:test'
+    testImplementation 'org.apache.kafka:kafka-clients:3.0.1:test'
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 }
 


### PR DESCRIPTION
…ion.properties and upgrade kafka dependencies (#2000)

Signed-off-by: Craig Perkins <cwperx@amazon.com>
(cherry picked from commit da24100ccc373dedb50d20ba18be96b5eb2d8b01)

### Description

backport-bot was not able to automatically create the backport to the 1.3 branch. This is a backport of https://github.com/opensearch-project/security/pull/2000

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
