### PR TITLE
Re-add jackson-annotations and jackson-databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -458,6 +458,9 @@ dependencies {
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 
+    implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
     //integration test framework:


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Reverts https://github.com/opensearch-project/security/pull/2325 and adds jackson-annotations and jackson-databind back as direct dependencies.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

https://github.com/opensearch-project/OpenSearch/issues/5504

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
