### PR TITLE
Disable BWC tests until they are supported by the distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,11 @@ jobs:
       run: echo "Check the artifact ${{ matrix.jdk }}-reports.zip for detailed test results"
 
   backward-compatibility:
+    ## Disable until 3.0 supports BWC https://github.com/opensearch-project/opensearch-plugins/issues/167
+    if: false
     runs-on: ubuntu-latest
     steps:
+
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1
       with:


### PR DESCRIPTION
### Description
Disable BWC tests until they are supported by the distribution

### Issues Resolved
- New issue to track this being fixed https://github.com/opensearch-project/security/issues/2109
- Related https://github.com/opensearch-project/opensearch-plugins/issues/167
- See also https://github.com/opensearch-project/OpenSearch/issues/3615

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
