### PR TITLE
Fix legacy check in SecurityAdmin

### DIFF
--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -713,8 +713,8 @@ public class SecurityAdmin {
 
             final boolean legacy = createLegacyMode || (indexExists
                     && securityIndex.getMappings() != null
-                    && securityIndex.getMappings().get(index) != null)
-                    && securityIndex.getMappings().get(index).getSourceAsMap().containsKey("security");
+                    && securityIndex.getMappings().get(index) != null
+                    && securityIndex.getMappings().get(index).getSourceAsMap().containsKey("security"));
             
             if(legacy) {
                 System.out.println("Legacy index '"+index+"' (ES 6) detected (or forced). You should migrate the configuration!");

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -713,7 +713,8 @@ public class SecurityAdmin {
 
             final boolean legacy = createLegacyMode || (indexExists
                     && securityIndex.getMappings() != null
-                    && securityIndex.getMappings().get(index) != null);
+                    && securityIndex.getMappings().get(index) != null)
+                    && securityIndex.getMappings().get(index).getSourceAsMap().containsKey("security");
             
             if(legacy) {
                 System.out.println("Legacy index '"+index+"' (ES 6) detected (or forced). You should migrate the configuration!");

--- a/src/test/java/org/opensearch/security/SecurityAdminTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminTests.java
@@ -17,7 +17,9 @@
 
 package org.opensearch.security;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +29,7 @@ import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
@@ -492,6 +495,48 @@ public class SecurityAdminTests extends SingleClusterTest {
         
         returnCode  = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
         Assert.assertNotEquals(0, returnCode);
+    }
+
+    @Test
+    public void testIsLegacySecurityIndexOnV7Index() throws Exception {
+        final Settings settings = Settings.builder()
+                .put("plugins.security.ssl.http.enabled",true)
+                .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("node-0-keystore.jks"))
+                .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("truststore.jks"))
+                .build();
+        setup(Settings.EMPTY, null, settings, false);
+        
+        final String prefix = getResourceFolder()==null?"":getResourceFolder()+"/";
+        
+        List<String> argsAsList = new ArrayList<>();
+        argsAsList.add("-ts");
+        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix+"truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add("-ks");
+        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix+"kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add("-p");
+        argsAsList.add(String.valueOf(clusterInfo.httpPort));
+        argsAsList.add("-cn");
+        argsAsList.add(clusterInfo.clustername);
+        addDirectoryPath(argsAsList, TEST_RESOURCE_ABSOLUTE_PATH);
+        argsAsList.add("-nhnv");
+
+        // Execute first time to create the index
+        int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
+        Assert.assertEquals(0, returnCode);
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        PrintStream ps = new PrintStream(baos);
+        PrintStream old = System.out;
+        System.setOut(ps);
+
+        returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
+        Assert.assertEquals(0, returnCode);
+
+        System.out.flush();
+        System.setOut(old);
+        String standardOut = baos.toString();
+        String legacyIndexOutput = "Legacy index '"+ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX+"' (ES 6) detected (or forced). You should migrate the configuration!";
+        Assert.assertFalse(standardOut.contains(legacyIndexOutput));
     }
 
     private void addDirectoryPath(final List<String> args, final String path) {

--- a/tools/SECURITY_ADMIN_TESTS.md
+++ b/tools/SECURITY_ADMIN_TESTS.md
@@ -1,0 +1,77 @@
+## Security Admin Tests
+
+A collection of tests to perform when making changes to `securityadmin.sh`
+
+### Running Security Admin
+
+Details about the Security Admin tool can be found on the [OpenSearch Documentation Website](https://opensearch.org/docs/latest/security-plugin/configuration/security-admin/).
+
+When running a cluster with the demo configuration, run the `securityadmin.sh` tool using:
+
+```
+./securityadmin.sh -cd ../../../config/opensearch-security/ -icl -nhnv \
+  -cacert ../../../config/root-ca.pem \
+  -cert ../../../config/kirk.pem \
+  -key ../../../config/kirk-key.pem
+```
+
+### Legacy Check Tests
+
+#### ODFE:<=0.10.0 (ES 6)
+
+In opendistro-for-elasticsearch:0.10.0 and before (See a full list of ODFE versions [here](https://opendistro.github.io/for-elasticsearch-docs/version-history/)), opendistro-for-elasticsearch (ODFE) security was configured with the legacy Security Config v6 format. 
+
+When running `securityadmin.sh` with the security index in the legacy v6 format, the following line will appear in the output when running the tool.
+
+```
+Legacy index '.opendistro_security' (ES 6) detected (or forced). You should migrate the configuration!
+````
+
+For information on how to migrate the security config from v6 to v7, see the [Backup, restore, and migrate](https://opensearch.org/docs/latest/security-plugin/configuration/security-admin/#backup-restore-and-migrate) section on the Security Admin Documentation page. 
+
+#### OpenSearch and ODFE:>=1.0.0 (ES 7)
+
+OpenSearch clusters and clusters running opendistro-for-elasticsearch:>=1.0.0 use the Security Config v7 format. When running the tool with the security index the in v7 format, the output will resemble:
+
+```
+./securityadmin.sh -cd ../../../config/opensearch-security/ -icl -nhnv \
+>   -cacert ../../../config/root-ca.pem \
+>   -cert ../../../config/kirk.pem \
+>   -key ../../../config/kirk-key.pem
+**************************************************************************
+** This tool will be deprecated in the next major release of OpenSearch **
+** https://github.com/opensearch-project/security/issues/1755           **
+**************************************************************************
+Security Admin v7
+Will connect to localhost:9200 ... done
+Connected as "CN=kirk,OU=client,O=client,L=test,C=de"
+OpenSearch Version: 2.2.0
+Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
+Clustername: opensearch-cluster
+Clusterstate: GREEN
+Number of nodes: 2
+Number of data nodes: 2
+.opendistro_security index already exists, so we do not need to create one.
+Populate config from /usr/share/opensearch/config/opensearch-security
+Will update '/config' with ../../../config/opensearch-security/config.yml
+   SUCC: Configuration for 'config' created or updated
+Will update '/roles' with ../../../config/opensearch-security/roles.yml
+   SUCC: Configuration for 'roles' created or updated
+Will update '/rolesmapping' with ../../../config/opensearch-security/roles_mapping.yml
+   SUCC: Configuration for 'rolesmapping' created or updated
+Will update '/internalusers' with ../../../config/opensearch-security/internal_users.yml
+   SUCC: Configuration for 'internalusers' created or updated
+Will update '/actiongroups' with ../../../config/opensearch-security/action_groups.yml
+   SUCC: Configuration for 'actiongroups' created or updated
+Will update '/tenants' with ../../../config/opensearch-security/tenants.yml
+   SUCC: Configuration for 'tenants' created or updated
+Will update '/nodesdn' with ../../../config/opensearch-security/nodes_dn.yml
+   SUCC: Configuration for 'nodesdn' created or updated
+Will update '/whitelist' with ../../../config/opensearch-security/whitelist.yml
+   SUCC: Configuration for 'whitelist' created or updated
+Will update '/audit' with ../../../config/opensearch-security/audit.yml
+   SUCC: Configuration for 'audit' created or updated
+Will update '/allowlist' with ../../../config/opensearch-security/allowlist.yml
+   SUCC: Configuration for 'allowlist' created or updated
+```
+

--- a/tools/SECURITY_ADMIN_TESTS.md
+++ b/tools/SECURITY_ADMIN_TESTS.md
@@ -74,4 +74,3 @@ Will update '/audit' with ../../../config/opensearch-security/audit.yml
 Will update '/allowlist' with ../../../config/opensearch-security/allowlist.yml
    SUCC: Configuration for 'allowlist' created or updated
 ```
-


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Security Admin tool contains a check to see if the security index is in the legacy v6 format. It works by checking to see if the security index has a property called `security`. If the `security` property exists it is in legacy format, otherwise its in the v7 format. Since OS 2.0.0 the check for the `security` property was removed which made the security admin tool always think the index was in the legacy format. The regression was introduced in this PR: https://github.com/opensearch-project/security/commit/4581a3d76ae3287c0821cd9beb3734b9fdcc57e8#diff-84a766aa2dc8279bc00a6447b9de6d8918a41f6522b150071f3f7d969b8d83c0L719

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug Fix

* Why these changes are required?

Fix for a regression in the `securityadmin.sh`.

### Issues Resolved

Issue where this was reported: https://github.com/opensearch-project/security/issues/1876

### Testing

Tested by running `securityadmin.sh` before and after the change with 2.2.0 cluster to verify that it is not identified as being in the legacy format. Before the change you will see output from the `securityadmin.sh` tool with the following line `Legacy index '.opendistro_security' (ES 6) detected (or forced). You should migrate the configuration!`, after the change this line does not appear.

Also tested and verified by running old ODFE-0.10.0 cluster (backed by ES6) to see the legacy security index format. Here's a sample of the index with ODFE-0.10.0

```
{
  ".opendistro_security" : {
    "aliases" : { },
    "mappings" : {
      "security" : {
        "properties" : {
          "actiongroups" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "config" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "internalusers" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "roles" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          },
          "rolesmapping" : {
            "type" : "text",
            "fields" : {
              "keyword" : {
                "type" : "keyword",
                "ignore_above" : 256
              }
            }
          }
        }
      }
    },
    "settings" : {
      "index" : {
        "number_of_shards" : "1",
        "auto_expand_replicas" : "0-all",
        "provided_name" : ".opendistro_security",
        "creation_date" : "1661434679747",
        "number_of_replicas" : "0",
        "uuid" : "mBp1PkBuRIC7dE2q93CA2Q",
        "version" : {
          "created" : "6080199"
        }
      }
    }
  }
}
```

Here's a sample of the v7 format of the security index:

```
{
  ".opendistro_security" : {
    "aliases" : { },
    "mappings" : {
      "properties" : {
        "actiongroups" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "audit" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "config" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "internalusers" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "nodesdn" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "roles" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "rolesmapping" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "tenants" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        },
        "whitelist" : {
          "type" : "text",
          "fields" : {
            "keyword" : {
              "type" : "keyword",
              "ignore_above" : 256
            }
          }
        }
      }
    },
    "settings" : {
      "index" : {
        "number_of_shards" : "1",
        "auto_expand_replicas" : "0-all",
        "provided_name" : ".opendistro_security",
        "creation_date" : "1661434851048",
        "number_of_replicas" : "1",
        "uuid" : "URNM7zbnTTaPO0yL1eCVSw",
        "version" : {
          "created" : "7100299"
        }
      }
    }
  }
}
```

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
