### PR TITLE
[BUG] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,7 @@ dependencies {
     runtimeOnly 'org.lz4:lz4-java:1.8.0'
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.4'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'
@@ -486,7 +487,6 @@ dependencies {
     integrationTestImplementation 'commons-io:commons-io:2.11.0'
     integrationTestImplementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     integrationTestImplementation 'org.apache.logging.log4j:log4j-jul:2.17.1'
-    integrationTestImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
     integrationTestImplementation "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
     integrationTestImplementation "org.bouncycastle:bcutil-jdk15on:${versions.bouncycastle}"


### PR DESCRIPTION
### Description

[Interesting issue](https://github.com/opensearch-project/OpenSearch/issues/6663) was reported recently. The OpenSearch core does not use SLF4J (but LOG4J2) however some plugins do:

```
./plugins/opensearch-ml/slf4j-api-1.7.36.jar
./plugins/opensearch-security/slf4j-api-1.7.30.jar
./plugins/opensearch-alerting/slf4j-api-1.7.30.jar
./plugins/opensearch-sql/slf4j-api-1.7.36.jar
./plugins/opensearch-sql/slf4j-reload4j-1.7.36.jar
```

The `security` plugin bundles `slf4j-api` but there is no binder to bridge SLF4J to LOG4J2. As the result, the following warnings prints out on startup:

```
[2023-03-17T14:00:00,953][WARN ][stderr                   ] [host] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".                  
[2023-03-17T14:00:00,954][WARN ][stderr                   ] [host] SLF4J: Defaulting to no-operation (NOP) logger implementation                                         
[2023-03-17T14:00:00,954][WARN ][stderr                   ] [host] SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.                                                                                                                                                                                                                  
[2023-03-17T14:00:00,965][INFO ][o.o.s.s.t.SSLConfig      ] [host] SSL dual mode is disabled                                                            
```

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/6663

### Testing
The test configuration included `log4j-slf4j-impl` so the issue didn't manifest

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
