### PR TITLE
Adds workflow that fails CI check on purpose if a pull request target was deprecated branch

### DIFF
--- a/.github/workflows/deprecated-branches.yml
+++ b/.github/workflows/deprecated-branches.yml
@@ -1,0 +1,24 @@
+name: Merge protection against deprecated branches
+
+on:
+  pull_request:
+    # Every-time a branch is deprecated it should be added here
+    branches:
+      - '1.0'
+      - '1.1'
+      - '1.2'
+      - '1.x'
+      - '2.0'
+      - '2.1'
+      - '2.2'
+
+jobs:
+  deprecated-branch-check:
+    runs-on: ubuntu-latest
+    name: Deprecated Branch Check
+    steps:
+      - name: Fail if this workflow is triggered
+        run: echo -e "\n\nThis PR was created against the branch ${GH_BRANCH##*/} that was deprecated\n\n";
+          exit 1
+        env:
+          GH_BRANCH: ${{ github.ref }}


### PR DESCRIPTION
### Description
This change adds a workflow that is built to fail on trigger. This workflow will only be triggered when a pull-request is opened against a deprecated branch mentioned in the workflow yaml, to prevent changes from going in.

* Category: Maintenance
* Why these changes are required?:  This change will serve as a reminder for Maintainers to not merge PRs into deprecated branches accidentally.

### Testing
Manual testing
See https://github.com/opensearch-project/security-dashboards-plugin/pull/1127 for details

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
