### PR TITLE
Update tool scripts to run in windows

### DIFF
--- a/tools/audit_config_migrater.bat
+++ b/tools/audit_config_migrater.bat
@@ -1,16 +1,19 @@
 @echo off
-set SCRIPT_DIR=%~dp0
+set DIR=%~dp0
 
 echo "**************************************************************************"
 echo "** This tool will be deprecated in the next major release of OpenSearch **"
 echo "** https://github.com/opensearch-project/security/issues/1755           **"
 echo "**************************************************************************"
 
-rem comparing to empty string makes this equivalent to bash -v check on env var
-if not "%OPENSEARCH_JAVA_HOME%" == "" (
+if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
-) else (
+) else if defined JAVA_HOME (
   set BIN_PATH="%JAVA_HOME%\bin\java.exe"
+) else (
+  echo Unable to find java runtime
+  echo OPENSEARCH_JAVA_HOME or JAVA_HOME must be defined
+  exit /b 1
 )
 
-%BIN_PATH% -cp "%SCRIPT_DIR%\..\..\opendistro_security_ssl\*;%SCRIPT_DIR%\..\deps\*;%SCRIPT_DIR%\..\*;%SCRIPT_DIR%\..\..\..\lib\*" org.opensearch.security.tools.AuditConfigMigrater %*
+%BIN_PATH% -cp "%DIR%\..\*;%DIR%\..\..\..\lib\*;%DIR%\..\deps\*" org.opensearch.security.tools.AuditConfigMigrater %*

--- a/tools/hash.bat
+++ b/tools/hash.bat
@@ -1,17 +1,20 @@
 @echo off
-set SCRIPT_DIR=%~dp0
+set DIR=%~dp0
 
 echo "**************************************************************************"
 echo "** This tool will be deprecated in the next major release of OpenSearch **"
 echo "** https://github.com/opensearch-project/security/issues/1755           **"
 echo "**************************************************************************"
 
-rem comparing to empty string makes this equivalent to bash -v check on env var
-if not "%OPENSEARCH_JAVA_HOME%" == "" (
+if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
-) else (
+) else if defined JAVA_HOME (
   set BIN_PATH="%JAVA_HOME%\bin\java.exe"
+) else (
+  echo Unable to find java runtime
+  echo OPENSEARCH_JAVA_HOME or JAVA_HOME must be defined
+  exit /b 1
 )
 
-%BIN_PATH% -cp "%SCRIPT_DIR%\..\..\opendistro_security_ssl\*;%SCRIPT_DIR%\..\deps\*;%SCRIPT_DIR%\..\*;%SCRIPT_DIR%\..\..\..\lib\*" org.opensearch.security.tools.Hasher %*
+%BIN_PATH% -cp "%DIR%\..\*;%DIR%\..\..\..\lib\*;%DIR%\..\deps\*" org.opensearch.security.tools.Hasher %*
 

--- a/tools/securityadmin.bat
+++ b/tools/securityadmin.bat
@@ -1,16 +1,19 @@
 @echo off
-set SCRIPT_DIR=%~dp0
+set DIR=%~dp0
 
 echo "**************************************************************************"
 echo "** This tool will be deprecated in the next major release of OpenSearch **"
 echo "** https://github.com/opensearch-project/security/issues/1755           **"
 echo "**************************************************************************"
 
-rem comparing to empty string makes this equivalent to bash -v check on env var
-if not "%OPENSEARCH_JAVA_HOME%" == "" (
+if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
-) else (
+) else if defined JAVA_HOME (
   set BIN_PATH="%JAVA_HOME%\bin\java.exe"
+) else (
+  echo Unable to find java runtime
+  echo OPENSEARCH_JAVA_HOME or JAVA_HOME must be defined
+  exit /b 1
 )
 
-%BIN_PATH% -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "%SCRIPT_DIR%\..\..\opendistro_security-ssl\*;%SCRIPT_DIR%\..\deps\*;%SCRIPT_DIR%\..\*;%SCRIPT_DIR%\..\..\..\lib\*" org.opensearch.security.tools.SecurityAdmin %* 2> nul
+%BIN_PATH% -Dorg.apache.logging.log4j.simplelog.StatusLogger.level=OFF -cp "%DIR%\..\*;%DIR%\..\..\..\lib\*;%DIR%\..\deps\*" org.opensearch.security.tools.SecurityAdmin %* 2> nul


### PR DESCRIPTION
### Description
Update tool scripts to run in windows.  They were missed during support for Windows, will backport this to 1.3.X as well

### Issues Resolved
- Resolves #2368

### Testing
Manually tested on my windows machine

#### Failure cause
```
...\opensearch-2.4.1\plugins\opensearch-security\tools>hash.bat test
OPENSEARCH_JAVA_HOME or JAVA_HOME must be defined
```
#### Success
```
.\opensearch-2.4.1\plugins\opensearch-security\tools>set OPENSEARCH_JAVA_HOME="...\opensearch-2.4.1-windows-x64\opensearch-2.4.1\jdk"
.\opensearch-2.4.1-windows-x64\opensearch-2.4.1\plugins\opensearch-security\tools>hash.bat test
Picked up JAVA_TOOL_OPTIONS: -Dlog4j2.formatMsgNoLookups=true
[Password:]
$2y$12$KjgWovKVps84wOMlwOQtu.b8TRL9uFrqv5eZ3/N4RgcHnOImln5aG
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
