### PR TITLE
 [Backport 2.6] Remediate CVE-2023-1370 and CVE-2023-20861 via version bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -318,7 +318,7 @@ dependencies {
     implementation 'com.jayway.jsonpath:json-path:2.4.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'net.minidev:json-smart:2.4.7'
+    implementation 'net.minidev:json-smart:2.4.10'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'
     runtimeOnly 'com.google.guava:failureaccess:1.0.1'
@@ -369,7 +369,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.3'
-    testRuntimeOnly ('org.springframework:spring-core:5.3.21') {
+    testRuntimeOnly ('org.springframework:spring-core:5.3.26') {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.9'


### PR DESCRIPTION
### Description
Bumps JSON-Smart to version 2.4.10 to address https://github.com/advisories/GHSA-493p-pfq6-5258.
Bumps Spring-core to version 5.3.26 to address https://github.com/advisories/GHSA-564r-hj7v-mcr5.

Backports https://github.com/opensearch-project/security/pull/2606

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
