### PR TITLE
Remove updateVersion tests that keeps breaking on env issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,17 +154,6 @@ jobs:
 
     - run: ./gradlew clean assemble -Dbuild.version_qualifier=${{ env.TEST_QUALIFIER }} && test -s ./build/distributions/opensearch-security-${{ env.SECURITY_PLUGIN_VERSION_ONLY_NUMBER }}-${{ env.TEST_QUALIFIER }}-SNAPSHOT.zip
 
-    - name: Verify updateVersion gradle tasks works
-      env:
-        ExpectedVersionString: "opensearch_version: 2.1.0-SNAPSHOT"
-      run:  |
-        ## Make sure the current doesn't match the test version
-        test "$(./gradlew properties | grep opensearch.version)" != "$ExpectedVersionString"
-        ## Update the new version to 2.1.0
-        ./gradlew clean updateVersion -DnewVersion=2.1.0-SNAPSHOT
-        ## Make sure the version matches expectation
-        test "$(./gradlew properties | grep opensearch.version)" = "$ExpectedVersionString"
-
     - name: List files in the build directory if there was an error
       run: ls -al ./build/distributions/
       if: failure()


### PR DESCRIPTION
### Description
The upgrade check tests were a great idea that ultimately exposes some problems with build compabtility between versions.  While we could upgrade the test to re-install gradle after the upgrade since we are effectively 'down grading' this is a really complex way to confirm that code we don't often mess with works.

### Issues
- Resolves https://github.com/opensearch-project/security/issues/2314 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
