### PR TITLE
Fix a test issue discovered in PR #2482

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -114,7 +114,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 		
 		AuthCredentials creds = jwtAuth.extractCredentials(
-				new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_EXPIRED_SIGNED_OCT_1),
+				new FakeRestRequest(ImmutableMap.of("Authorization", "Bearer " + TestJwts.MC_COY_EXPIRED_SIGNED_OCT_1),
 						new HashMap<String, String>()),
 				null);
 
@@ -137,7 +137,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			new FakeRestRequest(
 				ImmutableMap.of(
 					"Authorization", 
-					"bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+					"Bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
 				new HashMap<String, String>()),
 			null);
 
@@ -160,7 +160,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			new FakeRestRequest(
 				ImmutableMap.of(
 					"Authorization", 
-					"bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+					"Bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
 				new HashMap<String, String>()),
 			null);
 
@@ -181,7 +181,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
 		AuthCredentials creds = jwtAuth.extractCredentials(
 				new FakeRestRequest(
-						ImmutableMap.of("Authorization", "bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+						ImmutableMap.of("Authorization", "Bearer "+TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
 						new HashMap<String, String>()),
 				null);
 


### PR DESCRIPTION
### Description
Fix a test issue  in HTTPJwtKeyByOpenIdConnectAuthenticatorTest  discovered in PR #2482 ,
 
* Category Test fix
* Why these changes are required?
Fix the  "testExp" test
* What is the old behavior before changes and new behavior after changes?
The "testExp" test was missing the "Bearer" auth-scheme in the request, so the token expiration test was not actually being executed

### Issues Resolved
Thi is a follow-up PR no Issue has been opened

Is this a backport? 
No

### Testing
unit testing

### Check List
- [  ] New functionality includes testing
- [  ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
