### PR TITLE
Allow custom return attributes

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -30,6 +30,7 @@ import org.ldaptive.ConnectionConfig;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
@@ -57,10 +58,13 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
     private final int customAttrMaxValueLen;
     private final WildcardMatcher whitelistedCustomLdapAttrMatcher;
 
+    private final String[] returnAttributes;
+
     public LDAPAuthenticationBackend(final Settings settings, final Path configPath) {
         this.settings = settings;
         this.configPath = configPath;
         this.userBaseSettings = getUserBaseSettings(settings);
+        this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
 
         customAttrMaxValueLen = settings.getAsInt(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 36);
         whitelistedCustomLdapAttrMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST,
@@ -82,7 +86,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
             try {
                 ldapConnection = LDAPAuthorizationBackend.getConnection(settings, configPath);
 
-                entry = exists(user, ldapConnection, settings, userBaseSettings);
+                entry = exists(user, ldapConnection, settings, userBaseSettings, this.returnAttributes);
 
                 // fake a user that no exists
                 // makes guessing if a user exists or not harder when looking on the
@@ -156,7 +160,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
 
         try {
             ldapConnection = LDAPAuthorizationBackend.getConnection(settings, configPath);
-            LdapEntry userEntry = exists(userName, ldapConnection, settings, userBaseSettings);
+            LdapEntry userEntry = exists(userName, ldapConnection, settings, userBaseSettings, this.returnAttributes);
             boolean exists = userEntry != null;
             
             if(exists) {
@@ -197,20 +201,19 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
     }
 
     static LdapEntry exists(final String user, Connection ldapConnection, Settings settings,
-            List<Map.Entry<String, Settings>> userBaseSettings) throws Exception {
-
+            List<Map.Entry<String, Settings>> userBaseSettings, String[] returnAttributes) throws Exception {
         if (settings.getAsBoolean(ConfigConstants.LDAP_FAKE_LOGIN_ENABLED, false)
                 || settings.getAsBoolean(ConfigConstants.LDAP_SEARCH_ALL_BASES, false)
                 || settings.hasValue(ConfigConstants.LDAP_AUTHC_USERBASE)) {
-            return existsSearchingAllBases(user, ldapConnection, userBaseSettings);
+            return existsSearchingAllBases(user, ldapConnection, userBaseSettings, returnAttributes);
         } else {
-            return existsSearchingUntilFirstHit(user, ldapConnection, userBaseSettings);
+            return existsSearchingUntilFirstHit(user, ldapConnection, userBaseSettings, returnAttributes);
         }
 
     }
 
     private static LdapEntry existsSearchingUntilFirstHit(final String user, Connection ldapConnection,
-            List<Map.Entry<String, Settings>> userBaseSettings) throws Exception {
+            List<Map.Entry<String, Settings>> userBaseSettings, final String[] returnAttributes) throws Exception {
         final String username = user;
 
         final boolean isDebugEnabled = log.isDebugEnabled();
@@ -224,7 +227,8 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
             List<LdapEntry> result = LdapHelper.search(ldapConnection,
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
-                    SearchScope.SUBTREE);
+                    SearchScope.SUBTREE,
+                    returnAttributes);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for {} in base {} is {}", user, entry.getKey(), result);
@@ -239,7 +243,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
     }
 
     private static LdapEntry existsSearchingAllBases(final String user, Connection ldapConnection,
-            List<Map.Entry<String, Settings>> userBaseSettings) throws Exception {
+            List<Map.Entry<String, Settings>> userBaseSettings, final String[] returnAttributes) throws Exception {
         final String username = user;
         Set<LdapEntry> result = new HashSet<>();
 
@@ -254,7 +258,8 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
             List<LdapEntry> foundEntries = LdapHelper.search(ldapConnection,
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
-                    SearchScope.SUBTREE);
+                    SearchScope.SUBTREE,
+                    returnAttributes);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for " + user + " in base " + entry.getKey() + ":\n" + result);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -28,9 +28,9 @@ import org.apache.logging.log4j.Logger;
 import org.ldaptive.Connection;
 import org.ldaptive.ConnectionConfig;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.ReturnAttributes;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
-import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -65,6 +65,7 @@ import org.ldaptive.ssl.CredentialConfig;
 import org.ldaptive.ssl.CredentialConfigFactory;
 import org.ldaptive.ssl.SslConfig;
 import org.ldaptive.ssl.ThreadLocalTLSSocketFactory;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
@@ -103,6 +104,8 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
     private final List<Map.Entry<String, Settings>> roleBaseSettings;
     private final List<Map.Entry<String, Settings>> userBaseSettings;
 
+    private final String[] returnAttributes;
+
     public LDAPAuthorizationBackend(final Settings settings, final Path configPath) {
         this.settings = settings;
         this.skipUsersMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_AUTHZ_SKIP_USERS));
@@ -111,6 +114,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         this.configPath = configPath;
         this.roleBaseSettings = getRoleSearchSettings(settings);
         this.userBaseSettings = LDAPAuthenticationBackend.getUserBaseSettings(settings);
+        this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
     }
 
     @SuppressWarnings("removal")
@@ -724,7 +728,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                         log.debug("DBGTRACE (4): authenticatedUser="+authenticatedUser+" -> "+Arrays.toString(authenticatedUser.getBytes(StandardCharsets.UTF_8)));
                     }
 
-                    entry = LdapHelper.lookup(connection, authenticatedUser);
+                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes);
 
                     if (entry == null) {
                         throw new OpenSearchSecurityException("No user '" + authenticatedUser + "' found");
@@ -735,7 +739,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                     if (isDebugEnabled)
                         log.debug("DBGTRACE (5): authenticatedUser="+user.getName()+" -> "+Arrays.toString(user.getName().getBytes(StandardCharsets.UTF_8)));
 
-                    entry = LDAPAuthenticationBackend.exists(user.getName(), connection, settings, userBaseSettings);
+                    entry = LDAPAuthenticationBackend.exists(user.getName(), connection, settings, userBaseSettings, this.returnAttributes);
 
                     if (isTraceEnabled) {
                         log.trace("{} is not a valid DN and was resolved to {}", authenticatedUser, entry);
@@ -848,7 +852,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                     List<LdapEntry> rolesResult = LdapHelper.search(connection,
                             roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                             f,
-                            SearchScope.SUBTREE);
+                            SearchScope.SUBTREE, this.returnAttributes);
 
                     if (isTraceEnabled) {
                         log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchSettingsEntry.getKey(), rolesResult);
@@ -966,7 +970,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         final Set<LdapName> result = new HashSet<>(20);
         final HashMultimap<LdapName, Map.Entry<String, Settings>> resultRoleSearchBaseKeys = HashMultimap.create();
 
-        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString());
+        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes);
 
         if (e0.getAttribute(userRoleName) != null) {
             final Collection<String> userRoles = e0.getAttribute(userRoleName).getStringValues();
@@ -1018,7 +1022,8 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 List<LdapEntry> foundEntries = LdapHelper.search(ldapConnection,
                         roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                         f,
-                        SearchScope.SUBTREE);
+                        SearchScope.SUBTREE,
+                        this.returnAttributes);
 
                 if (isTraceEnabled) {
                     log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchBaseSettingsEntry.getKey(), foundEntries);
@@ -1096,7 +1101,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         }
 
         try {
-            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString());
+            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes);
 
             if(roleEntry != null) {
                 final LdapAttribute roleAttribute = roleEntry.getAttribute(role);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -53,6 +53,7 @@ import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.Response;
+import org.ldaptive.ReturnAttributes;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
 import org.ldaptive.control.RequestControl;
@@ -65,7 +66,6 @@ import org.ldaptive.ssl.CredentialConfig;
 import org.ldaptive.ssl.CredentialConfigFactory;
 import org.ldaptive.ssl.SslConfig;
 import org.ldaptive.ssl.ThreadLocalTLSSocketFactory;
-import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
@@ -73,6 +73,7 @@ public final class ConfigConstants {
     // custom attributes
     public static final String LDAP_CUSTOM_ATTR_MAXVAL_LEN = "custom_attr_maxval_len";
     public static final String LDAP_CUSTOM_ATTR_WHITELIST = "custom_attr_whitelist";
+    public static final String LDAP_RETURN_ATTRIBUTES = "custom_return_attributes";
 
     public static final String LDAP_CONNECTION_STRATEGY = "connection_strategy";
 

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
@@ -26,7 +26,6 @@ import org.ldaptive.DerefAliases;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.Response;
-import org.ldaptive.ReturnAttributes;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchOperation;
 import org.ldaptive.SearchRequest;
@@ -41,7 +40,7 @@ public class LdapHelper {
     private static SearchFilter ALL = new SearchFilter("(objectClass=*)");
     @SuppressWarnings("removal")
     public static List<LdapEntry> search(final Connection conn, final String unescapedDn, SearchFilter filter,
-            final SearchScope searchScope) throws LdapException {
+            final SearchScope searchScope, final String[] returnAttributes) throws LdapException {
 
         final SecurityManager sm = System.getSecurityManager();
 
@@ -59,7 +58,7 @@ public class LdapHelper {
                     request.setReferralHandler(new SearchReferralHandler());
                     request.setSearchScope(searchScope);
                     request.setDerefAliases(DerefAliases.ALWAYS);
-                    request.setReturnAttributes(ReturnAttributes.ALL.value());
+                    request.setReturnAttributes(returnAttributes);
                     final SearchOperation search = new SearchOperation(conn);
                     // referrals will be followed to build the response
                     final Response<SearchResult> r = search.execute(request);
@@ -81,9 +80,9 @@ public class LdapHelper {
         }
     }
 
-    public static LdapEntry lookup(final Connection conn, final String unescapedDn) throws LdapException {
+    public static LdapEntry lookup(final Connection conn, final String unescapedDn, final String[] returnAttributes) throws LdapException {
 
-        final List<LdapEntry> entries = search(conn, unescapedDn, ALL, SearchScope.OBJECT);
+        final List<LdapEntry> entries = search(conn, unescapedDn, ALL, SearchScope.OBJECT, returnAttributes);
 
         if (entries.size() == 1) {
             return entries.get(0);

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -31,6 +31,7 @@ import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.Response;
 import org.ldaptive.pool.ConnectionPool;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
@@ -58,6 +59,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
     private LDAPUserSearcher userSearcher;
     private final int customAttrMaxValueLen;
     private final WildcardMatcher whitelistedCustomLdapAttrMatcher;
+    private final String[] returnAttributes;
 
     public LDAPAuthenticationBackend2(final Settings settings, final Path configPath) throws SSLConfigException {
         this.settings = settings;
@@ -75,6 +77,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
         }
 
         this.userSearcher = new LDAPUserSearcher(settings);
+        this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
         customAttrMaxValueLen = settings.getAsInt(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 36);
         whitelistedCustomLdapAttrMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST,
                 Collections.singletonList("*")));
@@ -119,7 +122,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
             ldapConnection = connectionFactory.getConnection();
             ldapConnection.open();
 
-            LdapEntry entry = userSearcher.exists(ldapConnection, user);
+            LdapEntry entry = userSearcher.exists(ldapConnection, user, this.returnAttributes);
 
             // fake a user that no exists
             // makes guessing if a user exists or not harder when looking on the
@@ -211,7 +214,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
         try {
             ldapConnection = this.connectionFactory.getConnection();
             ldapConnection.open();
-            LdapEntry userEntry = this.userSearcher.exists(ldapConnection, userName);
+            LdapEntry userEntry = this.userSearcher.exists(ldapConnection, userName, this.returnAttributes);
             
             boolean exists = userEntry != null;
             

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -30,8 +30,8 @@ import org.ldaptive.Credential;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
 import org.ldaptive.Response;
-import org.ldaptive.pool.ConnectionPool;
 import org.ldaptive.ReturnAttributes;
+import org.ldaptive.pool.ConnectionPool;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -38,6 +39,7 @@ import org.ldaptive.LdapException;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
 import org.ldaptive.pool.ConnectionPool;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
@@ -73,6 +75,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
     private ConnectionPool connectionPool;
     private ConnectionFactory connectionFactory;
     private LDAPUserSearcher userSearcher;
+    private final String[] returnAttributes;
 
     public LDAPAuthorizationBackend2(final Settings settings, final Path configPath) throws SSLConfigException {
         this.settings = settings;
@@ -87,6 +90,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         this.connectionPool = ldapConnectionFactoryFactory.createConnectionPool();
         this.connectionFactory = ldapConnectionFactoryFactory.createConnectionFactory(this.connectionPool);
         this.userSearcher = new LDAPUserSearcher(settings);
+        this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
     }
 
     private static List<Map.Entry<String, Settings>> getRoleSearchSettings(Settings settings) {
@@ -203,14 +207,14 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                         log.trace("{} is a valid DN", authenticatedUser);
                     }
 
-                    entry = LdapHelper.lookup(connection, authenticatedUser);
+                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes);
 
                     if (entry == null) {
                         throw new OpenSearchSecurityException("No user '" + authenticatedUser + "' found");
                     }
 
                 } else {
-                    entry = this.userSearcher.exists(connection, user.getName());
+                    entry = this.userSearcher.exists(connection, user.getName(), this.returnAttributes);
 
                     if (isTraceEnabled) {
                         log.trace("{} is not a valid DN and was resolved to {}", authenticatedUser, entry);
@@ -309,7 +313,8 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                     List<LdapEntry> rolesResult = LdapHelper.search(connection,
                             roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                             f,
-                            SearchScope.SUBTREE);
+                            SearchScope.SUBTREE,
+                            this.returnAttributes);
 
                     if (isTraceEnabled) {
                         log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchSettingsEntry.getKey(), rolesResult);
@@ -425,7 +430,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         final Set<LdapName> result = new HashSet<>(20);
         final HashMultimap<LdapName, Map.Entry<String, Settings>> resultRoleSearchBaseKeys = HashMultimap.create();
 
-        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString());
+        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes);
         final boolean isDebugEnabled = log.isDebugEnabled();
 
         if (e0.getAttribute(userRoleName) != null) {
@@ -466,7 +471,8 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                 List<LdapEntry> foundEntries = LdapHelper.search(ldapConnection,
                         roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                         f,
-                        SearchScope.SUBTREE);
+                        SearchScope.SUBTREE,
+                        this.returnAttributes);
 
                 if (isTraceEnabled) {
                     log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchBaseSettingsEntry.getKey(), foundEntries);
@@ -544,7 +550,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         }
 
         try {
-            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString());
+            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes);
 
             if(roleEntry != null) {
                 final LdapAttribute roleAttribute = roleEntry.getAttribute(role);

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -15,6 +15,7 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -23,7 +24,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Arrays;
 
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
@@ -36,10 +36,10 @@ import org.ldaptive.ConnectionFactory;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.LdapException;
+import org.ldaptive.ReturnAttributes;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
 import org.ldaptive.pool.ConnectionPool;
-import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Arrays;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
@@ -26,7 +25,6 @@ import org.ldaptive.Connection;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.SearchFilter;
 import org.ldaptive.SearchScope;
-import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
 import com.amazon.dlic.auth.ldap.util.LdapHelper;

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.ldaptive.Connection;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend;
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthorizationBackend;
@@ -378,7 +379,7 @@ public class LdapBackendTest {
 
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST");
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -22,6 +22,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.ldaptive.Connection;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend;
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthorizationBackend;
@@ -340,7 +341,7 @@ public class LdapBackendTestNewStyleConfig {
 
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST");
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -14,8 +14,8 @@ package com.amazon.dlic.auth.ldap2;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.TreeSet;
 import java.util.Arrays;
+import java.util.TreeSet;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.AfterClass;

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -28,6 +28,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.ldaptive.Connection;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend;
@@ -375,7 +376,7 @@ public class LdapBackendTestNewStyleConfig2 {
                 .getConnection();
         try {
             con.open();
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST");
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
@@ -29,6 +29,7 @@ import org.junit.runners.Parameterized.Parameters;
 import org.ldaptive.Connection;
 import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
+import org.ldaptive.ReturnAttributes;
 
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend;
@@ -453,7 +454,7 @@ public class LdapBackendTestOldStyleConfig2 {
                 .getConnection();
         try {
             con.open();
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST");
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();


### PR DESCRIPTION
Signed-off-by: Martin Kemp <martin_leon.kemp@mercedes-benz.com>

### Description
Allows specifying which attributes to request from the ldap server.
* Category: New feature
* Why these changes are required?
It can be a security risk to request more attributes than needed from an ldap server.
* What is the old behavior before changes and new behavior after changes?
All attributes are requested.

### Issues Resolved
https://github.com/opensearch-project/security/issues/2032

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Manual testing with local ldap server. I made sure default behavior remains the same.
Updated unit tests.
This functionality is not tested directly with unit test, I can add one if needed.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
