### PR TITLE
Fix broken maven build v1.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.release>8</maven.compiler.release>
 
-        <opensearch.version>1.1.0-SNAPSHOT</opensearch.version>
+        <opensearch.version>1.1.0</opensearch.version>
 
         <!-- deps -->
         <netty-native.version>2.0.25.Final</netty-native.version>


### PR DESCRIPTION
### Description
When the OpenSearch project was first starting out the unified build system was new. Mistakes were made and the snapshot artifacts for OpenSearch-1.1.0 were deleted.

Luckily the release artifacts are still around, so by switching from snapshot to the release artifacts builds can function again.

See missing snapshot artifacts: https://aws.oss.sonatype.org/content/repositories/snapshots/org/opensearch/plugin/transport-netty4-client/
See release artifacts: https://repo1.maven.org/maven2/org/opensearch/plugin/transport-netty4-client/

### Issues Resolved
- Related https://github.com/opensearch-project/security/pull/2331

### Testing
It build the package locally

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
