### PR TITLE
Add action indices:admin/index_template/* to cluster_manage_index_tem…

### DIFF
--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -209,6 +209,7 @@ cluster_manage_index_templates:
   allowed_actions:
   - "indices:admin/template/*"
   - "indices:admin/index_template/*"
+  - "cluster:admin/component_template/*"
   type: "cluster"
   description: "Manage index templates"
 cluster_manage_pipelines:

--- a/src/main/resources/static_config/static_action_groups.yml
+++ b/src/main/resources/static_config/static_action_groups.yml
@@ -208,6 +208,7 @@ cluster_manage_index_templates:
   static: true
   allowed_actions:
   - "indices:admin/template/*"
+  - "indices:admin/index_template/*"
   type: "cluster"
   description: "Manage index templates"
 cluster_manage_pipelines:


### PR DESCRIPTION
…plates (#2407)

Signed-off-by: Stefan Reuter <stefan.reuter@reucon.com>

### Description
Adds permissions to manage composable templates to the default action group  `cluster_manage_index_templates`.

### Issues Resolved
#2407 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
