### PR TITLE
Cleanup download file output and improved error logging

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -26,14 +26,14 @@ runs:
 
     # Download OpenSearch
     - name: Download OpenSearch for Windows
-      uses: peternied/download-file@v1
+      uses: peternied/download-file@v2
       if: ${{ runner.os == 'Windows' }}
       with:
         url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
 
 
     - name: Download OpenSearch for Linux
-      uses: peternied/download-file@v1
+      uses: peternied/download-file@v2
       if: ${{ runner.os == 'Linux' }}
       with:
         url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-linux-x64-latest.tar.gz


### PR DESCRIPTION
### Description
There was a release to download-file that cleans up the amount of log output during the download and also added logging if there was an issue during the installation. 

### Testing
I'll do a comparison between the plugin-install workflows previous number of lines of output and the new number with this change

| Workflow | Link | Lines | Delta|
|-----------|------|--------|------|
| Plugin install ubuntu-latest |  [link](https://github.com/opensearch-project/security/actions/runs/3604084983/jobs/6073047571) |4977| - |
| Plugin install ubuntu-latest |  [link](https://github.com/opensearch-project/security/actions/runs/3605488561/jobs/6075937034) | 407 |  12.2x reduction |

#### Old
```
Length: 234472457 (224M) [application/x-gzip]
Saving to: ‘opensearch-min-3.0.0-SNAPSHOT-linux-x64-latest.tar.gz’

     0K .......... .......... .......... .......... ..........  0% 7.37M 30s
    50K .......... .......... .......... .......... ..........  0% 8.94M 28s
   100K .......... .......... .......... .......... ..........  0% 8.08M 28s
   150K .......... .......... .......... .......... ..........  0% 13.5M 25s
   200K .......... .......... .......... .......... ..........  0% 10.4M 24s
   250K .......... .......... .......... .......... ..........  0% 10.0M 24s
   300K .......... .......... .......... .......... ..........  0% 10.9M 23s
```

#### New
```
Length: 234472457 (224M) [application/x-gzip]
Saving to: ‘opensearch-min-3.0.0-SNAPSHOT-linux-x64-latest.tar.gz’

opensearch-min-3.0.   0%[                    ]       0  --.-KB/s               
opensearch-min-3.0.   2%[                    ]   6.63M  32.8MB/s               
opensearch-min-3.0.  12%[=>                  ]  28.20M  70.2MB/s               
opensearch-min-3.0.  24%[===>                ]  54.[51](M  90.6MB/s               
opensearch-min-3.0.  41%[=======>            ]  92.46M   115MB/s               
opensearch-min-3.0.  63%[===========>        ] 142.82M   143MB/s               
opensearch-min-3.0.  92%[=================>  ] 207.89M   173MB/s               
opensearch-min-3.0. 100%[===================>] 223.61M   179MB/s    in 1.2s
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
