### PR TITLE
[Feature] Agenda

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,56 +4,12 @@
 
 OpenSearch is a community project that is built and maintained by people just like **you**.
 [This document](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md) explains how you can contribute to this and related projects.
-The brief summary below outlines contribution guidelines specific to the OpenSearch-Security Repo.
 
-## Triaging
 
-The maintainers of the OpenSearch-Security Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project.
+Visit the following link(s) for more information on specific practices: 
 
-### Do I need to attend for my issue to be addressed/triaged?
+- [Triaging](./TRIAGING.md)
 
-Attendance is not required for your issue to be triaged or addressed. All new issues are triaged weekly.
 
-### What happens if my issue does not get covered this time?
 
-Each meeting we seek to  address all new issues. However, should we run out of time before your issue is discussed, you are always welcome to attend the next meeting or to follow up on the issue post itself. 
 
-### How do I join the Backlog & Triage meeting?
-  
-Meetings are hosted regularly at 3 PM Eastern Time (Noon Pacific Time) and can be joined via the links posted on the [Upcoming Events](https://opensearch.org/events) webpage.
-
-After joining the Zoom meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam or microphone available, you can still join in via the text chat.
-    
-If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.
-
-### Is there an agenda for each week? 
-
-Meetings are lightly structured such that [new issues](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) are reviewed first, then the [sprint backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3A%22sprint+backlog%22), and finally the [backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Atriaged+-label%3A%22sprint+backlog%22). There is no specific ordering within each category. 
-
-If you have an issue you would like to discuss but do not have the ability to attend the entire meeting please attend when is best for you and signal that you have an issue to discuss when you arrive. 
-
-### Do I need to have already contributed to the project to attend a triage meeting?
- 
-No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution. 
-
-### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
-
-You can always open an [issue](ttps://github.com/opensearch-project/security/issues/new/choose) including one that you think may be a duplicate. However, in cases where you believe there is an important distinction to be made between an existing issue and your newly created one, you are encouraged to attend the triaging meeting to explain. 
-
-### What if I have follow-up questions on an issue? 
-
-If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you are welcome to come to the triage meeting to discuss. 
-
-### Is this meeting a good place to get help setting up security features on my OpenSearch instance?
-
-While we are always happy to help the community, the best resource for implementation questions is [the OpenSearch forum](https://forum.opensearch.org/c/security/3).
-
-There you can find answers to many common questions as well as speak with implementation experts. 
-
-### Is this where I should bring up potential security vulnerabilities?
-
-Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined on the [SECURITY.md](https://github.com/opensearch-project/security/blob/main/SECURITY.md) document.
-
-### Who should I contact if I have further questions? 
-  
-You can always file an [issue](ttps://github.com/opensearch-project/security/issues/new/choose) for any question you have about the project. Alternatively, you can reach out to specific contacts helping to organize the project: Stephen Crawford (steecraw@amazon.com), Dave Lago (davelago@amazon.com), and Peter Nied (petern@amazon.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,11 +5,6 @@
 OpenSearch is a community project that is built and maintained by people just like **you**.
 [This document](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md) explains how you can contribute to this and related projects.
 
-
 Visit the following link(s) for more information on specific practices: 
 
 - [Triaging](./TRIAGING.md)
-
-
-
-

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,6 +1,6 @@
 <img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
 
-The maintainers of the OpenSearch-Security Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project.
+The maintainers of the OpenSearch-Security Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project. To learn more about contributing to the OpenSearch-security Repo visit the [Contributing](./CONTRIBUTING.md) documentation.
 
 ### Do I need to attend for my issue to be addressed/triaged?
 
@@ -23,9 +23,9 @@ If you have an issue you'd like to bring forth please consider getting a link to
 Meetings are lightly structured as follows: 
 
 1. Announcements: If there are any announcements to be made they will happen at the start of the meeting. 
-2. Review of new issues: The meetings always start with reviewing all [untriaged](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) issues. We will also provide an opportunity for any issues introduced since the last meeting but already triaged to be discussed. 
-3. Sprint backlog review: Next, we will review persisting issues in the [sprint backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3A%22sprint+backlog%22), checking to see that issues have not gone stale or been addressed. 
-4. Backlog review: Finally, any remaining time will be spent reviewing the [backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Atriaged+-label%3A%22sprint+backlog%22). 
+2. Review of new issues: The meetings always start with reviewing all untriaged issues for the [security](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) repo and [security-dashboards](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aissue+is%3Aopen+-label%3Atriaged) repo. We will also provide an opportunity for any issues introduced since the last meeting but already triaged to be discussed. 
+3. Sprint backlog review: Next, we will review persisting issues in the sprint backlog for the [security](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3A%22sprint+backlog%22) repo and [security-dashboards](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3A%22sprint+backlog%22) repo, checking to see that issues have not gone stale or been addressed. 
+4. Backlog review: Finally, any remaining time will be spent reviewing the [security](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Atriaged+-label%3A%22sprint+backlog%22) repo and [security-dashboards](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aopen+is%3Aissue+label%3Atriaged+-label%3A%22sprint+backlog%22+) repo. 
 
 There is no specific ordering within each category.
 
@@ -48,6 +48,10 @@ If you have an existing issue you would like to discuss, you can always comment 
 While we are always happy to help the community, the best resource for implementation questions is [the OpenSearch forum](https://forum.opensearch.org/c/security/3).
 
 There you can find answers to many common questions as well as speak with implementation experts.
+
+### What if my issue is critical to OpenSearch operations, do I have to wait for the weekly meeting for it to be addressed?
+
+All new issues for the [security](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) repo and [security-dashboards](https://github.com/opensearch-project/security-dashboards-plugin/issues?q=is%3Aissue+is%3Aopen+-label%3Atriaged) repo are reviewed daily to check for critical issues which require immediate triaging. If an issue relates to a severe concern for OpenSearch operation, it will be triaged by a maintainer mid-week. You can still come to discuss an issue at the following meeting even if it has already been triaged during the week. 
 
 ### Is this where I should bring up potential security vulnerabilities?
 

--- a/TRIAGING.md
+++ b/TRIAGING.md
@@ -1,0 +1,58 @@
+<img src="https://opensearch.org/assets/img/opensearch-logo-themed.svg" height="64px">
+
+The maintainers of the OpenSearch-Security Repo seek to promote an inclusive and engaged community of contributors. In order to facilitate this, weekly triage meetings are open-to-all and attendance is encouraged for anyone who hopes to contribute, discuss an issue, or learn more about the project.
+
+### Do I need to attend for my issue to be addressed/triaged?
+
+Attendance is not required for your issue to be triaged or addressed. All new issues are triaged weekly.
+
+### What happens if my issue does not get covered this time?
+
+Each meeting we seek to  address all new issues. However, should we run out of time before your issue is discussed, you are always welcome to attend the next meeting or to follow up on the issue post itself.
+
+### How do I join the Backlog & Triage meeting?
+
+Meetings are hosted regularly at 3 PM Eastern Time (Noon Pacific Time) and can be joined via the links posted on the [Upcoming Events](https://opensearch.org/events) webpage.
+
+After joining the Zoom meeting, you can enable your video / voice to join the discussion.  If you do not have a webcam or microphone available, you can still join in via the text chat.
+
+If you have an issue you'd like to bring forth please consider getting a link to the issue so it can be presented to everyone in the meeting.
+
+### Is there an agenda for each week?
+
+Meetings are lightly structured as follows: 
+
+1. Announcements: If there are any announcements to be made they will happen at the start of the meeting. 
+2. Review of new issues: The meetings always start with reviewing all [untriaged](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Auntriaged) issues. We will also provide an opportunity for any issues introduced since the last meeting but already triaged to be discussed. 
+3. Sprint backlog review: Next, we will review persisting issues in the [sprint backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3A%22sprint+backlog%22), checking to see that issues have not gone stale or been addressed. 
+4. Backlog review: Finally, any remaining time will be spent reviewing the [backlog](https://github.com/opensearch-project/security/issues?q=is%3Aissue+is%3Aopen+label%3Atriaged+-label%3A%22sprint+backlog%22). 
+
+There is no specific ordering within each category.
+
+If you have an issue you would like to discuss but do not have the ability to attend the entire meeting please attend when is best for you and signal that you have an issue to discuss when you arrive.
+
+### Do I need to have already contributed to the project to attend a triage meeting?
+
+No, all are welcome and encouraged to attend. Attending the Backlog & Triage meetings is a great way for a new contributor to learn about the project as well as explore different avenues of contribution.
+
+### What if I have an issue that is almost a duplicate, should I open a new one to be triaged?
+
+You can always open an [issue](ttps://github.com/opensearch-project/security/issues/new/choose) including one that you think may be a duplicate. However, in cases where you believe there is an important distinction to be made between an existing issue and your newly created one, you are encouraged to attend the triaging meeting to explain.
+
+### What if I have follow-up questions on an issue?
+
+If you have an existing issue you would like to discuss, you can always comment on the issue itself. Alternatively, you are welcome to come to the triage meeting to discuss.
+
+### Is this meeting a good place to get help setting up security features on my OpenSearch instance?
+
+While we are always happy to help the community, the best resource for implementation questions is [the OpenSearch forum](https://forum.opensearch.org/c/security/3).
+
+There you can find answers to many common questions as well as speak with implementation experts.
+
+### Is this where I should bring up potential security vulnerabilities?
+
+Due to the sensitive nature of security vulnerabilities, please report all potential vulnerabilities directly by following the steps outlined on the [SECURITY.md](https://github.com/opensearch-project/security/blob/main/SECURITY.md) document.
+
+### Who should I contact if I have further questions?
+
+You can always file an [issue](ttps://github.com/opensearch-project/security/issues/new/choose) for any question you have about the project. Alternatively, you can reach out to specific contacts helping to organize the project: Stephen Crawford (steecraw@amazon.com), Dave Lago (davelago@amazon.com), and Peter Nied (petern@amazon.com).


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

### Description
[Describe what this change achieves]
Split the Contributing Document to allow for further fine-tuning down the road. Created a separate Triaging document with previous info and also added a basic outline for the meeting structure. 

### Check List
- [ ] ~New functionality includes testing~
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
