### PR TITLE
Fix failing OpenSSL tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -455,8 +455,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
-        testImplementation "io.netty:netty-tcnative-classes:2.0.54.Final"
-        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.54.Final:${osdetector.classifier}"
+        testImplementation "io.netty:netty-tcnative-classes:2.0.59.Final"
+        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.59.Final:${osdetector.classifier}"
     }
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -323,7 +323,7 @@ public final class ClusterHelper {
 
             final List<NodeInfo> nodes = res.getNodes();
 
-            final List<NodeInfo> clusterManagerNodes = nodes.stream().filter(n->n.getNode().getRoles().contains(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)).collect(Collectors.toList());
+            final List<NodeInfo> clusterManagerNodes = nodes.stream().filter(n->n.getNode().getRoles().stream().anyMatch(r -> r.roleName().equals("master"))).collect(Collectors.toList());
             final List<NodeInfo> dataNodes = nodes.stream().filter(n->n.getNode().getRoles().contains(DiscoveryNodeRole.DATA_ROLE) && !n.getNode().getRoles().contains(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)).collect(Collectors.toList());
             // Sorting the nodes so that the node receiving the http requests is always deterministic
             dataNodes.sort(Comparator.comparing(nodeInfo -> nodeInfo.getNode().getName()));


### PR DESCRIPTION
### Description

Fixes failing OpenSSLTest errors where the cluster is not able to form because it cannot connect to cluster manager node. This change in main (https://github.com/opensearch-project/OpenSearch/pull/6331) made it so that these lines in ClusterHelper:

```
final List<NodeInfo> clusterManagerNodes = nodes.stream().filter(n->n.getNode().getRoles().contains(DiscoveryNodeRole.CLUSTER_MANAGER_ROLE)).collect(Collectors.toList());
```

returned an empty list. By change this line, I was able to fix the test issues.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
