### PR TITLE
Use correct format for push trigger

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,11 +3,10 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-      branches: [
-        main
-        1.*
-        2.*
-      ]
+      branches:
+        - 'main'
+        - '1.*'
+        - '2.*'
 
 jobs:
   build-and-publish-snapshots:


### PR DESCRIPTION
### Description
Use correct format for push trigger

Builds were not being automatically published, after reviewing the documentation
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs branches is an object, not an array.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
