### PR TITLE
Publish snapshots to maven

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,42 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+      branches: [
+        main
+        1.*
+        2.*
+      ]
+
+jobs:
+  build-and-publish-snapshots:
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    if: github.repository == 'opensearch-project/security'
+    runs-on: ${{ matrix.platform }}
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.jdk }}
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishMavenJavaPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -230,6 +230,16 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            name = "Snapshots" //  optional target repository name
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
 
 repositories {


### PR DESCRIPTION
### Description
Adds a workflow to publish snapshots to the OpenSearch-Project maven repository when updates are pushed to main, 1.* branches, or 2.* branches.

Following the example from https://github.com/opensearch-project/opensearch-sdk-java

### Issues Resolved
- Related https://github.com/opensearch-project/opensearch-build/issues/3199

### Testing
Note; cannot test the actual workflow, but I've confirmed the artifacts produced match what we need to consume

```
% find ~/.m2/* | grep security                                                                                                                                                                        ~/git/security
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security/maven-metadata-local.xml
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security/3.0.0.0-SNAPSHOT
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security/3.0.0.0-SNAPSHOT/maven-metadata-local.xml
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security/3.0.0.0-SNAPSHOT/opensearch-security-3.0.0.0-SNAPSHOT.zip
/home/petern/.m2/repository/org/opensearch/plugin/opensearch-security/3.0.0.0-SNAPSHOT/opensearch-security-3.0.0.0-SNAPSHOT.pom
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
