### PR TITLE
Fixes `RestHelper` and `IndexTemplateClusterPermissionsCheckTest` for backport of #1885 : `opendistro-1.13`

### DIFF
--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -9,16 +9,16 @@
  * GitHub history for details.
  */
 
-package org.opensearch.security;
+package com.amazon.opendistroforelasticsearch.security;
 
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.opensearch.security.test.SingleClusterTest;
-import org.opensearch.security.test.helper.rest.RestHelper;
-import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest{
         private RestHelper rh;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
@@ -75,9 +75,9 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.security.DefaultObjectMapper;
-import org.opensearch.security.test.helper.cluster.ClusterInfo;
-import org.opensearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.ClusterInfo;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
 
 import static org.junit.jupiter.api.Assertions.fail;
 


### PR DESCRIPTION
Fix for `RestHelper.java` and `IndexTemplateClusterPermissionsCheckTest.java` for opensearch-project/security#1986
### Description
Fixes backport of #1885 

### Issues Resolved
Backport PR #1885  

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
