### PR TITLE
Remove duplicate block of code in DynamicConfigFactory

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -145,16 +145,6 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             log.info("Static resources will not be loaded.");
         }
         
-        if(opensearchSettings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES, true)) {
-            try {
-                loadStaticConfig();
-            } catch (IOException e) {
-                throw new StaticResourceException("Unable to load static resources due to "+e, e);
-            }
-        } else {
-            log.info("Static resources will not be loaded.");
-        }
-        
         registerDCFListener(this.iab);
         this.cr.subscribeOnChange(this);
     }


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

While going through the code to understand how the security plugin persists data in a system index, I came across a duplicate block of code where the constructor of DynamicConfigFactory is performing `loadStaticConfig` twice. This PR removes the duplicate block so that it only loads static config once from `static_roles.yml`, `static_action_groups.yml` and `static_tenants.yml`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
