### PR TITLE
[Backport] [2.x] [BUG] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder" (#2564)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -358,6 +358,7 @@ dependencies {
     runtimeOnly 'org.lz4:lz4-java:1.8.0'
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'
+    runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.4'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/2564 to `2.x`