### PR TITLE
[Backport 2.x] Use ExtensionsManager.lookupExtensionSettingsById when verifying exte…

### DIFF
--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -331,7 +331,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
         String extensionUniqueId = getThreadContext().getHeader("extension_unique_id");
         if (extensionUniqueId != null) {
             ExtensionsManager extManager = OpenSearchSecurityPlugin.GuiceHolder.getExtensionsManager();
-            if (extManager.getExtensionIdMap().containsKey(extensionUniqueId)) {
+            if (extManager.lookupExtensionSettingsById(extensionUniqueId).isPresent()) {
                 getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_EXTENSION_REQUEST, Boolean.TRUE);
             }
         }


### PR DESCRIPTION
### Description
Use ExtensionsManager.lookupExtensionSettingsById when verifying extension unique id (#2749)

Signed-off-by: Craig Perkins <cwperx@amazon.com>
(cherry picked from commit 9d758f9166e6af76589ab403a6ee5ec22792bc64)

### Issues Resolved
- Resolves #2754

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
