### PR TITLE
Add Andriy Redko as a co-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cliu123 @cwperks @DarshitChanpura @davidlago @peternied @RyanL1997 @scrawfor99
+* @cliu123 @cwperks @DarshitChanpura @davidlago @peternied @RyanL1997 @scrawfor99 @reta

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,6 +21,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
+| Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 
 ## Practices
 


### PR DESCRIPTION
### Description
I nominated Andriy Redko (@reta) to be a co-maintainer for Security through our [nomination process](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#nomination). The maintainers have agreed, and Andriy has kindly accepted.

Andriy’s involvement has taken many shapes, here are some highlights:

* Code
  * Features work such as support for HTTP/2
  * Manual Backports for CVEs
  * Build infrastructure such as Gradle changes
  * Test infrastructure such as fixes to OpenSSLTests
* Particpation in issues
* Adding contributors
  * @reta
* Active participate in triage meeting / process
* Passion for quality

Thank you

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
