### PR TITLE
Add chmod 0600 to install_demo_configuration bash script

### DIFF
--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -354,6 +354,12 @@ echo "$ROOT_CA" | $SUDO_CMD tee "$OPENSEARCH_CONF_DIR/root-ca.pem" > /dev/null
 echo "$NODE_KEY" | $SUDO_CMD tee "$OPENSEARCH_CONF_DIR/esnode-key.pem" > /dev/null
 echo "$ADMIN_CERT_KEY" | $SUDO_CMD tee "$OPENSEARCH_CONF_DIR/kirk-key.pem" > /dev/null
 
+chmod 0600 "$OPENSEARCH_CONF_DIR/kirk.pem"
+chmod 0600 "$OPENSEARCH_CONF_DIR/esnode.pem"
+chmod 0600 "$OPENSEARCH_CONF_DIR/root-ca.pem"
+chmod 0600 "$OPENSEARCH_CONF_DIR/esnode-key.pem"
+chmod 0600 "$OPENSEARCH_CONF_DIR/kirk-key.pem"
+
 echo "" | $SUDO_CMD tee -a  "$OPENSEARCH_CONF_FILE"
 echo "######## Start OpenSearch Security Demo Configuration ########" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 echo "# WARNING: revise all the lines below before you go into production" | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null


### PR DESCRIPTION
### Description

Adds commands to change the permissions of the newly created demo certificates in the install_demo_configuration.sh script.

This PR only changes the certificate permissions, the other issue with the `config/` folder permissions should be addressed in opensearch-build:

```
... Directory /home/ec2-user/opensearch-1.1.0/config has insecure file permissions (should be 0700)
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

- https://github.com/opensearch-project/opensearch-build/issues/3262
- https://github.com/opensearch-project/security/issues/1465

### Testing

Tested a local distribution before and after the change and verified that the `...has insecure file permissions (should be 0600)` errors were not logged.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
