### PR TITLE
Fix testCheckForDeprecatedSettingFoundLegacy was broken with changes in calling patterns

### DIFF
--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -58,6 +58,6 @@ public class DeprecatedSettingsTest {
 
         checkForDeprecatedSetting(settings, "legacyKey", "properKey");
 
-        verify(logger).deprecate(eq("legacyKey"), anyString(), any());
+        verify(logger).deprecate(eq("legacyKey"), anyString(), any(), any());
     }
 }


### PR DESCRIPTION
### Description
We've seen failures with this mock test cases seeing different parameters.  This failure was completely blocking https://github.com/opensearch-project/security/pull/2427

I don't see an obvious change that could cause this, it could be changes in compiler settings of how the 'params' argument was treated differently, or a shift in Mockito version from core.

### Testing
Reproduced locally, and then with this fix it has been resolved

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
