### PR TITLE
Remove dependency on javax.annotation implementation as OpenSearch now has one.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,7 +346,6 @@ task integrationTest(type: Test) {
 check.dependsOn integrationTest
 
 dependencies {
-    implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "org.apache.httpcomponents.client5:httpclient5-cache:${versions.httpclient5}"


### PR DESCRIPTION
### Description
Removes the dependency on `jakarta.annotation` an implementation of `javax.annotation`, as OpenSearch now itself takes a dependency on an implementation of `javax.annotation`.

* Category: Bug fix
* Why these changes are required? OpenSearch now has a dependency on an implementation of `javax.annotation` causing a JAR hell error when installing the plugin.
* What is the old behavior before changes and new behavior after changes? install failed previously, now succeeds.

Also requires backporting to 2.x

### Issues Resolved
Resolves #2799

### Testing
Manual testing of repro steps in #2799 but using local build of plugin rather than published snapshot.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
