### PR TITLE
Added index search privilege to a security analytics full access role

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -307,6 +307,7 @@ security_analytics_full_access:
       allowed_actions:
         - 'indices:admin/mapping/put'
         - 'indices:admin/mappings/get'
+        - 'indices:data/read/search"'
 
 # Allows users to view and acknowledge alerts
 security_analytics_ack_alerts:


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

### Description
[Describe what this change achieves]
* Enhancement
* New index privilege has been added in order to security analytics full access role
* Users with security analytics full access role can create detectors on indices

### Issues Resolved
https://github.com/opensearch-project/security-analytics/issues/182

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
