### PR TITLE
Force woodstox to 6.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ configurations.all {
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.20"
         force "com.google.guava:guava:30.0-jre"
+        force "com.fasterxml.woodstox:woodstox-core:6.4.0"
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

### Description
Fixes a remaining dependency to Woodstox 6.2.6 library as a follow-up to https://github.com/opensearch-project/security/pull/2197. I incorrectly looked at only the direct dependencies previously not accounting for the transient dependencies introduced by other libraries. This force should make the Woodstox version match the desired 6.4.0. 

### Issues Resolved
Further resolves the Woodstox dependency problem. 

### Testing 
After the change, runnning `./gradlew dependencies` shows all references to Woodstox-core being bumped to 6.4.0.

### Check List
- [x] New functionality includes testing
- [] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
