### PR TITLE
Fix the inconsistent variable for DLS

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -115,7 +115,7 @@ public class DlsFilterLevelActionHandler {
     private final ThreadContext threadContext;
     private final IndexNameExpressionResolver resolver;
     private BoolQueryBuilder filterLevelQueryBuilder;
-    private DocumentAllowList documentWhitelist;
+    private DocumentAllowList documentAllowlist;
 
     DlsFilterLevelActionHandler(String action, ActionRequest request, ActionListener<?> listener, EvaluatedDlsFlsConfig evaluatedDlsFlsConfig,
                                 Resolved resolved, Client nodeClient, ClusterService clusterService, IndicesService indicesService,
@@ -178,8 +178,8 @@ public class DlsFilterLevelActionHandler {
     }
 
     private boolean handle(SearchRequest searchRequest, StoredContext ctx) {
-        if (documentWhitelist != null) {
-            documentWhitelist.applyTo(threadContext);
+        if (documentAllowlist != null) {
+            documentAllowlist.applyTo(threadContext);
         }
 
         String localClusterAlias = LOCAL_CLUSTER_ALIAS_GETTER.apply(searchRequest);
@@ -225,8 +225,8 @@ public class DlsFilterLevelActionHandler {
     }
 
     private boolean handle(GetRequest getRequest, StoredContext ctx) {
-        if (documentWhitelist != null) {
-            documentWhitelist.applyTo(threadContext);
+        if (documentAllowlist != null) {
+            documentAllowlist.applyTo(threadContext);
         }
 
         SearchRequest searchRequest = new SearchRequest(getRequest.indices());
@@ -270,8 +270,8 @@ public class DlsFilterLevelActionHandler {
     }
 
     private boolean handle(MultiGetRequest multiGetRequest, StoredContext ctx) {
-        if (documentWhitelist != null) {
-            documentWhitelist.applyTo(threadContext);
+        if (documentAllowlist != null) {
+            documentAllowlist.applyTo(threadContext);
         }
 
         Map<String, Set<String>> idsGroupedByIndex = multiGetRequest.getItems().stream()
@@ -395,7 +395,7 @@ public class DlsFilterLevelActionHandler {
         Map<String, Set<String>> filterLevelQueries = evaluatedDlsFlsConfig.getDlsQueriesByIndex();
 
         BoolQueryBuilder dlsQueryBuilder = QueryBuilders.boolQuery().minimumShouldMatch(1);
-        DocumentAllowList documentWhitelist = new DocumentAllowList();
+        DocumentAllowList documentAllowlist = new DocumentAllowList();
 
         int queryCount = 0;
 
@@ -450,7 +450,7 @@ public class DlsFilterLevelActionHandler {
                 for (QueryBuilder queryBuilder : queryBuilders) {
                     TermsQueryBuilder termsQueryBuilder = (TermsQueryBuilder) queryBuilder;
 
-                    documentWhitelist.add(termsQueryBuilder.termsLookup().index(), termsQueryBuilder.termsLookup().id());
+                    documentAllowlist.add(termsQueryBuilder.termsLookup().index(), termsQueryBuilder.termsLookup().id());
                 }
             }
 
@@ -461,7 +461,7 @@ public class DlsFilterLevelActionHandler {
             return false;
         } else {
             this.filterLevelQueryBuilder = dlsQueryBuilder;
-            this.documentWhitelist = documentWhitelist;
+            this.documentAllowlist = documentAllowlist;
             return true;
         }
     }


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Fixed the inconsistent variable with name "`documentWhitelist`" and changed it into "`documentAllowlist`" with all its references in `DlsFilterLevelActionHandler.java`.

### Issues Resolved
Resolve https://github.com/opensearch-project/security/issues/1665

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
