### PR TITLE
Remove jackson-databind and jackson-annotations dependency now coming from core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build test -Dbuild.snapshot=false
+          build test --refresh-dependencies -Dbuild.snapshot=false
           -x integrationTest
           -x spotlessCheck
           -x checkstyleMain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build test --refresh-dependencies -Dbuild.snapshot=false
+          build test -Dbuild.snapshot=false
           -x integrationTest
           -x spotlessCheck
           -x checkstyleMain

--- a/build.gradle
+++ b/build.gradle
@@ -426,10 +426,6 @@ dependencies {
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 
-
-
-    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
     //integration test framework:

--- a/build.gradle
+++ b/build.gradle
@@ -256,7 +256,6 @@ configurations {
             force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
             force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
             force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
-            force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
             force "io.netty:netty-buffer:${versions.netty}"
             force "io.netty:netty-common:${versions.netty}"
             force "io.netty:netty-handler:${versions.netty}"
@@ -430,7 +429,6 @@ dependencies {
 
 
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -256,6 +256,7 @@ configurations {
             force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
             force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
             force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
+            force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
             force "io.netty:netty-buffer:${versions.netty}"
             force "io.netty:netty-common:${versions.netty}"
             force "io.netty:netty-handler:${versions.netty}"


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

jackson-databind and jackson-annotations were added as api dependencies in `server` of opensearch core. The security plugin now gets these dependencies transitively and does not need direct dependencies on the jars.

PR in core where the dependencies are added: https://github.com/opensearch-project/OpenSearch/pull/5366

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance 

### Issues Resolved

https://github.com/opensearch-project/security/issues/2324

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
