### PR TITLE
[Backport 2.x] Fixes CVE-2022-42920 by forcing bcel version to resovle to 6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ configurations.all {
         force "io.netty:netty-handler:${versions.netty}"
         force "io.netty:netty-transport:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
+        force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
     }
 }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/2275 to 2.x