### PR TITLE
[Backport 1.3] Fixes CVE-2022-42920 by forcing bcel version to resovle to 6.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ configurations.all {
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"
+        force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
     }
 }
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/2275 to 1.3