### PR TITLE
[Backport 2.4] Fix windows encoding issues (#2206)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           -x spotlessCheck
           -x checkstyleMain
           -x checkstyleTest
+          -x spotbugsMain
 
     - name: Coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -42,3 +42,18 @@ jobs:
       - uses: gradle/gradle-build-action@v2
         with:
           arguments: checkstyleMain checkstyleTest
+
+  spotbugs:
+    runs-on: ubuntu-latest
+    name: Spotbugs scan
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: 11
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          arguments: spotbugsMain

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ plugins {
     id 'checkstyle'
     id 'nebula.ospackage'  version "8.3.0"
     id "org.gradle.test-retry" version "1.3.1"
+    id "com.github.spotbugs" version "5.0.13"
 }
 
 allprojects {
@@ -74,6 +75,14 @@ spotless {
     // note: you can use an empty string for all the imports you didn't specify explicitly, and '\\#` prefix for static imports
     importOrder('java', 'javax', '', 'com.amazon', 'org.opensearch', '\\#')
   }
+}
+
+spotbugs {
+    includeFilter = file('spotbugs-include.xml')
+}
+
+spotbugsTest {
+    enabled = false
 }
 
 java.sourceCompatibility = JavaVersion.VERSION_11

--- a/spotbugs-include.xml
+++ b/spotbugs-include.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Bug category="I18N" />
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -14,6 +14,7 @@ package com.amazon.dlic.auth.http.saml;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -152,7 +153,7 @@ class AuthTokenProcessorHandler {
             SettingsException {
         if (token_log.isDebugEnabled()) {
             try {
-                token_log.debug("SAMLResponse for {}\n{}", samlRequestId, new String(Util.base64decoder(samlResponseBase64), "UTF-8"));
+                token_log.debug("SAMLResponse for {}\n{}", samlRequestId, new String(Util.base64decoder(samlResponseBase64), StandardCharsets.UTF_8));
             } catch (Exception e) {
                 token_log.warn(
                         "SAMLResponse for {} cannot be decoded from base64\n{}",

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -419,7 +419,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                     try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, originalResult.internalSourceRef(), XContentType.JSON)) {
                         Object base64 = parser.map().values().iterator().next();
                         if(base64 instanceof String) {
-                            originalSource = (new String(BaseEncoding.base64().decode((String) base64)));
+                            originalSource = (new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8));
                         } else {
                             originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
                         }
@@ -430,7 +430,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                     try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, currentIndex.source(), XContentType.JSON)) {
                         Object base64 = parser.map().values().iterator().next();
                         if(base64 instanceof String) {
-                            currentSource = (new String(BaseEncoding.base64().decode((String) base64)));
+                            currentSource = new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8);
                         } else {
                             currentSource = XContentHelper.convertToJson(currentIndex.source(), false, XContentType.JSON);
                         }
@@ -457,7 +457,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                 try (XContentParser parser = XContentHelper.createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, currentIndex.source(), XContentType.JSON)) {
                    Object base64 = parser.map().values().iterator().next();
                    if(base64 instanceof String) {
-                       msg.addSecurityConfigContentToRequestBody(new String(BaseEncoding.base64().decode((String) base64)), id);
+                       msg.addSecurityConfigContentToRequestBody(new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8), id);
                    } else {
                        msg.addSecurityConfigTupleToRequestBody(new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()), id);
                    }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -27,6 +27,7 @@
 package org.opensearch.security.configuration;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -271,7 +272,7 @@ public class ConfigurationLoaderSecurity7 {
 
             parser.nextToken();
 
-            final String jsonAsString = SecurityUtils.replaceEnvVars(new String(parser.binaryValue()), settings);
+            final String jsonAsString = SecurityUtils.replaceEnvVars(new String(parser.binaryValue(), StandardCharsets.UTF_8), settings);
             final JsonNode jsonNode = DefaultObjectMapper.readTree(jsonAsString);
             int configVersion = 1;
 

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -20,6 +20,7 @@ package org.opensearch.security.ssl;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -638,7 +639,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
         final Function<? super X509Certificate, String> certificateSignature = cert -> {
             final byte[] signature = cert !=null && cert.getSignature() != null ? cert.getSignature() : null;
-            return new String(signature);
+            return new String(signature, StandardCharsets.UTF_8);
         };
 
         final Set<String> currentCertSignatureSet = Arrays.stream(currentX509Certs)

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -31,6 +31,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -91,7 +92,7 @@ public class ConfigHelper {
     public static Reader createFileOrStringReader(CType cType, int configVersion, String filepath, boolean populateEmptyIfFileMissing) throws Exception {
         Reader reader;
         if (!populateEmptyIfFileMissing || new File(filepath).exists()) {
-            reader = new FileReader(filepath);
+            reader = new FileReader(filepath, StandardCharsets.UTF_8);
         } else {
             reader = new StringReader(createEmptySdcYaml(cType, configVersion));
         }
@@ -143,7 +144,7 @@ public class ConfigHelper {
     }
 
     public static <T> SecurityDynamicConfiguration<T> fromYamlFile(String filepath, CType ctype, int version, long seqNo, long primaryTerm) throws IOException {
-        return fromYamlReader(new FileReader(filepath), ctype, version, seqNo, primaryTerm);
+        return fromYamlReader(new FileReader(filepath, StandardCharsets.UTF_8), ctype, version, seqNo, primaryTerm);
     }
 
     public static <T> SecurityDynamicConfiguration<T> fromYamlString(String yamlString, CType ctype, int version, long seqNo, long primaryTerm) throws IOException {

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -888,7 +888,7 @@ public class SecurityAdmin {
         }
         
         System.out.println("Will retrieve '"+"/" +id+"' into "+filepath+" "+(legacy?"(legacy mode)":""));
-        try (Writer writer = new FileWriter(filepath)) {
+        try (Writer writer = new FileWriter(filepath, StandardCharsets.UTF_8)) {
 
 			final GetResponse response = restHighLevelClient.get(new GetRequest(index).id(id).refresh(true).realtime(false), RequestOptions.DEFAULT);
 

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -34,7 +34,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.message.BasicHeader;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -270,7 +269,6 @@ public class IntegrationTests extends SingleClusterTest {
     }
 
     @Test
-    @Ignore // https://github.com/opensearch-project/security/issues/2194
     public void testSpecialUsernames() throws Exception {
     
         setup();    


### PR DESCRIPTION
### Description
Adds spotbugs [1] to detect internalization before they are added to the codebase, also fixed several encoding bugs that impact windows users.

[1] https://spotbugs.readthedocs.io/en/stable/index.html

Closes https://github.com/opensearch-project/security/issues/2194

Signed-off-by: Peter Nied <petern@amazon.com>
(cherry picked from commit a040b86a48eebcbe2791ba6371772fb9d386d6f2)

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
