### PR TITLE
Switch from ImmutableOpenMap to Map in AliasExistsMatcher

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
@@ -9,23 +9,20 @@
 */
 package org.opensearch.test.framework.matcher;
 
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.AliasMetadata;
+
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-
-import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
-import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
-import org.opensearch.client.Client;
-import org.opensearch.cluster.metadata.AliasMetadata;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Spliterator.IMMUTABLE;

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
@@ -44,11 +44,7 @@ class AliasExistsMatcher extends TypeSafeDiagnosingMatcher<Client> {
 		try {
 			GetAliasesResponse response = client.admin().indices().getAliases(new GetAliasesRequest(aliasName)).get();
 
-			final Map<String, List<AliasMetadata>> aliases = new HashMap<>();
-			for (ObjectObjectCursor<String, List<AliasMetadata>> cursor : response.getAliases()) {
-				aliases.put(cursor.key, cursor.value);
-			}
-
+			Map<String, List<AliasMetadata>> aliases = response.getAliases();
 			Set<String> actualAliasNames = StreamSupport.stream(spliteratorUnknownSize(aliases.values().iterator(), IMMUTABLE), false)
 					.flatMap(Collection::stream)
 					.map(AliasMetadata::getAlias)
@@ -61,7 +57,7 @@ class AliasExistsMatcher extends TypeSafeDiagnosingMatcher<Client> {
 			return true;
 		} catch (InterruptedException | ExecutionException e) {
 			mismatchDescription.appendText("Error occurred during checking if cluster contains alias ")
-				.appendValue(e);
+					.appendValue(e);
 			return false;
 		}
 	}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/AliasExistsMatcher.java
@@ -9,13 +9,6 @@
 */
 package org.opensearch.test.framework.matcher;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeDiagnosingMatcher;
-import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
-import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
-import org.opensearch.client.Client;
-import org.opensearch.cluster.metadata.AliasMetadata;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +16,14 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.action.admin.indices.alias.get.GetAliasesRequest;
+import org.opensearch.action.admin.indices.alias.get.GetAliasesResponse;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.AliasMetadata;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Spliterator.IMMUTABLE;

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainTemplateWithAliasMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainTemplateWithAliasMatcher.java
@@ -9,6 +9,7 @@
 */
 package org.opensearch.test.framework.matcher;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,7 +22,6 @@ import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesRequest
 import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.AliasMetadata;
-import org.opensearch.common.collect.ImmutableOpenMap;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,8 +60,10 @@ class ClusterContainTemplateWithAliasMatcher extends TypeSafeDiagnosingMatcher<C
 				.collect(Collectors.toSet());
 	}
 
-	private Stream<String> aliasNames(ImmutableOpenMap<String, AliasMetadata> aliasMap) {
-		return StreamSupport.stream(aliasMap.keys().spliterator(), false).map(objectCursor -> objectCursor.value);
+	private Stream<String> aliasNames(Map<String, AliasMetadata> aliasMap) {
+		Iterable<Map.Entry<String, AliasMetadata>> iterable = () -> aliasMap.entrySet().iterator();
+		return StreamSupport.stream(iterable.spliterator(), false)
+				.map(entry -> entry.getValue().getAlias());
 	}
 
 

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainTemplateWithAliasMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainTemplateWithAliasMatcher.java
@@ -9,14 +9,11 @@
 */
 package org.opensearch.test.framework.matcher;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
@@ -24,6 +21,7 @@ import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesRequest
 import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.common.collect.ImmutableOpenMap;
 
 import static java.util.Objects.requireNonNull;
 
@@ -57,21 +55,13 @@ class ClusterContainTemplateWithAliasMatcher extends TypeSafeDiagnosingMatcher<C
 	private Set<String> getAliases(GetIndexTemplatesResponse response) {
 		return response.getIndexTemplates()
 				.stream()
-				.map(metadata -> {
-							Map<String, AliasMetadata> aliases = new HashMap<>();
-							for (ObjectObjectCursor<String, AliasMetadata> cursor : metadata.getAliases()) {
-								aliases.put(cursor.key, cursor.value);
-							}
-							return aliases;
-						})
+				.map(metadata -> metadata.getAliases())
 				.flatMap(aliasMap -> aliasNames(aliasMap))
 				.collect(Collectors.toSet());
 	}
 
-	private Stream<String> aliasNames(Map<String, AliasMetadata> aliasMap) {
-		Iterable<Map.Entry<String, AliasMetadata>> iterable = () -> aliasMap.entrySet().iterator();
-		return StreamSupport.stream(iterable.spliterator(), false)
-				.map(entry -> entry.getValue().getAlias());
+	private Stream<String> aliasNames(ImmutableOpenMap<String, AliasMetadata> aliasMap) {
+		return StreamSupport.stream(aliasMap.keys().spliterator(), false).map(objectCursor -> objectCursor.value);
 	}
 
 

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/GetSettingsResponseContainsIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/GetSettingsResponseContainsIndicesMatcher.java
@@ -9,14 +9,11 @@
 */
 package org.opensearch.test.framework.matcher;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
+import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 
 import static java.util.Objects.isNull;
@@ -35,15 +32,12 @@ class GetSettingsResponseContainsIndicesMatcher extends TypeSafeDiagnosingMatche
 	@Override
 	protected boolean matchesSafely(GetSettingsResponse response, Description mismatchDescription) {
 
-		final Map<String, Settings> indexToSettings = new HashMap<>();
-		for (ObjectObjectCursor<String, Settings> cursor : response.getIndexToSettings()) {
-			indexToSettings.put(cursor.key, cursor.value);
-		}
+		final ImmutableOpenMap<String, Settings> indexToSettings = response.getIndexToSettings();
 		for (String index : expectedIndices) {
 			if (!indexToSettings.containsKey(index)) {
 				mismatchDescription
 						.appendText("Response contains settings of indices: ")
-						.appendValue(indexToSettings.keySet());
+						.appendValue(indexToSettings.keysIt());
 				return false;
 			}
 		}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/GetSettingsResponseContainsIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/GetSettingsResponseContainsIndicesMatcher.java
@@ -37,7 +37,7 @@ class GetSettingsResponseContainsIndicesMatcher extends TypeSafeDiagnosingMatche
 			if (!indexToSettings.containsKey(index)) {
 				mismatchDescription
 						.appendText("Response contains settings of indices: ")
-						.appendValue(indexToSettings.keysIt());
+						.appendValue(indexToSettings.keys());
 				return false;
 			}
 		}

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -78,7 +78,6 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
-import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -673,14 +672,14 @@ public class PrivilegesEvaluator {
 
             final List<AliasMetadata> filteredAliases = new ArrayList<AliasMetadata>();
 
-            final ImmutableOpenMap<String, AliasMetadata> aliases = indexMetaData.getAliases();
+            final Map<String, AliasMetadata> aliases = indexMetaData.getAliases();
 
             if(aliases != null && aliases.size() > 0) {
                 if (isDebugEnabled) {
                     log.debug("Aliases for {}: {}", indexMetaData.getIndex().getName(), aliases);
                 }
 
-                final Iterator<String> it = aliases.keysIt();
+                final Iterator<String> it = aliases.keySet().iterator();
                 while(it.hasNext()) {
                     final String alias = it.next();
                     final AliasMetadata aliasMetadata = aliases.get(alias);

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -29,7 +29,6 @@ package org.opensearch.security.privileges;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -38,7 +37,6 @@ import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
-import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.apache.logging.log4j.LogManager;
@@ -80,6 +78,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Strings;
+import org.opensearch.common.collect.ImmutableOpenMap;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.transport.TransportAddress;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -674,17 +673,14 @@ public class PrivilegesEvaluator {
 
             final List<AliasMetadata> filteredAliases = new ArrayList<AliasMetadata>();
 
-            final Map<String, AliasMetadata> aliases = new HashMap<>();
-            for (ObjectObjectCursor<String, AliasMetadata> cursor : indexMetaData.getAliases()) {
-                aliases.put(cursor.key, cursor.value);
-            }
+            final ImmutableOpenMap<String, AliasMetadata> aliases = indexMetaData.getAliases();
 
             if(aliases != null && aliases.size() > 0) {
                 if (isDebugEnabled) {
                     log.debug("Aliases for {}: {}", indexMetaData.getIndex().getName(), aliases);
                 }
 
-                final Iterator<String> it = aliases.keySet().iterator();
+                final Iterator<String> it = aliases.keysIt();
                 while(it.hasNext()) {
                     final String alias = it.next();
                     final AliasMetadata aliasMetadata = aliases.get(alias);


### PR DESCRIPTION
### Description

Addresses comments raised here: https://github.com/opensearch-project/security/pull/2715#discussion_r1177857146

There is a compilation error in AliasExistsMatcher and this fixes the issue.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
