### PR TITLE
Adding tenancy access to user info in security thread context

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -188,10 +188,28 @@ public class PrivilegesEvaluator {
             joiner.add(String.join(",", user.getRoles()));
             joiner.add(String.join(",", Sets.union(user.getSecurityRoles(), mappedRoles)));
             String requestedTenant = user.getRequestedTenant();
-            if (!Strings.isNullOrEmpty(requestedTenant)) {
-                joiner.add(requestedTenant);
-            }
+            joiner.add(requestedTenant);
+            String tenantAccessToCheck = getTenancyAccess(requestedTenant, mapTenants(user, mappedRoles));
+            joiner.add(tenantAccessToCheck);
+            log.info(joiner);
             threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, joiner.toString());
+        }
+    }
+
+    private String getTenancyAccess(String requestedTenant, Map<String, Boolean> tenancyAccessMap) {
+        if(Strings.isNullOrEmpty(requestedTenant)) {
+            requestedTenant = "global_tenant";
+        }
+        if(requestedTenant.equals("__user__")) {
+            return "WRITE";
+        }
+        else{
+            if(!tenancyAccessMap.containsKey(requestedTenant)) {
+                return "NO";
+            }
+            else {
+                return tenancyAccessMap.get(requestedTenant) ? "WRITE" : "READ";
+            }
         }
     }
 


### PR DESCRIPTION
Signed-off-by: vamsi-amazon <reddyvam@amazon.com>

### Description
[Describe what this change achieves]
* Adding tenancy access info into thread context.
* Downstream plugins could utilize this information to base their behavior.

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Manual Testing.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
