### PR TITLE
Fix lost privileges during auto initializing of the index

### DIFF
--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -56,7 +58,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
 public class ConfigHelper {
-    
+
     private static final Logger LOGGER = LogManager.getLogger(ConfigHelper.class);
 
     public static void uploadFile(Client tc, String filepath, String index, CType cType, int configVersion) throws Exception {
@@ -67,27 +69,30 @@ public class ConfigHelper {
         final String configType = cType.toLCString();
         LOGGER.info("Will update '" + configType + "' with " + filepath + " and populate it with empty doc if file missing and populateEmptyIfFileMissing=" + populateEmptyIfFileMissing);
 
-        if (!populateEmptyIfFileMissing) {
-            ConfigHelper.fromYamlFile(filepath, cType, configVersion, 0, 0);
-        }
-
-        try (Reader reader = createFileOrStringReader(cType, configVersion, filepath, populateEmptyIfFileMissing)) {
-
-            final IndexRequest indexRequest = new IndexRequest(index)
-                    .id(configType)
-                    .opType(OpType.CREATE)
-                    .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
-                    .source(configType, readXContent(reader, XContentType.YAML));
-            final String res = tc.index(indexRequest).actionGet().getId();
-
-            if (!configType.equals(res)) {
-                throw new Exception("   FAIL: Configuration for '" + configType
-                        + "' failed for unknown reasons. Pls. consult logfile of opensearch");
+        AccessController.doPrivileged((PrivilegedExceptionAction<Void>) () -> {
+            if (!populateEmptyIfFileMissing) {
+                ConfigHelper.fromYamlFile(filepath, cType, configVersion, 0, 0);
             }
-            LOGGER.info("Doc with id '{}' and version {} is updated in {} index.", configType, configVersion, index);
-        } catch (VersionConflictEngineException versionConflictEngineException) {
-            LOGGER.info("Index {} already contains doc with id {}, skipping update.", index, configType);
-        }
+
+            try (Reader reader = createFileOrStringReader(cType, configVersion, filepath, populateEmptyIfFileMissing)) {
+
+                final IndexRequest indexRequest = new IndexRequest(index)
+                        .id(configType)
+                        .opType(OpType.CREATE)
+                        .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                        .source(configType, readXContent(reader, XContentType.YAML));
+                final String res = tc.index(indexRequest).actionGet().getId();
+
+                if (!configType.equals(res)) {
+                    throw new Exception("   FAIL: Configuration for '" + configType
+                            + "' failed for unknown reasons. Pls. consult logfile of opensearch");
+                }
+                LOGGER.info("Doc with id '{}' and version {} is updated in {} index.", configType, configVersion, index);
+            } catch (VersionConflictEngineException versionConflictEngineException) {
+                LOGGER.info("Index {} already contains doc with id {}, skipping update.", index, configType);
+            }
+            return null;
+        });
     }
 
     public static Reader createFileOrStringReader(CType cType, int configVersion, String filepath, boolean populateEmptyIfFileMissing) throws Exception {


### PR DESCRIPTION
### Description
If `plugins.security.allow_default_init_securityindex` set to `true`, the cluster should initialize the configuration index. Since reading of configuration files was done without `AccessController` in the diff thread on `JDK17` (not sure about `JDK11`) it fails randomly for the different file (for at least 3 nodes cluster) as result the configuration could be lost partially and the security configuration could be in the inconsistent state.
Beside that a check for the cluster global state lock was added, so index will be created after lead elation has been finished.  The main idea is do not bother cluster and reduce global state block exceptions in the log file. 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
