### PR TITLE
Dynamic tenancy configurations

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -68,6 +68,8 @@ config:
     #kibana:
     # Kibana multitenancy
     #multitenancy_enabled: true
+    #private_tenant_enabled: true
+    #default_tenant: ""
     #server_username: kibanaserver
     #index: '.kibana'
     http:

--- a/legacy/securityconfig_v6/config.yml
+++ b/legacy/securityconfig_v6/config.yml
@@ -60,6 +60,7 @@ opendistro_security:
     #filtered_alias_mode: warn
     #kibana:
       #multitenancy_enabled: true
+
       #server_username: kibanaserver
       #index: '.kibana'
       #do_not_fail_on_forbidden: false

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -115,6 +115,11 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.query.QuerySearchResult;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
 import org.opensearch.security.action.configupdate.TransportConfigUpdateAction;
+import org.opensearch.security.action.tenancy.TenancyConfigRestHandler;
+import org.opensearch.security.action.tenancy.TenancyConfigRetrieveActions;
+import org.opensearch.security.action.tenancy.TenancyConfigRetrieveTransportAction;
+import org.opensearch.security.action.tenancy.TenancyConfigUpdateAction;
+import org.opensearch.security.action.tenancy.TenancyConfigUpdateTransportAction;
 import org.opensearch.security.action.whoami.TransportWhoAmIAction;
 import org.opensearch.security.action.whoami.WhoAmIAction;
 import org.opensearch.security.auditlog.AuditLog;
@@ -469,6 +474,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
                         Objects.requireNonNull(cs), Objects.requireNonNull(adminDns), Objects.requireNonNull(cr)));
                 handlers.add(new SecurityConfigUpdateAction(settings, restController, Objects.requireNonNull(threadPool), adminDns, configPath, principalExtractor));
                 handlers.add(new SecurityWhoAmIAction(settings, restController, Objects.requireNonNull(threadPool), adminDns, configPath, principalExtractor));
+                handlers.add(new TenancyConfigRestHandler());
                 handlers.addAll(
                         SecurityRestApiActions.getHandler(
                                 settings,
@@ -505,6 +511,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
         if(!disabled && !SSLConfig.isSslOnlyMode()) {
             actions.add(new ActionHandler<>(ConfigUpdateAction.INSTANCE, TransportConfigUpdateAction.class));
             actions.add(new ActionHandler<>(WhoAmIAction.INSTANCE, TransportWhoAmIAction.class));
+
+            actions.add(new ActionHandler<>(TenancyConfigRetrieveActions.INSTANCE, TenancyConfigRetrieveTransportAction.class));
+            actions.add(new ActionHandler<>(TenancyConfigUpdateAction.INSTANCE, TenancyConfigUpdateTransportAction.class));
+
         }
         return actions;
     }

--- a/src/main/java/org/opensearch/security/action/tenancy/EmptyRequest.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/EmptyRequest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+
+public class EmptyRequest extends ActionRequest {
+
+    public EmptyRequest(final StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public EmptyRequest() throws IOException {
+        super();
+    }
+
+    @Override
+    public ActionRequestValidationException validate()
+    {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRestHandler.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRestHandler.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class TenancyConfigRestHandler extends BaseRestHandler {
+
+    public TenancyConfigRestHandler() {
+        super();
+    }
+
+    @Override
+    public String getName() {
+        return "Multi Tenancy actions to Retrieve / Update configs.";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ImmutableList.of(
+                new Route(GET, "/_plugins/_security/api/tenancy/config"),
+                new Route(PUT, "/_plugins/_security/api/tenancy/config")
+        );
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(final RestRequest request, final NodeClient nodeClient) throws IOException {
+
+        switch (request.method()) {
+            case GET:
+                return channel -> nodeClient.execute(
+                        TenancyConfigRetrieveActions.INSTANCE,
+                        new EmptyRequest(),
+                        new RestToXContentListener<>(channel));
+            case PUT:
+                return channel -> nodeClient.execute(
+                        TenancyConfigUpdateAction.INSTANCE,
+                        TenancyConfigUpdateRequest.fromXContent(request.contentParser()),
+                        new RestToXContentListener<>(channel));
+            default:
+                throw new RuntimeException("Not implemented");
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveActions.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveActions.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import org.opensearch.action.ActionType;
+
+public class TenancyConfigRetrieveActions extends ActionType<TenancyConfigRetrieveResponse> {
+
+    public static final TenancyConfigRetrieveActions INSTANCE = new TenancyConfigRetrieveActions();
+    public static final String NAME = "cluster:feature/tenancy/config/read";
+
+    protected TenancyConfigRetrieveActions() {
+        super(NAME, TenancyConfigRetrieveResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveResponse.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveResponse.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionResponse;
+import org.opensearch.common.Strings;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.common.io.stream.StreamOutput;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class TenancyConfigRetrieveResponse extends ActionResponse implements ToXContentObject {
+
+    public TenancyConfigs tenancyConfigs = new TenancyConfigs();
+
+    public TenancyConfigRetrieveResponse(final StreamInput in) throws IOException {
+        super(in);
+        this.tenancyConfigs.multitenancy_enabled = in.readOptionalBoolean();
+        this.tenancyConfigs.private_tenant_enabled = in.readOptionalBoolean();
+        this.tenancyConfigs.default_tenant = in.readOptionalString();
+    }
+
+    public TenancyConfigRetrieveResponse(final TenancyConfigs tenancyConfigs) {
+        this.tenancyConfigs = tenancyConfigs;
+    }
+
+    public TenancyConfigs getMultitenancyConfig() {
+        return tenancyConfigs;
+    }
+
+    public Boolean getMultitenancyEnabled() { return tenancyConfigs.multitenancy_enabled; }
+
+    public Boolean getPrivateTenantEnabled() { return tenancyConfigs.private_tenant_enabled; }
+
+    public String getDefaultTenant() { return tenancyConfigs.default_tenant; }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeBoolean(getMultitenancyEnabled());
+        out.writeBoolean(getPrivateTenantEnabled());
+        out.writeString(getDefaultTenant());
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(XContentType.JSON, this, true, true);
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        builder.field("multitenancy_enabled", getMultitenancyEnabled());
+        builder.field("private_tenant_enabled", getPrivateTenantEnabled());
+        builder.field("default_tenant", getDefaultTenant());
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveTransportAction.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigRetrieveTransportAction.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import java.util.Collections;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class TenancyConfigRetrieveTransportAction
+        extends HandledTransportAction<EmptyRequest, TenancyConfigRetrieveResponse> {
+
+    private final ConfigurationRepository config;
+
+    @Inject
+    public TenancyConfigRetrieveTransportAction(final Settings settings,
+                                                final TransportService transportService,
+                                                final ActionFilters actionFilters,
+                                                final ConfigurationRepository config) {
+        super(TenancyConfigRetrieveActions.NAME, transportService, actionFilters, EmptyRequest::new);
+
+        this.config = config;
+    }
+
+    /** Load the configuration from the security index and return a copy */
+    protected final SecurityDynamicConfiguration<?> load() {
+        return config.getConfigurationsFromIndex(Collections.singleton(CType.CONFIG), false).get(CType.CONFIG).deepClone();
+    }
+
+    @Override
+    protected void doExecute(final Task task, final EmptyRequest request, final ActionListener<TenancyConfigRetrieveResponse> listener) {
+
+        // Get the security configuration and lookup the config setting state
+        final SecurityDynamicConfiguration<?> dynamicConfig = load();
+        ConfigV7 config = (ConfigV7)dynamicConfig.getCEntry("config");
+
+        final TenancyConfigs tenancyConfigs= new TenancyConfigs();
+
+        tenancyConfigs.multitenancy_enabled = config.dynamic.kibana.multitenancy_enabled;
+        tenancyConfigs.private_tenant_enabled = config.dynamic.kibana.private_tenant_enabled;
+        tenancyConfigs.default_tenant = config.dynamic.kibana.default_tenant;
+
+        listener.onResponse(new TenancyConfigRetrieveResponse(tenancyConfigs));
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateAction.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import org.opensearch.action.ActionType;
+
+public class TenancyConfigUpdateAction extends ActionType<TenancyConfigRetrieveResponse> {
+
+    public static final TenancyConfigUpdateAction INSTANCE = new TenancyConfigUpdateAction();
+    public static final String NAME = "cluster:feature/tenancy/config/update";
+
+
+    protected TenancyConfigUpdateAction()
+    {
+        super(NAME, TenancyConfigRetrieveResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateRequest.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateRequest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.common.io.stream.StreamInput;
+import org.opensearch.core.ParseField;
+import org.opensearch.core.xcontent.ConstructingObjectParser;
+import org.opensearch.core.xcontent.XContentParser;
+
+public class TenancyConfigUpdateRequest extends ActionRequest {
+
+    private TenancyConfigs tenancyConfigs = new TenancyConfigs();
+
+    public TenancyConfigUpdateRequest(final StreamInput in) throws IOException {
+        super(in);
+        in.readOptionalBoolean();
+        in.readOptionalBoolean();
+        in.readOptionalString();
+    }
+
+    public TenancyConfigUpdateRequest(final Boolean multitenancy_enabled, final Boolean private_tenant_enabled, final String default_tenant) {
+        super();
+        this.tenancyConfigs.multitenancy_enabled = multitenancy_enabled;
+        this.tenancyConfigs.private_tenant_enabled = private_tenant_enabled;
+        this.tenancyConfigs.default_tenant = default_tenant;
+    }
+
+    public TenancyConfigs getTenancyConfigs() {
+        return tenancyConfigs;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        if (getTenancyConfigs() == null) {
+            final ActionRequestValidationException validationException = new ActionRequestValidationException();
+            validationException.addValidationError("Missing tenancy configs");
+            return validationException;
+        }
+        return null;
+    }
+
+    private static final ConstructingObjectParser<TenancyConfigUpdateRequest, Void> PARSER = new ConstructingObjectParser<>(
+            TenancyConfigUpdateRequest.class.getName(),
+            args -> new TenancyConfigUpdateRequest((Boolean)args[0], (Boolean) args[1], (String) args[2])
+    );
+
+    static {
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), new ParseField("multitenancy_enabled"));
+        PARSER.declareBoolean(ConstructingObjectParser.optionalConstructorArg(), new ParseField("private_tenant_enabled"));
+        PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), new ParseField("default_tenant"));
+
+    }
+
+    public static TenancyConfigUpdateRequest fromXContent(final XContentParser parser) {
+        return PARSER.apply(parser, null);
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateTransportAction.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigUpdateTransportAction.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.ActionListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.client.Client;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.dlic.rest.api.AbstractApiAction;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+public class TenancyConfigUpdateTransportAction extends HandledTransportAction<TenancyConfigUpdateRequest, TenancyConfigRetrieveResponse> {
+
+    private static final Logger log = LogManager.getLogger(TenancyConfigUpdateTransportAction.class);
+
+    private final String securityIndex;
+    private final ConfigurationRepository config;
+    private final Client client;
+    private final ThreadPool pool;
+
+    @Inject
+    public TenancyConfigUpdateTransportAction(final Settings settings,
+                                              final TransportService transportService,
+                                              final ActionFilters actionFilters,
+                                              final ConfigurationRepository config,
+                                              final ThreadPool pool,
+                                              final Client client) {
+        super(TenancyConfigUpdateAction.NAME, transportService, actionFilters, TenancyConfigUpdateRequest::new);
+
+        this.securityIndex = settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);
+
+        this.config = config;
+        this.client = client;
+        this.pool = pool;
+    }
+
+    /** Load the configuration from the security index and return a copy */
+    protected final SecurityDynamicConfiguration<?> load() {
+        return config.getConfigurationsFromIndex(Collections.singleton(CType.CONFIG), false).get(CType.CONFIG).deepClone();
+    }
+
+    private Set<String> getAcceptableDefaultTenants() {
+        Set<String> acceptableDefaultTenants = new HashSet<String>();
+        acceptableDefaultTenants.add(ConfigConstants.TENANCY_GLOBAL_TENANT_DEFAULT_NAME);
+        acceptableDefaultTenants.add(ConfigConstants.TENANCY_GLOBAL_TENANT_NAME);
+        acceptableDefaultTenants.add(ConfigConstants.TENANCY_PRIVATE_TENANT_NAME);
+        return acceptableDefaultTenants;
+    }
+
+    private Set<String> getAllConfiguredTenantNames() {
+
+        return this.config.getConfiguration(CType.TENANTS).getCEntries().keySet();
+    }
+
+    protected void validate(ConfigV7 updatedConfig) {
+        if(!updatedConfig.dynamic.kibana.private_tenant_enabled && (updatedConfig.dynamic.kibana.default_tenant).equals(ConfigConstants.TENANCY_PRIVATE_TENANT_NAME)) {
+            throw new IllegalArgumentException("Private tenant can not be disabled if it is the default tenant.");
+        }
+
+        Set<String> acceptableDefaultTenants = getAcceptableDefaultTenants();
+
+        if(acceptableDefaultTenants.contains(updatedConfig.dynamic.kibana.default_tenant)) {
+            return;
+        }
+
+        Set<String> availableTenants = getAllConfiguredTenantNames();
+
+        if(!availableTenants.contains(updatedConfig.dynamic.kibana.default_tenant)){
+            throw new IllegalArgumentException(updatedConfig.dynamic.kibana.default_tenant + " can not be set to default tenant. Default tenant should be selected from one of the available tenants.");
+        }
+
+    }
+
+    @Override
+    protected void doExecute(final Task task, final TenancyConfigUpdateRequest request, final ActionListener<TenancyConfigRetrieveResponse> listener) {
+
+        // Get the current security config and prepare the config with the updated value
+        final SecurityDynamicConfiguration dynamicConfig = load();
+        final ConfigV7 config = (ConfigV7)dynamicConfig.getCEntry("config");
+
+        final TenancyConfigs tenancyConfigs = request.getTenancyConfigs();
+        if(tenancyConfigs.multitenancy_enabled != null)
+        {
+            config.dynamic.kibana.multitenancy_enabled = tenancyConfigs.multitenancy_enabled;
+        }
+
+        if(tenancyConfigs.private_tenant_enabled != null)
+        {
+            config.dynamic.kibana.private_tenant_enabled = tenancyConfigs.private_tenant_enabled;
+        }
+
+        if(tenancyConfigs.default_tenant != null)
+        {
+            config.dynamic.kibana.default_tenant = tenancyConfigs.default_tenant;
+        }
+
+        validate(config);
+
+        dynamicConfig.putCEntry("config", config);
+
+        // When performing an update to the configuration run as admin
+        try (final ThreadContext.StoredContext stashedContext = pool.getThreadContext().stashContext()) {
+            // Update the security configuration and make sure the cluster has fully refreshed
+            AbstractApiAction.saveAndUpdateConfigs(this.securityIndex, this.client, CType.CONFIG, dynamicConfig, new ActionListener<IndexResponse>(){
+
+                @Override
+                public void onResponse(final IndexResponse response) {
+                    // After processing the request, restore the user context
+                    stashedContext.close();
+                    try {
+                        // Lookup the current value and notify the listener
+                        client.execute(TenancyConfigRetrieveActions.INSTANCE, new EmptyRequest(), listener);
+                    } catch (IOException ioe) {
+                        log.error(ioe);
+                        listener.onFailure(ioe);
+                    }
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    log.error(e);
+                    listener.onFailure(e);
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigs.java
+++ b/src/main/java/org/opensearch/security/action/tenancy/TenancyConfigs.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.tenancy;
+
+public class TenancyConfigs {
+    public Boolean multitenancy_enabled;
+    public Boolean private_tenant_enabled;
+    public String default_tenant;
+}

--- a/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -108,6 +108,13 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         final String dashboardsIndexName = config.getDashboardsIndexname();//config.dynamic.kibana.index;
 
         String requestedTenant = user.getRequestedTenant();
+        if(USER_TENANT.equals(requestedTenant)) {
+            final boolean private_tenant_enabled = config.isDashboardsPrivateTenantEnabled();
+            if(!private_tenant_enabled) {
+                return ACCESS_DENIED_REPLACE_RESULT;
+            }
+        }
+
         final boolean isDebugEnabled = log.isDebugEnabled();
         if (isDebugEnabled) {
             log.debug("raw requestedTenant: '" + requestedTenant + "'");

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -73,7 +73,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 	protected final ConfigurationRepository cl;
 	protected final ClusterService cs;
 	final ThreadPool threadPool;
-	protected String opendistroIndex;
+	protected String securityIndexName;
 	private final RestApiPrivilegesEvaluator restApiPrivilegesEvaluator;
 	protected final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator;
 	protected final AuditLog auditLog;
@@ -85,7 +85,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
                                 ThreadPool threadPool, AuditLog auditLog) {
 		super();
 		this.settings = settings;
-		this.opendistroIndex = settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
+		this.securityIndexName = settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
 				ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);
 
 		this.cl = cl;
@@ -153,7 +153,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		existingConfiguration.remove(name);
 
 		if (existed) {
-			saveAnUpdateConfigs(client, request, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
+			AbstractApiAction.saveAndUpdateConfigs(this.securityIndexName, client, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
 				@Override
 				public void onResponse(IndexResponse response) {
@@ -203,7 +203,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		}
 		existingConfiguration.putCObject(name, newContent);
 
-		saveAnUpdateConfigs(client, request, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
+		AbstractApiAction.saveAndUpdateConfigs(this.securityIndexName, client, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
 			@Override
 			public void onResponse(IndexResponse response) {
@@ -266,7 +266,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
     }
 
 	protected boolean ensureIndexExists() {
-		if (!cs.state().metadata().hasConcreteIndex(this.opendistroIndex)) {
+		if (!cs.state().metadata().hasConcreteIndex(this.securityIndexName)) {
 			return false;
 		}
 		return true;
@@ -309,11 +309,8 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
 	}
 
-	protected void saveAnUpdateConfigs(final Client client, final RestRequest request, final CType cType,
-									   final SecurityDynamicConfiguration<?> configuration, OnSucessActionListener<IndexResponse> actionListener) {
-		final IndexRequest ir = new IndexRequest(this.opendistroIndex);
-
-		//final String type = "_doc";
+	public static void saveAndUpdateConfigs(final String indexName, final Client client, final CType cType, final SecurityDynamicConfiguration<?> configuration, final ActionListener<IndexResponse> actionListener) {
+		final IndexRequest ir = new IndexRequest(indexName);
 		final String id = cType.toLCString();
 
 		configuration.removeStatic();
@@ -481,6 +478,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		try {
 			final XContentBuilder builder = channel.newBuilder();
 			builder.startObject();
+			builder.endObject();
 			channel.sendResponse(
 					new BytesRestResponse(RestStatus.OK, builder));
 		} catch (IOException e) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -224,7 +224,7 @@ public class AccountApiAction extends AbstractApiAction {
 
         internalUserEntry.setHash(hash);
 
-        saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internalUser, new OnSucessActionListener<IndexResponse>(channel) {
+        AccountApiAction.saveAndUpdateConfigs(this.securityIndexName, client, CType.INTERNALUSERS, internalUser, new OnSucessActionListener<IndexResponse>(channel) {
             @Override
             public void onResponse(IndexResponse response) {
                 successResponse(channel, "'" + username + "' updated.");

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AllowlistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AllowlistApiAction.java
@@ -141,7 +141,7 @@ public class AllowlistApiAction extends PatchableResourceApiAction {
         boolean existed = existingConfiguration.exists(name);
         existingConfiguration.putCObject(name, DefaultObjectMapper.readTree(content, existingConfiguration.getImplementingClass()));
 
-        saveAnUpdateConfigs(client, request, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
+        saveAndUpdateConfigs(this.securityIndexName,client, getConfigName(), existingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
             @Override
             public void onResponse(IndexResponse response) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -172,7 +172,7 @@ public class InternalUsersApiAction extends PatchableResourceApiAction {
         // checks complete, create or update the user
         internalUsersConfiguration.putCObject(username, DefaultObjectMapper.readTree(contentAsNode,  internalUsersConfiguration.getImplementingClass()));
 
-        saveAnUpdateConfigs(client, request, CType.INTERNALUSERS, internalUsersConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
+        saveAndUpdateConfigs(this.securityIndexName,client, CType.INTERNALUSERS, internalUsersConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
             @Override
             public void onResponse(IndexResponse response) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/PatchableResourceApiAction.java
@@ -162,7 +162,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             }
         }
 
-        saveAnUpdateConfigs(client, request, getConfigName(), mdc, new OnSucessActionListener<IndexResponse>(channel){
+        saveAndUpdateConfigs(this.securityIndexName,client, getConfigName(), mdc, new OnSucessActionListener<IndexResponse>(channel){
 
             @Override
             public void onResponse(IndexResponse response) {
@@ -244,7 +244,7 @@ public abstract class PatchableResourceApiAction extends AbstractApiAction {
             }
         }
 
-        saveAnUpdateConfigs(client, request, getConfigName(), mdc, new OnSucessActionListener<IndexResponse>(channel) {
+        saveAndUpdateConfigs(this.securityIndexName,client, getConfigName(), mdc, new OnSucessActionListener<IndexResponse>(channel) {
 
             @Override
             public void onResponse(IndexResponse response) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -82,7 +82,7 @@ public class RolesMappingApiAction extends PatchableResourceApiAction {
 		}
 		rolesMappingConfiguration.putCObject(name, DefaultObjectMapper.readTree(content, rolesMappingConfiguration.getImplementingClass()));
 
-		saveAnUpdateConfigs(client, request, getConfigName(), rolesMappingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
+		saveAndUpdateConfigs(this.securityIndexName,client, getConfigName(), rolesMappingConfiguration, new OnSucessActionListener<IndexResponse>(channel) {
 
 			@Override
 			public void onResponse(IndexResponse response) {

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -525,6 +525,15 @@ public class PrivilegesEvaluator {
                 && dcm.isDashboardsMultitenancyEnabled();
     }
 
+    public boolean privateTenantEnabled() {
+        return privilegesInterceptor.getClass() != PrivilegesInterceptor.class
+                && dcm.isDashboardsPrivateTenantEnabled();
+    }
+
+    public String dashboardsDefaultTenant() {
+        return dcm.getDashboardsDefaultTenant();
+    }
+
     public boolean notFailOnForbiddenEnabled() {
         return privilegesInterceptor.getClass() != PrivilegesInterceptor.class
                 && dcm.isDnfofEnabled();

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -103,6 +103,9 @@ public class DashboardsInfoAction extends BaseRestHandler {
                     builder.field("opensearch_dashboards_mt_enabled", evaluator.multitenancyEnabled());
                     builder.field("opensearch_dashboards_index", evaluator.dashboardsIndex());
                     builder.field("opensearch_dashboards_server_user", evaluator.dashboardsServerUsername());
+                    builder.field("multitenancy_enabled", evaluator.multitenancyEnabled());
+                    builder.field("private_tenant_enabled", evaluator.privateTenantEnabled());
+                    builder.field("default_tenant", evaluator.dashboardsDefaultTenant());
                     builder.endObject();
 
                     response = new BytesRestResponse(RestStatus.OK, builder);

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModel.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModel.java
@@ -68,6 +68,8 @@ public abstract class DynamicConfigModel {
     public abstract String getDashboardsOpenSearchRole();
     public abstract String getDashboardsIndexname();
     public abstract boolean isDashboardsMultitenancyEnabled();
+    public abstract boolean isDashboardsPrivateTenantEnabled();
+    public abstract String getDashboardsDefaultTenant();
     public abstract boolean isDnfofEnabled();
     public abstract boolean isMultiRolespanEnabled();
     public abstract String getFilteredAliasMode();

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
@@ -141,6 +141,12 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         return config.dynamic.kibana.multitenancy_enabled;
     }
     @Override
+    public boolean isDashboardsPrivateTenantEnabled() {
+        return config.dynamic.kibana.private_tenant_enabled;
+    }
+    @Override
+    public String getDashboardsDefaultTenant() { return config.dynamic.kibana.default_tenant; }
+    @Override
     public boolean isDnfofEnabled() {
         return config.dynamic.do_not_fail_on_forbidden || config.dynamic.kibana.do_not_fail_on_forbidden;
     }

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -141,6 +141,12 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         return config.dynamic.kibana.multitenancy_enabled;
     }
     @Override
+    public boolean isDashboardsPrivateTenantEnabled() {
+        return config.dynamic.kibana.private_tenant_enabled;
+    }
+    @Override
+    public String getDashboardsDefaultTenant() { return config.dynamic.kibana.default_tenant; }
+    @Override
     public boolean isDnfofEnabled() {
         return config.dynamic.do_not_fail_on_forbidden;
     }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -83,6 +83,10 @@ public class ConfigV6 {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean multitenancy_enabled = true;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public boolean private_tenant_enabled = true;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public String default_tenant = "";
         public String server_username = "kibanaserver";
         public String opendistro_role = null;
         public String index = ".kibana";

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -69,6 +69,8 @@ public class ConfigV7 {
         
         dynamic.kibana.index = c6.dynamic.kibana.index;
         dynamic.kibana.multitenancy_enabled = c6.dynamic.kibana.multitenancy_enabled;
+        dynamic.kibana.private_tenant_enabled = true;
+        dynamic.kibana.default_tenant = "";
         dynamic.kibana.server_username = c6.dynamic.kibana.server_username;
         
         dynamic.http = new Http();
@@ -135,12 +137,18 @@ public class ConfigV7 {
 
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean multitenancy_enabled = true;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public boolean private_tenant_enabled = true;
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        public String default_tenant = "";
         public String server_username = "kibanaserver";
         public String opendistro_role = null;
         public String index = ".kibana";
         @Override
         public String toString() {
-            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", server_username=" + server_username + ", opendistro_role=" + opendistro_role
+            return "Kibana [multitenancy_enabled=" + multitenancy_enabled + ", private_tenant_enabled=" +
+                    private_tenant_enabled + ", default_tenant=" + default_tenant + ", server_username=" +
+                    server_username + ", opendistro_role=" + opendistro_role
             + ", index=" + index + "]";
         }
         

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -287,6 +287,10 @@ public class ConfigConstants {
     public static final String SECURITY_SYSTEM_INDICES_KEY = "plugins.security.system_indices.indices";
     public static final List<String> SECURITY_SYSTEM_INDICES_DEFAULT = Collections.emptyList();
 
+    public static final String TENANCY_PRIVATE_TENANT_NAME = "Private";
+    public static final String TENANCY_GLOBAL_TENANT_NAME = "Global";
+    public static final String TENANCY_GLOBAL_TENANT_DEFAULT_NAME = "";
+
     public static Set<String> getSettingAsSet(final Settings settings, final String key, final List<String> defaultList, final boolean ignoreCaseForNone) {
         final List<String> list = settings.getAsList(key, defaultList);
         if (list.size() == 1 && "NONE".equals(ignoreCaseForNone? list.get(0).toUpperCase() : list.get(0))) {

--- a/src/test/java/org/opensearch/security/multitenancy/test/TenancyDefaultTenantTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/TenancyDefaultTenantTests.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.multitenancy.test;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.Test;
+
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class TenancyDefaultTenantTests extends SingleClusterTest {
+    private final Header asAdminUser = encodeBasicHeader("admin", "admin");
+    private final Header asUser = encodeBasicHeader("kirk", "kirk");
+
+    @Override
+    protected String getResourceFolder() {
+        return "multitenancy";
+    }
+
+    @Test
+    public void testDefaultTenantUpdate() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asAdminUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getSettingResponse.findValueInJson("default_tenant"), equalTo(ConfigConstants.TENANCY_GLOBAL_TENANT_DEFAULT_NAME));
+
+        HttpResponse getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getDashboardsinfoResponse.findValueInJson("default_tenant"), equalTo(ConfigConstants.TENANCY_GLOBAL_TENANT_DEFAULT_NAME));
+
+        final HttpResponse setPrivateTenantAsDefaultResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"Private\"}", asAdminUser);
+        assertThat(setPrivateTenantAsDefaultResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getDashboardsinfoResponse.findValueInJson("default_tenant"), equalTo(ConfigConstants.TENANCY_PRIVATE_TENANT_NAME));
+    }
+
+    @Test
+    public void testDefaultTenant_UpdateFailed() throws Exception {
+        setup();
+
+        final HttpResponse disablePrivateTenantResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"private_tenant_enabled\":false}", asAdminUser);
+        assertThat(disablePrivateTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+
+
+        final HttpResponse setPrivateTenantAsDefaultFailResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"Private\"}", asAdminUser);
+        assertThat(setPrivateTenantAsDefaultFailResponse.getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(setPrivateTenantAsDefaultFailResponse.findValueInJson("error.reason"), containsString("Private tenant can not be disabled if it is the default tenant."));
+
+        final HttpResponse enablePrivateTenantResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"private_tenant_enabled\":true}", asAdminUser);
+        assertThat(enablePrivateTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+
+        final HttpResponse setPrivateTenantAsDefaultResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"Private\"}", asAdminUser);
+        assertThat(setPrivateTenantAsDefaultResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+
+        final HttpResponse getSettingResponseAfterUpdate = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asAdminUser);
+        assertThat(getSettingResponseAfterUpdate.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getSettingResponseAfterUpdate.findValueInJson("default_tenant"), equalTo(ConfigConstants.TENANCY_PRIVATE_TENANT_NAME));
+
+        HttpResponse getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.findValueInJson("default_tenant"),equalTo(ConfigConstants.TENANCY_PRIVATE_TENANT_NAME));
+
+        final HttpResponse setRandomStringAsDefaultTenant = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"NonExistentTenant\"}", asAdminUser);
+        assertThat(setRandomStringAsDefaultTenant.getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(setRandomStringAsDefaultTenant.findValueInJson("error.reason"), containsString("Default tenant should be selected from one of the available tenants."));
+
+    }
+    @Test
+    public void testForbiddenAccess() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(getSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/read]"));
+
+        final HttpResponse updateSettingResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"Private\"}", asUser);
+        assertThat(updateSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(updateSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/update]"));
+    }
+}

--- a/src/test/java/org/opensearch/security/multitenancy/test/TenancyMultitenancyEnabledTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/TenancyMultitenancyEnabledTests.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.multitenancy.test;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.Test;
+
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class TenancyMultitenancyEnabledTests extends SingleClusterTest {
+    private final Header asAdminUser = encodeBasicHeader("admin", "admin");
+    private final Header asUser = encodeBasicHeader("kirk", "kirk");
+    private final Header onUserTenant = new BasicHeader("securitytenant", "__user__");
+    
+    private static String createIndexPatternDoc(final String title) {
+        return "{"+
+        "\"type\" : \"index-pattern\","+
+        "\"updated_at\" : \"2018-09-29T08:56:59.066Z\","+
+        "\"index-pattern\" : {"+
+            "\"title\" : \"" + title + "\""+
+            "}}";
+    } 
+
+    @Override
+    protected String getResourceFolder() {
+        return "multitenancy";
+    }
+
+    @Test
+    public void testMultitenancyDisabled_endToEndTest() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asAdminUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getSettingResponse.findValueInJson("multitenancy_enabled"), equalTo("true"));
+
+        HttpResponse getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.findValueInJson("multitenancy_enabled"),equalTo("true"));
+
+        final HttpResponse createDocInGlobalTenantResponse = nonSslRestHelper().executePostRequest(".kibana/_doc?refresh=true", createIndexPatternDoc("globalIndex"), asAdminUser);
+        assertThat(createDocInGlobalTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_CREATED));
+        final HttpResponse createDocInUserTenantResponse = nonSslRestHelper().executePostRequest(".kibana/_doc?refresh=true", createIndexPatternDoc("userIndex"), onUserTenant, asAdminUser);
+        assertThat(createDocInUserTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_CREATED));
+
+        final HttpResponse searchInUserTenantWithMutlitenancyEnabled = nonSslRestHelper().executeGetRequest(".kibana/_search", onUserTenant, asAdminUser);
+        assertThat(searchInUserTenantWithMutlitenancyEnabled.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(searchInUserTenantWithMutlitenancyEnabled.findValueInJson("hits.hits[0]._source.index-pattern.title"), equalTo("userIndex"));
+
+        final HttpResponse updateMutlitenancyToDisabled = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"multitenancy_enabled\": \"false\"}", asAdminUser);
+        assertThat(updateMutlitenancyToDisabled.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(updateMutlitenancyToDisabled.findValueInJson("multitenancy_enabled"), equalTo("false"));
+
+        getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.findValueInJson("multitenancy_enabled"),equalTo("false"));
+
+        final HttpResponse searchInUserTenantWithMutlitenancyDisabled = nonSslRestHelper().executeGetRequest(".kibana/_search", onUserTenant, asAdminUser);
+        assertThat(searchInUserTenantWithMutlitenancyDisabled.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(searchInUserTenantWithMutlitenancyDisabled.findValueInJson("hits.hits[0]._source.index-pattern.title"), equalTo("globalIndex"));
+    }
+
+    @Test
+    public void testForbiddenAccess() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(getSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/read]"));
+
+        final HttpResponse updateSettingResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"multitenancy_enabled\": \"false\"}", asUser);
+        assertThat(updateSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(updateSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/update]"));
+    }
+}

--- a/src/test/java/org/opensearch/security/multitenancy/test/TenancyPrivateTenantEnabledTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/TenancyPrivateTenantEnabledTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.multitenancy.test;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.Test;
+
+import org.opensearch.security.test.SingleClusterTest;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class TenancyPrivateTenantEnabledTests extends SingleClusterTest {
+    private final Header asAdminUser = encodeBasicHeader("admin", "admin");
+    private final Header asUser = encodeBasicHeader("kirk", "kirk");
+    private final Header onUserTenant = new BasicHeader("securitytenant", "__user__");
+
+    private static String createIndexPatternDoc(final String title) {
+        return "{"+
+                "\"type\" : \"index-pattern\","+
+                "\"updated_at\" : \"2018-09-29T08:56:59.066Z\","+
+                "\"index-pattern\" : {"+
+                "\"title\" : \"" + title + "\""+
+                "}}";
+    }
+
+    @Override
+    protected String getResourceFolder() {
+        return "multitenancy";
+    }
+
+    @Test
+    public void testPrivateTenantDisabled_Update() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asAdminUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(getSettingResponse.findValueInJson("private_tenant_enabled"), equalTo("true"));
+
+        HttpResponse getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.findValueInJson("private_tenant_enabled"), equalTo("true"));
+
+        final HttpResponse createDocInGlobalTenantResponse = nonSslRestHelper().executePostRequest(".kibana/_doc?refresh=true", createIndexPatternDoc("globalIndex"), asAdminUser);
+        assertThat(createDocInGlobalTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_CREATED));
+        final HttpResponse createDocInUserTenantResponse = nonSslRestHelper().executePostRequest(".kibana/_doc?refresh=true", createIndexPatternDoc("userIndex"), onUserTenant, asUser);
+        assertThat(createDocInUserTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_CREATED));
+
+        final HttpResponse searchInUserTenantWithPrivateTenantEnabled = nonSslRestHelper().executeGetRequest(".kibana/_search", onUserTenant, asUser);
+        assertThat(searchInUserTenantWithPrivateTenantEnabled.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(searchInUserTenantWithPrivateTenantEnabled.findValueInJson("hits.hits[0]._source.index-pattern.title"), equalTo("userIndex"));
+
+        final HttpResponse disablePrivateTenantResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"private_tenant_enabled\": \"false\"}", asAdminUser);
+        assertThat(disablePrivateTenantResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(disablePrivateTenantResponse.findValueInJson("private_tenant_enabled"), equalTo("false"));
+
+        getDashboardsinfoResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/dashboardsinfo", asAdminUser);
+        assertThat(getDashboardsinfoResponse.findValueInJson("private_tenant_enabled"),equalTo("false"));
+
+        final HttpResponse searchInUserTenantWithPrivateTenantDisabled = nonSslRestHelper().executeGetRequest(".kibana/_search", onUserTenant, asUser);
+        assertThat(searchInUserTenantWithPrivateTenantDisabled.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(searchInUserTenantWithPrivateTenantDisabled.findValueInJson("error.reason"), containsString("no permissions for [indices:data/read/search] and User"));
+
+    }
+
+    @Test
+    public void testPrivateTenantDisabled_UpdateFailed() throws Exception {
+        setup();
+
+        final HttpResponse setPrivateTenantAsDefaultResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"default_tenant\": \"Private\"}", asAdminUser);
+        assertThat(setPrivateTenantAsDefaultResponse.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        final HttpResponse updateSettingResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"private_tenant_enabled\":false}", asAdminUser);
+        assertThat(updateSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
+        assertThat(updateSettingResponse.findValueInJson("error.reason"), containsString("Private tenant can not be disabled if it is the default tenant."));
+    }
+
+    @Test
+    public void testForbiddenAccess() throws Exception {
+        setup();
+
+        final HttpResponse getSettingResponse = nonSslRestHelper().executeGetRequest("/_plugins/_security/api/tenancy/config", asUser);
+        assertThat(getSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(getSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/read]"));
+
+        final HttpResponse updateSettingResponse = nonSslRestHelper().executePutRequest("/_plugins/_security/api/tenancy/config", "{\"private_tenant_enabled\": false}", asUser);
+        assertThat(updateSettingResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        assertThat(updateSettingResponse.findValueInJson("error.reason"), containsString("no permissions for [cluster:feature/tenancy/config/update]"));
+    }
+}

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -92,8 +92,6 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.file.FileHelper;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 public class RestHelper {
 
 	protected final Logger log = LogManager.getLogger(RestHelper.class);
@@ -480,7 +478,7 @@ public class RestHelper {
 		public String findValueInJson(final String jsonDotPath) {
 			// Make sure its json / then parse it
 			if (!isJsonContentType()) {
-				fail("Response was expected to be JSON, body was: \n" + body);
+				throw new RuntimeException("Response was expected to be JSON, body was: \n" + body);
 			}
 			JsonNode currentNode = null;
 			try {
@@ -492,7 +490,7 @@ public class RestHelper {
 			// Break the path into parts, and scan into the json object
 			try (final Scanner jsonPathScanner = new Scanner(jsonDotPath).useDelimiter("\\.")) {
 				if (!jsonPathScanner.hasNext()) {
-					fail("Invalid json dot path '" + jsonDotPath + "', rewrite with '.' characters between path elements.");
+					throw new RuntimeException("Invalid json dot path '" + jsonDotPath + "', rewrite with '.' characters between path elements.");
 				}
 				do {
 					String pathEntry = jsonPathScanner.next();
@@ -510,23 +508,23 @@ public class RestHelper {
 					}
 
 					if (!currentNode.has(pathEntry)) {
-						fail("Unable to resolve '" + jsonDotPath + "', on path entry '" + pathEntry + "' from available fields " + currentNode.toPrettyString());
+						throw new RuntimeException("Unable to resolve '" + jsonDotPath + "', on path entry '" + pathEntry + "' from available fields " + currentNode.toPrettyString());
 					}
 					currentNode = currentNode.get(pathEntry);
 
 					// if it's an Array lookup we get the requested index item
 					if (arrayEntryIdx > -1) {
 						if(!currentNode.isArray()) {
-							fail("Unable to resolve '" + jsonDotPath + "', the '" + pathEntry + "' field is not an array " + currentNode.toPrettyString());
+							throw new RuntimeException("Unable to resolve '" + jsonDotPath + "', the '" + pathEntry + "' field is not an array " + currentNode.toPrettyString());
 						} else if (!currentNode.has(arrayEntryIdx)) {
-							fail("Unable to resolve '" + jsonDotPath + "', index '" + arrayEntryIdx + "' is out of bounds for array '" + pathEntry + "' \n" + currentNode.toPrettyString());
+							throw new RuntimeException("Unable to resolve '" + jsonDotPath + "', index '" + arrayEntryIdx + "' is out of bounds for array '" + pathEntry + "' \n" + currentNode.toPrettyString());
 						}
 						currentNode = currentNode.get(arrayEntryIdx);
 					}
 				} while (jsonPathScanner.hasNext());
 
 				if (!currentNode.isValueNode()) {
-					fail("Unexpected value note, index directly to the object to reference, object\n" + currentNode.toPrettyString());
+					throw new RuntimeException("Unexpected value note, index directly to the object to reference, object\n" + currentNode.toPrettyString());
 				}
 				return currentNode.asText();
 			}

--- a/src/test/resources/auditlog/config.yml
+++ b/src/test/resources/auditlog/config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/cache/config.yml
+++ b/src/test/resources/cache/config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/composite_config.yml
+++ b/src/test/resources/composite_config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config.yml
+++ b/src/test/resources/config.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_anon.yml
+++ b/src/test/resources/config_anon.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_clientcert.yml
+++ b/src/test/resources/config_clientcert.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_disable_all.yml
+++ b/src/test/resources/config_disable_all.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_dnfof.yml
+++ b/src/test/resources/config_dnfof.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_invalidlic.yml
+++ b/src/test/resources/config_invalidlic.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_lic.yml
+++ b/src/test/resources/config_lic.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_lic_rk.yml
+++ b/src/test/resources/config_lic_rk.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_multirolespan.yml
+++ b/src/test/resources/config_multirolespan.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_protected_indices.yml
+++ b/src/test/resources/config_protected_indices.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_proxy.yml
+++ b/src/test/resources/config_proxy.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_proxy_custom.yml
+++ b/src/test/resources/config_proxy_custom.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_respect_indices_options.yml
+++ b/src/test/resources/config_respect_indices_options.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_rest_impersonation.yml
+++ b/src/test/resources/config_rest_impersonation.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_system_indices.yml
+++ b/src/test/resources/config_system_indices.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_transport_username.yml
+++ b/src/test/resources/config_transport_username.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/config_xff.yml
+++ b/src/test/resources/config_xff.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/dlsfls/config.yml
+++ b/src/test/resources/dlsfls/config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/ldap/config.yml
+++ b/src/test/resources/ldap/config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/ldap/config_ldap2.yml
+++ b/src/test/resources/ldap/config_ldap2.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/multitenancy/config.yml
+++ b/src/test/resources/multitenancy/config.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/multitenancy/config_anonymous.yml
+++ b/src/test/resources/multitenancy/config_anonymous.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/multitenancy/config_basic_auth.yml
+++ b/src/test/resources/multitenancy/config_basic_auth.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/multitenancy/config_nodnfof.yml
+++ b/src/test/resources/multitenancy/config_nodnfof.yml
@@ -11,6 +11,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/restapi/config.yml
+++ b/src/test/resources/restapi/config.yml
@@ -10,6 +10,8 @@ config:
     license: null
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:

--- a/src/test/resources/restapi/invalid_config.json
+++ b/src/test/resources/restapi/invalid_config.json
@@ -7,6 +7,8 @@
     "respect_request_indices_options":false,
     "kibana":{
       "multitenancy_enabled":true,
+      "private_tenant_enabled" : true,
+      "default_tenant" : "",
       "server_username":"kibanaserver",
       "index":".kibana"
     },

--- a/src/test/resources/restapi/security_config.json
+++ b/src/test/resources/restapi/security_config.json
@@ -7,6 +7,8 @@
           "respect_request_indices_options":false,
           "kibana":{
              "multitenancy_enabled":true,
+             "private_tenant_enabled" : true,
+             "default_tenant" : "",
              "server_username":"kibanaserver",
              "index":".kibana"
           },

--- a/src/test/resources/restapi/securityconfig.json
+++ b/src/test/resources/restapi/securityconfig.json
@@ -7,6 +7,8 @@
     "respect_request_indices_options":false,
     "kibana":{
       "multitenancy_enabled":true,
+      "private_tenant_enabled" : true,
+      "default_tenant" : "",
       "server_username":"kibanaserver",
       "index":".kibana"
     },

--- a/src/test/resources/restapi/securityconfig_nondefault.json
+++ b/src/test/resources/restapi/securityconfig_nondefault.json
@@ -6,6 +6,8 @@
     "respect_request_indices_options" : false,
     "kibana" : {
       "multitenancy_enabled" : true,
+      "private_tenant_enabled" : true,
+      "default_tenant" : "",
       "server_username" : "kibanaserver",
       "index" : ".kibana"
     },

--- a/src/test/resources/security_passive/config.yml
+++ b/src/test/resources/security_passive/config.yml
@@ -10,6 +10,8 @@ config:
     respect_request_indices_options: false
     kibana:
       multitenancy_enabled: true
+      private_tenant_enabled: true
+      default_tenant: ""
       server_username: "kibanaserver"
       index: ".kibana"
     http:


### PR DESCRIPTION

### Description
* Category : Enhancement
* Why these changes are required?
These changes are required to dynamically enable/disable multi-tenancy, private tenant and set a default tenant.
* What is the old behavior before changes and new behavior after changes?
Earlier users had to change YAML files in each node and restart node to enable/disable multi-tenancy and private tenant. With our changes, users will be able to change these settings dynamically. We will also give admins the option to set a default tenant for all users for first time log in.
More details can be found here:
https://github.com/opensearch-project/OpenSearch/issues/5853
https://github.com/opensearch-project/security-dashboards-plugin/issues/1302

Previous PR for the same issue: https://github.com/opensearch-project/security/pull/2444

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/1302

Is this a backport? If so, please add backport PR # and/or commits #
Nope

### Testing
We have done manual testing for all changes on our local server. We have also unit tests for our api changes. 

### Check List
- [ ✅ ] New functionality includes testing
- [] New functionality has been documented. : Will document in further commits.
- [ ✅ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
