### PR TITLE
Configure LDAP Referral Followinng

### DIFF
--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -55,7 +55,7 @@ Lists of 69 third-party dependencies.
      (The Apache Software License, Version 2.0) server (org.elasticsearch:elasticsearch:6.2.0 - https://github.com/elastic/elasticsearch)
      (The Apache Software License, Version 2.0) cli (org.elasticsearch:elasticsearch-cli:6.2.0 - https://github.com/elastic/elasticsearch)
      (The Apache Software License, Version 2.0) elasticsearch-core (org.elasticsearch:elasticsearch-core:6.2.0 - https://github.com/elastic/elasticsearch)
-     (The Apache Software License, Version 2.0) Elastic JNA Distribution (org.elasticsearch:jna:4.5.1 - https://github.com/java-native-access/jna)
+     (The Apache Software License, Version 2.0) java native access (net.java.dev.jna:jna:5.5.0 - https://github.com/java-native-access/jna)
      (The Apache Software License, Version 2.0) Elasticsearch SecureSM (org.elasticsearch:securesm:1.2 - http://nexus.sonatype.org/oss-repository-hosting.html/securesm)
      (The Apache Software License, Version 2.0) rest (org.elasticsearch.client:elasticsearch-rest-client:6.2.0 - https://github.com/elastic/elasticsearch)
      (The Apache Software License, Version 2.0) aggs-matrix-stats (org.elasticsearch.plugin:aggs-matrix-stats-client:6.2.0 - https://github.com/elastic/elasticsearch)

--- a/config/opensearch.yml.example
+++ b/config/opensearch.yml.example
@@ -38,6 +38,9 @@ plugins.security.authcz.admin_dn:
 # BOTH - backend roles are mapped to Security roles mapped directly and via roles_mapping.yml in addition
 plugins.security.roles_mapping_resolution: MAPPING_ONLY
 
+# Define behavior for following referalls from LDAP reponses (default: true)
+plugins.security.FOLLOW_REFERRALS: true
+
 ############## REST Management API configuration settings ##############
 # Enable or disable role based access to the REST management API
 # Default is that no role is allowed to access the REST management API.

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -262,7 +262,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
                     SearchScope.SUBTREE,
-                    returnAttributes);
+                    returnAttributes, baseSettings);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for " + user + " in base " + entry.getKey() + ":\n" + result);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -54,6 +54,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
 
     private final Settings settings;
     private final Path configPath;
+    private final boolean followReferrals;
     private final List<Map.Entry<String, Settings>> userBaseSettings;
     private final int customAttrMaxValueLen;
     private final WildcardMatcher whitelistedCustomLdapAttrMatcher;
@@ -65,10 +66,12 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
         this.configPath = configPath;
         this.userBaseSettings = getUserBaseSettings(settings);
         this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
+        this.followReferrals = settings.getAsBoolean(ConfigConstants.FOLLOW_REFERRALS, true);
 
         customAttrMaxValueLen = settings.getAsInt(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 36);
         whitelistedCustomLdapAttrMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST,
                 Collections.singletonList("*")));
+        
     }
 
     @Override

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthenticationBackend.java
@@ -231,7 +231,7 @@ public class LDAPAuthenticationBackend implements AuthenticationBackend {
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
                     SearchScope.SUBTREE,
-                    returnAttributes);
+                    returnAttributes, baseSettings);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for {} in base {} is {}", user, entry.getKey(), result);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -99,7 +99,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
     private final Settings settings;
     private final WildcardMatcher skipUsersMatcher;
     private final WildcardMatcher nestedRoleMatcher;
-
+    //private final boolean followReferrals;
     private final Path configPath;
     private final List<Map.Entry<String, Settings>> roleBaseSettings;
     private final List<Map.Entry<String, Settings>> userBaseSettings;
@@ -112,6 +112,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         this.nestedRoleMatcher = settings.getAsBoolean(ConfigConstants.LDAP_AUTHZ_RESOLVE_NESTED_ROLES, false) ?
                 WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_AUTHZ_NESTEDROLEFILTER)) : null;
         this.configPath = configPath;
+        //this.followReferrals = settings.getAsBoolean(ConfigConstants.FOLLOW_REFERRALS, true);
         this.roleBaseSettings = getRoleSearchSettings(settings);
         this.userBaseSettings = LDAPAuthenticationBackend.getUserBaseSettings(settings);
         this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -729,7 +729,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                         log.debug("DBGTRACE (4): authenticatedUser="+authenticatedUser+" -> "+Arrays.toString(authenticatedUser.getBytes(StandardCharsets.UTF_8)));
                     }
 
-                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes);
+                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes, settings);
 
                     if (entry == null) {
                         throw new OpenSearchSecurityException("No user '" + authenticatedUser + "' found");
@@ -853,7 +853,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                     List<LdapEntry> rolesResult = LdapHelper.search(connection,
                             roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                             f,
-                            SearchScope.SUBTREE, this.returnAttributes);
+                            SearchScope.SUBTREE, this.returnAttributes, settings);
 
                     if (isTraceEnabled) {
                         log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchSettingsEntry.getKey(), rolesResult);
@@ -971,7 +971,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         final Set<LdapName> result = new HashSet<>(20);
         final HashMultimap<LdapName, Map.Entry<String, Settings>> resultRoleSearchBaseKeys = HashMultimap.create();
 
-        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes);
+        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes, settings);
 
         if (e0.getAttribute(userRoleName) != null) {
             final Collection<String> userRoles = e0.getAttribute(userRoleName).getStringValues();
@@ -1024,7 +1024,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                         roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                         f,
                         SearchScope.SUBTREE,
-                        this.returnAttributes);
+                        this.returnAttributes, settings);
 
                 if (isTraceEnabled) {
                     log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchBaseSettingsEntry.getKey(), foundEntries);
@@ -1102,7 +1102,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         }
 
         try {
-            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes);
+            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes, settings);
 
             if(roleEntry != null) {
                 final LdapAttribute roleAttribute = roleEntry.getAttribute(role);

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/ConfigConstants.java
@@ -35,6 +35,9 @@ public final class ConfigConstants {
     public static final String LDAP_AUTHZ_MAX_NESTED_DEPTH = "max_nested_depth";
     public static final int LDAP_AUTHZ_MAX_NESTED_DEPTH_DEFAULT = 30;
 
+    public static final String FOLLOW_REFERRALS = "follow_referrals";
+    public static final boolean FOLLOW_REFERRALS_DEFAULT = true;
+
     public static final String LDAP_HOSTS = "hosts";
     public static final String LDAP_BIND_DN = "bind_dn";
     public static final String LDAP_PASSWORD = "password";

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
@@ -57,10 +57,6 @@ public class LdapHelper {
                     final List<LdapEntry> entries = new ArrayList<>();
                     final SearchRequest request = new SearchRequest(baseDn, filter);
 
-                      // Check to see if follow referrals is on
-                    
-                    
-
                     request.setSearchScope(searchScope);
                     request.setDerefAliases(DerefAliases.ALWAYS);
                     request.setReturnAttributes(returnAttributes);
@@ -75,7 +71,7 @@ public class LdapHelper {
                         return entries;
                     } 
                     else{
-                        
+
                         return entries;
                     }
                 }

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthenticationBackend2.java
@@ -57,6 +57,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
     private ConnectionFactory connectionFactory;
     private ConnectionFactory authConnectionFactory;
     private LDAPUserSearcher userSearcher;
+    //private boolean followReferrals;
     private final int customAttrMaxValueLen;
     private final WildcardMatcher whitelistedCustomLdapAttrMatcher;
     private final String[] returnAttributes;
@@ -77,6 +78,7 @@ public class LDAPAuthenticationBackend2 implements AuthenticationBackend, Destro
         }
 
         this.userSearcher = new LDAPUserSearcher(settings);
+        //this.followReferrals = settings.getAsBoolean(ConfigConstants.FOLLOW_REFERRALS, true);
         this.returnAttributes = settings.getAsList(ConfigConstants.LDAP_RETURN_ATTRIBUTES, Arrays.asList(ReturnAttributes.ALL.value())).toArray(new String[0]);
         customAttrMaxValueLen = settings.getAsInt(ConfigConstants.LDAP_CUSTOM_ATTR_MAXVAL_LEN, 36);
         whitelistedCustomLdapAttrMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.LDAP_CUSTOM_ATTR_WHITELIST,

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -207,7 +207,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                         log.trace("{} is a valid DN", authenticatedUser);
                     }
 
-                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes);
+                    entry = LdapHelper.lookup(connection, authenticatedUser, this.returnAttributes, settings);
 
                     if (entry == null) {
                         throw new OpenSearchSecurityException("No user '" + authenticatedUser + "' found");
@@ -314,7 +314,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                             roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                             f,
                             SearchScope.SUBTREE,
-                            this.returnAttributes);
+                            this.returnAttributes, settings);
 
                     if (isTraceEnabled) {
                         log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchSettingsEntry.getKey(), rolesResult);
@@ -430,7 +430,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         final Set<LdapName> result = new HashSet<>(20);
         final HashMultimap<LdapName, Map.Entry<String, Settings>> resultRoleSearchBaseKeys = HashMultimap.create();
 
-        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes);
+        final LdapEntry e0 = LdapHelper.lookup(ldapConnection, roleDn.toString(), this.returnAttributes, settings);
         final boolean isDebugEnabled = log.isDebugEnabled();
 
         if (e0.getAttribute(userRoleName) != null) {
@@ -472,7 +472,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                         roleSearchSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_ROLEBASE),
                         f,
                         SearchScope.SUBTREE,
-                        this.returnAttributes);
+                        this.returnAttributes, settings);
 
                 if (isTraceEnabled) {
                     log.trace("Results for LDAP group search for {} in base {}:\n{}", escapedDn, roleSearchBaseSettingsEntry.getKey(), foundEntries);
@@ -550,7 +550,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         }
 
         try {
-            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes);
+            final LdapEntry roleEntry = LdapHelper.lookup(ldapConnection, ldapName.toString(), this.returnAttributes, settings);
 
             if(roleEntry != null) {
                 final LdapAttribute roleAttribute = roleEntry.getAttribute(role);

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPUserSearcher.java
@@ -96,7 +96,7 @@ public class LDAPUserSearcher {
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
                     SearchScope.SUBTREE,
-                    returnAttributes);
+                    returnAttributes, settings);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for {} in base {}:\n{}", user, entry.getKey(), result);
@@ -125,7 +125,7 @@ public class LDAPUserSearcher {
                     baseSettings.get(ConfigConstants.LDAP_AUTHCZ_BASE, DEFAULT_USERBASE),
                     f,
                     SearchScope.SUBTREE,
-                    returnAttributes);
+                    returnAttributes, settings);
 
             if (isDebugEnabled) {
                 log.debug("Results for LDAP search for {} in base {}:\n{}", user, entry.getKey(), result);

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -79,6 +79,8 @@ public class ConfigConstants {
     
     public static final String OPENDISTRO_SECURITY_INITIAL_ACTION_CLASS_HEADER = OPENDISTRO_SECURITY_CONFIG_PREFIX+"initial_action_class_header";
 
+
+
     /**
      * Set by SSL plugin for https requests only
      */
@@ -190,6 +192,9 @@ public class ConfigConstants {
     public static final String SECURITY_AUDIT_WEBHOOK_SSL_VERIFY = "webhook.ssl.verify";
     public static final String SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_FILEPATH = "webhook.ssl.pemtrustedcas_filepath";
     public static final String SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_CONTENT = "webhook.ssl.pemtrustedcas_content";
+
+    //LDAP
+    public static final String FOLLOW_REFERRALS = "plugins.security.follow_referrals";
     
     // Log4j
     public static final String SECURITY_AUDIT_LOG4J_LOGGER_NAME = "log4j.logger_name";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -164,6 +164,8 @@ public class ConfigConstants {
     
     public static final String SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX = "plugins.security.audit.config.";
 
+    
+
     // Internal / External OpenSearch
     public static final String SECURITY_AUDIT_OPENSEARCH_INDEX = "index";
     public static final String SECURITY_AUDIT_OPENSEARCH_TYPE = "type";
@@ -192,9 +194,6 @@ public class ConfigConstants {
     public static final String SECURITY_AUDIT_WEBHOOK_SSL_VERIFY = "webhook.ssl.verify";
     public static final String SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_FILEPATH = "webhook.ssl.pemtrustedcas_filepath";
     public static final String SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_CONTENT = "webhook.ssl.pemtrustedcas_content";
-
-    //LDAP
-    public static final String FOLLOW_REFERRALS = "plugins.security.follow_referrals";
     
     // Log4j
     public static final String SECURITY_AUDIT_LOG4J_LOGGER_NAME = "log4j.logger_name";

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -408,7 +408,7 @@ public class LdapBackendTest {
 
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), settings);
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -341,7 +341,7 @@ public class LdapBackendTestNewStyleConfig {
 
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), settings);
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -402,7 +402,7 @@ public class LdapBackendTestNewStyleConfig2 {
                 .getConnection();
         try {
             con.open();
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), settings);
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
@@ -454,7 +454,7 @@ public class LdapBackendTestOldStyleConfig2 {
                 .getConnection();
         try {
             con.open();
-            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value());
+            final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), settings);
             Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
         } finally {
             con.close();


### PR DESCRIPTION
These changes allow for the configuration of the LDAP referral response behavior. Behavior can be set by modifying the `plugins.security.FOLLOW_REFERRALS` field of the `opensearch.yml` file. By default, referrals are followed in exactly the same way as previous releases. 


- Resolves #195 

### Testing
Integration testing was manually conducted as further details on reproducing the undesired behavior would be necessary for unit tests or function tests. The changes were tested by following the developer guide for manual set up and integration of the security plugin with the new setting configured to both `true` and `false`. Because the developer guide's predicted results were met in both cases, it was determined that the configuration change was at least integrated into the code base properly. 

Further suggestions for testing would be welcome. 

### Check List
- [ ] ~New functionality includes testing~ (See above) 
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
