### PR TITLE
Add score based password verification

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -395,6 +395,7 @@ dependencies {
     implementation ('org.opensaml:opensaml-saml-impl:3.4.5') {
         exclude(group: 'org.apache.velocity', module: 'velocity')
     }
+    implementation "com.nulab-inc:zxcvbn:1.7.0"
     testImplementation 'org.opensaml:opensaml-messaging-impl:3.4.5'
     implementation 'org.opensaml:opensaml-messaging-api:3.4.5'
     runtimeOnly 'org.opensaml:opensaml-profile-api:3.4.5'

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
@@ -49,10 +49,10 @@ public class SecurityConfigurationTests {
 		.roles(new Role("limited-role").indexPermissions("indices:data/read/search", "indices:data/read/get").on("user-${user.name}"));
 	public static final String LIMITED_USER_INDEX = "user-" + LIMITED_USER.getName();
 	public static final String ADDITIONAL_USER_1 = "additional00001";
-	public static final String ADDITIONAL_PASSWORD_1 = ADDITIONAL_USER_1;
+	public static final String ADDITIONAL_PASSWORD_1 = "user 1 fair password";
 
 	public static final String ADDITIONAL_USER_2 = "additional2";
-	public static final String ADDITIONAL_PASSWORD_2 = ADDITIONAL_USER_2;
+	public static final String ADDITIONAL_PASSWORD_2 = "user 2 fair password";
 	public static final String CREATE_USER_BODY = "{\"password\": \"%s\",\"opendistro_security_roles\": []}";
 	public static final String INTERNAL_USERS_RESOURCE = "_plugins/_security/api/internalusers/";
 	public static final String ID_1 = "one";

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -138,6 +138,7 @@ import org.opensearch.security.configuration.PrivilegesInterceptorImpl;
 import org.opensearch.security.configuration.Salt;
 import org.opensearch.security.configuration.SecurityFlsDlsIndexSearcherWrapper;
 import org.opensearch.security.dlic.rest.api.SecurityRestApiActions;
+import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.filter.SecurityFilter;
 import org.opensearch.security.filter.SecurityRestFilter;
 import org.opensearch.security.http.SecurityHttpServerTransport;
@@ -1043,6 +1044,19 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
             settings.add(Setting.simpleString(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, Property.NodeScope, Property.Filtered));
             settings.add(Setting.simpleString(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE, Property.NodeScope, Property.Filtered));
 
+            settings.add(
+                    Setting.intSetting(
+                            ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH,
+                            -1, -1, Property.NodeScope, Property.Filtered)
+            );
+            settings.add(
+                    Setting.simpleString(
+                            ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH,
+                            PasswordValidator.ScoreStrength.STRONG.name(),
+                            PasswordValidator.ScoreStrength::fromConfiguration,
+                            Property.NodeScope, Property.Filtered
+                    )
+            );
 
             // Compliance
             settings.add(Setting.listSetting(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/AbstractConfigurationValidator.java
@@ -249,8 +249,18 @@ public abstract class AbstractConfigurationValidator {
                     break;
                 case INVALID_PASSWORD:
                     builder.field("status", "error");
-                    builder.field("reason", opensearchSettings.get(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,
+                    builder.field("reason", opensearchSettings.get(
+                            ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,
                             "Password does not match minimum criteria"));
+                    break;
+                case WEAK_PASSWORD:
+                case SIMILAR_PASSWORD:
+                    builder.field("status", "error");
+                    builder.field(
+                            "reason",
+                            opensearchSettings.get(
+                                    ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,
+                                    errorType.message));
                     break;
                 case WRONG_DATATYPE:
                     builder.field("status", "error");
@@ -289,8 +299,14 @@ public abstract class AbstractConfigurationValidator {
     }
 
     public static enum ErrorType {
-        NONE("ok"), INVALID_CONFIGURATION("Invalid configuration"), INVALID_PASSWORD("Invalid password"), WRONG_DATATYPE("Wrong datatype"),
-        BODY_NOT_PARSEABLE("Could not parse content of request."), PAYLOAD_NOT_ALLOWED("Request body not allowed for this action."),
+        NONE("ok"),
+        INVALID_CONFIGURATION("Invalid configuration"),
+        INVALID_PASSWORD("Invalid password"),
+        WEAK_PASSWORD("Weak password"),
+        SIMILAR_PASSWORD("Password is similar to user name"),
+        WRONG_DATATYPE("Wrong datatype"),
+        BODY_NOT_PARSEABLE("Could not parse content of request."),
+        PAYLOAD_NOT_ALLOWED("Request body not allowed for this action."),
         PAYLOAD_MANDATORY("Request body required for this action."), SECURITY_NOT_INITIALIZED("Security index not initialized"),
         NULL_ARRAY_ELEMENT("`null` is not allowed as json array element");
 

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/CredentialsValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/CredentialsValidator.java
@@ -12,7 +12,6 @@
 package org.opensearch.security.dlic.rest.validation;
 
 import java.util.Map;
-import java.util.regex.Pattern;
 
 import org.opensearch.common.Strings;
 import org.opensearch.common.bytes.BytesReference;
@@ -22,17 +21,21 @@ import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.ssl.util.Utils;
-import org.opensearch.security.support.ConfigConstants;
 
 /**
  * Validator for validating password and hash present in the payload
  */
 public class CredentialsValidator extends AbstractConfigurationValidator {
 
-    public CredentialsValidator(final RestRequest request, BytesReference ref, final Settings opensearchSettings,
+    private final PasswordValidator passwordValidator;
+
+    public CredentialsValidator(final RestRequest request,
+                                final BytesReference ref,
+                                final Settings opensearchSettings,
                                 Object... param) {
         super(request, ref, opensearchSettings, param);
         this.payloadMandatory = true;
+        this.passwordValidator = PasswordValidator.of(opensearchSettings);
         allowedKeys.put("hash", DataType.STRING);
         allowedKeys.put("password", DataType.STRING);
     }
@@ -46,49 +49,29 @@ public class CredentialsValidator extends AbstractConfigurationValidator {
         if (!super.validate()) {
             return false;
         }
-
-        final String regex = this.opensearchSettings.get(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, null);
-
         if ((request.method() == RestRequest.Method.PUT || request.method() == RestRequest.Method.PATCH)
                 && this.content != null
                 && this.content.length() > 1) {
             try {
                 final Map<String, Object> contentAsMap = XContentHelper.convertToMap(this.content, false, XContentType.JSON).v2();
-                String password = (String) contentAsMap.get("password");
+                final String password = (String) contentAsMap.get("password");
                 if (password != null) {
                     // Password is not allowed to be empty if present.
                     if (password.isEmpty()) {
                         this.errorType = ErrorType.INVALID_PASSWORD;
                         return false;
                     }
-
-                    if (!Strings.isNullOrEmpty(regex)) {
-                        // Password can be null for an existing user. Regex will validate password if present
-                        if (!Pattern.compile("^"+regex+"$").matcher(password).matches()) {
-                            if(log.isDebugEnabled()) {
-                                log.debug("Regex does not match password");
-                            }
-                            this.errorType = ErrorType.INVALID_PASSWORD;
-                            return false;
+                    final String username = Utils.coalesce(request.param("name"), hasParams() ? (String) param[0] : null);
+                    if (Strings.isNullOrEmpty(username)) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Unable to validate username because no user is given");
                         }
-
-                        final String username = Utils.coalesce(request.param("name"), hasParams() ? (String) param[0] : null);
-                        final boolean isDebugEnabled = log.isDebugEnabled();
-
-                        if (username == null || username.isEmpty()) {
-                            if (isDebugEnabled) {
-                                log.debug("Unable to validate username because no user is given");
-                            }
-                            return false;
-                        }
-
-                        if (username.toLowerCase().equals(password.toLowerCase())) {
-                            if (isDebugEnabled) {
-                                log.debug("Username must not match password");
-                            }
-                            this.errorType = ErrorType.INVALID_PASSWORD;
-                            return false;
-                        }
+                        return false;
+                    }
+                    final ErrorType passwordValidationResult = passwordValidator.validate(username, password);
+                    if (passwordValidationResult != ErrorType.NONE) {
+                        this.errorType = passwordValidationResult;
+                        return false;
                     }
                 }
             } catch (NotXContentException e) {
@@ -99,4 +82,5 @@ public class CredentialsValidator extends AbstractConfigurationValidator {
         }
         return true;
     }
+
 }

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/PasswordValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/PasswordValidator.java
@@ -1,0 +1,185 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.validation;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.StringJoiner;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+import com.google.common.collect.ImmutableList;
+import com.nulabinc.zxcvbn.Strength;
+import com.nulabinc.zxcvbn.Zxcvbn;
+import com.nulabinc.zxcvbn.matchers.Match;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.Strings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.dlic.rest.validation.AbstractConfigurationValidator.ErrorType;
+
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
+
+public class PasswordValidator {
+
+    private static final int MAX_LENGTH = 100;
+
+    /**
+     * Checks a username similarity and a password
+     * names and passwords like:
+     *  - some_user_name/456Some_uSer_Name_1234
+     *  - some_user_name/some_user_name_Ydfge
+     *  - some_user_name/eman_resu_emos
+     *  are similar
+     * "user_inputs" - is a default dictionary zxcvbn creates for checking similarity
+     */
+    private final static Predicate<Match> USERNAME_SIMILARITY_CHECK = m ->
+            m.pattern == com.nulabinc.zxcvbn.Pattern.Dictionary && "user_inputs".equals(m.dictionaryName);
+
+    private final Logger logger = LogManager.getLogger(this.getClass());
+
+    private final int minPasswordLength;
+
+    private final Pattern passwordRegexpPattern;
+
+    private final ScoreStrength scoreStrength;
+
+    private final Zxcvbn zxcvbn;
+
+    private PasswordValidator(final int minPasswordLength,
+                              final Pattern passwordRegexpPattern,
+                              final ScoreStrength scoreStrength) {
+        this.minPasswordLength = minPasswordLength;
+        this.passwordRegexpPattern = passwordRegexpPattern;
+        this.scoreStrength = scoreStrength;
+        this.zxcvbn = new Zxcvbn();
+    }
+
+    public static PasswordValidator of(final Settings settings) {
+        final String passwordRegex = settings.get(SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, null);
+        final ScoreStrength scoreStrength = ScoreStrength.fromConfiguration(
+                    settings.get(SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH, ScoreStrength.STRONG.name())
+            );
+        final int minPasswordLength = settings.getAsInt(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, -1);
+        return new PasswordValidator(
+                minPasswordLength,
+                !Strings.isNullOrEmpty(passwordRegex) ? Pattern.compile(String.format("^%s$", passwordRegex)) : null,
+                scoreStrength);
+    }
+
+    ErrorType validate(final String username, final String password) {
+        if (minPasswordLength > 0 && password.length() < minPasswordLength) {
+            logger.debug(
+                    "Password is too short, the minimum required length is {}, but current length is {}",
+                    minPasswordLength,
+                    password.length()
+            );
+            return ErrorType.INVALID_PASSWORD;
+        }
+        if (password.length() > MAX_LENGTH) {
+            logger.debug(
+                    "Password is too long, the maximum required length is {}, but current length is {}",
+                    MAX_LENGTH,
+                    password.length()
+            );
+            return ErrorType.INVALID_PASSWORD;
+        }
+        if (Objects.nonNull(passwordRegexpPattern)
+                && !passwordRegexpPattern.matcher(password).matches()) {
+            logger.debug("Regex does not match password");
+            return ErrorType.INVALID_PASSWORD;
+        }
+        final Strength strength = zxcvbn.measure(password, ImmutableList.of(username));
+        if (strength.getScore() < scoreStrength.score()) {
+            logger.debug(
+                    "Password is weak the required score is {}, but current is {}",
+                    scoreStrength,
+                    ScoreStrength.fromScore(strength.getScore())
+            );
+            return ErrorType.WEAK_PASSWORD;
+        }
+        final boolean similar = strength.getSequence()
+                .stream()
+                .anyMatch(USERNAME_SIMILARITY_CHECK);
+        if (similar) {
+            logger.debug("Password is too similar to the user name {}", username);
+            return ErrorType.SIMILAR_PASSWORD;
+        }
+        return ErrorType.NONE;
+    }
+
+    public enum ScoreStrength {
+
+        // The weak score defines here only for debugging information
+        // and doesn't use as a configuration setting value.
+        WEAK(0, "too guessable: risky password"),
+        FAIR(1, "very guessable: protection from throttled online attacks"),
+        GOOD(2, "somewhat guessable: protection from unthrottled online attacks"),
+        STRONG(3, "safely unguessable: moderate protection from offline slow-hash scenario"),
+        VERY_STRONG(4, "very unguessable: strong protection from offline slow-hash scenario");
+
+        private final int score;
+
+        private final String description;
+
+        static final List<ScoreStrength> CONFIGURATION_VALUES = ImmutableList.of(FAIR, STRONG, VERY_STRONG);
+
+        static final String EXPECTED_CONFIGURATION_VALUES =
+                new StringJoiner(",")
+                        .add(FAIR.name().toLowerCase(Locale.ROOT))
+                        .add(STRONG.name().toLowerCase(Locale.ROOT))
+                        .add(VERY_STRONG.name().toLowerCase(Locale.ROOT))
+                        .toString();
+
+        private ScoreStrength(final int score, final String description) {
+            this.score = score;
+            this.description = description;
+        }
+
+        public static ScoreStrength fromScore(final int score) {
+            for (final ScoreStrength strength : values()) {
+                if (strength.score == score)
+                    return strength;
+            }
+            throw new IllegalArgumentException("Unknown score " + score);
+        }
+
+        public static ScoreStrength fromConfiguration(final String value) {
+            for (final ScoreStrength strength : CONFIGURATION_VALUES) {
+                if (strength.name().equalsIgnoreCase(value))
+                    return strength;
+            }
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Setting [%s] cannot be used with the configured: %s. Expected one of [%s]",
+                            SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH,
+                            value,
+                            EXPECTED_CONFIGURATION_VALUES
+                    )
+            );
+        }
+
+        @Override
+        public String toString() {
+            return String.format("Password strength score %s. %s", score, description);
+        }
+
+        public int score() {
+            return this.score;
+        }
+
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -255,7 +255,9 @@ public class ConfigConstants {
     public static final String SECURITY_RESTAPI_ENDPOINTS_DISABLED = "plugins.security.restapi.endpoints_disabled";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX = "plugins.security.restapi.password_validation_regex";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE = "plugins.security.restapi.password_validation_error_message";
-
+    public static final String SECURITY_RESTAPI_PASSWORD_MIN_LENGTH = "plugins.security.restapi.password_min_length";
+    public static final String SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH = "plugins.security.restapi.password_score_based_validation_strength";
+    // Illegal Opcodes from here on
     public static final String SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "plugins.security.unsupported.disable_rest_auth_initially";
     public static final String SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY = "plugins.security.unsupported.disable_intertransport_auth_initially";
     public static final String SECURITY_UNSUPPORTED_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY = "plugins.security.unsupported.passive_intertransport_auth_initially";

--- a/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -42,7 +42,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         TestAuditlogImpl.clear();
-        String body = "{ \"password\":\"test\",\"backend_roles\":[\"role1\",\"role2\"] }";
+        String body = "{ \"password\":\"some new password\",\"backend_roles\":[\"role1\",\"role2\"] }";
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body, encodeBasicHeader("admin", "admin"));
         Thread.sleep(1500);
         System.out.println(TestAuditlogImpl.sb.toString());
@@ -71,7 +71,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         TestAuditlogImpl.clear();
-        String body = "{ \"password\":\"test\",\"backend_roles\":[\"role1\",\"role2\"] }";
+        String body = "{ \"password\":\"some new password\",\"backend_roles\":[\"role1\",\"role2\"] }";
 
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
@@ -169,12 +169,13 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         TestAuditlogImpl.clear();
-        String body = "{ \"password\":\"test\",\"backend_roles\":[\"role1\",\"role2\"] }";
+        String body = "{ \"password\":\"some new password\",\"backend_roles\":[\"role1\",\"role2\"] }";
         System.out.println("exec");
-        HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body, encodeBasicHeader("admin", "admin"));
+        HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty",
+                body, encodeBasicHeader("admin", "admin"));
         Thread.sleep(1500);
         System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size()+"", TestAuditlogImpl.messages.isEmpty());
     }
 
@@ -241,7 +242,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         // create internal user and verify no BCrypt hash is present in audit logs
         TestAuditlogImpl.clear();
-        rh.executePutRequest("/_opendistro/_security/api/internalusers/test",  "{ \"password\":\"test\"}");
+        rh.executePutRequest("/_opendistro/_security/api/internalusers/test",  "{ \"password\":\"some new user password\"}");
         Assert.assertEquals(1, TestAuditlogImpl.messages.size());
         Assert.assertFalse(AuditMessage.BCRYPT_HASH.matcher(TestAuditlogImpl.sb.toString()).matches());
     }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
@@ -45,7 +45,7 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         // arrange
         setup();
         final String testUser = "test-user";
-        final String testPass = "test-pass";
+        final String testPass = "some password for user";
         addUserWithPassword(testUser, testPass, HttpStatus.SC_CREATED);
 
         // test - unauthorized access as credentials are missing.

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiTest.java
@@ -53,9 +53,9 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
         rh.sendAdminCertificate = true;
         verifyGetForSuperAdmin(new Header[0]);
         rh.sendAdminCertificate = true;
@@ -122,21 +122,21 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         rh.sendAdminCertificate = false;
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
         // put picard in captains role. Role opendistro_security_role_captains uses the CRUD_UT
         // action group
         // which uses READ_UT and WRITE action groups. We removed READ_UT, so only
         // WRITE is possible
-        addUserWithPassword("picard", "picard", new String[] { "captains" }, HttpStatus.SC_OK);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "captains" }, HttpStatus.SC_OK);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
 
         // now remove also CRUD_UT groups, write also not possible anymore
         rh.sendAdminCertificate = true;
         response = rh.executeDeleteRequest(ENDPOINT+"/CRUD_UT", new Header[0]);
         rh.sendAdminCertificate = false;
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
     }
 
     void verifyPutForSuperAdmin(final Header[] header, final boolean userAdminCert) throws Exception {
@@ -161,8 +161,8 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         rh.sendAdminCertificate = false;
 
         // write access allowed again, read forbidden, since READ_UT group is still missing
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
 
         // restore READ_UT action groups
         rh.sendAdminCertificate = userAdminCert;
@@ -171,8 +171,8 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
         rh.sendAdminCertificate = false;
         // read/write allowed again
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
 
         // -- PUT, new JSON format including readonly flag, disallowed in REST API
         rh.sendAdminCertificate = userAdminCert;
@@ -370,9 +370,9 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
         verifyGetForSuperAdmin(new Header[] {restApiAdminHeader});
         verifyDeleteForSuperAdmin(new Header[]{restApiAdminHeader}, false);
         verifyPutForSuperAdmin(new Header[]{restApiAdminHeader}, false);
@@ -388,9 +388,9 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
         final Header restApiAdminActionGroupsHeader = encodeBasicHeader("rest_api_admin_actiongroups", "rest_api_admin_actiongroups");
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "starfleet" }, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 0);
         verifyGetForSuperAdmin(new Header[] {restApiAdminActionGroupsHeader});
         verifyDeleteForSuperAdmin(new Header[]{restApiAdminActionGroupsHeader}, false);
         verifyPutForSuperAdmin(new Header[]{restApiAdminActionGroupsHeader}, false);

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
@@ -151,9 +151,9 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicardpicard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         rh.sendAdminCertificate = true;
         verifyGetForSuperAdmin(new Header[0]);
@@ -220,17 +220,17 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         rh.sendAdminCertificate = false;
         // user has only role starfleet left, role has READ access only
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 1);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicardpicard", "sf", "_doc", 1);
         // ES7 only supports one doc type, but OpenSearch permission checks run first
         // So we also get a 403 FORBIDDEN when tring to add new document type
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         rh.sendAdminCertificate = sendAdminCert;
         // remove also starfleet role, nothing is allowed anymore
         response = rh.executeDeleteRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet", header);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
     }
 
     void verifyPutForSuperAdmin(final Header[] header, final boolean sendAdminCert) throws Exception {
@@ -282,14 +282,14 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
                 FileHelper.loadFile("restapi/roles_starfleet.json"), header);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         rh.sendAdminCertificate = false;
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         // now picard is only in opendistro_security_role_starfleet, which has write access to
         // all indices. We collapse all document types in ODFE7 so this permission in the
         // starfleet role grants all permissions:
         //   _doc:
         //       - 'indices:*'
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         rh.sendAdminCertificate = sendAdminCert;
 
@@ -298,18 +298,13 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
                 FileHelper.loadFile("restapi/roles_captains.json"), header);
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         rh.sendAdminCertificate = false;
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         rh.sendAdminCertificate = sendAdminCert;
         response = rh.executePutRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains",
                 FileHelper.loadFile("restapi/roles_complete_invalid.json"), header);
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-
-//        rh.sendAdminCertificate = sendAdminCert;
-//        response = rh.executePutRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains",
-//                FileHelper.loadFile("restapi/roles_multiple.json"), header);
-//        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
 
         response = rh.executePutRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains",
                 FileHelper.loadFile("restapi/roles_multiple_2.json"), header);
@@ -530,9 +525,9 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicardpicard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
         verifyGetForSuperAdmin(new Header[]{restApiAdminHeader});
         verifyDeleteForSuperAdmin(new Header[]{restApiAdminHeader}, false);
@@ -550,9 +545,9 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
 
         // add user picard, role starfleet, maps to opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 0);
+        addUserWithPassword("picard", "picardpicardpicardpicard", new String[]{"starfleet", "captains"}, HttpStatus.SC_CREATED);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicardpicard", "sf", "_doc", 0);
 
 
         verifyGetForSuperAdmin(new Header[]{restApiRolesHeader});

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -53,8 +53,8 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
         // add user picard, role captains initially maps to
         // opendistro_security_role_starfleet_captains and opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[] { "captains" }, HttpStatus.SC_CREATED);
-        checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "_doc", 1);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "captains" }, HttpStatus.SC_CREATED);
+        checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picardpicardpicard", "sf", "_doc", 1);
         // TODO: only one doctype allowed for ES6
         //checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "_doc", 1);
         rh.sendAdminCertificate = true;
@@ -65,35 +65,35 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         verifyPutForSuperAdmin(new Header[0]);
         verifyPatchForSuperAdmin(new Header[0]);
         // mapping with several backend roles, one of the is captain
-        deleteAndputNewMapping(new Header[0],"rolesmapping_backendroles_captains_list.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_backendroles_captains_list.json", true);
         checkAllSfAllowed();
 
         // mapping with one backend role, captain
-        deleteAndputNewMapping(new Header[0],"rolesmapping_backendroles_captains_single.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_backendroles_captains_single.json", true);
         checkAllSfAllowed();
 
         // mapping with several users, one is picard
-        deleteAndputNewMapping(new Header[0],"rolesmapping_users_picard_list.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_users_picard_list.json", true);
         checkAllSfAllowed();
 
         // just user picard
-        deleteAndputNewMapping(new Header[0],"rolesmapping_users_picard_single.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_users_picard_single.json", true);
         checkAllSfAllowed();
 
         // hosts
-        deleteAndputNewMapping(new Header[0],"rolesmapping_hosts_list.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_hosts_list.json", true);
         checkAllSfAllowed();
 
         // hosts
-        deleteAndputNewMapping(new Header[0],"rolesmapping_hosts_single.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_hosts_single.json", true);
         checkAllSfAllowed();
 
         // full settings, access
-        deleteAndputNewMapping(new Header[0],"rolesmapping_all_access.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_all_access.json", true);
         checkAllSfAllowed();
 
         // full settings, no access
-        deleteAndputNewMapping(new Header[0],"rolesmapping_all_noaccess.json", true);
+        deleteAndPutNewMapping(new Header[0],"rolesmapping_all_noaccess.json", true);
         checkAllSfForbidden();
     }
 
@@ -107,8 +107,8 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         setupStarfleetIndex();
         // add user picard, role captains initially maps to
         // opendistro_security_role_starfleet_captains and opendistro_security_role_starfleet
-        addUserWithPassword("picard", "picard", new String[] { "captains" }, HttpStatus.SC_CREATED);
-        checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "_doc", 1);
+        addUserWithPassword("picard", "picardpicardpicard", new String[] { "captains" }, HttpStatus.SC_CREATED);
+        checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picardpicardpicard", "sf", "_doc", 1);
         // TODO: only one doctype allowed for ES6
         //checkWriteAccess(HttpStatus.SC_CREATED, "picard", "picard", "sf", "_doc", 1);
 
@@ -117,35 +117,35 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
         verifyPutForSuperAdmin(new Header[]{restApiAdminHeader});
         verifyPatchForSuperAdmin(new Header[]{restApiAdminHeader});
         // mapping with several backend roles, one of the is captain
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader}, "rolesmapping_backendroles_captains_list.json", false);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader}, "rolesmapping_backendroles_captains_list.json", false);
         checkAllSfAllowed();
 
         // mapping with one backend role, captain
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_backendroles_captains_single.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_backendroles_captains_single.json", true);
         checkAllSfAllowed();
 
         // mapping with several users, one is picard
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_users_picard_list.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_users_picard_list.json", true);
         checkAllSfAllowed();
 
         // just user picard
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_users_picard_single.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_users_picard_single.json", true);
         checkAllSfAllowed();
 
         // hosts
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_hosts_list.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_hosts_list.json", true);
         checkAllSfAllowed();
 
         // hosts
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_hosts_single.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_hosts_single.json", true);
         checkAllSfAllowed();
 
         // full settings, access
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_all_access.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_all_access.json", true);
         checkAllSfAllowed();
 
         // full settings, no access
-        deleteAndputNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_all_noaccess.json", true);
+        deleteAndPutNewMapping(new Header[]{restApiAdminHeader},"rolesmapping_all_noaccess.json", true);
         checkAllSfForbidden();
 
     }
@@ -221,7 +221,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
         // now picard is only in opendistro_security_role_starfleet, which has write access to
         // public, but not to _doc
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 1);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 1);
 
         // TODO: only one doctype allowed for ES6
         // checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 1);
@@ -382,17 +382,17 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
     private void checkAllSfAllowed() throws Exception {
         rh.sendAdminCertificate = false;
-        checkReadAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 1);
-        checkWriteAccess(HttpStatus.SC_OK, "picard", "picard", "sf", "_doc", 1);
+        checkReadAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 1);
+        checkWriteAccess(HttpStatus.SC_OK, "picard", "picardpicardpicard", "sf", "_doc", 1);
     }
 
     private void checkAllSfForbidden() throws Exception {
         rh.sendAdminCertificate = false;
-        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 1);
-        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picard", "sf", "_doc", 1);
+        checkReadAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 1);
+        checkWriteAccess(HttpStatus.SC_FORBIDDEN, "picard", "picardpicardpicard", "sf", "_doc", 1);
     }
 
-    private HttpResponse deleteAndputNewMapping(final Header[] header, final String fileName, final boolean useAdminCert) throws Exception {
+    private HttpResponse deleteAndPutNewMapping(final Header[] header, final String fileName, final boolean useAdminCert) throws Exception {
         rh.sendAdminCertificate = useAdminCert;
         HttpResponse response = rh.executeDeleteRequest(ENDPOINT + "/rolesmapping/opendistro_security_role_starfleet_captains",
                         header);

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTest.java
@@ -1,0 +1,197 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.validation;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+
+import static org.junit.Assert.assertEquals;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
+
+public class PasswordValidatorTest {
+
+    static final List<String> WEAK_PASSWORDS = ImmutableList.of(
+            "q", "5", "&", "admin", "123456", "password"
+    );
+
+    static final List<String> FAIR_PASSWORDS = ImmutableList.of(
+            "p@$$word@dmin", "qwertyuiop@[",
+            "zxcvbnm,./_", "asdfghjkl;:]", "20300101",
+            "pandapandapandapandapandapandapandapandapandaa",
+            "appleappleappleappleappleappleappleappleapplea",
+            "aelppaaelppaaelppaaelppaaelppaaelppaaelppaaelppa"
+    );
+
+    static final List<String> GOOD_PASSWORDS = ImmutableList.of(
+            "xsw234rfvb", "yaq123edc", "cde345tgbn", "yaqwedcvb",
+            "Tr0ub4dour&3", "qwER43@!"
+    );
+
+    static final List<String> STRONG_PASSWORDS = ImmutableList.of(
+            "YWert,H90", "Admincc,H90", "Hadmin,120"
+    );
+
+    static final List<String> VERY_STRONG_PASSWORDS = ImmutableList.of(
+            "AeTq($%u-44c_j9NJB45a#2#JP7sH", "IB7~EOw!51gug+7s#+%A9P1O/w8f",
+            "1v_f%7JvS8w!_t398+ON-CObI#v0", "8lFmfc0!w)&iU9DM6~4_w)D)Y44J"
+    );
+
+    static final List<String> SIMILAR_PASSWORDS = ImmutableList.of(
+            "some_user_name,H2344cc", "H3235,Some_User_Name,cc",
+            "H3235,cc,some_User_Name", "H3235,SOME_User_Name,cc",
+            "H3235,eman_resu_emos,cc"
+    );
+
+    public void verifyWeakPasswords(final PasswordValidator passwordValidator,
+                                    final AbstractConfigurationValidator.ErrorType expectedValidationResult) {
+        for (final String password : WEAK_PASSWORDS)
+            assertEquals(
+                    password,
+                    expectedValidationResult,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    public void verifyFairPasswords(final PasswordValidator passwordValidator,
+                                    final AbstractConfigurationValidator.ErrorType expectedValidationResult) {
+        for (final String password : FAIR_PASSWORDS)
+            assertEquals(
+                    password,
+                    expectedValidationResult,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    public void verifyGoodPasswords(final PasswordValidator passwordValidator,
+                                    final AbstractConfigurationValidator.ErrorType expectedValidationResult) {
+        for (final String password : GOOD_PASSWORDS)
+            assertEquals(
+                    password,
+                    expectedValidationResult,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    public void verifyStrongPasswords(final PasswordValidator passwordValidator,
+                                      final AbstractConfigurationValidator.ErrorType expectedValidationResult) {
+        for (final String password : STRONG_PASSWORDS)
+            assertEquals(
+                    password,
+                    expectedValidationResult,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    public void verifyVeryStrongPasswords(final PasswordValidator passwordValidator,
+                                          final AbstractConfigurationValidator.ErrorType expectedValidationResult) {
+        for (final String password : VERY_STRONG_PASSWORDS)
+            assertEquals(
+                    password,
+                    expectedValidationResult,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    public void verifySimilarPasswords(final PasswordValidator passwordValidator) {
+        for (final String password : SIMILAR_PASSWORDS)
+            assertEquals(
+                    password,
+                    AbstractConfigurationValidator.ErrorType.SIMILAR_PASSWORD,
+                    passwordValidator.validate("some_user_name", password)
+            );
+
+    }
+
+    @Test
+    public void testRegExpBasedValidation() {
+        final PasswordValidator passwordValidator =
+                PasswordValidator.of(
+                        Settings.builder()
+                                .put(
+                                        SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX,
+                                        "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}")
+                                .build()
+                );
+        verifyWeakPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.INVALID_PASSWORD);
+        verifyFairPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.INVALID_PASSWORD);
+        for (final String password : GOOD_PASSWORDS.subList(0, GOOD_PASSWORDS.size() - 2))
+            assertEquals(
+                    password,
+                    AbstractConfigurationValidator.ErrorType.INVALID_PASSWORD,
+                    passwordValidator.validate("some_user_name", password)
+            );
+        for (final String password: GOOD_PASSWORDS.subList(GOOD_PASSWORDS.size() - 2, GOOD_PASSWORDS.size()))
+            assertEquals(
+                    password,
+                    AbstractConfigurationValidator.ErrorType.WEAK_PASSWORD,
+                    passwordValidator.validate("some_user_name", password)
+            );
+        verifyStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifyVeryStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifySimilarPasswords(passwordValidator);
+    }
+
+    @Test
+    public void testMinLength() {
+        final PasswordValidator passwordValidator =
+                PasswordValidator.of(
+                        Settings.builder()
+                                .put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, 15)
+                                .build()
+                );
+        for (final String password: STRONG_PASSWORDS) {
+            assertEquals(
+                    AbstractConfigurationValidator.ErrorType.INVALID_PASSWORD,
+                    passwordValidator.validate(password, "some_user_name")
+            );
+        }
+
+    }
+
+    @Test
+    public void testScoreBasedValidation() {
+        PasswordValidator passwordValidator = PasswordValidator.of(Settings.EMPTY);
+        verifyWeakPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.WEAK_PASSWORD);
+        verifyFairPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.WEAK_PASSWORD);
+        verifyGoodPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.WEAK_PASSWORD);
+        verifyStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifyVeryStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifySimilarPasswords(passwordValidator);
+
+        passwordValidator =
+                PasswordValidator.of(
+                        Settings.builder()
+                                .put(
+                                        SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH,
+                                        PasswordValidator.ScoreStrength.FAIR.name()
+                        ).build());
+
+        verifyWeakPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.WEAK_PASSWORD);
+        verifyFairPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifyGoodPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifyStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifyVeryStrongPasswords(passwordValidator, AbstractConfigurationValidator.ErrorType.NONE);
+        verifySimilarPasswords(passwordValidator);
+    }
+
+}


### PR DESCRIPTION
### Description
The aim of this PR is to add support for a score-based password verification using  `zxcvbn` library.
For that 2 new settings were added to the plugin configuration:
- `plugins.security.restapi.password_min_length` - minimum password length, default and minimum is `8` 
- `plugins.security.restapi.password_score_based_validation_strength` - the strength of the valid password
   Possible values:
     - `fair` - very guessable password: protection from throttled online attacks
     - `good` - somewhat guessable password: protection from unthrottled online attacks
     - `strong` - safely unguessable password: moderate protection from offline slow-hash scenario
     - `very_strong` - very unguessable password: strong protection from offline slow-hash scenario
By default the plugin always checks strength of the password and its minimal length together with the regular expression if its set.

The calculation time for passwords around `100` characters is `~100ms` as result to avoid of performance degradation for big passwords I suggest to set max length of the password to `100`.   

All other settings I mentioned before are not needed.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
