### PR TITLE
Update cxf-core to 3.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ dependencies {
 
     runtimeOnly 'net.minidev:accessors-smart:2.4.7'
 
-    runtimeOnly 'org.apache.cxf:cxf-core:3.4.5'
+    runtimeOnly 'org.apache.cxf:cxf-core:3.5.5'
     implementation 'org.apache.cxf:cxf-rt-rs-json-basic:3.4.5'
     runtimeOnly 'org.apache.cxf:cxf-rt-security:3.4.5'
 


### PR DESCRIPTION
Signed-off-by: Stephen Crawford <steecraw@amazon.com>

### Description
Updates the cxf-core dependency to use version 3.5.5.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
