### PR TITLE
Remove MacOS platform from CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        platform: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        platform: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
### Description
Remove MacOS platform from CI checks, they take a long time and have been more unreliable than other platforms.  

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/2467

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
