### PR TITLE
Add default roles for SQL plugin: PPL and cross-cluster search

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -136,6 +136,19 @@ observability_full_access:
     - 'cluster:admin/opensearch/observability/delete'
     - 'cluster:admin/opensearch/observability/get'
 
+# Allows users to all PPL functionality
+ppl_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/ppl'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/mappings/get'
+        - 'indices:data/read/search*'
+        - 'indices:monitor/settings/get'
+
 # Allows users to read and download Reports
 reports_instances_read_access:
   reserved: true
@@ -227,6 +240,16 @@ cross_cluster_replication_follower_full_access:
         - "indices:admin/plugins/replication/index/stop"
         - "indices:admin/plugins/replication/index/update"
         - "indices:admin/plugins/replication/index/status_check"
+
+# Allows users to use all cross cluster search functionality at remote cluster
+cross_cluster_search_remote_full_access:
+  reserved: true
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/shards/search_shards'
+        - 'indices:data/read/search'
 
 # Allow users to read ML stats/models/tasks
 ml_read_access:


### PR DESCRIPTION
### Description
1. Add a new full access role for ppl so that sql plugin users can query with piped processing language.
2. Add a new role for cross-cluster search.

User docs for these roles([ppl security](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/admin/security.rst), [cross-cluster search](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/admin/cross_cluster_search.rst#authentication-and-permission))

### Issues Resolved
https://github.com/opensearch-project/sql/issues/789

We predefine the roles for easier use of the new feature.

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
