### PR TITLE
[Backport 2.x] Add release notes for 2.6.0.0

### DIFF
--- a/release-notes/opensearch-security.release-notes-2.6.0.0.md
+++ b/release-notes/opensearch-security.release-notes-2.6.0.0.md
@@ -1,0 +1,15 @@
+## 2023-02-28 Version 2.6.0.0
+
+Compatible with OpenSearch 2.6.0
+
+### Enhancements
+
+* Add actions cluster:admin/component_template/* to cluster_manage_index_templates ([#2409](https://github.com/opensearch-project/security/pull/2409))
+* Publish snapshots to maven ([#2438](https://github.com/opensearch-project/security/pull/2438))
+* Integrate k-NN functionality with security plugin ([#2274](https://github.com/opensearch-project/security/pull/2274))
+
+### Maintenance
+
+* Updates toString calls affected by change in method signature ([#2418](https://github.com/opensearch-project/security/pull/2418))
+* Updates DlsFlsFilterLeafReader with Lucene change and fix broken deprecation logger test ([#2429](https://github.com/opensearch-project/security/pull/2429))
+* Add CODEOWNERS ([#2445](https://github.com/opensearch-project/security/pull/2445))


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/security/pull/2456