### PR TITLE
[Backport 1.3] Fix issues with datastream backing indexes

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -359,7 +359,7 @@ public class ConfigModelV7 extends ConfigModel {
                     final Set<String> maskedFields = ip.getMaskedFields();
                     if (!maskedFields.isEmpty()) {
                         final String indexPattern = ip.getUnresolvedIndexPattern(user);
-                        Set<String> concreteIndices = ip.getResolvedIndexPattern(user, resolver, cs);
+                        Set<String> concreteIndices = ip.getResolvedIndexPattern(user, resolver, cs, false);
 
                         Set<String> currentMaskedFields = maskedFieldsMap.get(indexPattern);
                         if (currentMaskedFields != null) {
@@ -397,7 +397,7 @@ public class ConfigModelV7 extends ConfigModel {
                     Set<String> concreteIndices = new HashSet<>();
 
                     if ((dls != null && dls.length() > 0) || (fls != null && fls.size() > 0)) {
-                        concreteIndices = ip.getResolvedIndexPattern(user, resolver, cs);
+                        concreteIndices = ip.getResolvedIndexPattern(user, resolver, cs, false);
                     }
 
                     if (dls != null && dls.length() > 0) {
@@ -549,7 +549,7 @@ public class ConfigModelV7 extends ConfigModel {
 //                }
                 if (patternMatch) {
                     //resolved but can contain patterns for nonexistent indices
-                    final WildcardMatcher permitted = WildcardMatcher.from(p.getResolvedIndexPattern(user, resolver, cs)); //maybe they do not exist
+                    final WildcardMatcher permitted = WildcardMatcher.from(p.getResolvedIndexPattern(user, resolver, cs, true)); //maybe they do not exist
                     final Set<String> res = new HashSet<>();
                     if (!resolved.isLocalAll() && !resolved.getAllIndices().contains("*") && !resolved.getAllIndices().contains("_all")) {
                         //resolved but can contain patterns for nonexistent indices

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -66,6 +66,7 @@ import com.google.common.collect.MultimapBuilder.SetMultimapBuilder;
 import com.google.common.collect.SetMultimap;
 
 import static org.opensearch.cluster.metadata.IndexAbstraction.Type.ALIAS;
+import static org.opensearch.cluster.metadata.IndexAbstraction.Type.DATA_STREAM;
 
 public class ConfigModelV7 extends ConfigModel {
 
@@ -756,20 +757,22 @@ public class ConfigModelV7 extends ConfigModel {
             final ImmutableSet.Builder<String> resolvedIndices = new ImmutableSet.Builder<>();
 
             final WildcardMatcher matcher = WildcardMatcher.from(unresolved);
+            boolean includeDataStreams = true;
             if (!(matcher instanceof WildcardMatcher.Exact)) {
-                final String[] aliasesForPermittedPattern = cs.state().getMetadata().getIndicesLookup().entrySet().stream()
-                        .filter(e -> e.getValue().getType() == ALIAS)
+                final String[] aliasesAndDataStreamsForPermittedPattern = cs.state().getMetadata().getIndicesLookup().entrySet().stream()
+                        .filter(e -> (e.getValue().getType() == ALIAS) || (e.getValue().getType() == DATA_STREAM))
                         .filter(e -> matcher.test(e.getKey()))
                         .map(e -> e.getKey())
                         .toArray(String[]::new);
-                if (aliasesForPermittedPattern.length > 0) {
-                    final String[] resolvedAliases = resolver.concreteIndexNames(cs.state(), IndicesOptions.lenientExpandOpen(), aliasesForPermittedPattern);
-                    resolvedIndices.addAll(Arrays.asList(resolvedAliases));
+                if (aliasesAndDataStreamsForPermittedPattern.length > 0) {
+                    final String[] resolvedAliasesAndDataStreamIndices = resolver.concreteIndexNames(cs.state(),
+                            IndicesOptions.lenientExpandOpen(), includeDataStreams, aliasesAndDataStreamsForPermittedPattern);
+                    resolvedIndices.addAll(Arrays.asList(resolvedAliasesAndDataStreamIndices));
                 }
             }
 
             if (Strings.isNotBlank(unresolved)) {
-                final String[] resolvedIndicesFromPattern = resolver.concreteIndexNames(cs.state(), IndicesOptions.lenientExpandOpen(), unresolved);
+                final String[] resolvedIndicesFromPattern = resolver.concreteIndexNames(cs.state(), IndicesOptions.lenientExpandOpen(), includeDataStreams, unresolved);
                 resolvedIndices.addAll(Arrays.asList(resolvedIndicesFromPattern));
             }
 

--- a/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
@@ -25,6 +25,17 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class DataStreamIntegrationTests extends SingleClusterTest {
 
+     final String bulkDocsBody =
+        "{ \"create\" : {} }" + System.lineSeparator() +
+        "{ \"@timestamp\" : \"2099-03-08T11:04:05.000Z\", \"user\" : { \"id\" : \"vlb44hny\", \"name\": \"Sam\"}, \"message\" : \"Login attempt failed\" }" + System.lineSeparator() +
+        "{ \"create\" : {} }" + System.lineSeparator() +
+        "{ \"@timestamp\" : \"2099-03-08T11:04:05.000Z\", \"user\" : { \"id\" : \"8a4f500d\", \"name\": \"Dam\"}, \"message\" : \"Login successful\" }" + System.lineSeparator() +
+        "{ \"create\" : {} }" + System.lineSeparator() +
+        "{ \"@timestamp\" : \"2099-03-08T11:04:05.000Z\", \"user\" : { \"id\" : \"l7gk7f82\", \"name\": \"Pam\"}, \"message\" : \"Login attempt failed\" }" + System.lineSeparator();
+
+    final String searchQuery1 = "{ \"seq_no_primary_term\" : true, \"query\": { \"match\": { \"user.id\": \"8a4f500d\"}}}";
+    final String searchQuery2 = "{ \"seq_no_primary_term\" : true, \"query\": { \"match\": { \"user.id\": \"l7gk7f82\"}}}";
+
     public String getIndexTemplateBody() {
         return  "{\"index_patterns\": [ \"my-data-stream*\" ], \"data_stream\": { }, \"priority\": 200, \"template\": {\"settings\": { } } }";
     }
@@ -211,7 +222,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
     }
 
     @Test
-    public void testBackingIndicesOfDataStream() throws Exception {
+    public void testGetIndexOnBackingIndicesOfDataStream() throws Exception {
 
         setup();
         RestHelper rh = nonSslRestHelper();
@@ -246,12 +257,248 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
         response = rh.executeGetRequest(".ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         response = rh.executeGetRequest(".ds-my-data-stream21-000001,.ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         response = rh.executeGetRequest(".ds-my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+    }
+
+    @Test
+    public void testDocumentLevelSecurityOnDataStream() throws Exception {
+
+        setup();
+        RestHelper rh = nonSslRestHelper();
+        createSampleDataStreams(rh);
+        HttpResponse response;
+
+        rh.executePutRequest("/my-data-stream11/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+        rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+
+        response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_dls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertFalse(response.getBody().contains("l7gk7f82"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_dls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_dls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_dls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("8a4f500d"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_dls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertFalse(response.getBody().contains("l7gk7f82"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
+
+        response = rh.executePostRequest("/.ds-my-*/_search", searchQuery2, encodeBasicHeader("ds_dls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertFalse(response.getBody().contains("l7gk7f82"));
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
+    }
+
+    @Test
+    public void testFLSOnBackingIndicesOfDataStream() throws Exception {
+
+        setup();
+        RestHelper rh = nonSslRestHelper();
+        createSampleDataStreams(rh);
+        HttpResponse response;
+
+        rh.executePutRequest("/my-data-stream11/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+        rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+
+        response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\"Login successful\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\"Login successful\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_fls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\"Login attempt failed\""));
+
+        response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_fls1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_fls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_fls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_fls3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Pam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\""));
+    }
+
+    @Test
+    public void testFieldMaskingOnDataStream() throws Exception {
+
+        setup();
+        RestHelper rh = nonSslRestHelper();
+        createSampleDataStreams(rh);
+        HttpResponse response;
+
+        rh.executePutRequest("/my-data-stream11/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+        rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
+
+        response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_fm1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Pam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login attempt failed\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_fm1", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_fm3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_fm3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\"Dam\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login successful\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
+
+        response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_fm3", "nagilum"));
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
+        Assert.assertFalse(response.getBody().contains("\"name\":\"Pam\""));
+        Assert.assertTrue(response.getBody().contains("\"name\":\""));
+        Assert.assertFalse(response.getBody().contains("\"message\":\"Login attempt failed\""));
+        Assert.assertTrue(response.getBody().contains("\"message\":\""));
     }
 }

--- a/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -36,10 +36,10 @@ public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest{
         }
         @Test
         public void testPutIndexTemplateByNonPrivilegedUser() throws Exception {
-            String expectedFailureResponse = getFailureResponseReason("ds3");
+            String expectedFailureResponse = getFailureResponseReason("ds4");
 
             // should fail, as user `ds3` doesn't have correct permissions
-            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("ds3", "nagilum"));
+            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("ds4", "nagilum"));
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
             Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
         }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsIndexingTests.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsIndexingTests.java
@@ -1,0 +1,160 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.dlsfls;
+
+import org.apache.http.Header;
+import org.apache.http.HttpStatus;
+import org.junit.Test;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.client.Client;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.security.test.DynamicSecurityConfig;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class FlsIndexingTests extends AbstractDlsFlsTest {
+
+    protected void populateData(final Client tc) {
+        // Create several documents in different indices with shared field names,
+        // different roles will have different levels of FLS restrictions
+        tc.index(new IndexRequest("yellow-pages").id("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{\"phone-all\":1001,\"phone-some\":1002,\"phone-one\":1003}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest("green-pages").id("2").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{\"phone-all\":2001,\"phone-some\":2002,\"phone-one\":2003}", XContentType.JSON)).actionGet();
+        tc.index(new IndexRequest("blue-book").id("3").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{\"phone-all\":3001,\"phone-some\":3002,\"phone-one\":3003}", XContentType.JSON)).actionGet();
+
+            // Seperate index used to test aliasing
+        tc.index(new IndexRequest(".hidden").id("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .source("{}", XContentType.JSON)).actionGet();
+    }
+
+    private Header asPhoneOneUser = encodeBasicHeader("user_aaa", "password");
+    private Header asPhoneSomeUser = encodeBasicHeader("user_bbb", "password");
+    private Header asPhoneAllUser = encodeBasicHeader("user_ccc", "password");
+
+    private final String searchQuery = "/*/_search?filter_path=hits.hits&pretty";
+
+    @Test
+    public void testSingleIndexFlsApplied() throws Exception {
+        setup(new DynamicSecurityConfig()
+            .setSecurityRoles("roles_fls_indexing.yml")
+            .setSecurityRolesMapping("roles_mapping_fls_indexing.yml"));
+      
+        final HttpResponse phoneOneFilteredResponse = rh.executeGetRequest(searchQuery, asPhoneOneUser);
+        assertThat(phoneOneFilteredResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("1003")));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("1002"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("1001"));
+
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("2003"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("2002"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("2001"));
+
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("3003"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("3002"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("3001"));
+    }
+
+    @Test
+    public void testSingleIndexFlsAppliedForLimitedResults() throws Exception {
+        setup(new DynamicSecurityConfig()
+            .setSecurityRoles("roles_fls_indexing.yml")
+            .setSecurityRolesMapping("roles_mapping_fls_indexing.yml"));
+  
+        final HttpResponse phoneOneFilteredResponse = rh.executeGetRequest("/yellow-pages/_search?filter_path=hits.hits&pretty", asPhoneOneUser);
+        assertThat(phoneOneFilteredResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("1003")));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("1002"));
+        assertThat(phoneOneFilteredResponse.getBody(), containsString("1001"));
+
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("2003")));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("2002")));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("2001")));
+
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("3003")));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("3002")));
+        assertThat(phoneOneFilteredResponse.getBody(), not(containsString("3001")));
+    }
+
+    @Test
+    public void testSeveralIndexFlsApplied() throws Exception {
+        setup(new DynamicSecurityConfig()
+            .setSecurityRoles("roles_fls_indexing.yml")
+            .setSecurityRolesMapping("roles_mapping_fls_indexing.yml"));
+
+        final HttpResponse phoneSomeFilteredResponse = rh.executeGetRequest(searchQuery, asPhoneSomeUser);
+        assertThat(phoneSomeFilteredResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("1003"));
+        assertThat(phoneSomeFilteredResponse.getBody(), not(containsString("1002")));
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("1001"));
+
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("2003"));
+        assertThat(phoneSomeFilteredResponse.getBody(), not(containsString("2002")));
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("2001"));
+
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("3003"));
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("3002"));
+        assertThat(phoneSomeFilteredResponse.getBody(), containsString("3001"));
+    }
+
+    @Test
+    public void testAllIndexFlsApplied() throws Exception {
+        setup(new DynamicSecurityConfig()
+            .setSecurityRoles("roles_fls_indexing.yml")
+            .setSecurityRolesMapping("roles_mapping_fls_indexing.yml"));
+
+        final HttpResponse phoneAllFilteredResponse = rh.executeGetRequest(searchQuery, asPhoneAllUser);
+        assertThat(phoneAllFilteredResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("1003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("1002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("1001")));
+
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("2003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("2002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("2001")));
+
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("3003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("3002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("3001")));
+    }
+
+    @Test
+    public void testAllIndexFlsAppliedWithAlias() throws Exception {
+        setup(new DynamicSecurityConfig()
+            .setSecurityRoles("roles_fls_indexing.yml")
+            .setSecurityRolesMapping("roles_mapping_fls_indexing.yml"));
+
+        final HttpResponse createAlias = rh.executePostRequest("_aliases", "{\"actions\":[{\"add\":{\"index\":\".hidden\",\"alias\":\"ducky\"}}]}", asPhoneAllUser);
+        assertThat(createAlias.getStatusCode(), equalTo(HttpStatus.SC_OK));
+
+        final HttpResponse phoneAllFilteredResponse = rh.executeGetRequest(searchQuery, asPhoneAllUser);
+        assertThat(phoneAllFilteredResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("1003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("1002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("1001")));
+
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("2003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("2002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("2001")));
+
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("3003"));
+        assertThat(phoneAllFilteredResponse.getBody(), containsString("3002"));
+        assertThat(phoneAllFilteredResponse.getBody(), not(containsString("3001")));
+    }
+}

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsIndexingTests.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsIndexingTests.java
@@ -18,6 +18,7 @@ import org.junit.Test;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.client.Client;
+import org.opensearch.client.transport.TransportClient;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
@@ -29,7 +30,8 @@ import static org.hamcrest.core.StringContains.containsString;
 
 public class FlsIndexingTests extends AbstractDlsFlsTest {
 
-    protected void populateData(final Client tc) {
+    @Override
+    void populateData(final TransportClient tc) {
         // Create several documents in different indices with shared field names,
         // different roles will have different levels of FLS restrictions
         tc.index(new IndexRequest("yellow-pages").id("1").setRefreshPolicy(RefreshPolicy.IMMEDIATE)

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.securityconf.impl.v7;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.google.common.collect.ImmutableSet;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.quality.Strictness;
+
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.cluster.metadata.IndexAbstraction.Type;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.security.securityconf.ConfigModelV7.IndexPattern;
+import org.opensearch.security.user.User;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IndexPatternTests {
+
+    @Mock
+    private User user;
+    @Mock
+    private IndexNameExpressionResolver resolver;
+    @Mock
+    private ClusterService clusterService;
+
+    private IndexPattern ip;
+
+    @Before
+    public void before() {
+        ip = spy(new IndexPattern("defaultPattern"));
+    }
+
+    @After
+    public void after() {
+        verifyNoMoreInteractions(user, resolver, clusterService);
+    } 
+
+    @Test
+    public void testCtor() {
+        assertThrows(NullPointerException.class, () -> new IndexPattern(null));
+    }
+
+    /** Ensure that concreteIndexNames sends correct parameters are sent to getResolvedIndexPattern */
+    @Test
+    public void testConcreteIndexNamesOverload() {
+        doReturn(ImmutableSet.of("darn")).when(ip).getResolvedIndexPattern(user, resolver, clusterService, false);    
+
+        final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("darn"));
+
+        verify(ip).getResolvedIndexPattern(user, resolver, clusterService, false);
+        verify(ip).concreteIndexNames(user, resolver, clusterService);
+        verifyNoMoreInteractions(ip);
+    }
+
+    /** Ensure that attemptResolveIndexNames sends correct parameters are sent to getResolvedIndexPattern */
+    @Test
+    public void testAttemptResolveIndexNamesOverload() {
+        doReturn(ImmutableSet.of("yarn")).when(ip).getResolvedIndexPattern(user, resolver, clusterService, true);
+    
+        final Set<String> results = ip.attemptResolveIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("yarn"));
+
+        verify(ip).getResolvedIndexPattern(user, resolver, clusterService, true);
+        verify(ip).attemptResolveIndexNames(user, resolver, clusterService);
+        verifyNoMoreInteractions(ip);
+    }
+
+    /** Verify concreteIndexNames when there are no matches */
+    @Test
+    public void testExactNameWithNoMatches() {
+        doReturn("index-17").when(ip).getUnresolvedIndexPattern(user);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"))).thenReturn(new String[]{});
+
+        final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("index-17"));
+
+        verify(clusterService).state();
+        verify(ip).getUnresolvedIndexPattern(user);
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"));
+    }
+
+    /** Verify concreteIndexNames on exact name matches */
+    @Test
+    public void testExactName() {
+        doReturn("index-17").when(ip).getUnresolvedIndexPattern(user);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"))).thenReturn(new String[]{"resolved-index-17"});
+
+        final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("resolved-index-17"));
+
+        verify(clusterService).state();
+        verify(ip).getUnresolvedIndexPattern(user);
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"));
+    }
+
+    /** Verify concreteIndexNames on multiple matches */
+    @Test
+    public void testMultipleConcreteIndices() {
+        doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
+        doReturn(createClusterState()).when(clusterService).state();
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+
+        final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("resolved-index-17", "resolved-index-18"));
+
+        verify(clusterService, times(2)).state();
+        verify(ip).getUnresolvedIndexPattern(user);
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+    }
+
+    /** Verify concreteIndexNames when there is an alias */
+    @Test
+    public void testMultipleConcreteIndicesWithOneAlias() {
+        doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
+
+        doReturn(createClusterState(
+            new IndexShorthand("index-111", Type.DATA_STREAM), // Name matches/wrong type
+            new IndexShorthand("index-100", Type.ALIAS), // Name and type match
+            new IndexShorthand("19", Type.ALIAS) // Type matches/wrong name
+            )).when(clusterService).state();
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"))).thenReturn(new String[]{"resolved-index-100"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+
+        final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("resolved-index-100", "resolved-index-17", "resolved-index-18"));
+
+        verify(clusterService, times(3)).state();
+        verify(ip).getUnresolvedIndexPattern(user);
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+    }
+    
+    /** Verify attemptResolveIndexNames with multiple aliases */
+    @Test
+    public void testMultipleConcreteAliasedAndUnresolved() {
+        doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
+        doReturn(createClusterState(
+            new IndexShorthand("index-111", Type.DATA_STREAM), // Name matches/wrong type
+            new IndexShorthand("index-100", Type.ALIAS), // Name and type match
+            new IndexShorthand("index-101", Type.ALIAS), // Name and type match
+            new IndexShorthand("19", Type.ALIAS) // Type matches/wrong name
+            )).when(clusterService).state();
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"), eq("index-101"))).thenReturn(new String[]{"resolved-index-100", "resolved-index-101"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+
+        final Set<String> results = ip.attemptResolveIndexNames(user, resolver, clusterService);
+
+        assertThat(results, contains("resolved-index-100", "resolved-index-101", "resolved-index-17", "resolved-index-18", "index-1*"));
+
+        verify(clusterService, times(3)).state();
+        verify(ip).getUnresolvedIndexPattern(user);
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"), eq("index-101"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+    }
+
+    private ClusterState createClusterState(final IndexShorthand... indices) {
+        final TreeMap<String, IndexAbstraction> indexMap = new TreeMap<String, IndexAbstraction>();
+        Arrays.stream(indices).forEach(indexShorthand -> {
+            final IndexAbstraction indexAbstraction = mock(IndexAbstraction.class);
+            when(indexAbstraction.getType()).thenReturn(indexShorthand.type);
+            indexMap.put(indexShorthand.name, indexAbstraction);    
+        });
+
+        final Metadata mockMetadata = mock(Metadata.class, withSettings().strictness(Strictness.LENIENT));
+        when(mockMetadata.getIndicesLookup()).thenReturn(indexMap);
+
+        final ClusterState mockClusterState = mock(ClusterState.class, withSettings().strictness(Strictness.LENIENT));
+        when(mockClusterState.getMetadata()).thenReturn(mockMetadata);
+
+        return mockClusterState;
+    }
+
+    private class IndexShorthand {
+        public final String name;
+        public final Type type;
+        public IndexShorthand(final String name, final Type type) {
+            this.name = name;
+            this.type = type;
+        }
+    }
+}

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
@@ -108,7 +108,7 @@ public class IndexPatternTests {
     public void testExactNameWithNoMatches() {
         doReturn("index-17").when(ip).getUnresolvedIndexPattern(user);
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"))).thenReturn(new String[]{});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-17"))).thenReturn(new String[]{});
 
         final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
 
@@ -116,7 +116,7 @@ public class IndexPatternTests {
 
         verify(clusterService).state();
         verify(ip).getUnresolvedIndexPattern(user);
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-17"));
     }
 
     /** Verify concreteIndexNames on exact name matches */
@@ -124,7 +124,7 @@ public class IndexPatternTests {
     public void testExactName() {
         doReturn("index-17").when(ip).getUnresolvedIndexPattern(user);
         when(clusterService.state()).thenReturn(mock(ClusterState.class));
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"))).thenReturn(new String[]{"resolved-index-17"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-17"))).thenReturn(new String[]{"resolved-index-17"});
 
         final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
 
@@ -132,7 +132,7 @@ public class IndexPatternTests {
 
         verify(clusterService).state();
         verify(ip).getUnresolvedIndexPattern(user);
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-17"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-17"));
     }
 
     /** Verify concreteIndexNames on multiple matches */
@@ -140,7 +140,7 @@ public class IndexPatternTests {
     public void testMultipleConcreteIndices() {
         doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
         doReturn(createClusterState()).when(clusterService).state();
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
 
         final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
 
@@ -148,7 +148,7 @@ public class IndexPatternTests {
 
         verify(clusterService, times(2)).state();
         verify(ip).getUnresolvedIndexPattern(user);
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"));
     }
 
     /** Verify concreteIndexNames when there is an alias */
@@ -157,12 +157,11 @@ public class IndexPatternTests {
         doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
 
         doReturn(createClusterState(
-            new IndexShorthand("index-111", Type.DATA_STREAM), // Name matches/wrong type
             new IndexShorthand("index-100", Type.ALIAS), // Name and type match
             new IndexShorthand("19", Type.ALIAS) // Type matches/wrong name
             )).when(clusterService).state();
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"))).thenReturn(new String[]{"resolved-index-100"});
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-100"))).thenReturn(new String[]{"resolved-index-100"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
 
         final Set<String> results = ip.concreteIndexNames(user, resolver, clusterService);
 
@@ -170,8 +169,8 @@ public class IndexPatternTests {
 
         verify(clusterService, times(3)).state();
         verify(ip).getUnresolvedIndexPattern(user);
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"));
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-100"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"));
     }
     
     /** Verify attemptResolveIndexNames with multiple aliases */
@@ -179,13 +178,12 @@ public class IndexPatternTests {
     public void testMultipleConcreteAliasedAndUnresolved() {
         doReturn("index-1*").when(ip).getUnresolvedIndexPattern(user);
         doReturn(createClusterState(
-            new IndexShorthand("index-111", Type.DATA_STREAM), // Name matches/wrong type
             new IndexShorthand("index-100", Type.ALIAS), // Name and type match
             new IndexShorthand("index-101", Type.ALIAS), // Name and type match
             new IndexShorthand("19", Type.ALIAS) // Type matches/wrong name
             )).when(clusterService).state();
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"), eq("index-101"))).thenReturn(new String[]{"resolved-index-100", "resolved-index-101"});
-        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-100"), eq("index-101"))).thenReturn(new String[]{"resolved-index-100", "resolved-index-101"});
+        when(resolver.concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"))).thenReturn(new String[]{"resolved-index-17", "resolved-index-18"});
 
         final Set<String> results = ip.attemptResolveIndexNames(user, resolver, clusterService);
 
@@ -193,8 +191,8 @@ public class IndexPatternTests {
 
         verify(clusterService, times(3)).state();
         verify(ip).getUnresolvedIndexPattern(user);
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-100"), eq("index-101"));
-        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq("index-1*"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-100"), eq("index-101"));
+        verify(resolver).concreteIndexNames(any(), eq(IndicesOptions.lenientExpandOpen()), eq(true), eq("index-1*"));
     }
 
     private ClusterState createClusterState(final IndexShorthand... indices) {

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/IndexPatternTests.java
@@ -205,10 +205,10 @@ public class IndexPatternTests {
             indexMap.put(indexShorthand.name, indexAbstraction);    
         });
 
-        final Metadata mockMetadata = mock(Metadata.class, withSettings().strictness(Strictness.LENIENT));
+        final Metadata mockMetadata = mock(Metadata.class, withSettings().lenient());
         when(mockMetadata.getIndicesLookup()).thenReturn(indexMap);
 
-        final ClusterState mockClusterState = mock(ClusterState.class, withSettings().strictness(Strictness.LENIENT));
+        final ClusterState mockClusterState = mock(ClusterState.class, withSettings().lenient());
         when(mockClusterState.getMetadata()).thenReturn(mockMetadata);
 
         return mockClusterState;

--- a/src/test/resources/dlsfls/internal_users.yml
+++ b/src/test/resources/dlsfls/internal_users.yml
@@ -51,6 +51,13 @@ perf_named_only:
   backend_roles: []
   attributes: {}
   description: "Migrated from v6"
+user_ccc:
+  hash: "$2a$12$YCBrpxYyFusK609FurY5Ee3BlmuzWw0qHwpwqEyNhM2.XnQY3Bxpe"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  attributes: {}
+  description: "Migrated from v6"
 user_bbb:
   hash: "$2a$12$YCBrpxYyFusK609FurY5Ee3BlmuzWw0qHwpwqEyNhM2.XnQY3Bxpe"
   reserved: false

--- a/src/test/resources/dlsfls/roles_fls_indexing.yml
+++ b/src/test/resources/dlsfls/roles_fls_indexing.yml
@@ -1,0 +1,39 @@
+---
+_meta:
+  type: "roles"
+  config_version: 2
+all_indices_no_phone:
+  cluster_permissions:
+  - "*"
+  index_permissions:
+  - index_patterns:
+    - "*"
+    dls: ""
+    fls:
+    - "~phone-all"
+    allowed_actions:
+    - "ALL"
+some_indices_no_phone:
+  index_permissions:
+  - index_patterns:
+    - "*pages*"
+    fls:
+    - "~phone-some"
+    allowed_actions:
+    - "ALL"
+  - index_patterns:
+    - "*"
+    allowed_actions:
+    - "read"
+once_indices_no_phone:
+  index_permissions:
+  - index_patterns:
+    - "yellow-pages"
+    fls:
+    - "~phone-one"
+    allowed_actions:
+    - "ALL"
+  - index_patterns:
+    - "*"
+    allowed_actions:
+    - "read"

--- a/src/test/resources/dlsfls/roles_mapping_fls_indexing.yml
+++ b/src/test/resources/dlsfls/roles_mapping_fls_indexing.yml
@@ -1,0 +1,31 @@
+---
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+all_indices_no_phone:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  and_backend_roles: []
+  description: "All indices do not have phone access"
+  users:
+  - "user_ccc"
+some_indices_no_phone:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  and_backend_roles: []
+  description: "Some indices do not have phone access"
+  users:
+  - "user_bbb"
+once_indices_no_phone:
+  reserved: false
+  hidden: false
+  backend_roles: []
+  hosts: []
+  and_backend_roles: []
+  description: "One indices do not have phone access"
+  users:
+  - "user_aaa"

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -346,6 +346,36 @@ ds2:
 ds3:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum
+ds_admin:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_dls1:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_dls2:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_dls3:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fls1:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fls2:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fls3:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fm1:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fm2:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
+ds_fm3:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
 hidden_test:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   opendistro_security_roles:

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -346,6 +346,9 @@ ds2:
 ds3:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum
+ds4:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
 ds_admin:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1122,12 +1122,144 @@ data_stream_3:
   reserved: true
   hidden: false
   description: "Migrated from v6 (all types mapped)"
-  cluster_permissions: []
+  cluster_permissions:
+    - "*"
   index_permissions:
     - index_patterns:
         - "*"
       allowed_actions:
         - "DATASTREAM_ALL"
+        - "indices:data/write/index"
+        - "indices:data/write/bulk*"
+
+data_stream_admin:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions:
+    - "*"
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream*"
+      allowed_actions:
+        - "*"
+
+data_stream_dls_1:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream11"
+      dls: "{\n  \"bool\": {\n \"must\": {\n \"match\": {\n \"user.id\": \"8a4f500d\"\n }\n }\n }\n}"
+      allowed_actions:
+        - "read"
+
+data_stream_dls_2:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream2*"
+      dls: "{\n  \"bool\": {\n \"must\": {\n \"match\": {\n \"user.id\": \"8a4f500d\"\n }\n }\n }\n}"
+      allowed_actions:
+        - "read"
+
+data_stream_dls_3:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream*"
+      dls: "{\n  \"bool\": {\n \"must\": {\n \"match\": {\n \"user.id\": \"8a4f500d\"\n }\n }\n }\n}"
+      allowed_actions:
+        - "read"
+
+data_stream_fls_1:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream11"
+      fls:
+        - "user.id"
+        - "message"
+      allowed_actions:
+        - "read"
+
+data_stream_fls_2:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream2*"
+      fls:
+        - "user.id"
+        - "user.name"
+      allowed_actions:
+        - "read"
+
+data_stream_fls_3:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream*"
+      fls:
+        - "~message"
+      allowed_actions:
+        - "read"
+
+data_stream_fm_1:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream11"
+      masked_fields:
+        - "message"
+      allowed_actions:
+        - "read"
+
+data_stream_fm_2:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream2*"
+      masked_fields:
+        - "message"
+      allowed_actions:
+        - "read"
+
+data_stream_fm_3:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "my-data-stream*"
+      masked_fields:
+        - "user.name"
+        - "message"
+      allowed_actions:
+        - "read"
 
 hidden_test:
   cluster_permissions:

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1132,6 +1132,17 @@ data_stream_3:
         - "indices:data/write/index"
         - "indices:data/write/bulk*"
 
+data_stream_4:
+  reserved: true
+  hidden: false
+  description: "Migrated from v6 (all types mapped)"
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "*"
+      allowed_actions:
+        - "DATASTREAM_ALL"
+
 data_stream_admin:
   reserved: true
   hidden: false

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -413,6 +413,11 @@ data_stream_3:
   hidden: false
   users:
     - "ds3"
+data_stream_4:
+  reserved: false
+  hidden: false
+  users:
+    - "ds4"
 data_stream_admin:
   reserved: false
   hidden: false

--- a/src/test/resources/roles_mapping.yml
+++ b/src/test/resources/roles_mapping.yml
@@ -413,6 +413,56 @@ data_stream_3:
   hidden: false
   users:
     - "ds3"
+data_stream_admin:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_admin"
+data_stream_dls_1:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_dls1"
+data_stream_dls_2:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_dls2"
+data_stream_dls_3:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_dls3"
+data_stream_fls_1:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fls1"
+data_stream_fls_2:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fls2"
+data_stream_fls_3:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fls3"
+data_stream_fm_1:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fm1"
+data_stream_fm_2:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fm2"
+data_stream_fm_3:
+  reserved: false
+  hidden: false
+  users:
+    - "ds_fm3"
 sem-role:
   reserved: false
   hidden: false


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/commit/f7cc569c9d3fa5d5432c76c854eed280d45ce6f4 to 2.x

Also includes changes from:

- https://github.com/opensearch-project/security/pull/2002
- https://github.com/opensearch-project/security/pull/1735 - Adds `appendUnresolved` from here