### PR TITLE
Fix the format of the codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,1 @@
-# Should now match maintainers list
-* @cliu123
-* @cwperks
-* @DarshitChanpura
-* @davidlago
-* @peternied
-* @RyanL1997
-* @scrawfor99
+* @cliu123 @cwperks @DarshitChanpura @davidlago @peternied @RyanL1997 @scrawfor99


### PR DESCRIPTION
### Description
Fix the format of the codeowners file

All maintainers are considered code-owners instead of only @scrawfor99 :D

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
