### PR TITLE
Incorporate changes introduced in PR branch when running BWC check for CI

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -22,6 +22,8 @@ runs:
     - name: Checkout Security Repo
       if: ${{ inputs.plugin-branch == 'this' }}
       uses: actions/checkout@v2
+      with:
+        path: ${{ inputs.plugin-branch }}
 
     - uses: actions/checkout@v3
       if: ${{ inputs.plugin-branch != 'this' }}

--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -19,14 +19,14 @@ runs:
       run: git config --system core.longpaths true
       shell: pwsh
 
-    - name: Checkout Security Repo
-      if: ${{ inputs.plugin-branch == 'this' }}
+    - name: Checkout Branch from Fork
+      if: ${{ inputs.plugin-branch == 'current_branch' }}
       uses: actions/checkout@v2
       with:
         path: ${{ inputs.plugin-branch }}
 
     - uses: actions/checkout@v3
-      if: ${{ inputs.plugin-branch != 'this' }}
+      if: ${{ inputs.plugin-branch != 'current_branch' }}
       with:
         repository: opensearch-project/security
         ref: ${{ inputs.plugin-branch }}

--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -19,7 +19,12 @@ runs:
       run: git config --system core.longpaths true
       shell: pwsh
 
+    - name: Checkout Security Repo
+      if: ${{ inputs.plugin-branch == 'this' }}
+      uses: actions/checkout@v2
+
     - uses: actions/checkout@v3
+      if: ${{ inputs.plugin-branch != 'this' }}
       with:
         repository: opensearch-project/security
         ref: ${{ inputs.plugin-branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       uses: ./.github/actions/run-bwc-suite
       with:
         plugin-previous-branch: "2.x"
-        plugin-next-branch: "this"
+        plugin-next-branch: "current_branch"
         report-artifact-name: bwc-${{ matrix.platform }}-jdk${{ matrix.jdk }}
 
   code-ql:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
       uses: ./.github/actions/run-bwc-suite
       with:
         plugin-previous-branch: "2.x"
-        plugin-next-branch: "main"
+        plugin-next-branch: "this"
         report-artifact-name: bwc-${{ matrix.platform }}-jdk${{ matrix.jdk }}
 
   code-ql:

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -394,10 +394,10 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader  {
         }
 
         @Override
-        public void visitDocument(final int docID, StoredFieldVisitor visitor) throws IOException {
+        public void document(final int docID, StoredFieldVisitor visitor) throws IOException {
             visitor = getDlsFlsVisitor(visitor);
             try {
-                in.visitDocument(docID, visitor);
+                in.document(docID, visitor);
             } finally {
                 finishVisitor(visitor);
             }


### PR DESCRIPTION
### Description

Uses the changes from the PR's branch when running `backwards-compatibility` check during CI. The current `backwards-compatibility` check checks out branches from the main repo and ignores changes introduced in a PR.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/2365

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
