### PR TITLE
Scope updateVersion to only build.gradle in 1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -384,13 +384,6 @@ task updateVersion {
     doLast {
         ext.newVersion = System.getProperty('newVersion')
         println "Setting version to ${newVersion}."
-        // String tokenization to support -SNAPSHOT
-        ant.replaceregexp(match: opensearch_version.tokenize('-')[0], replace: newVersion.tokenize('-')[0], flags:'g', byline:true) {
-            fileset(dir: projectDir) {
-                // Include the required files that needs to be updated with new Version
-                // No BWC tests in this major release
-            }
-        }
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
 } 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The last version increment automation to run against 1.3 picked up all files of the project since it did not include an explicit `include` directive in the block. These lines are not needed in this branch since the only reference to the version is in `build.gradle`. 

See relevant conversation on this PR: https://github.com/opensearch-project/security/pull/2119

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
