### PR TITLE
Add security changes for point in time API

### DIFF
--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -116,7 +116,6 @@ cluster_composite_ops:
   - "indices:admin/aliases*"
   - "indices:data/write/reindex"
   - "cluster_composite_ops_ro"
-  - "indices:data/read/point_in_time/delete"
   type: "cluster"
   description: "Allow read/write bulk and m* operations"
 cluster_composite_ops_ro:
@@ -131,8 +130,6 @@ cluster_composite_ops_ro:
   - "indices:admin/aliases/get*"
   - "indices:data/read/scroll"
   - "indices:admin/resolve/index"
-  - "indices:data/read/point_in_time/read*"
-  - "indices:data/read/point_in_time/create"
   type: "cluster"
   description: "Allow readonly bulk and m* operations"
 get:
@@ -230,3 +227,14 @@ manage_data_streams:
   - "indices:monitor/data_stream/stats"
   type: "index"
   description: "Manage data streams"
+manage_point_in_time:
+  reserved: true
+  hidden: false
+  static: true
+  allowed_actions:
+    - "indices:data/read/point_in_time/create"
+    - "cluster:admin/point_in_time/delete"
+    - "cluster:admin/point_in_time/read*"
+    - "indices:monitor/point_in_time/segments"
+  type: "cluster"
+  description: "Manage point in time actions"

--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -85,9 +85,9 @@ kibana_server:
   cluster_permissions:
   - "cluster_monitor"
   - "cluster_composite_ops"
+  - "manage_point_in_time"
   - "indices:admin/template*"
   - "indices:data/read/scroll*"
-  - "indices:data/read/point_in_time*"
   index_permissions:
   - index_patterns:
     - ".kibana"


### PR DESCRIPTION
Signed-off-by: Bharathwaj G <bharath78910@gmail.com>

### Description
The existing model requires indices read access to 'pit delete' and 'list all pits' to all users. 
So changing the action names to 'cluster:admin/<action_name>".

Now , we can't add these cluster permissions to 'cluster_composite_ops' or 'ops_ro' since user has access to 'my_index' role which has access to 'cluster_composite_ops' which will make all users to access list and delete pit.

So changing the approach to new one below.
Add point in time permissions to 'manage_point_in_time' which is part of default static action groups.

Point in time apis - and associated action names :

1. Create PIT -     - "indices:data/read/point_in_time/create" ( indices:data/read is chosen because this will make sure users have read permission to the passed indices )
2. Delete PIT - "cluster:admin/point_in_time/delete" ( cluster:admin/*  is used because the apis are not dependent on indices like create pit and should just work based on this standalone permission )
3. List all PITs - "cluster:admin/point_in_time/read*"
4. PIT segments API - "indices:monitor/point_in_time/segments"

All the above actions are added to new action group 'manage_point_in_time'

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
 New feature - Point in time feature
* Why these changes are required?
 These changes are required for access of various point in time APIs
* What is the old behavior before changes and new behavior after changes?
This is a new feature

Design document:
https://github.com/opensearch-project/OpenSearch/issues/3960

Api changes:
https://github.com/opensearch-project/OpenSearch/pull/4064 - create pit and delete pit api
https://github.com/opensearch-project/OpenSearch/pull/4016 - list all


### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/3959

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested locally by running opensearch server alongside security plugin.
Only when index permissions and 'manage_point_in_time' action group permission is present , create api succeeds
For rest of the APIs, 'manage_point_in_time' action group permission controls whether the api can be accessible or not, which has been tested as well.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
