### PR TITLE
Add backwards compatibility tests for Windows and JDK11/17 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
       run: |
         ls build/distributions/
         cp -r build/ ./bwc-test/
-        mkdir ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}
-        cp build/distributions/opensearch-security-${{ steps.opensearch-versions.outputs.version-current }}.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}
+        mkdir ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}.0
+        cp build/distributions/opensearch-security-${{ steps.opensearch-versions.outputs.version-current }}.0.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}.0
         mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0
 
     - name: wget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        platform: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,24 +122,24 @@ jobs:
       run: |
         cp -r build/ ./bwc-test/
         mkdir ./bwc-test/src/test/resources/security_plugin_version_no_snapshot
-        cp build/distributions/opensearch-security-${{ steps.opensearch-versions.output.version-current }}.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-current }}
-        mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-previous }}.0
+        cp build/distributions/opensearch-security-${{ steps.opensearch-versions.outputs.version-current }}.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}
+        mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0
 
     - name: wget
       if: runner.os == 'Windows'
       uses: wei/wget@v1
       with:
-        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.output.version-previous }}/latest/windows/x64/zip/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip
+        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/windows/x64/zip/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name: wget
       if: runner.os == 'Linux'
       uses: wei/wget@v1
       with:
-        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.output.version-previous }}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip
+        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name:
       run: |
-        mv opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-previous }}.0/
+        mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/
         cd bwc-test/
 
     - name: Run BWC tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,16 +138,14 @@ jobs:
       with:
         args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
-    - name:
-      run: |
-        mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/
-        cd bwc-test/
+    - name: Copy downloaded security version to bwc-test archives
+      run: mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/
 
     - name: Run BWC tests
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: |
-          bwcTestSuite -Dtests.security.manager=false
+        arguments: bwcTestSuite -Dtests.security.manager=false
+        build-root-directory: bwc-test
 
   code-ql:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v2
 
-    - name: Build and Test
+    - name: Build
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
@@ -126,17 +126,17 @@ jobs:
         cp build/distributions/opensearch-security-${{ steps.opensearch-versions.outputs.version-current }}.0.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}.0
         mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0
 
-    - name: wget
-      if: runner.os == 'Windows'
-      uses: wei/wget@v1
+    - id: download-platform
+      uses: haya14busa/action-cond@v1
       with:
-        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/windows/x64/zip/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
+        cond: ${{ runner.os == 'Windows' }}
+        if_true: 'windows/x64/zip'  # string value
+        if_false: 'linux/x64/tar' # string value
 
     - name: wget
-      if: runner.os == 'Linux'
       uses: wei/wget@v1
       with:
-        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
+        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name: Copy downloaded security version to bwc-test archives
       run: mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,6 @@ jobs:
           -x test
           -x integrationTest
 
-
     - name: Copy current distro into the expected folder
       run: |
         ls build/distributions/
@@ -130,14 +129,12 @@ jobs:
       uses: haya14busa/action-cond@v1
       with:
         cond: ${{ runner.os == 'Windows' }}
-        if_true: 'windows/x64/zip'  # string value
-        if_false: 'linux/x64/tar' # string value
+        if_true: 'windows/x64/zip'
+        if_false: 'linux/x64/tar'
 
-    - id: install-wget
-      if: ${{ runner.os == 'Windows'}}
-      run: choco install wget --no-progress 
-
-    - run: wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
+    - uses: peternied/download-file@v1
+      with:
+        url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name: Copy downloaded security version to bwc-test archives
       run: mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,24 +84,69 @@ jobs:
           -x spotbugsMain
 
   backward-compatibility:
-    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    runs-on: ${{ matrix.platform }}
+
     steps:
-    - uses: actions/checkout@v2
+
+    - id: opensearch-versions
+      run: |
+        echo "::set-output name=version-current::3.0.0"
+        echo "::set-output name=version-previous::2.4.0"
+
     - uses: actions/setup-java@v1
       with:
-        java-version: 11
-    - run: ./gradlew clean build -Dbuild.snapshot=false -x test -x integrationTest
-    - run: |
-        echo "Running backwards compatibility tests ..."
-        security_plugin_version_no_snapshot=$(./gradlew properties -q | grep -E '^version:' | awk '{print $2}' | sed 's/-SNAPSHOT//g')
+        java-version: ${{ matrix.jdk }}
+
+    - name: Checkout security
+      uses: actions/checkout@v2
+
+    - name: Build and Test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          build -Dbuild.snapshot=false
+          -x spotlessCheck
+          -x checkstyleMain
+          -x checkstyleTest
+          -x test
+          -x integrationTest
+
+
+    - name: Copy current distro into the expected folder
+      run: |
         cp -r build/ ./bwc-test/
         mkdir ./bwc-test/src/test/resources/security_plugin_version_no_snapshot
-        cp build/distributions/opensearch-security-${security_plugin_version_no_snapshot}.zip ./bwc-test/src/test/resources/${security_plugin_version_no_snapshot}
-        mkdir bwc-test/src/test/resources/2.4.0.0
-        wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.4.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.4.0.0.zip
-        mv opensearch-security-2.4.0.0.zip bwc-test/src/test/resources/2.4.0.0/
+        cp build/distributions/opensearch-security-${{ steps.opensearch-versions.output.version-current }}.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-current }}
+        mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-previous }}.0
+
+    - name: wget
+      if: runner.os == 'Windows'
+      uses: wei/wget@v1
+      with:
+        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.output.version-previous }}/latest/windows/x64/zip/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip
+
+    - name: wget
+      if: runner.os == 'Linux'
+      uses: wei/wget@v1
+      with:
+        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.output.version-previous }}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip
+
+    - name:
+      run: |
+        mv opensearch-security-${{ steps.opensearch-versions.output.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.output.version-previous }}.0/
         cd bwc-test/
-        ./gradlew bwcTestSuite -Dtests.security.manager=false
+
+    - name: Run BWC tests
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          bwcTestSuite -Dtests.security.manager=false
 
   code-ql:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,11 @@ jobs:
         if_true: 'windows/x64/zip'  # string value
         if_false: 'linux/x64/tar' # string value
 
-    - name: wget
-      uses: wei/wget@v1
-      with:
-        args: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
+    - id: install-wget
+      if: ${{ runner.os == 'Windows'}}
+      run: choco install wget --no-progress 
+
+    - run: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name: Copy downloaded security version to bwc-test archives
       run: mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,9 @@ jobs:
 
     - name: Copy current distro into the expected folder
       run: |
+        ls build/distributions/
         cp -r build/ ./bwc-test/
-        mkdir ./bwc-test/src/test/resources/security_plugin_version_no_snapshot
+        mkdir ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}
         cp build/distributions/opensearch-security-${{ steps.opensearch-versions.outputs.version-current }}.zip ./bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-current }}
         mkdir bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       if: ${{ runner.os == 'Windows'}}
       run: choco install wget --no-progress 
 
-    - run: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
+    - run: wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ steps.opensearch-versions.outputs.version-previous }}/latest/${{ steps.download-platform.outputs.value }}/builds/opensearch/plugins/opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip
 
     - name: Copy downloaded security version to bwc-test archives
       run: mv opensearch-security-${{ steps.opensearch-versions.outputs.version-previous }}.0.zip bwc-test/src/test/resources/${{ steps.opensearch-versions.outputs.version-previous }}.0/


### PR DESCRIPTION
### Description
Update the backward compatibility tests to run on windows in JDK11/17

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/2232
- Resolves https://github.com/opensearch-project/security/issues/1474

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
