### PR TITLE
[Backport 2.x] fix kafka CVE-2023-25194, update kafka client to 3.4.0 (#2484)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.1.0.0')
-        kafka_version  = '3.0.2'
+        kafka_version  = '3.4.0'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -317,16 +317,16 @@ dependencies {
     runtimeOnly 'com.google.j2objc:j2objc-annotations:1.3'
     runtimeOnly 'com.google.code.findbugs:jsr305:3.0.2'
     runtimeOnly 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
-    runtimeOnly 'org.lz4:lz4-java:1.7.1'
+    runtimeOnly 'org.lz4:lz4-java:1.8.0'
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'
-    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.1'
+    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.4'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
-    runtimeOnly 'com.github.luben:zstd-jni:1.5.0-2'
+    runtimeOnly 'com.github.luben:zstd-jni:1.5.2-1'
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
 
@@ -347,9 +347,10 @@ dependencies {
     testImplementation 'javax.servlet:servlet-api:2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}"
+    testImplementation "org.apache.kafka:kafka-group-coordinator:${kafka_version}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.8.6'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.6'
     testImplementation 'org.springframework:spring-beans:5.3.20'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'


### PR DESCRIPTION
Backports #2484


### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
