### PR TITLE
Remove references to LegacyESVersion.V_7x constants

### DIFF
--- a/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.action.FailedNodeException;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.action.support.nodes.BaseNodeRequest;
 import org.opensearch.action.support.nodes.TransportNodesAction;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -47,6 +46,7 @@ import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportService;
 
 public class TransportConfigUpdateAction
@@ -72,7 +72,7 @@ TransportNodesAction<ConfigUpdateRequest, ConfigUpdateResponse, TransportConfigU
         this.dynamicConfigFactory = dynamicConfigFactory;
     }
 
-    public static class NodeConfigUpdateRequest extends BaseNodeRequest {
+    public static class NodeConfigUpdateRequest extends TransportRequest {
 
         ConfigUpdateRequest request;
 

--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -26,49 +26,23 @@
 
 package org.opensearch.security.configuration;
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.cluster.ClusterChangedEvent;
-import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateListener;
-import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
-import org.opensearch.index.Index;
 
 public class ClusterInfoHolder implements ClusterStateListener {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
-    private volatile Boolean has6xNodes = null;
-    private volatile Boolean has6xIndices = null;
     private volatile DiscoveryNodes nodes = null;
     private volatile Boolean isLocalNodeElectedClusterManager = null;
     private volatile boolean initialized;
     
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
-        final boolean isTraceEnabled = log.isTraceEnabled();
-        if(has6xNodes == null || event.nodesChanged()) {
-            has6xNodes = Boolean.valueOf(clusterHas6xNodes(event.state()));
-            if (isTraceEnabled) {
-                log.trace("has6xNodes: {}", has6xNodes);
-            }
-        }
-        
-        final List<String> indicesCreated = event.indicesCreated();
-        final List<Index> indicesDeleted = event.indicesDeleted();
-        if(has6xIndices == null || !indicesCreated.isEmpty() || !indicesDeleted.isEmpty()) {
-            has6xIndices = Boolean.valueOf(clusterHas6xIndices(event.state()));
-            if (isTraceEnabled) {
-                log.trace("has6xIndices: {}", has6xIndices);
-            }
-        }
-        
         if(nodes == null || event.nodesChanged()) {
             nodes = event.state().nodes();
             if (log.isDebugEnabled()) {
@@ -78,14 +52,6 @@ public class ClusterInfoHolder implements ClusterStateListener {
         }
         
         isLocalNodeElectedClusterManager = event.localNodeClusterManager()?Boolean.TRUE:Boolean.FALSE;
-    }
-
-    public Boolean getHas6xNodes() {
-        return has6xNodes;
-    }
-
-    public Boolean getHas6xIndices() {
-        return has6xIndices;
     }
 
     public Boolean isLocalNodeElectedClusterManager() {
@@ -105,20 +71,5 @@ public class ClusterInfoHolder implements ClusterStateListener {
         }
         
         return nodes.nodeExists(node)?Boolean.TRUE:Boolean.FALSE;
-    }
-
-    private static boolean clusterHas6xNodes(ClusterState state) {
-        return state.nodes().getMinNodeVersion().before(LegacyESVersion.V_7_0_0);
-    }
-    
-    private static boolean clusterHas6xIndices(ClusterState state) {
-        final Iterator<IndexMetadata> indices = state.metadata().indices().valuesIt();
-        while (indices.hasNext()) {
-            final IndexMetadata indexMetadata = indices.next();
-            if (indexMetadata.getCreationVersion().before(LegacyESVersion.V_7_0_0)) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -125,23 +125,6 @@ public class ConfigurationLoaderSecurity7 {
             public void noData(String id) {
                 CType cType = CType.fromString(id);
 
-                //when index was created with ES 6 there are no separate tenants. So we load just empty ones.
-                //when index was created with ES 7 and type not "security" (ES 6 type) there are no rolemappings anymore.
-                if(cs.state().metadata().index(securityIndex).getCreationVersion().before(LegacyESVersion.V_7_0_0)) {
-                    //created with SG 6
-                    //skip tenants
-
-                    if (isDebugEnabled) {
-                        log.debug("Skip tenants because we not yet migrated to ES 7 (index was created with ES 6)");
-                    }
-
-                    if(cType == CType.TENANTS) {
-                        rs.put(cType, SecurityDynamicConfiguration.empty());
-                        latch.countDown();
-                        return;
-                    }
-                }
-
                 // Since NODESDN is newly introduced data-type applying for existing clusters as well, we make it backward compatible by returning valid empty
                 // SecurityDynamicConfiguration.
                 // Same idea for new setting WHITELIST/ALLOWLIST

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -39,7 +39,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.LegacyESVersion;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.get.MultiGetItemResponse;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -98,8 +98,6 @@ public class MigrateApiAction extends AbstractApiAction {
     @Override
     protected void handlePost(RestChannel channel, RestRequest request, Client client, final JsonNode content) throws IOException {
 
-        final Version oldestNodeVersion = cs.state().getNodes().getMinNodeVersion();
-
         final SecurityDynamicConfiguration<?> loadedConfig = load(CType.CONFIG, true);
 
         if (loadedConfig.getVersion() != 1) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -20,8 +20,6 @@ import java.util.List;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
-import org.opensearch.LegacyESVersion;
-import org.opensearch.Version;
 import org.opensearch.action.ActionListener;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.bulk.BulkRequestBuilder;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -100,11 +100,6 @@ public class MigrateApiAction extends AbstractApiAction {
 
         final Version oldestNodeVersion = cs.state().getNodes().getMinNodeVersion();
 
-        if(oldestNodeVersion.before(LegacyESVersion.V_7_0_0)) {
-            badRequestResponse(channel, "Can not migrate configuration because cluster is not fully migrated.");
-            return;
-        }
-
         final SecurityDynamicConfiguration<?> loadedConfig = load(CType.CONFIG, true);
 
         if (loadedConfig.getVersion() != 1) {


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Removes all 7.x constants and logic that is no longer supported in 3.0. 

See: https://github.com/opensearch-project/OpenSearch/issues/2747

Related distribution build failure due to removal of these constants in core: 
- Resolves https://github.com/opensearch-project/security/issues/2149

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
