### PR TITLE
Remove broken link from DEVELOPER_GUIDE.md

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -45,9 +45,6 @@ cd $OPENSEARCH_HOME
 
 The `curl localhost:9200` call should succeed again. Kill the server with `Ctrl+c`. We are now ready to install the security plugin.
 
->Worth noting:\
-> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `1.3.0.0-SNAPSHOT` compatible with OpenSearch `1.3.0-SNAPSHOT` that gets built from branch `1.x`. Check the expected compatible version [here](https://github.com/opensearch-project/security/blob/main/plugin-descriptor.properties#L27) and make sure you get the correct branch from OpenSearch when building that project.
-
 ## Building
 
 First create a fork of this repo and clone it locally. You should then change to the directory containing the clone and run this to build the project:
@@ -55,6 +52,9 @@ First create a fork of this repo and clone it locally. You should then change to
 ```bash
 ./gradlew clean assemble
 ```
+
+>Worth noting:\
+> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `1.3.0.0-SNAPSHOT` compatible with OpenSearch `1.3.0-SNAPSHOT` that gets built from branch `1.x`. Check the expected compatible version of OpenSearch in plugin-descriptor.properties after building the project.
 
 To install the built plugin into the OpenSearch server run:
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -54,7 +54,7 @@ First create a fork of this repo and clone it locally. You should then change to
 ```
 
 >Worth noting:\
-> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `1.3.0.0-SNAPSHOT` compatible with OpenSearch `1.3.0-SNAPSHOT` that gets built from branch `1.x`. Check the expected compatible version of OpenSearch in plugin-descriptor.properties after building the project.
+> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `3.0.0.0-SNAPSHOT` compatible with OpenSearch `3.0.0`. Check the expected compatible version of OpenSearch in plugin-descriptor.properties after building the project.
 
 To install the built plugin into the OpenSearch server run:
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -45,6 +45,17 @@ cd $OPENSEARCH_HOME
 
 The `curl localhost:9200` call should succeed again. Kill the server with `Ctrl+c`. We are now ready to install the security plugin.
 
+
+>Worth noting:\
+> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `3.0.0.0-SNAPSHOT` compatible with OpenSearch `3.0.0`. Check the expected compatible version in `build.gradle` file [here](https://github.com/opensearch-project/security/blob/main/build.gradle) and make sure you get the correct branch from OpenSearch when building that project.
+> 
+> The line to look for: `opensearch_version = System.getProperty("opensearch.version", "x")`
+> 
+> Alternatively, you can find the compatible version of OpenSearch by running in project root folder
+> ```
+> ./gradlew properties -q | grep -E '^version:' | awk '{print $2}'
+> ```
+
 ## Building
 
 First create a fork of this repo and clone it locally. You should then change to the directory containing the clone and run this to build the project:
@@ -52,13 +63,6 @@ First create a fork of this repo and clone it locally. You should then change to
 ```bash
 ./gradlew clean assemble
 ```
-
->Worth noting:\
-> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `3.0.0.0-SNAPSHOT` compatible with OpenSearch `3.0.0`. Check the expected compatible version in `build.gradle` file [here](https://github.com/opensearch-project/security/blob/main/build.gradle) and make sure you get the correct branch from OpenSearch when building that project.
-> 
-> The line to look for: `opensearch_version = System.getProperty("opensearch.version", "x")`
-> 
-> Alternatively, you can find the compatible version of OpenSearch by running `./gradlew properties -q | grep -E '^version:' | awk '{print $2}'` in project root folder.
 
 To install the built plugin into the OpenSearch server run:
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -54,7 +54,11 @@ First create a fork of this repo and clone it locally. You should then change to
 ```
 
 >Worth noting:\
-> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `3.0.0.0-SNAPSHOT` compatible with OpenSearch `3.0.0`. Check the expected compatible version of OpenSearch in plugin-descriptor.properties after building the project.
+> The version of OpenSearch and the security plugin must match as there is an explicit version check at startup. This can be a bit confusing as, for example, at the time of writing this guide, the `main` branch of this security plugin builds version `3.0.0.0-SNAPSHOT` compatible with OpenSearch `3.0.0`. Check the expected compatible version in `build.gradle` file [here](https://github.com/opensearch-project/security/blob/main/build.gradle) and make sure you get the correct branch from OpenSearch when building that project.
+> 
+> The line to look for: `opensearch_version = System.getProperty("opensearch.version", "x")`
+> 
+> Alternatively, you can find the compatible version of OpenSearch by running `./gradlew properties -q | grep -E '^version:' | awk '{print $2}'` in project root folder.
 
 To install the built plugin into the OpenSearch server run:
 


### PR DESCRIPTION
### Description
* Category
Documentation
* Why these changes are required?
These changes keep the documentation up-to-date according to the changes which were introduced in earlier contributions. 
* What is the old behavior before changes and new behavior after changes?
Before the changes, when clicking on the "here" link in the "Native platforms" section of [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/security/blob/main/DEVELOPER_GUIDE.md) the user was redirected to a page with 404 error and a message `The 'opensearch-project/security' repository doesn't contain the 'plugin-descriptor.properties' path in 'main'.`

After the changes, the "Worth noting" paragraph was put after building code snippet, so that the user will be able to access the `plugin-descriptor.properties` file, which is created programmatically after [#1623](https://github.com/opensearch-project/security/pull/1623)

### Issues Resolved
*  Resolve: #2581

### Testing
Tested manually by reviewing the edited .md document in the forked repo.
![image](https://user-images.githubusercontent.com/39532643/227200174-9a7b2670-bff0-4bb9-9ed9-cf66b14ca865.png)


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
