### PR TITLE
[Backport 1.3] Add plugin install workflow and action 

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   setup-script-name:
-    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave this field empty to indicate that no script should be run.'
+    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave this field empty to indicate no script should be run.'
     required: false
 
 runs:

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -1,0 +1,120 @@
+name: 'Launch OpenSearch with a single plugin installed'
+description: 'Downloads latest build of OpenSearch, installs a plugin, executes a script and then starts OpenSearch on localhost:9200'
+
+inputs:
+  opensearch-version:
+    description: 'The version of OpenSearch that should be used, e.g "3.0.0"'
+    required: true
+
+  plugin-name:
+    description: 'The name of the plugin to use, such as opensearch-security'
+    required: true
+
+  setup-script-name:
+    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave empty to indicate one should not be run.'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+
+    # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
+    # Download OpenSearch
+    - name: Download OpenSearch for Windows
+      uses: peternied/download-file@v1
+      if: ${{ runner.os == 'Windows' }}
+      with:
+        url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+
+
+    - name: Download OpenSearch for Linux
+      uses: peternied/download-file@v1
+      if: ${{ runner.os == 'Linux' }}
+      with:
+        url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-linux-x64-latest.tar.gz
+
+    # Extract downloaded zip
+    - name: Extract downloaded tar
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        tar -xzf opensearch-*.tar.gz
+        rm -f opensearch-*.tar.gz
+      shell: bash
+
+    - name: Extract downloaded zip
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        tar -xzf opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+        del opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+      shell: pwsh
+
+    # Move and rename the plugin for installation
+    - name: Move and rename the plugin for installation
+      run: mv ./build/distributions/${{ inputs.plugin-name }}-*-SNAPSHOT.zip ${{ inputs.plugin-name }}.zip
+      shell: bash
+
+    # Install the plugin
+    - name: Install Plugin into OpenSearch for Linux
+      if: ${{ runner.os == 'Linux'}}
+      run: |
+        chmod +x ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch-plugin
+        /bin/bash -c "yes | ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/opensearch-security.zip"
+      shell: bash
+
+    - name: Install Plugin into OpenSearch for Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: |
+        'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
+      shell: pwsh
+
+    # Run any configuration scripts
+    - name: Run Setup Script for Linux
+      if: ${{ runner.os == 'Linux' && inputs.setup-script-name != '' }}
+      run: |
+        echo "running linux setup"
+        chmod +x ./${{ inputs.setup-script-name }}.sh
+        ./${{ inputs.setup-script-name }}.sh
+      shell: bash
+
+    - name: Run Setup Script for Windows
+      if: ${{ runner.os == 'Windows' && inputs.setup-script-name != '' }}
+      run: .\${{ inputs.setup-script-name }}.bat
+      shell: pwsh
+
+    # Run OpenSearch
+    - name: Run OpenSearch with plugin on Linux
+      if: ${{ runner.os == 'Linux'}}
+      run: /bin/bash -c "./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch &"
+      shell: bash
+
+    - name: Run OpenSearch with plugin on Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: start .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch.bat
+      shell: pwsh
+
+    # Give the OpenSearch process some time to boot up before sending any requires, might need to increase the default time!
+    - name: Sleep while OpenSearch starts
+      uses: peternied/action-sleep@v1
+      with:
+        seconds: 30
+
+    # Verify that the server is operational
+    - name: Check OpenSearch Running on Linux
+      if: ${{ runner.os != 'Windows'}}
+      run: curl https://localhost:9200/_cat/plugins -u 'admin:admin' -k -v
+      shell: bash
+
+    - name: Check OpenSearch Running on Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: |
+        $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:admin")
+        $encodedCredentials = [Convert]::ToBase64String($credentialBytes)
+        $baseCredentials = "Basic $encodedCredentials"
+        $Headers = @{ Authorization = $baseCredentials }
+        Invoke-WebRequest -SkipCertificateCheck -Uri 'https://localhost:9200/_cat/plugins' -Headers $Headers;
+      shell: pwsh

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   setup-script-name:
-    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave empty to indicate one should not be run.'
+    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave this field empty to indicate that no script should be run.'
     required: false
 
 runs:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -2,118 +2,51 @@ name: Plugin Install
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  OPENSEARCH_VERSION: 1.3.7
+  PLUGIN_NAME: opensearch-security
+
 jobs:
-
-  linux-install:
-
-    runs-on: ubuntu-latest
+  plugin-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest] #windows-latest does not currently have a min distribution
+        jdk: [11, 17]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.jdk }}
 
-      - name: Build
-        run: ./gradlew clean assemble -Dbuild.snapshot=false -x bundleSecurityAdminStandalone
-
-      - name: Download OpenSearch Core
-        run: |
-          opensearch_version=`./gradlew properties -q | grep "opensearch_version:" | awk '{print $2}' | sed 's/-SNAPSHOT//g'`
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$opensearch_version/latest/linux/x64/tar/builds/opensearch/dist/opensearch-min-$opensearch_version-linux-x64.tar.gz
-          tar -xzf opensearch-*.tar.gz
-          rm -f opensearch-*.tar.gz
-
-      - name: Move and rename security plugin for installation
-        run: mv build/distributions/opensearch-security-*.zip opensearch-security.zip
-
-      - name: Run OpenSearch with plugin
-        run: |
-          cat > os-ep.sh <<EOF
-          yes | opensearch-plugin install file:///docker-host/security-plugin.zip
-          chmod +x plugins/opensearch-security/tools/install_demo_configuration.sh
-          yes | plugins/opensearch-security/tools/install_demo_configuration.sh
-          chown 1001:1001 -R /opensearch
-          su -c "/opensearch/bin/opensearch" -s /bin/bash opensearch
-          EOF
-          docker build -t opensearch-test:latest -f- . <<EOF
-          FROM ubuntu:latest
-          COPY --chown=1001:1001 os-ep.sh /docker-host/
-          COPY --chown=1001:1001 opensearch-security.zip /docker-host/security-plugin.zip
-          COPY --chown=1001:1001 opensearch* /opensearch/
-          RUN chmod +x /docker-host/os-ep.sh
-          RUN useradd -u 1001 -s /sbin/nologin opensearch
-          ENV PATH="/opensearch/bin:${PATH}"
-          WORKDIR /opensearch/
-          ENTRYPOINT /docker-host/os-ep.sh
-          EOF
-          docker run --name ops -d -p 9200:9200 -p 9600:9600 -i opensearch-test:latest
-
-      - name: Sleep while OpenSearch finishes starting up
-        uses: whatnick/wait-action@v0.1.2
-        with:
-          time: '30s'
-
-      - name: Check OpenSearch Running
-        run: curl -XGET https://localhost:9200 -u 'admin:admin' -k -v
-
-      - name: Get Docker Logs
-        if: always()
-        run: docker logs ops
-
-  windows-install:
-
-    runs-on: windows-latest
-
-    steps:
-      - name: Enable longer filenames for Windows
-        run: git config --system core.longpaths true
-
-      - name: Checkout Plugin
+      - name: Checkout Branch
         uses: actions/checkout@v2
 
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Assemble target plugin
+        uses: gradle/gradle-build-action@v2
         with:
-          java-version: 11
+          arguments: assemble
 
-      - name: Download OpenSearch Core
+      - name: Create Setup Script
+        if: ${{ runner.os == 'Linux' }}
         run: |
-          cd ..
-          Invoke-WebRequest https://artifacts.opensearch.org/snapshots/core/opensearch/1.3.7-SNAPSHOT/opensearch-min-1.3.7-SNAPSHOT-windows-x64-latest.zip -Outfile opensearch-1.3.7.zip
-          tar -xzf opensearch-1.3.7.zip 
-          del opensearch-1.3.7.zip
-          Rename-Item opensearch-* Opensearch
+          cat > setup.sh <<'EOF'
+          chmod +x  ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/plugins/${{ env.PLUGIN_NAME }}/tools/install_demo_configuration.sh 
+          /bin/bash -c "yes | ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/plugins/${{ env.PLUGIN_NAME }}/tools/install_demo_configuration.sh"
+          EOF
 
-      - name: Build Security Plugin with Gradle
+      - name: Create Setup Script
+        if: ${{ runner.os == 'Windows' }}
         run: |
-          .\gradlew.bat assemble -x bundleSecurityAdminStandalone
-        env:
-          _JAVA_OPTIONS: -Xmx4096M
+          New-Item .\setup.bat -type file
+          Set-Content .\setup.bat -Value "powershell.exe -noexit -command `"echo 'y' | .\opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT\plugins\${{ env.PLUGIN_NAME }}\tools\install_demo_configuration.bat`""
+          Get-Content .\setup.bat
 
-      - name: Move and rename security plugin
-        run: move build\distributions\opensearch-security-*.zip ..\opensearch-security.zip
-
-      - name: Install the plugin
-        run: |
-          cd ..
-          'y' | .\Opensearch\bin\opensearch-plugin.bat install file:\a\security\opensearch-security.zip
-          'y', 'y', 'N' | .\Opensearch\plugins\opensearch-security\tools\install_demo_configuration.bat
-
-      - name: Run OpenSearch with plugin
-        run: |
-          cd ..
-          start .\Opensearch\bin\opensearch.bat
-
-      - name: Sleep while OpenSearch finishes starting up
-        run: Start-Sleep -s 30
-
-      - name: Check OpenSearch Running
-        run: |
-          $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:admin")
-          $encodedCredentials = [Convert]::ToBase64String($credentialBytes)
-          $baseCredentials = "Basic $encodedCredentials"
-          $Headers = @{ Authorization = $baseCredentials }
-          Invoke-WebRequest -SkipCertificateCheck -Uri 'https://localhost:9200' -Headers $Headers
+      - name: Run Opensearch with A Single Plugin
+        uses: ./.github/actions/start-opensearch-with-one-plugin
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugin-name: ${{ env.PLUGIN_NAME }}
+          setup-script-name: setup

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] #windows-latest does not currently have a min distribution
+        os: [ubuntu-latest, windows-latest]
         jdk: [8, 11, 14]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest] #windows-latest does not currently have a min distribution
-        jdk: [11, 17]
+        jdk: [8, 11, 14]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

### Description
Backport the plugin install workflow and github action to 1.3. The backport got missed when everything else was merged into one branch. 

Backports merged PR #2271 to 1.3 branch. 

### Testing
Tested for functionality on Java and Windows with JDK 8, 11, 14. It is worth noting that the plugin install workflow seems slightly flaky on jdk 11 alone. I encountered this issue first when I was originally merging PR #2271. For whatever reason the setup.bat file does not always echo the  'yes' response into the install script as expected. It passes over 50% of the time though. 

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
