### PR TITLE
Support multitenancy for the anonymous user

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -338,8 +338,12 @@ public class BackendRegistry {
             }
 
             if(authCredenetials == null && anonymousAuthEnabled) {
-            	threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, User.ANONYMOUS);
-            	auditLog.logSucceededLogin(User.ANONYMOUS.getName(), false, null, request);
+                final String tenant = Utils.coalesce(request.header("securitytenant"), request.header("security_tenant"));
+                User anonymousUser = new User(User.ANONYMOUS.getName(), new HashSet<String>(User.ANONYMOUS.getRoles()), null);
+                anonymousUser.setRequestedTenant(tenant);
+
+                threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, anonymousUser);
+                auditLog.logSucceededLogin(anonymousUser.getName(), false, null, request);
                 if (isDebugEnabled) {
                     log.debug("Anonymous User is authenticated");
                 }

--- a/src/test/resources/multitenancy/config_anonymous.yml
+++ b/src/test/resources/multitenancy/config_anonymous.yml
@@ -1,0 +1,39 @@
+---
+_meta:
+  type: "config"
+  config_version: 2
+config:
+  dynamic:
+    filtered_alias_mode: "warn"
+    disable_rest_auth: false
+    disable_intertransport_auth: false
+    respect_request_indices_options: false
+    license: null
+    kibana:
+      multitenancy_enabled: true
+      server_username: "kibanaserver"
+      index: ".kibana"
+    http:
+      anonymous_auth_enabled: true
+      xff:
+        enabled: true
+        internalProxies: ".*"
+        remoteIpHeader: "x-forwarded-for"
+    authc:
+      basic_internal_auth_domain:
+        http_enabled: true
+        transport_enabled: true
+        order: 0
+        http_authenticator:
+          challenge: true
+          type: "basic"
+          config: {}
+        authentication_backend:
+          type: "intern"
+          config: {}
+        description: "Migrated from v6"
+    authz: {}
+    do_not_fail_on_forbidden: true
+    multi_rolespan_enabled: false
+    hosts_resolver_mode: "ip-only"
+    transport_userrname_attribute: null

--- a/src/test/resources/multitenancy/roles.yml
+++ b/src/test/resources/multitenancy/roles.yml
@@ -225,6 +225,7 @@ opendistro_security_all_access:
   - tenant_patterns:
     - "adm_tenant"
     - "test_tenant_ro"
+    - "anonymous_tenant"
     allowed_actions:
     - "kibana_all_write"
 opendistro_security_logstash:
@@ -480,3 +481,22 @@ opendistro_security_role_tenant_parameters_substitution:
     - "${attr.internal.attribute1}_1"
     allowed_actions:
     - "kibana_all_write"
+opendistro_security_anonymous_multitenancy:
+  reserved: false
+  hidden: false
+  description: "PR#2459"
+  cluster_permissions:
+  - "OPENDISTRO_SECURITY_CLUSTER_COMPOSITE_OPS_RO"
+  index_permissions:
+  - index_patterns:
+    - "*"
+    dls: null
+    fls: null
+    masked_fields: null
+    allowed_actions:
+    - "OPENDISTRO_SECURITY_READ"
+  tenant_permissions:
+  - tenant_patterns:
+    - "anonymous_tenant"
+    allowed_actions:
+    - "kibana_all_read"

--- a/src/test/resources/multitenancy/roles_mapping.yml
+++ b/src/test/resources/multitenancy/roles_mapping.yml
@@ -169,3 +169,13 @@ opendistro_security_role_tenant_parameters_substitution:
   - "user_tenant_parameters_substitution"
   and_backend_roles: []
   description: "PR#819 / Issue#817"
+opendistro_security_anonymous_multitenancy:
+  reserved: false
+  hidden: false
+  backend_roles:
+  - opendistro_security_anonymous_backendrole
+  hosts: []
+  users:
+  - "opendistro_security_anonymous"
+  and_backend_roles: []
+  description: "PR#2459"

--- a/src/test/resources/multitenancy/roles_tenants.yml
+++ b/src/test/resources/multitenancy/roles_tenants.yml
@@ -62,3 +62,7 @@ tenant_parameters_substitution_1:
   reserved: false
   hidden: false
   description: "PR#819 / Issue#817"
+anonymous_tenant:
+  reserved: false
+  hidden: false
+  description: "PR#2459"


### PR DESCRIPTION
### Description

* Category Bug fix

* Why these changes are required?
Multitenancy for the anonymous user is not supported. It's implied in Opensearch-Dashboards that this isn't the expected behaviour. From the UI, anonymous users can switch between tenants but in the end all the operations are run on the
Global tenant (even when the UI says the user is in a different tenant).

* What is the old behavior before changes and new behavior after changes?
The current version of the plugin supports multitenancy for all the users but not for the anonymous user.
The header 'securitytenant' is ignored when this user is authorized. Therefore, all the operations run
with it, use the default tenant - normally the 'Global' tenant -.
This patch fixes this issue assigning the selected tenant - defined by the 'securitytenant' header -
to the anonymous user.

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1336

### Testing
- unit testing
- manual testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
