### PR TITLE
Switch to ClusterManager terminology

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -157,7 +157,7 @@ Checkstyle enforced several rules within this codebase.  Sometimes exceptions wi
 
 *Example violation*
 ```
-[ant:checkstyle] [ERROR] /local/home/petern/git/security/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java:178: Usage should be switched to cluster manager [RegexpSingleline]
+[ant:checkstyle] [ERROR] /local/home/security/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java:178: Usage should be switched to cluster manager [RegexpSingleline]
 ```
 
 *Single Rule Suppression*

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -8,6 +8,7 @@ So you want to contribute code to this project? Excellent! We're glad you're her
   - [Using IntelliJ IDEA](#using-intellij-idea)
   - [Running integration tests](#running-integration-tests)
     - [Bulk test runs](#bulk-test-runs)
+    - [Checkstyle Violations](#checkstyle-violations)
   - [Submitting Changes](#submitting-changes)
   - [Backports](#backports)
 
@@ -145,6 +146,35 @@ Integration tests are automatically run on all pull requests for all supported v
 
 ### Bulk test runs
 To collect reliability data on test runs there is a manual GitHub action workflow called `Bulk Integration Test`.  The workflow is started for a branch on this project or in a fork by going to [GitHub action workflows](https://github.com/opensearch-project/security/actions/workflows/integration-tests.yml) and selecting `Run Workflow`.
+
+### Checkstyle Violations
+Checkstyle enforced several rules within this codebase.  Sometimes exceptions will be necessary for components that are set for deprecation but the new version is unavailable.  There are two formats of suppression that can be used when dealing with violations of this nature, one for disabling a single rule, or another for disabling all rules - its best to be as specific as possible.
+
+*Execute Checkstyle*
+```
+./gradlew checkstyleMain checkstyleTest 
+```
+
+*Example violation*
+```
+[ant:checkstyle] [ERROR] /local/home/petern/git/security/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java:178: Usage should be switched to cluster manager [RegexpSingleline]
+```
+
+*Single Rule Suppression*
+```
+    // CS-SUPPRESS-SINGLE: RegexpSingleline See http://github/issues/1234
+    ...
+    Code that violates the rule
+    ...
+    // CS-ENFORCE-SINGLE
+```
+
+*Suppression All Checkstyle Rules*
+```
+  // CS-SUPRESS-ALL: Legacy code to be deleted in Z.Y.X see http://github/issues/1234
+  ...
+  // CS-ENFORCE-ALL
+```
 
 ## Submitting Changes
 

--- a/checkstyle/sun_checks.xml
+++ b/checkstyle/sun_checks.xml
@@ -201,7 +201,18 @@
     <property name="format" value="master"/>
     <property name="ignoreCase" value="true"/>
     <property name="message" value="Usage should be switched to cluster manager" />
-    <property name="severity" value="ignore"/>
+    <property name="severity" value="error"/>
+  </module>
+
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="offCommentFormat" value="CS-SUPPRESS-ALL: .+"/> <!-- Require an explaination after surpressing -->
+    <property name="onCommentFormat" value="CS-ENFORCE-ALL"/>
+  </module>
+
+  <module name="SuppressWithPlainTextCommentFilter">
+    <property name="offCommentFormat" value="CS-SUPPRESS-SINGLE\: ([\w\|]+) .+"/> <!-- Require an explaination after surpressing -->
+    <property name="onCommentFormat" value="CS-ENFORCE-SINGLE"/>
+    <property name="checkFormat" value="$1"/>
   </module>
 
 </module>

--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -77,7 +77,7 @@ public class ClusterInfoHolder implements ClusterStateListener {
             initialized = true;
         }
         
-        isLocalNodeElectedClusterManager = event.localNodeMaster()?Boolean.TRUE:Boolean.FALSE;
+        isLocalNodeElectedClusterManager = event.localNodeClusterManager()?Boolean.TRUE:Boolean.FALSE;
     }
 
     public Boolean getHas6xNodes() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -174,7 +174,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
             //When we encounter a terms or sampler aggregation with masked fields activated we forcibly
             //need to switch off global ordinals because field masking can break ordering
+            // CS-SUPPRESS-SINGLE: RegexpSingleline Ignore term inside of url
             //https://www.elastic.co/guide/en/elasticsearch/reference/master/eager-global-ordinals.html#_avoiding_global_ordinal_loading
+            // CS-ENFORCE-SINGLE
             if (evaluatedDlsFlsConfig.hasFieldMasking()) {
 
                 if (searchRequest.source() != null && searchRequest.source().aggregations() != null) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.security.dlic.rest.api;
 
+// CS-SUPPRESS-SINGLE: RegexpSingleline https://github.com/opensearch-project/OpenSearch/issues/3663
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -69,6 +70,7 @@ import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+// CS-ENFORCE-SINGLE
 
 public class MigrateApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.security.tools;
 
+// CS-SUPPRESS-SINGLE: RegexpSingleline https://github.com/opensearch-project/OpenSearch/issues/3663
 import java.io.ByteArrayInputStream;
 import java.io.Console;
 import java.io.File;
@@ -139,6 +140,7 @@ import org.opensearch.security.support.SecurityJsonNode;
 
 import static org.opensearch.common.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 import static org.opensearch.security.support.SecurityUtils.replaceEnvVars;
+// CS-ENFORCE-SINGLE
 
 @SuppressWarnings("deprecation")
 public class SecurityAdmin {

--- a/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
@@ -45,6 +45,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.threadpool.ThreadPool;
@@ -83,12 +84,9 @@ public class RolesInjectorIntegTest extends SingleClusterTest {
         Assert.assertEquals(ClusterHealthStatus.GREEN, clusterHelper.nodeClient().admin().cluster().
                 health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
 
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/RolesValidationIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesValidationIntegTest.java
@@ -39,6 +39,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.threadpool.ThreadPool;
@@ -74,12 +75,9 @@ public class RolesValidationIntegTest extends SingleClusterTest {
     public void testRolesValidation() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles("roles.yml"), Settings.EMPTY);
 
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -42,6 +42,7 @@ import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
@@ -70,12 +71,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(ClusterHealthStatus.GREEN, clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
     
         
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")
@@ -100,12 +98,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(ClusterHealthStatus.GREEN, clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
     
         
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")
@@ -134,12 +129,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(clusterInfo.numNodes, clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes());
         Assert.assertEquals(ClusterHealthStatus.GREEN, clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
      
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/TransportUserInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/TransportUserInjectorIntegTest.java
@@ -37,6 +37,7 @@ import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.script.ScriptService;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.threadpool.ThreadPool;
@@ -72,12 +73,9 @@ public class TransportUserInjectorIntegTest extends SingleClusterTest {
                 .put(ConfigConstants.SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, true)
                 .build();
         setup(clusterNodeSettings, new DynamicSecurityConfig().setSecurityRolesMapping("roles_transport_inject_user.yml"), Settings.EMPTY);
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")
@@ -129,12 +127,9 @@ public class TransportUserInjectorIntegTest extends SingleClusterTest {
                 .put(ConfigConstants.SECURITY_UNSUPPORTED_INJECT_USER_ENABLED, false)
                 .build();
         setup(clusterNodeSettings, new DynamicSecurityConfig().setSecurityRolesMapping("roles_transport_inject_user.yml"), Settings.EMPTY);
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", clusterInfo.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -84,7 +84,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         }
 
         public ClusterTransportClientSettings(Settings clusterSettings, Settings transportSettings) {
-            super(clusterSettings, transportSettings);
+            super(Settings.builder()
+                .put(clusterSettings)
+                .putList("node.roles", "remote_cluster_client").build(), transportSettings);
         }
 
         public Settings clusterSettings() {
@@ -1001,7 +1003,8 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
                     .source("{\"cluster\": \""+cl2Info.clustername+"\"}", XContentType.JSON)).actionGet();
         }
 
-        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
+        final Settings.Builder clusterClientSettings = Settings.builder().putList("node.roles", "remote_cluster_client");
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(clusterClientSettings, false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", cl1Info.clustername)
                 .put("path.data", "./target/data/" + cl1Info.clustername + "/cert/data")

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -1001,12 +1001,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
                     .source("{\"cluster\": \""+cl2Info.clustername+"\"}", XContentType.JSON)).actionGet();
         }
 
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
                 .put(minimumSecuritySettings(Settings.EMPTY).get(0))
                 .put("cluster.name", cl1Info.clustername)
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + cl1Info.clustername + "/cert/data")
                 .put("path.logs", "./target/data/" + cl1Info.clustername + "/cert/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.security.dlic.dlsfls;
 
+// CS-SUPPRESS-SINGLE: RegexpSingleline https://github.com/opensearch-project/OpenSearch/issues/3663
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -59,12 +60,14 @@ import org.opensearch.rest.RestStatus;
 import org.opensearch.script.ScriptService;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Netty4Plugin;
 import org.opensearch.transport.TransportService;
 import org.opensearch.watcher.ResourceWatcherService;
+// CS-ENFORCE-SINGLE
 
 public class CCReplicationTest extends AbstractDlsFlsTest {
     public static class MockReplicationPlugin extends Plugin implements ActionPlugin {
@@ -180,14 +183,11 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
         Assert.assertEquals(clusterInfo.numNodes, clusterHelper.nodeClient().admin().cluster().health(
             new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes());
         Assert.assertEquals(ClusterHealthStatus.GREEN, clusterHelper.nodeClient().admin().cluster().
-            health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
+        health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus());
 
-        final Settings tcSettings = Settings.builder()
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
             .put(minimumSecuritySettings(Settings.EMPTY).get(0))
             .put("cluster.name", clusterInfo.clustername)
-            .put("node.data", false)
-            .put("node.master", false)
-            .put("node.ingest", false)
             .put("path.data", "./target/data/" + clusterInfo.clustername + "/cert/data")
             .put("path.logs", "./target/data/" + clusterInfo.clustername + "/cert/logs")
             .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
@@ -47,7 +47,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         System.setProperty("security.display_lic_none","true");
 
-        cl2Info = cl2.startCluster(minimumSecuritySettings(Settings.EMPTY), ClusterConfiguration.DEFAULT);
+        cl2Info = cl2.startCluster(minimumSecuritySettings(Settings.builder().putList("node.roles", "remote_cluster_client").build()), ClusterConfiguration.DEFAULT);
         initialize(cl2, cl2Info, new DynamicSecurityConfig().setSecurityRoles(remoteRoles));
         System.out.println("### cl2 complete ###");
 
@@ -66,7 +66,8 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
     private Settings crossClusterNodeSettings(ClusterInfo remote) {
         Settings.Builder builder = Settings.builder()
-                .putList("cluster.remote.cross_cluster_two.seeds", remote.nodeHost+":"+remote.nodePort);
+                .putList("cluster.remote.cross_cluster_two.seeds", remote.nodeHost+":"+remote.nodePort)
+                .putList("node.roles", "remote_cluster_client");
         return builder.build();
     }
 

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -40,6 +40,7 @@ import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.transport.Netty4Plugin;
@@ -206,11 +207,9 @@ public class OpenSSLTest extends SSLTest {
         
         RestHelper rh = nonSslRestHelper();
 
-        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", "/tmp")
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
+                .put("cluster.name", clusterInfo.clustername).put("path.home", "/tmp")
                 .put("node.name", "client_node_" + new Random().nextInt())
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/" + clusterInfo.clustername + "/ssl/data")
                 .put("path.logs", "./target/data/" + clusterInfo.clustername + "/ssl/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -56,6 +56,7 @@ import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
@@ -495,11 +496,9 @@ public class SSLTest extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
 
-        final Settings tcSettings = Settings.builder().put("cluster.name", clusterInfo.clustername).put("path.home", ".")
+        final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false) 
+                .put("cluster.name", clusterInfo.clustername).put("path.home", ".")
                 .put("node.name", "client_node_" + new Random().nextInt())
-                .put("node.data", false)
-                .put("node.master", false)
-                .put("node.ingest", false)
                 .put("path.data", "./target/data/"+clusterInfo.clustername+"/ssl/data")
                 .put("path.logs", "./target/data/"+clusterInfo.clustername+"/ssl/logs")
                 .put("path.home", "./target")

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -71,6 +71,7 @@ import org.opensearch.client.Client;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
 import org.opensearch.security.action.configupdate.ConfigUpdateRequest;
@@ -200,10 +201,10 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
     public static Settings.Builder nodeRolesSettings(final Settings.Builder settingsBuilder, final boolean isClusterManager, final boolean isDataNode) {
         final ImmutableList.Builder<String> nodeRolesBuilder = ImmutableList.<String>builder();
         if (isDataNode) {
-            nodeRolesBuilder.add("data");
+            nodeRolesBuilder.add(DiscoveryNodeRole.DATA_ROLE.roleName());
         }
         if (isClusterManager) {
-            nodeRolesBuilder.add("cluster_manager");
+            nodeRolesBuilder.add(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE.roleName());
         }
 
         final Settings nodeRoleSettings = Settings.builder().putList(NODE_ROLE_KEY, nodeRolesBuilder.build()).build();

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLContext;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
+import com.google.common.collect.ImmutableList;
 import io.netty.handler.ssl.OpenSsl;
 import org.apache.http.Header;
 import org.apache.http.HttpHost;
@@ -192,6 +193,17 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
         if (retainedException.isPresent()) {
             throw new RuntimeException(retainedException.get());
         }
+    }
+
+    public static Settings.Builder nodeRolesSettings(final Settings.Builder settingsBuilder, final boolean isClusterManager, final boolean isDataNode) {
+        final ImmutableList.Builder<String> nodeRolesBuilder = ImmutableList.<String>builder();
+        if (isDataNode) {
+            nodeRolesBuilder.add("data");
+        }
+        if (isClusterManager) {
+            nodeRolesBuilder.add("cluster_manager");
+        }
+        return settingsBuilder.putList("node.roles", nodeRolesBuilder.build());
     }
 
     protected void initialize(ClusterHelper clusterHelper, ClusterInfo clusterInfo, DynamicSecurityConfig securityConfig) throws IOException {

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -372,7 +372,7 @@ public final class ClusterHelper {
     private Settings.Builder getMinimumNonSecurityNodeSettingsBuilder(final int nodenum, final boolean isClusterManagerNode,
                                                                 final boolean isDataNode, int nodeCount, SortedSet<Integer> clusterManagerTcpPorts, int tcpPort, int httpPort) {
 
-        return AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), isDataNode, isClusterManagerNode)
+        return AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), isClusterManagerNode, isDataNode)
                 .put("node.name", "node_"+clustername+ "_num" + nodenum)
                 .put("cluster.name", clustername)
                 .put("path.data", "./target/data/"+clustername+"/data")

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -174,9 +174,15 @@ public final class ClusterHelper {
         for (int i = 0; i < internalClusterManagerNodeSettings.size(); i++) {
             NodeSettings setting = internalClusterManagerNodeSettings.get(i);
             int nodeNum = nodeNumCounter--;
-            PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode,
-                    getMinimumNonSecurityNodeSettingsBuilder(nodeNum, setting.clusterManagerNode, setting.dataNode, internalNodeSettings.size(), tcpClusterManagerPortsOnly, tcpPortsAllIt.next(), httpPortsIt.next())
-                            .put(nodeSettingsSupplier == null ? Settings.Builder.EMPTY_SETTINGS : nodeSettingsSupplier.get(nodeNum)).build(), setting.getPlugins());
+            final Settings.Builder nodeSettingsBuilder = getMinimumNonSecurityNodeSettingsBuilder(nodeNum, setting.clusterManagerNode, setting.dataNode, internalNodeSettings.size(), tcpClusterManagerPortsOnly, tcpPortsAllIt.next(), httpPortsIt.next());
+            final Settings settingsForNode;
+            if (nodeSettingsSupplier != null) {
+                final Settings suppliedSettings = nodeSettingsSupplier.get(nodeNum);
+                settingsForNode = AbstractSecurityUnitTest.mergeNodeRolesAndSettings(nodeSettingsBuilder, suppliedSettings).build();
+            } else {
+                settingsForNode = nodeSettingsBuilder.build();
+            }
+            PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode, settingsForNode, setting.getPlugins());
             System.out.println(node.settings());
 
             new Thread(new Runnable() {
@@ -200,9 +206,15 @@ public final class ClusterHelper {
         for (int i = 0; i < internalNonClusterManagerNodeSettings.size(); i++) {
             NodeSettings setting = internalNonClusterManagerNodeSettings.get(i);
             int nodeNum = nodeNumCounter--;
-            PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode,
-                    getMinimumNonSecurityNodeSettingsBuilder(nodeNum, setting.clusterManagerNode, setting.dataNode, internalNodeSettings.size(), tcpClusterManagerPortsOnly, tcpPortsAllIt.next(), httpPortsIt.next())
-                            .put(nodeSettingsSupplier == null ? Settings.Builder.EMPTY_SETTINGS : nodeSettingsSupplier.get(nodeNum)).build(), setting.getPlugins());
+            final Settings.Builder nodeSettingsBuilder = getMinimumNonSecurityNodeSettingsBuilder(nodeNum, setting.clusterManagerNode, setting.dataNode, internalNodeSettings.size(), tcpClusterManagerPortsOnly, tcpPortsAllIt.next(), httpPortsIt.next());
+            final Settings settingsForNode;
+            if (nodeSettingsSupplier != null) {
+                final Settings suppliedSettings = nodeSettingsSupplier.get(nodeNum);
+                settingsForNode = AbstractSecurityUnitTest.mergeNodeRolesAndSettings(nodeSettingsBuilder, suppliedSettings).build();
+            } else {
+                settingsForNode = nodeSettingsBuilder.build();
+            }
+            PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode, settingsForNode, setting.getPlugins());
             System.out.println(node.settings());
 
             new Thread(new Runnable() {

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.security.test.helper.cluster;
 
+// CS-SUPPRESS-SINGLE: RegexpSingleline https://github.com/opensearch-project/OpenSearch/issues/3663
 import java.io.File;
 import java.io.IOException;
 import java.util.Comparator;
@@ -60,11 +61,13 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.http.HttpInfo;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
+import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.NodeSettingsSupplier;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration.NodeSettings;
 import org.opensearch.security.test.helper.network.SocketUtils;
 import org.opensearch.transport.TransportInfo;
+// CS-ENFORCE-SINGLE
 
 public final class ClusterHelper {
 
@@ -293,7 +296,7 @@ public final class ClusterHelper {
         try {
             log.debug("waiting for cluster state {} and {} nodes", status.name(), expectedNodeCount);
             final ClusterHealthResponse healthResponse = client.admin().cluster().prepareHealth()
-                    .setWaitForStatus(status).setTimeout(timeout).setMasterNodeTimeout(timeout).setWaitForNodes("" + expectedNodeCount).execute()
+                    .setWaitForStatus(status).setTimeout(timeout).setClusterManagerNodeTimeout(timeout).setWaitForNodes("" + expectedNodeCount).execute()
                     .actionGet();
             if (healthResponse.isTimedOut()) {
                 throw new IOException("cluster state is " + healthResponse.getStatus().name() + " with "
@@ -366,13 +369,11 @@ public final class ClusterHelper {
     }
 
     // @formatter:off
-    private Settings.Builder getMinimumNonSecurityNodeSettingsBuilder(final int nodenum, final boolean clusterManagerNode,
-                                                                final boolean dataNode, int nodeCount, SortedSet<Integer> clusterManagerTcpPorts, int tcpPort, int httpPort) {
+    private Settings.Builder getMinimumNonSecurityNodeSettingsBuilder(final int nodenum, final boolean isClusterManagerNode,
+                                                                final boolean isDataNode, int nodeCount, SortedSet<Integer> clusterManagerTcpPorts, int tcpPort, int httpPort) {
 
-        return Settings.builder()
+        return AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), isDataNode, isClusterManagerNode)
                 .put("node.name", "node_"+clustername+ "_num" + nodenum)
-                .put("node.data", dataNode)
-                .put("node.master", clusterManagerNode)
                 .put("cluster.name", clustername)
                 .put("path.data", "./target/data/"+clustername+"/data")
                 .put("path.logs", "./target/data/"+clustername+"/logs")


### PR DESCRIPTION
### Description

Enforce usage of ClusterManager terminology in the codebase
Include mechanism to disable checkstyle rule

Signed-off-by: Peter Nied <petern@amazon.com>

### Issues Resolved
* Related to https://github.com/opensearch-project/security/issues/2050

### Testing
Added Checkstyle mechanism to prevent usage of non-inclusive terminology

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
