### PR TITLE
Make ldap pool period and idle time configurable

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
@@ -82,6 +82,9 @@ public final class ConfigConstants {
 
     public static final String LDAP_POOL_TYPE = "pool.type";
 
+    public static final String LDAP_POOL_PRUNING_PERIOD = "pool.pruning_period";
+    public static final String LDAP_POOL_IDLE_TIME = "pool.idle_time";
+
     private ConfigConstants() {
 
     }

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
@@ -127,8 +127,11 @@ public class LDAPConnectionFactoryFactory {
         }
 
         result.setValidator(getConnectionValidator());
-        result.setPruneStrategy(new IdlePruneStrategy(Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_PRUNING_PERIOD, 5l)),
-                Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_IDLE_TIME, 10l))));
+          
+        result.setPruneStrategy(new IdlePruneStrategy(
+            Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_PRUNING_PERIOD, this.settings.getAsLong("pruning.period", 5l))),
+            Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_IDLE_TIME, this.settings.getAsLong("pruning.idleTime", 10l))))
+        );
 
         result.initialize();
 

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java
@@ -127,8 +127,8 @@ public class LDAPConnectionFactoryFactory {
         }
 
         result.setValidator(getConnectionValidator());
-        result.setPruneStrategy(new IdlePruneStrategy(Duration.ofMinutes(this.settings.getAsLong("pruning.period", 5l)),
-                Duration.ofMinutes(this.settings.getAsLong("pruning.idleTime", 10l))));
+        result.setPruneStrategy(new IdlePruneStrategy(Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_PRUNING_PERIOD, 5l)),
+                Duration.ofMinutes(this.settings.getAsLong(ConfigConstants.LDAP_POOL_IDLE_TIME, 10l))));
 
         result.initialize();
 


### PR DESCRIPTION
### Description
Configure ldap connection pool pruning period and idle time through config.yml. For example, currently you can enable pooling and set the min and max size. ideally pool.idle_time and pool.pruning_period should also be configurable. Like this:
```
pool.enabled: true
pool.min_size: 0
pool.max_size: 5
pool.idle_time: 2
pool.pruning_period: 1
```
* Category (Enhancement)
* Why these changes are required?
To comply with strict ldap providers.
* What is the old behavior before changes and new behavior after changes?
Defaults are the same, this just makes things configurable.

### Issues Resolved
https://github.com/opensearch-project/security/issues/2090

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Manual testing locally.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
