### PR TITLE
Changes in role.yml for long-running operation notification feature in Index-Management repo

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -205,6 +205,8 @@ index_management_full_access:
     - "cluster:admin/opendistro/ism/*"
     - "cluster:admin/opendistro/rollup/*"
     - "cluster:admin/opendistro/transform/*"
+    - "cluster:admin/opensearch/controlcenter/lron/*"
+    - "cluster:admin/opensearch/notifications/channels/get"
     - "cluster:admin/opensearch/notifications/feature/publish"
   index_permissions:
     - index_patterns:


### PR DESCRIPTION
### Description
In **2.8**, index-management will have a new feature of sending notifications for long-running index operations(https://github.com/opensearch-project/OpenSearch/issues/5479). And to build this feature, index-management plugin introduce 3 new backend API(https://github.com/opensearch-project/index-management/issues/700). We want to add cluster permissions of these APIs to existing `index_management_full_access` role. It will also include list notification channels cluster permission.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/issues/5479
https://github.com/opensearch-project/index-management/issues/700
https://github.com/opensearch-project/index-management/issues/703
https://github.com/opensearch-project/index-management-dashboards-plugin/issues/618
https://github.com/opensearch-project/documentation-website/issues/4170

Is this a backport? If so, please add backport PR # and/or commits #
It should be backport to 2.x and released in 2.8.
### Testing
The new feature has testing in index-management repo.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
