### PR TITLE
Automatically add `untriaged` label on issues

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -1,0 +1,19 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })


### PR DESCRIPTION
### Description
Sometimes when new issues are opened, they don't use the template or are transfered in from another repo, or even are reopened when we ran triage slightly differently.  This automation adds the `untriaged` tag if any of these states are applied.

Coming from
- https://github.com/opensearch-project/.github/pull/111

### Testing
On my fork of this repo I enabled issues and created a couple and they were automatically tagged on open [1] and reopen [2] by the github action bot for various scenarios [2].

[1] https://github.com/peternied/.github/issues/4
[2] https://github.com/peternied/.github/issues/6
[3] https://github.com/peternied/.github/actions

### Documentation

Note; I'm not adding any documentation on this tool because it automates everything that we were doing manually and didn't have documented.  Less documentation feels better in my book, but definitely open to other opinions, what do you think the documentation would look like?

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
