### PR TITLE
Revert "Updates toString calls affected by change in method signature"

### DIFF
--- a/src/main/java/org/opensearch/security/action/whoami/WhoAmIResponse.java
+++ b/src/main/java/org/opensearch/security/action/whoami/WhoAmIResponse.java
@@ -34,7 +34,6 @@ import org.opensearch.common.io.stream.StreamInput;
 import org.opensearch.common.io.stream.StreamOutput;
 import org.opensearch.common.xcontent.ToXContent;
 import org.opensearch.common.xcontent.XContentBuilder;
-import org.opensearch.common.xcontent.XContentType;
 
 public class WhoAmIResponse extends ActionResponse implements ToXContent {
     
@@ -106,6 +105,6 @@ public class WhoAmIResponse extends ActionResponse implements ToXContent {
 
     @Override
     public String toString() {
-        return Strings.toString(XContentType.JSON,this, true, true);
+        return Strings.toString(this, true, true);
     }
 }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -63,7 +63,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.env.Environment;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.config.AuditConfig;
@@ -380,7 +379,7 @@ public class ConfigurationRepository {
         if (logComplianceEvent && auditLog.getComplianceConfig().isEnabled()) {
             CType configurationType = configTypes.iterator().next();
             Map<String, String> fields = new HashMap<String, String>();
-            fields.put(configurationType.toLCString(), Strings.toString(XContentType.JSON, retVal.get(configurationType)));
+            fields.put(configurationType.toLCString(), Strings.toString(retVal.get(configurationType)));
             auditLog.logDocumentRead(this.securityIndex, configurationType.toLCString(), null, fields);
         }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -52,7 +52,6 @@ import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.xcontent.NamedXContentRegistry;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.ParsedQuery;
 import org.opensearch.rest.RestStatus;
 import org.opensearch.search.DocValueFormat;
@@ -210,10 +209,10 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     StringBuilder sb = new StringBuilder();
 
                     if (searchRequest.source() != null) {
-                        sb.append(Strings.toString(XContentType.JSON, searchRequest.source()) + System.lineSeparator());
+                        sb.append(Strings.toString(searchRequest.source()) + System.lineSeparator());
                     }
 
-                    sb.append(Strings.toString(XContentType.JSON, af) + System.lineSeparator());
+                    sb.append(Strings.toString(af) + System.lineSeparator());
 
                     LogManager.getLogger("debuglogger").error(sb.toString());
 
@@ -223,7 +222,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     searchRequest.requestCache(Boolean.FALSE);
                 } else {
                 	LogManager.getLogger("debuglogger").error("Shard requestcache enabled for "
-                            + (searchRequest.source() == null ? "<NULL>" : Strings.toString(XContentType.JSON, searchRequest.source())));
+                            + (searchRequest.source() == null ? "<NULL>" : Strings.toString(searchRequest.source())));
                 }
 
             } else {

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -999,7 +999,7 @@ public class SecurityAdmin {
         try {
             sb.append("ClusterHealthRequest:"+System.lineSeparator());
 			ClusterHealthResponse nir = restHighLevelClient.cluster().health(new ClusterHealthRequest(), RequestOptions.DEFAULT);
-			sb.append(Strings.toString(XContentType.JSON, nir, true, true));
+			sb.append(Strings.toString(nir, true, true));
         } catch (Exception e1) {
             sb.append(ExceptionsHelper.stackTrace(e1));
         }

--- a/src/test/java/org/opensearch/security/ConfigTests.java
+++ b/src/test/java/org/opensearch/security/ConfigTests.java
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import org.opensearch.common.Strings;
 import org.opensearch.common.collect.Tuple;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.securityconf.Migration;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
@@ -60,18 +59,18 @@ public class ConfigTests {
         Tuple<SecurityDynamicConfiguration<RoleV7>, SecurityDynamicConfiguration<TenantV7>> rolesResult = Migration.migrateRoles((SecurityDynamicConfiguration<RoleV6>)load("./legacy/securityconfig_v6/roles.yml", CType.ROLES),
                 (SecurityDynamicConfiguration<RoleMappingsV6>)load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING));
         
-        System.out.println(Strings.toString(XContentType.JSON, rolesResult.v2(), true, false));
-        System.out.println(Strings.toString(XContentType.JSON, rolesResult.v1(), true, false));
+        System.out.println(Strings.toString(rolesResult.v2(), true, false));
+        System.out.println(Strings.toString(rolesResult.v1(), true, false));
         
         
         SecurityDynamicConfiguration<ActionGroupsV7> actionGroupsResult = Migration.migrateActionGroups((SecurityDynamicConfiguration<ActionGroupsV6>)load("./legacy/securityconfig_v6/action_groups.yml", CType.ACTIONGROUPS));
-        System.out.println(Strings.toString(XContentType.JSON, actionGroupsResult, true, false));
+        System.out.println(Strings.toString(actionGroupsResult, true, false));
         SecurityDynamicConfiguration<ConfigV7> configResult =Migration.migrateConfig((SecurityDynamicConfiguration<ConfigV6>)load("./legacy/securityconfig_v6/config.yml", CType.CONFIG));
-        System.out.println(Strings.toString(XContentType.JSON, configResult, true, false));
+        System.out.println(Strings.toString(configResult, true, false));
         SecurityDynamicConfiguration<InternalUserV7> internalUsersResult = Migration.migrateInternalUsers((SecurityDynamicConfiguration<InternalUserV6>)load("./legacy/securityconfig_v6/internal_users.yml", CType.INTERNALUSERS));
-        System.out.println(Strings.toString(XContentType.JSON, internalUsersResult, true, false));
+        System.out.println(Strings.toString(internalUsersResult, true, false));
         SecurityDynamicConfiguration<RoleMappingsV7> rolemappingsResult = Migration.migrateRoleMappings((SecurityDynamicConfiguration<RoleMappingsV6>)load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING));
-        System.out.println(Strings.toString(XContentType.JSON, rolemappingsResult, true, false));
+        System.out.println(Strings.toString(rolemappingsResult, true, false));
     }
     
     @Test
@@ -114,7 +113,7 @@ public class ConfigTests {
         //Assert.assertTrue(dc.getCEntries().size() > 0);
         String jsonSerialize = DefaultObjectMapper.objectMapper.writeValueAsString(dc);
         SecurityDynamicConfiguration<?> conf = SecurityDynamicConfiguration.fromJson(jsonSerialize, cType, configVersion, 0, 0);
-        SecurityDynamicConfiguration.fromJson(Strings.toString(XContentType.JSON, conf), cType, configVersion, 0, 0);
+        SecurityDynamicConfiguration.fromJson(Strings.toString(conf), cType, configVersion, 0, 0);
         
     }
     

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
@@ -42,7 +42,7 @@ public class DlsTest extends AbstractDlsFlsTest{
             e.printStackTrace();
         }
         System.out.println("q");
-        System.out.println(Strings.toString(XContentType.JSON, tc.search(new SearchRequest().indices(".opendistro_security")).actionGet()));
+        System.out.println(Strings.toString(tc.search(new SearchRequest().indices(".opendistro_security")).actionGet()));
         tc.search(new SearchRequest().indices("deals")).actionGet();
     }
 


### PR DESCRIPTION
### Description

Reverts https://github.com/opensearch-project/security/pull/2452 in response to the reversion from core (https://github.com/opensearch-project/OpenSearch/pull/6431).

This retains the change in 2.x, but reverts for 2.6.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
