### PR TITLE
[Backport 2.x] Updates DlsFlsFilterLeafReader with Lucene change and fix broken deprecation logger test

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -395,10 +395,10 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader  {
         }
 
         @Override
-        public void visitDocument(final int docID, StoredFieldVisitor visitor) throws IOException {
+        public void document(final int docID, StoredFieldVisitor visitor) throws IOException {
             visitor = getDlsFlsVisitor(visitor);
             try {
-                in.visitDocument(docID, visitor);
+                in.document(docID, visitor);
             } finally {
                 finishVisitor(visitor);
             }

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -58,6 +58,6 @@ public class DeprecatedSettingsTest {
 
         checkForDeprecatedSetting(settings, "legacyKey", "properKey");
 
-        verify(logger).deprecate(eq("legacyKey"), anyString(), any());
+        verify(logger).deprecate(eq("legacyKey"), anyString(), any(), any());
     }
 }


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/security/commit/7a6909f6912e888caa500a281bd7fe5d7e6c1ecf from https://github.com/opensearch-project/security/pull/2362 - Updates DlsFlsFilterLeafReader to use new Lucene document() instead of visitDocument()

Backport https://github.com/opensearch-project/security/commit/710baecff933f5e6bb936abbfa758daf7f26e7e2 from https://github.com/opensearch-project/security/pull/2428 - Fix testCheckForDeprecatedSettingFoundLegacy was broken with changes in calling patterns

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
