### PR TITLE
OpenSSLTest is not using the OpenSSL Provider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ plugins {
     id "org.gradle.test-retry" version "1.3.1"
     id 'eclipse'
     id "com.github.spotbugs" version "5.0.13"
+    id "com.google.osdetector" version "1.7.1"
 }
 
 allprojects {
@@ -408,6 +409,11 @@ dependencies {
     testImplementation 'org.springframework:spring-beans:5.3.20'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    // Only osx-x86_64 and linux-x86_64 are available
+    if (osdetector.classifier in ["osx-x86_64", "linux-x86_64"]) {
+        testImplementation "io.netty:netty-tcnative-classes:2.0.54.Final"
+        testImplementation "io.netty:netty-tcnative:2.0.54.Final:${osdetector.classifier}"
+    }
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
     // Kafka test execution
@@ -421,9 +427,6 @@ dependencies {
     testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.7.1'
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
-
-
-
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
OpenSSLTest should be using the OpenSSL Provider. There are few issues with `netty-tcnative` and OpenSSL:
 - it uses OpenSSL 1.0 and needs `compat-openssl10` 
 - https://github.com/netty/netty-tcnative/issues/746
 - https://github.com/netty/netty-tcnative/issues/742
 - https://github.com/netty/netty-tcnative/issues/703

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/2208

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
