### PR TITLE
Fix windows action backport to be callable from other repos

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -31,7 +31,6 @@ runs:
       with:
         url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
 
-
     - name: Download OpenSearch for Linux
       uses: peternied/download-file@v2
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -1,0 +1,119 @@
+name: 'Launch OpenSearch with a single plugin installed'
+description: 'Downloads latest build of OpenSearch, installs a plugin, executes a script and then starts OpenSearch on localhost:9200'
+
+inputs:
+  opensearch-version:
+    description: 'The version of OpenSearch that should be used, e.g "3.0.0"'
+    required: true
+
+  plugin-name:
+    description: 'The name of the plugin to use, such as opensearch-security'
+    required: true
+
+  setup-script-name:
+    description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave empty to indicate one should not be run.'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+
+    # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
+    # Download OpenSearch
+    - name: Download OpenSearch for Windows
+      uses: peternied/download-file@v2
+      if: ${{ runner.os == 'Windows' }}
+      with:
+        url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+
+
+    - name: Download OpenSearch for Linux
+      uses: peternied/download-file@v2
+      if: ${{ runner.os == 'Linux' }}
+      with:
+        url: https://artifacts.opensearch.org/snapshots/core/opensearch/${{ inputs.opensearch-version }}-SNAPSHOT/opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-linux-x64-latest.tar.gz
+
+    # Extract downloaded zip
+    - name: Extract downloaded tar
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        tar -xzf opensearch-*.tar.gz
+        rm -f opensearch-*.tar.gz
+      shell: bash
+
+    - name: Extract downloaded zip
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        tar -xzf opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+        del opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
+      shell: pwsh
+
+    # Install the plugin
+    - name: Install Plugin into OpenSearch for Linux
+      if: ${{ runner.os == 'Linux'}}
+      run: |
+        chmod +x ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch-plugin
+        /bin/bash -c "yes | ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch-plugin install file:$(pwd)/opensearch-security.zip"
+      shell: bash
+
+    - name: Install Plugin into OpenSearch for Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: |
+        'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
+      shell: pwsh
+
+    # Run any configuration scripts
+    - name: Run Setup Script for Linux
+      if: ${{ runner.os == 'Linux' && inputs.setup-script-name != '' }}
+      run: |
+        echo "running linux setup"
+        chmod +x ./${{ inputs.setup-script-name }}.sh
+        ./${{ inputs.setup-script-name }}.sh
+      shell: bash
+
+    - name: Run Setup Script for Windows
+      if: ${{ runner.os == 'Windows' && inputs.setup-script-name != '' }}
+      run: .\${{ inputs.setup-script-name }}.bat
+      shell: pwsh
+
+    # Run OpenSearch
+    - name: Run OpenSearch with plugin on Linux
+      if: ${{ runner.os == 'Linux'}}
+      run: /bin/bash -c "./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/bin/opensearch &"
+      shell: bash
+
+    - name: Run OpenSearch with plugin on Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: start .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch.bat
+      shell: pwsh
+
+    # Give the OpenSearch process some time to boot up before sending any requires, might need to increase the default time!
+    - name: Sleep while OpenSearch starts
+      uses: peternied/action-sleep@v1
+      with:
+        seconds: 30
+
+    # Verify that the server is operational
+    - name: Check OpenSearch Running on Linux
+      if: ${{ runner.os != 'Windows'}}
+      run: curl https://localhost:9200/_cat/plugins -u 'admin:admin' -k -v
+      shell: bash
+
+    - name: Check OpenSearch Running on Windows
+      if: ${{ runner.os == 'Windows'}}
+      run: |
+        $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:admin")
+        $encodedCredentials = [Convert]::ToBase64String($credentialBytes)
+        $baseCredentials = "Basic $encodedCredentials"
+        $Headers = @{ Authorization = $baseCredentials }
+        Invoke-WebRequest -SkipCertificateCheck -Uri 'https://localhost:9200/_cat/plugins' -Headers $Headers;
+      shell: pwsh
+
+    - if: always()
+      run: cat ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/logs/opensearch.log
+      shell: bash

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -53,11 +53,6 @@ runs:
         del opensearch-min-${{ inputs.opensearch-version }}-SNAPSHOT-windows-x64-latest.zip
       shell: pwsh
 
-    # Move and rename the plugin for installation
-    - name: Move and rename the plugin for installation
-      run: mv ./build/distributions/${{ inputs.plugin-name }}-*.zip ${{ inputs.plugin-name }}.zip
-      shell: bash
-
     # Install the plugin
     - name: Install Plugin into OpenSearch for Linux
       if: ${{ runner.os == 'Linux'}}

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -2,121 +2,61 @@ name: Plugin Install
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  OPENSEARCH_VERSION: 2.x.0
+  PLUGIN_NAME: opensearch-security
+
 jobs:
-
-  linux-install:
-
-    runs-on: ubuntu-latest
+  plugin-install:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        jdk: [11, 17]
+    runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
-
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.jdk }}
 
-      - name: Build
-        run: ./gradlew clean assemble -Dbuild.snapshot=false
-
-      - name: Download OpenSearch Core
-        run: |
-          opensearch_version=`./gradlew properties -q | grep "opensearch_version:" | awk '{print $2}' | sed 's/-SNAPSHOT//g'`
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/$opensearch_version/latest/linux/x64/tar/builds/opensearch/dist/opensearch-min-$opensearch_version-linux-x64.tar.gz
-          tar -xzf opensearch-*.tar.gz
-          rm -f opensearch-*.tar.gz
-
-      - name: Move and rename security plugin for installation
-        run: mv build/distributions/opensearch-security-*.zip opensearch-security.zip
-
-      - name: Run OpenSearch with plugin
-        run: |
-          cat > os-ep.sh <<EOF
-          yes | opensearch-plugin install file:///docker-host/security-plugin.zip
-          chmod +x plugins/opensearch-security/tools/install_demo_configuration.sh
-          yes | plugins/opensearch-security/tools/install_demo_configuration.sh
-          chown 1001:1001 -R /opensearch
-          su -c "/opensearch/bin/opensearch" -s /bin/bash opensearch
-          EOF
-          docker build -t opensearch-test:latest -f- . <<EOF
-          FROM ubuntu:latest
-          COPY --chown=1001:1001 os-ep.sh /docker-host/
-          COPY --chown=1001:1001 opensearch-security.zip /docker-host/security-plugin.zip
-          COPY --chown=1001:1001 opensearch* /opensearch/
-          RUN chmod +x /docker-host/os-ep.sh
-          RUN useradd -u 1001 -s /sbin/nologin opensearch
-          ENV PATH="/opensearch/bin:${PATH}"
-          WORKDIR /opensearch/
-          ENTRYPOINT /docker-host/os-ep.sh
-          EOF
-          docker run --name ops -d -p 9200:9200 -p 9600:9600 -i opensearch-test:latest
-
-      - name: Sleep while OpenSearch finishes starting up
-        uses: whatnick/wait-action@v0.1.2
-        with:
-          time: '30s'
-
-      - name: Check OpenSearch Running
-        run: curl -XGET https://localhost:9200 -u 'admin:admin' -k -v
-
-      - name: Get Docker Logs
-        if: always()
-        run: docker logs ops
-
-      - name: Run sanity tests
-        run: ./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=admin
-
-  windows-install:
-
-    runs-on: windows-latest
-
-    steps:
-      - name: Enable longer filenames for Windows
-        run: git config --system core.longpaths true
-
-      - name: Checkout Plugin
+      - name: Checkout Branch
         uses: actions/checkout@v2
 
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Assemble target plugin
+        uses: gradle/gradle-build-action@v2
         with:
-          java-version: 11
+          arguments: assemble
 
-      - name: Download OpenSearch Core
+      # Move and rename the plugin for installation
+      - name: Move and rename the plugin for installation
+        run: mv ./build/distributions/${{ env.PLUGIN_NAME }}-*.zip ${{ env.PLUGIN_NAME }}.zip
+        shell: bash
+
+      - name: Create Setup Script
+        if: ${{ runner.os == 'Linux' }}
         run: |
-          cd ..
-          Invoke-WebRequest https://artifacts.opensearch.org/snapshots/core/opensearch/2.5.0-SNAPSHOT/opensearch-min-2.5.0-SNAPSHOT-windows-x64-latest.zip -Outfile opensearch-2.5.0.zip
-          tar -xzf opensearch-2.5.0.zip 
-          del opensearch-2.5.0.zip
-          Rename-Item opensearch-* Opensearch
+          cat > setup.sh <<'EOF'
+          chmod +x  ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/plugins/${{ env.PLUGIN_NAME }}/tools/install_demo_configuration.sh 
+          /bin/bash -c "./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/plugins/${{ env.PLUGIN_NAME }}/tools/install_demo_configuration.sh -y"
+          EOF
 
-      - name: Build Security Plugin with Gradle
+      - name: Create Setup Script
+        if: ${{ runner.os == 'Windows' }}
         run: |
-          .\gradlew.bat assemble
-        env:
-          _JAVA_OPTIONS: -Xmx4096M
+          New-Item .\setup.bat -type file
+          Set-Content .\setup.bat -Value "powershell.exe .\opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT\plugins\${{ env.PLUGIN_NAME }}\tools\install_demo_configuration.bat -y"
+          Get-Content .\setup.bat
 
-      - name: Move and rename security plugin
-        run: move build\distributions\opensearch-security-*.zip ..\opensearch-security.zip
+      - name: Run Opensearch with A Single Plugin
+        uses: ./.github/actions/start-opensearch-with-one-plugin
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugin-name: ${{ env.PLUGIN_NAME }}
+          setup-script-name: setup
 
-      - name: Install the plugin
-        run: |
-          cd ..
-          'y' | .\Opensearch\bin\opensearch-plugin.bat install file:\a\security\opensearch-security.zip
-          'y', 'y', 'N' | .\Opensearch\plugins\opensearch-security\tools\install_demo_configuration.bat
-
-      - name: Run OpenSearch with plugin
-        run: |
-          cd ..
-          start .\Opensearch\bin\opensearch.bat
-
-      - name: Sleep while OpenSearch finishes starting up
-        run: Start-Sleep -s 30
-
-      - name: Check OpenSearch Running
-        run: |
-          $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:admin")
-          $encodedCredentials = [Convert]::ToBase64String($credentialBytes)
-          $baseCredentials = "Basic $encodedCredentials"
-          $Headers = @{ Authorization = $baseCredentials }
-          Invoke-WebRequest -SkipCertificateCheck -Uri 'https://localhost:9200' -Headers $Headers
+      - name: Run sanity tests
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=admin

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           arguments: assemble
 
+      # Move and rename the plugin for installation
+      - name: Move and rename the plugin for installation
+        run: mv ./build/distributions/${{ env.PLUGIN_NAME }}-*.zip ${{ env.PLUGIN_NAME }}.zip
+        shell: bash
+
       - name: Create Setup Script
         if: ${{ runner.os == 'Linux' }}
         run: |
@@ -42,6 +47,7 @@ jobs:
         run: |
           New-Item .\setup.bat -type file
           Set-Content .\setup.bat -Value "powershell.exe .\opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT\plugins\${{ env.PLUGIN_NAME }}\tools\install_demo_configuration.bat -y"
+          Get-Content .\setup.bat
 
       - name: Run Opensearch with A Single Plugin
         uses: ./.github/actions/start-opensearch-with-one-plugin

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -62,6 +62,11 @@ if %cluster_mode% == 0 (
     )
 )
 
+if %assumeyes% == 1 (
+  set "initsecurity=1"
+  set "cluster_mode=1"
+)
+
 set BASE_DIR=%SCRIPT_DIR%\..\..\..\
 if not exist %BASE_DIR% (
     echo "basedir does not exist"

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -97,6 +97,10 @@ if [ "$cluster_mode" == 0 ] && [ "$assumeyes" == 0 ]; then
 	esac
 fi
 
+if [ "$assumeyes" == 1 ]; then
+  cluster_mode=1
+  initsecurity=1
+fi
 
 set -e
 BASE_DIR="$DIR/../../.."


### PR DESCRIPTION
### Description
Addresses changes that standardize the plugin install workflow across versions and makes older versions compatible with being called from other repos. 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
