### PR TITLE
[Backport] [1.3] Address CVE-2022-42889 by updating commons-text

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,6 +114,8 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'
+    runtimeOnly 'org.apache.commons:commons-text:1.10.0'
+
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
     testImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/2177/commits/8d2e309380e0b07fe3c803d1e19bb9aaef0ac321 to 1.3