### PR TITLE
Changing logging type to give warning for basic auth with no creds

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -267,7 +267,7 @@ public class BackendRegistry {
 
                 if(authDomain.isChallenge() && httpAuthenticator.reRequestAuthentication(channel, null)) {
                     auditLog.logFailedLogin("<NONE>", false, null, request);
-                    log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                    log.warn("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                     return false;
                 } else {
                     //no reRequest possible


### PR DESCRIPTION
Signed-off-by: Abhi Kalra <abhivka@amazon.com>

### Description
[Describe what this change achieves]
* Category 
Bug Fix

* Why these changes are required?
Changing logging type to give warning for basic auth with no creds.

* What is the old behavior before changes and new behavior after changes?
When using basic auth without credentials, users just get a message telling "Unauthorized" which is not very descriptive. As an admin, I don't have any visibility into why my users are not able to login without enabling this log which is currently at trace level. Hence, changing log level to warn.

### Issues Resolved
https://github.com/opensearch-project/security/issues/2346

Is this a backport? If so, please add backport PR # and/or commits #
We want to backport it to latest OS versions.

 Signed-off-by: Abhi Kalra <abhivka@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
