### PR TITLE
[Backport 1.3] Remediate CVE-2023-1370 and CVE-2023-20861 via version bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,11 +78,11 @@ configurations.all {
         force 'commons-codec:commons-codec:1.14'
         force 'org.apache.santuario:xmlsec:2.2.3'
         force 'org.cryptacular:cryptacular:1.2.4'
-        force 'net.minidev:json-smart:2.4.7'
+        force 'net.minidev:json-smart:2.4.10'
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
-        force "org.springframework:spring-core:5.3.20"
+        force "org.springframework:spring-core:5.3.26"
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"


### PR DESCRIPTION
### Description
Bumps JSON-Smart to version 2.4.10 to address https://github.com/advisories/GHSA-493p-pfq6-5258.
Bumps Spring-core to version 5.3.26 to address https://github.com/advisories/GHSA-564r-hj7v-mcr5.

Backport of #2606 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
