### PR TITLE
`deserializeSafeFromHeader` uses `context.getHeader(headerName)` instead of `context.getHeaders()`

### DIFF
--- a/src/main/java/org/opensearch/security/support/HeaderHelper.java
+++ b/src/main/java/org/opensearch/security/support/HeaderHelper.java
@@ -57,15 +57,8 @@ public class HeaderHelper {
             return null;
         }
 
-        String headerValue = null;
-        	
-        Map<String, String> headers = context.getHeaders();
-        if (!headers.containsKey(headerName) || (headerValue = headers.get(headerName)) == null) {
-            return null;
-        }
-
         if (isInterClusterRequest(context) || isTrustedClusterRequest(context) || isDirectRequest(context)) {
-            return headerValue;
+            return context.getHeader(headerName);
         }
 
         return null;

--- a/src/main/java/org/opensearch/security/support/HeaderHelper.java
+++ b/src/main/java/org/opensearch/security/support/HeaderHelper.java
@@ -27,7 +27,6 @@
 package org.opensearch.security.support;
 
 import java.io.Serializable;
-import java.util.Map;
 
 import com.google.common.base.Strings;
 


### PR DESCRIPTION
**Description**
Category:  Performance Bug Fix

**Why these changes are required?**
`HeaderHelper.deserializeSafeFromHeader` is invoked O(segment) times during every search request and introduced a huge overhead. This optimisation has resulted in good gains with respect to search throughput and latency in our experiments.

**Issues Resolved**
* Resolves #2757 


### Issues Resolved


### Testing
* Current test suite should pass.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
