### PR TITLE
Use ExtensionsManager.lookupExtensionSettingsById when verifying extension unique id

### DIFF
--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -331,7 +331,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
         String extensionUniqueId = getThreadContext().getHeader("extension_unique_id");
         if (extensionUniqueId != null) {
             ExtensionsManager extManager = OpenSearchSecurityPlugin.GuiceHolder.getExtensionsManager();
-            if (extManager.lookupInitializedExtensionById(extensionUniqueId).isPresent()) {
+            if (extManager.lookupExtensionSettingsById(extensionUniqueId).isPresent()) {
                 getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_EXTENSION_REQUEST, Boolean.TRUE);
             }
         }


### PR DESCRIPTION
### Description

The current method being used to permit handshake requests from extensions is failing because an extension with the unique id is not present in the map of initialized extensions. Since the handshake is the first request performed to initialize an extension, the extension will not be available in the map of initialized extensions. This PR consumes a new method defined in core to get extension settings by unique id which checks to see if the extension unique id is present in the list of extensions in `extensions/extensions.yml`

Associated PR in core: https://github.com/opensearch-project/OpenSearch/pull/7466

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/2747

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
