### PR TITLE
Additional two integration tests IndicesAliasesRequest,CreateIndexRequest

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
@@ -1,0 +1,66 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.common.collect.ImmutableOpenMap;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Spliterator.IMMUTABLE;
+import static java.util.Spliterators.spliteratorUnknownSize;
+
+class AliasExistsMatcher extends TypeSafeDiagnosingMatcher<Client> {
+
+	private final String aliasName;
+
+	public AliasExistsMatcher(String aliasName) {
+		this.aliasName = requireNonNull(aliasName, "Alias name is required");
+	}
+
+	@Override
+	protected boolean matchesSafely(Client client, Description mismatchDescription) {
+		try {
+			GetAliasesResponse response = client.admin().indices().getAliases(new GetAliasesRequest(aliasName)).get();
+			ImmutableOpenMap<String, List<AliasMetadata>> aliases = response.getAliases();
+			Set<String> actualAliasNames = StreamSupport.stream(spliteratorUnknownSize(aliases.valuesIt(), IMMUTABLE), false)
+					.flatMap(Collection::stream)
+					.map(AliasMetadata::getAlias)
+					.collect(Collectors.toSet());
+			if(actualAliasNames.contains(aliasName) == false) {
+				String existingAliases = String.join(", ", actualAliasNames);
+				mismatchDescription.appendText(" alias does not exist, defined aliases ").appendValue(existingAliases);
+				return false;
+			}
+			return true;
+		} catch (InterruptedException | ExecutionException e) {
+			mismatchDescription.appendText("Error occured during checking if cluster contains alias ")
+				.appendValue(e);
+			return false;
+		}
+	}
+
+	@Override
+	public void describeTo(Description description) {
+		description.appendText("Cluster should contain ").appendValue(aliasName).appendText(" alias");
+	}
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterMatchers.java
@@ -52,6 +52,10 @@ public class ClusterMatchers {
 		return new SnapshotInClusterDoesNotExist(repositoryName, snapshotName);
 	}
 
+	public static Matcher<Client> aliasExists(String aliasName) {
+		return new AliasExistsMatcher(aliasName);
+	}
+
 	public static Matcher<LocalCluster> indexExists(String expectedIndexName) {
 		return new IndexExistsMatcher(expectedIndexName);
 	}


### PR DESCRIPTION
Signed-off-by: Lukasz Soszynski <lukasz.soszynski@eliatra.com>

### Description
[Describe what this change achieves]
* Category (Integration tests)
* Why these changes are required?
* What is the old behaviour before changes and new behaviour after changes?

Two additional test cases associated with

1. index deletion with IndicesAliasesRequest
2. Alias creation with CreateIndexRequest

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
