### PR TITLE
Prevent message collection from being updated after message count has been received

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: ./gradlew clean build -Dbuild.snapshot=false -x test -x integrationTest
 
     - name: Test
-      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test integrationTest -i
+      run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test integrationTest
 
     - name: Coverage
       uses: codecov/codecov-action@v1

--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
@@ -84,7 +84,6 @@ public final class AuditMessage {
     public static final String REMOTE_ADDRESS = "audit_request_remote_address";
 
     public static final String REST_REQUEST_PATH = "audit_rest_request_path";
-    //public static final String REST_REQUEST_BODY = "audit_rest_request_body";
     public static final String REST_REQUEST_PARAMS = "audit_rest_request_params";
     public static final String REST_REQUEST_HEADERS = "audit_rest_request_headers";
     public static final String REST_REQUEST_METHOD = "audit_rest_request_method";
@@ -447,6 +446,18 @@ public final class AuditMessage {
 
     public String getExceptionStackTrace() {
         return (String) this.auditInfo.get(EXCEPTION);
+    }
+
+    public String getRequestBody() {
+        return (String) this.auditInfo.get(REQUEST_BODY);
+    }
+
+    public String getNodeId() {
+        return (String) this.auditInfo.get(NODE_ID);
+    }
+
+    public String getDocId() {
+        return (String) this.auditInfo.get(ID);
     }
 
 	@Override

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -43,6 +43,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertThrows;
@@ -90,10 +93,11 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         });
 
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_DOC_READ"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("Designation"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("Salary"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("Gender"));
+        assertThat(message.getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
+        assertThat(message.getRequestBody(), not(containsString("Designation")));
+        assertThat(message.getRequestBody(), not(containsString("Salary")));
+        assertThat(message.getRequestBody(), containsString("Gender"));
+
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
 
@@ -200,17 +204,21 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 "   }" +
                 "}"+System.lineSeparator();
 
-        TestAuditlogImpl.doThenWaitForMessages(() -> {
+        final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             HttpResponse response = rh.executePostRequest("_msearch?pretty", search, encodeBasicHeader("admin", "admin"));
             assertNotContains(response, "*exception*");
             Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         }, 2);
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_DOC_READ"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("Salary"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("Gender"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("Designation"));
-        Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
+
+        assertThat(messages.get(0).getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
+        assertThat(messages.get(0).getRequestBody(), containsString("Designation"));
+        assertThat(messages.get(0).getRequestBody(), not(containsString("Salary")));
+
+        assertThat(messages.get(1).getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
+        assertThat(messages.get(1).getRequestBody(), containsString("Gender"));
+        assertThat(messages.get(1).getRequestBody(), not(containsString("Salary")));
+
+        Assert.assertTrue(validateMsgs(messages));
     }
 
     @Test
@@ -230,6 +238,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
 
+        final List<String> expectedDocumentsTypes = List.of("config", "actiongroups", "internalusers", "roles", "rolesmapping", "tenants", "audit");
         final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             try (RestHighLevelClient restHighLevelClient = getRestClient(clusterInfo, "kirk-keystore.jks", "truststore.jks")) {
                 for (IndexRequest ir: new DynamicSecurityConfig().setSecurityRoles("roles_2.yml").getDynamicConfig(getResourceFolder())) {
@@ -245,21 +254,19 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
         }, 14);
 
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_INTERNAL_CONFIG_READ"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_INTERNAL_CONFIG_WRITE"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("anonymous_auth_enabled"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/read/suggest"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("internalusers"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("opendistro_security_all_access"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/read/suggest"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("eyJzZWFyY2hndWFy"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("eyJBTEwiOlsiaW"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("eyJhZG1pbiI6e"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("eyJzZ19hb"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("eyJzZ19hbGx"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("dvcmYiOnsiY2x"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\\\"op\\\":\\\"remove\\\",\\\"path\\\":\\\"/opendistro_security_worf\\\""));
-        Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
+        final List<String> documentIds = messages.stream().map(AuditMessage::getDocId).distinct().collect(Collectors.toList());
+        assertThat(documentIds, equalTo(expectedDocumentsTypes));
+
+        messages.stream().collect(Collectors.groupingBy(AuditMessage::getDocId)).entrySet().forEach((e) -> {
+            final String docId = e.getKey();
+            final List<AuditMessage> messagesByDocId = e.getValue();
+            assertThat("Doc " + docId + " should have a read/write config message",
+                messagesByDocId.stream().map(AuditMessage::getCategory).collect(Collectors.toList()),
+                equalTo(List.of(AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE, AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ))
+            );
+        });
+
+        Assert.assertTrue(validateMsgs(messages));
     }
 
     @Test
@@ -276,7 +283,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
                 .build();
 
-        TestAuditlogImpl.doThenWaitForMessages(() -> {
+        final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             try {
                 setup(additionalSettings);
             } catch (final Exception ex) {
@@ -293,10 +300,17 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         }, 4);
 
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("external_configuration"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_EXTERNAL_CONFIG"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("opensearch_yml"));
-        Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
+        // Record the updated config, and then for each node record that the config was updated
+        assertThat(messages.get(0).getCategory(), equalTo(AuditCategory.COMPLIANCE_INTERNAL_CONFIG_WRITE));
+        assertThat(messages.get(1).getCategory(), equalTo(AuditCategory.COMPLIANCE_EXTERNAL_CONFIG));
+        assertThat(messages.get(2).getCategory(), equalTo(AuditCategory.COMPLIANCE_EXTERNAL_CONFIG));
+        assertThat(messages.get(3).getCategory(), equalTo(AuditCategory.COMPLIANCE_EXTERNAL_CONFIG));
+
+        // Make sure that the config update messsages are for each node in the cluster
+        assertThat(messages.get(1).getNodeId(), not(equalTo(messages.get(2).getNodeId())));
+        assertThat(messages.get(2).getNodeId(), not(equalTo(messages.get(3).getNodeId())));
+
+        Assert.assertTrue(validateMsgs(messages));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -43,7 +43,6 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.AnyOf.anyOf;

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -209,13 +209,16 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         }, 2);
 
-        assertThat(messages.get(0).getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
-        assertThat(messages.get(0).getRequestBody(), containsString("Designation"));
-        assertThat(messages.get(0).getRequestBody(), not(containsString("Salary")));
 
-        assertThat(messages.get(1).getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
-        assertThat(messages.get(1).getRequestBody(), containsString("Gender"));
-        assertThat(messages.get(1).getRequestBody(), not(containsString("Salary")));
+        final AuditMessage desginationMsg = messages.stream().filter(msg -> msg.getRequestBody().contains("Designation")).findFirst().orElseThrow();
+        assertThat(desginationMsg.getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
+        assertThat(desginationMsg.getRequestBody(), containsString("Designation"));
+        assertThat(desginationMsg.getRequestBody(), not(containsString("Salary")));
+
+        final AuditMessage genderMsg = messages.stream().filter(msg -> msg.getRequestBody().contains("Gender")).findFirst().orElseThrow();
+        assertThat(genderMsg.getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
+        assertThat(genderMsg.getRequestBody(), containsString("Gender"));
+        assertThat(genderMsg.getRequestBody(), not(containsString("Salary")));
 
         Assert.assertTrue(validateMsgs(messages));
     }

--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -133,7 +133,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             final RuntimeException ex = Assert.assertThrows(RuntimeException.class,
                 () -> nonSslRestHelper().executeGetRequest("_search", encodeBasicHeader("admin", "admin")));
             Assert.assertEquals("org.apache.hc.core5.http.NoHttpResponseException", ex.getCause().getClass().getName());
-        }, 1);
+        }, 2);
 
         // All of the messages should be the same as the http client is attempting multiple times.
         messages.stream().forEach((message) -> {


### PR DESCRIPTION
### Description
Prevent message collection from being updated after message count has been received

Also added mechanism to detect if messages were missed so tests can be updated to appropriate counts

### Issues Resolved
Saw a failure for PR https://github.com/opensearch-project/security/pull/2167 which had no code impact, saw the test `testSSLPlainText` was failing, looks like it was exiting early because the test was only looking for a smaller number of messages.

### Testing
Tested locally, CI should confirm things are working as expected.  Also ran the bulk integration test workflow [1], 18 runs with no issues

[1] https://github.com/peternied/security/actions/runs/3291303445/jobs/5425278205

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
