### PR TITLE
Remove unneeded jdk and platform from publishing workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -11,13 +11,7 @@ on:
 
 jobs:
   build-and-publish-snapshots:
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
-    if: github.repository == 'opensearch-project/security'
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write
@@ -27,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: ${{ matrix.jdk }}
+          java-version: 11
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
### Description
Maven doesn't have a way to filter published artifacts by platform build for and since our plugin zip works in both platforms switching to a single publishing leg.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
