### PR TITLE
Integrate k-NN functionality with security plugin

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -68,6 +68,29 @@ anomaly_full_access:
         - 'indices:admin/aliases/get'
         - 'indices:admin/mappings/get'
 
+# Allow users to execute read only k-NN actions
+knn_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/knn_search_model_action'
+    - 'cluster:admin/knn_get_model_action'
+    - 'cluster:admin/knn_stats_action'
+
+# Allow users to use all k-NN functionality
+knn_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/knn_training_model_action'
+    - 'cluster:admin/knn_training_job_router_action'
+    - 'cluster:admin/knn_training_job_route_decision_info_action'
+    - 'cluster:admin/knn_warmup_action'
+    - 'cluster:admin/knn_delete_model_action'
+    - 'cluster:admin/knn_remove_model_from_cache_action'
+    - 'cluster:admin/knn_update_model_graveyard_action'
+    - 'cluster:admin/knn_search_model_action'
+    - 'cluster:admin/knn_get_model_action'
+    - 'cluster:admin/knn_stats_action'
+
 # Allows users to read Notebooks
 notebooks_read_access:
   reserved: true

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -315,7 +315,7 @@ echo plugins.security.enable_snapshot_restore_privilege: true >> "%OPENSEARCH_CO
 echo plugins.security.check_snapshot_restore_write_privileges: true >> "%OPENSEARCH_CONF_FILE%"
 echo plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"] >> "%OPENSEARCH_CONF_FILE%"
 echo plugins.security.system_indices.enabled: true >> "%OPENSEARCH_CONF_FILE%"
-echo plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"] >> "%OPENSEARCH_CONF_FILE%"
+echo plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".opensearch-knn-models"] >> "%OPENSEARCH_CONF_FILE%"
 
 :: network.host
 >nul findstr /b /c:"network.host" "%OPENSEARCH_CONF_FILE%" && (

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -378,7 +378,7 @@ echo "plugins.security.enable_snapshot_restore_privilege: true" | $SUDO_CMD tee 
 echo "plugins.security.check_snapshot_restore_write_privileges: true" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 echo 'plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 echo 'plugins.security.system_indices.enabled: true' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
-echo 'plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
+echo 'plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".opensearch-knn-models"]' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 
 #network.host
 if $SUDO_CMD grep --quiet -i "^network.host" "$OPENSEARCH_CONF_FILE"; then


### PR DESCRIPTION
### Description
Adds 2 k-NN related roles to the plugin: read only and fully access.

Adds k-NN system index to demo scripts as well.

### Issues Resolved
#2265 

### Testing
Pending

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
