### PR TITLE
[Backport 2.x] Upgrade spring-core from 5.3.26 to 5.3.27

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -403,7 +403,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.0.0'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.3'
-    testRuntimeOnly ('org.springframework:spring-core:5.3.26') {
+    testRuntimeOnly ('org.springframework:spring-core:5.3.27') {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.9'


### PR DESCRIPTION
Backport https://github.com/opensearch-project/security/commit/54d47ab181c4c782af37c96521238f7dbaf50cb2 from https://github.com/opensearch-project/security/pull/2717