### PR TITLE
Corrects CVE-2023-20863 by forcing spring-expression version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ configurations.all {
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.26"
+        force "org.springframework:spring-expression:5.3.27"
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"


### PR DESCRIPTION
### Description
Corrects CVE-2023-20863 by forcing spring-expression up to a corrected version. 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
