### PR TITLE
Extend JWT Signing Algorithms to Support RSA and EC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -567,12 +567,12 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.3'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.36.0'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
     testImplementation "org.opensaml:opensaml-messaging-impl:${open_saml_version}"
     implementation 'org.apache.commons:commons-lang3:3.13.0'
+    implementation "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     testImplementation "org.opensearch:common-utils:${common_utils_version}"
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"

--- a/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
@@ -19,8 +19,25 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 public class OnBehalfOfConfig implements ToXContentObject {
     private Boolean oboEnabled;
-    private String signing_key;
     private String encryption_key;
+    private String algorithm;
+    // HMAC
+    private String signing_key;
+    // EC
+    private String ec_private_key;
+    private String ec_private;
+    private String ec_x_coordinate;
+    private String ec_y_coordinate;
+    // RSA
+    private String rsa_private_key;
+    private String rsa_modulus;
+    private String rsa_public_exp;
+    private String rsa_private_exp;
+    private String rsa_first_prime_factor;
+    private String rsa_second_prime_factor;
+    private String rsa_first_prime_crt;
+    private String rsa_second_prime_crt;
+    private String rsa_first_crt_coefficient;
 
     public OnBehalfOfConfig oboEnabled(Boolean oboEnabled) {
         this.oboEnabled = oboEnabled;
@@ -32,8 +49,77 @@ public class OnBehalfOfConfig implements ToXContentObject {
         return this;
     }
 
+    public OnBehalfOfConfig algorithm(String algorithm) {
+        this.algorithm = algorithm;
+        return this;
+    }
     public OnBehalfOfConfig encryptionKey(String encryption_key) {
         this.encryption_key = encryption_key;
+        return this;
+    }
+
+    public OnBehalfOfConfig ecPrivateKey(String ec_private_key) {
+        this.ec_private_key = ec_private_key;
+        return this;
+    }
+
+    public OnBehalfOfConfig ecPrivate(String ec_private) {
+        this.ec_private = ec_private;
+        return this;
+    }
+
+    public OnBehalfOfConfig ecXCoordinate(String ec_x_coordinate) {
+        this.ec_x_coordinate = ec_x_coordinate;
+        return this;
+    }
+
+    public OnBehalfOfConfig ecYCoordinate(String ec_y_coordinate) {
+        this.ec_y_coordinate = ec_y_coordinate;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaPrivateKey(String rsa_private_key) {
+        this.rsa_private_key = rsa_private_key;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaModulus(String rsa_modulus) {
+        this.rsa_modulus = rsa_modulus;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaPublicExp(String rsa_public_exp) {
+        this.rsa_public_exp = rsa_public_exp;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaPrivateExp(String rsa_private_exp) {
+        this.rsa_private_exp = rsa_private_exp;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaFirstPrimeFactor(String rsa_first_prime_factor) {
+        this.rsa_first_prime_factor = rsa_first_prime_factor;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaSecondPrimeFactor(String rsa_second_prime_factor) {
+        this.rsa_second_prime_factor = rsa_second_prime_factor;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaFirstPrimeCrt(String rsa_first_prime_crt) {
+        this.rsa_first_prime_crt = rsa_first_prime_crt;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaSecondPrimeCrt(String rsa_second_prime_crt) {
+        this.rsa_second_prime_crt = rsa_second_prime_crt;
+        return this;
+    }
+
+    public OnBehalfOfConfig rsaFirstCrtCoefficient(String rsa_first_crt_coefficient) {
+        this.rsa_first_crt_coefficient = rsa_first_crt_coefficient;
         return this;
     }
 
@@ -42,8 +128,50 @@ public class OnBehalfOfConfig implements ToXContentObject {
         xContentBuilder.startObject();
         xContentBuilder.field("enabled", oboEnabled);
         xContentBuilder.field("signing_key", signing_key);
+        if (StringUtils.isNoneBlank(algorithm)) {
+            xContentBuilder.field("algorithm", algorithm);
+        }
         if (StringUtils.isNoneBlank(encryption_key)) {
             xContentBuilder.field("encryption_key", encryption_key);
+        }
+        if (StringUtils.isNoneBlank(ec_private_key)) {
+            xContentBuilder.field("ec_private_key", ec_private_key);
+        }
+        if (StringUtils.isNoneBlank(ec_private)) {
+            xContentBuilder.field("ec_private", ec_private);
+        }
+        if (StringUtils.isNoneBlank(ec_x_coordinate)) {
+            xContentBuilder.field("ec_x_coordinate", ec_x_coordinate);
+        }
+        if (StringUtils.isNoneBlank(ec_y_coordinate)) {
+            xContentBuilder.field("ec_y_coordinate", ec_y_coordinate);
+        }
+        if (StringUtils.isNoneBlank(rsa_private_key)) {
+            xContentBuilder.field("rsa_private_key", rsa_private_key);
+        }
+        if (StringUtils.isNoneBlank(rsa_modulus)) {
+            xContentBuilder.field("rsa_modulus", rsa_modulus);
+        }
+        if (StringUtils.isNoneBlank(rsa_public_exp)) {
+            xContentBuilder.field("rsa_public_exp", rsa_public_exp);
+        }
+        if (StringUtils.isNoneBlank(rsa_private_exp)) {
+            xContentBuilder.field("rsa_private_exp", rsa_private_exp);
+        }
+        if (StringUtils.isNoneBlank(rsa_first_prime_factor)) {
+            xContentBuilder.field("rsa_first_prime_factor", rsa_first_prime_factor);
+        }
+        if (StringUtils.isNoneBlank(rsa_second_prime_factor)) {
+            xContentBuilder.field("rsa_second_prime_factor", rsa_second_prime_factor);
+        }
+        if (StringUtils.isNoneBlank(rsa_first_prime_crt)) {
+            xContentBuilder.field("rsa_first_prime_crt", rsa_first_prime_crt);
+        }
+        if (StringUtils.isNoneBlank(rsa_second_prime_crt)) {
+            xContentBuilder.field("rsa_second_prime_crt", rsa_second_prime_crt);
+        }
+        if (StringUtils.isNoneBlank(rsa_first_crt_coefficient)) {
+            xContentBuilder.field("rsa_first_crt_coefficient", rsa_first_crt_coefficient);
         }
         xContentBuilder.endObject();
         return xContentBuilder;

--- a/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
@@ -53,6 +53,7 @@ public class OnBehalfOfConfig implements ToXContentObject {
         this.algorithm = algorithm;
         return this;
     }
+
     public OnBehalfOfConfig encryptionKey(String encryption_key) {
         this.encryption_key = encryption_key;
         return this;

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwkUtil.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwkUtil.java
@@ -1,0 +1,233 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.authtoken.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils;
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
+import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
+import org.apache.cxf.rs.security.jose.jwk.KeyType;
+import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
+import org.opensearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_256_ALGO;
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_384_ALGO;
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_512_ALGO;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P256;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P384;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P521;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_PRIVATE_KEY;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_X_COORDINATE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_Y_COORDINATE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_CRT_COEFFICIENT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_CRT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_FACTOR;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_MODULUS;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PRIVATE_EXP;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PUBLIC_EXP;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_CRT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_FACTOR;
+
+public class JwkUtil {
+    /*
+     * The default configuration of this web key should be:
+     *   KeyType: OCTET
+     *   PublicKeyUse: SIGN
+     *   Encryption Algorithm: HS512
+     * */
+    static JsonWebKey createJwkFromSettings(Settings settings) {
+        String algorithm = settings.get("algorithm");
+        Settings jwkSettings = settings.getAsSettings("jwt").getAsSettings("key");
+
+        if (algorithm != null) {
+            return getSigningJwk(algorithm.toUpperCase(Locale.ROOT), settings);
+        } else if (!jwkSettings.isEmpty()) {
+            JsonWebKey jwk = new JsonWebKey();
+
+            for (String key : jwkSettings.keySet()) {
+                jwk.setProperty(key, jwkSettings.get(key));
+            }
+
+            return jwk;
+        } else {
+            // try default
+            return getSigningJwk("HS512", settings);
+        }
+    }
+
+    private static JsonWebKey getSigningJwk(String algorithm, Settings settings) throws IllegalArgumentException {
+        JsonWebKey jwk;
+
+        if (AlgorithmUtils.isOctet(algorithm)) {
+            jwk = new JsonWebKey();
+            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+            jwk.setKeyType(KeyType.OCTET);
+            String signingKey = Optional.ofNullable(settings.get("signing_key"))
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret."
+                    )
+                );
+            jwk.setProperty("k", signingKey);
+            jwk.setAlgorithm(algorithm);
+        } else if (AlgorithmUtils.isEcDsaSign(algorithm)) {
+            jwk = getECSigningJWK(algorithm, settings);
+        } else if (AlgorithmUtils.isRsaSign(algorithm)) {
+            jwk = getRsaSigningJWK(algorithm, settings);
+        } else {
+            throw new IllegalArgumentException("Signing algorithm not recognized: " + algorithm);
+        }
+        return jwk;
+    }
+
+    private static JsonWebKey getRsaSigningJWK(String algorithm, Settings settings) {
+        JsonWebKey jwk;
+        // try load private key
+        if (settings.get("rsa_private_key") != null) {
+            try {
+                String privateKey = settings.get("rsa_private_key")
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replaceAll("\n|\r\n", "")
+                    .replace("-----END PRIVATE KEY-----", "");
+
+                byte[] decoded = Decoders.BASE64.decode(privateKey);
+
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+                RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
+                jwk = JwkUtils.fromRSAPrivateKey(rsaPrivateKey, algorithm);
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new RuntimeException("Unable to read RSA private key.", e);
+            }
+        } else {
+            jwk = new JsonWebKey();
+            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+            jwk.setKeyType(KeyType.RSA);
+            jwk.setAlgorithm(algorithm);
+
+            jwk.setProperty(
+                RSA_MODULUS,
+                Optional.ofNullable(settings.get("rsa_modulus"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for RSA modulus is missing. Please specify rsa_modulus."))
+            );
+            jwk.setProperty(
+                RSA_PUBLIC_EXP,
+                Optional.ofNullable(settings.get("rsa_public_exp"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException("Settings for RSA public exponent is missing. Please specify rsa_public_exp.")
+                    )
+            );
+            jwk.setProperty(
+                RSA_PRIVATE_EXP,
+                Optional.ofNullable(settings.get("rsa_private_exp"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException("Settings for RSA private exponent is missing. Please specify rsa_private_exp.")
+                    )
+            );
+
+            // optional settings, we need either none, or all of those
+            List<String> rsaMissingSettings = new ArrayList<>();
+            Map<String, String> optionalRSAParameters = Map.of(
+                "rsa_first_prime_factor",
+                RSA_FIRST_PRIME_FACTOR,
+                "rsa_second_prime_factor",
+                RSA_SECOND_PRIME_FACTOR,
+                "rsa_first_prime_crt",
+                RSA_FIRST_PRIME_CRT,
+                "rsa_second_prime_crt",
+                RSA_SECOND_PRIME_CRT,
+                "rsa_first_crt_coefficient",
+                RSA_FIRST_CRT_COEFFICIENT
+            );
+            optionalRSAParameters.forEach(
+                (param, variable) -> Optional.ofNullable(settings.get(param))
+                    .ifPresentOrElse(v -> jwk.setProperty(variable, v), () -> rsaMissingSettings.add(param))
+            );
+
+            if (!rsaMissingSettings.isEmpty() && rsaMissingSettings.size() != 5) {
+                // incorrect optional settings
+                throw new IllegalArgumentException(
+                    "Settings for RSA key is missing, missing properties: " + String.join(", ", rsaMissingSettings)
+                );
+            }
+        }
+        return jwk;
+    }
+
+    private static JsonWebKey getECSigningJWK(String algorithm, Settings settings) {
+        JsonWebKey jwk = new JsonWebKey();
+        jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+        jwk.setKeyType(KeyType.EC);
+        jwk.setAlgorithm(algorithm);
+        jwk.setProperty(EC_CURVE, calcCurve(algorithm));
+        // try to load key from file
+        if (settings.get("ec_private_key") != null) {
+            try {
+                StringReader rdr = new StringReader(settings.get("ec_private_key"));
+                Object parsed = new org.bouncycastle.openssl.PEMParser(rdr).readObject();
+                ECPrivateKey privateKey = (ECPrivateKey) new org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter().getKeyPair(
+                    (org.bouncycastle.openssl.PEMKeyPair) parsed
+                ).getPrivate();
+                jwk.setProperty(EC_PRIVATE_KEY, Base64.getUrlEncoder().encodeToString(privateKey.getS().toByteArray()));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Unable to read EC private key.", e);
+            }
+        } else {
+            jwk.setProperty(
+                EC_PRIVATE_KEY,
+                Optional.ofNullable(settings.get("ec_private"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException(
+                            "Settings for EC private key is missing. Please specify ec_private with required x and y coordinates."
+                        )
+                    )
+            );
+            jwk.setProperty(
+                EC_X_COORDINATE,
+                Optional.ofNullable(settings.get("ec_x"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC x coordinate is missing."))
+            );
+            jwk.setProperty(
+                EC_Y_COORDINATE,
+                Optional.ofNullable(settings.get("ec_y"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC y coordinate is missing."))
+            );
+        }
+        return jwk;
+    }
+
+    private static String calcCurve(String algorithm) {
+        switch (algorithm) {
+            case ES_SHA_256_ALGO:
+                return EC_CURVE_P256;
+            case ES_SHA_384_ALGO:
+                return EC_CURVE_P384;
+            case ES_SHA_512_ALGO:
+                return EC_CURVE_P521;
+            default:
+                throw new IllegalArgumentException("Not recognized Elliptic Curve algorithm: " + algorithm);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -11,29 +11,12 @@
 
 package org.opensearch.security.authtoken.jwt;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.ECPrivateKey;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-import io.jsonwebtoken.io.Decoders;
 import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
-import org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
-import org.apache.cxf.rs.security.jose.jwk.KeyType;
-import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
 import org.apache.cxf.rs.security.jose.jws.JwsUtils;
 import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
 import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
@@ -44,24 +27,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.ExceptionUtils;
-import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_256_ALGO;
-import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_384_ALGO;
-import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_512_ALGO;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P256;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P384;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P521;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_PRIVATE_KEY;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_X_COORDINATE;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_Y_COORDINATE;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_CRT_COEFFICIENT;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_CRT;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_FACTOR;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_MODULUS;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PRIVATE_EXP;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PUBLIC_EXP;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_CRT;
-import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_FACTOR;
 
 public class JwtVendor {
     private static final Logger logger = LogManager.getLogger(JwtVendor.class);
@@ -79,7 +44,7 @@ public class JwtVendor {
     public JwtVendor(final Settings settings, final Optional<LongSupplier> timeProvider) {
         JoseJwtProducer jwtProducer = new JoseJwtProducer();
         try {
-            this.signingKey = createJwkFromSettings(settings);
+            this.signingKey = JwkUtil.createJwkFromSettings(settings);
         } catch (Exception e) {
             throw ExceptionUtils.createJwkCreationException(e);
         }
@@ -94,186 +59,6 @@ public class JwtVendor {
             this.timeProvider = timeProvider.get();
         } else {
             this.timeProvider = () -> System.currentTimeMillis() / 1000;
-        }
-    }
-
-    /*
-     * The default configuration of this web key should be:
-     *   KeyType: OCTET
-     *   PublicKeyUse: SIGN
-     *   Encryption Algorithm: HS512
-     * */
-    static JsonWebKey createJwkFromSettings(Settings settings) {
-        String algorithm = settings.get("algorithm");
-        Settings jwkSettings = settings.getAsSettings("jwt").getAsSettings("key");
-
-        if (algorithm != null) {
-            return getSigningJwk(algorithm.toUpperCase(Locale.ROOT), settings);
-        } else if (!jwkSettings.isEmpty()) {
-            JsonWebKey jwk = new JsonWebKey();
-
-            for (String key : jwkSettings.keySet()) {
-                jwk.setProperty(key, jwkSettings.get(key));
-            }
-
-            return jwk;
-        } else {
-            // try default
-            return getSigningJwk("HS512", settings);
-        }
-    }
-
-    private static JsonWebKey getSigningJwk(String algorithm, Settings settings) throws IllegalArgumentException {
-        JsonWebKey jwk;
-
-        if (AlgorithmUtils.isOctet(algorithm)) {
-            jwk = new JsonWebKey();
-            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-            jwk.setKeyType(KeyType.OCTET);
-            String signingKey = Optional.ofNullable(settings.get("signing_key"))
-                .orElseThrow(
-                    () -> new IllegalArgumentException(
-                        "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret."
-                    )
-                );
-            jwk.setProperty("k", signingKey);
-            jwk.setAlgorithm(algorithm);
-        } else if (AlgorithmUtils.isEcDsaSign(algorithm)) {
-            jwk = getECSigningJWK(algorithm, settings);
-        } else if (AlgorithmUtils.isRsaSign(algorithm)) {
-            jwk = getRsaSigningJWK(algorithm, settings);
-        } else {
-            throw new IllegalArgumentException("Signing algorithm not recognized: " + algorithm);
-        }
-        return jwk;
-    }
-
-    private static JsonWebKey getRsaSigningJWK(String algorithm, Settings settings) {
-        JsonWebKey jwk;
-        // try load private key
-        if (settings.get("rsa_private_key") != null) {
-            try {
-                String privateKey = settings.get("rsa_private_key")
-                    .replace("-----BEGIN PRIVATE KEY-----", "")
-                    .replaceAll("\n|\r\n", "")
-                    .replace("-----END PRIVATE KEY-----", "");
-
-                byte[] decoded = Decoders.BASE64.decode(privateKey);
-
-                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
-                RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
-                jwk = JwkUtils.fromRSAPrivateKey(rsaPrivateKey, algorithm);
-            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-                throw new RuntimeException("Unable to read RSA private key.", e);
-            }
-        } else {
-            jwk = new JsonWebKey();
-            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-            jwk.setKeyType(KeyType.RSA);
-            jwk.setAlgorithm(algorithm);
-
-            jwk.setProperty(
-                RSA_MODULUS,
-                Optional.ofNullable(settings.get("rsa_modulus"))
-                    .orElseThrow(() -> new IllegalArgumentException("Settings for RSA modulus is missing. Please specify rsa_modulus."))
-            );
-            jwk.setProperty(
-                RSA_PUBLIC_EXP,
-                Optional.ofNullable(settings.get("rsa_public_exp"))
-                    .orElseThrow(
-                        () -> new IllegalArgumentException("Settings for RSA public exponent is missing. Please specify rsa_public_exp.")
-                    )
-            );
-            jwk.setProperty(
-                RSA_PRIVATE_EXP,
-                Optional.ofNullable(settings.get("rsa_private_exp"))
-                    .orElseThrow(
-                        () -> new IllegalArgumentException("Settings for RSA private exponent is missing. Please specify rsa_private_exp.")
-                    )
-            );
-
-            // optional settings, we need either none, or all of those
-            List<String> rsaMissingSettings = new ArrayList<>();
-            Map<String, String> optionalRSAParameters = Map.of(
-                "rsa_first_prime_factor",
-                RSA_FIRST_PRIME_FACTOR,
-                "rsa_second_prime_factor",
-                RSA_SECOND_PRIME_FACTOR,
-                "rsa_first_prime_crt",
-                RSA_FIRST_PRIME_CRT,
-                "rsa_second_prime_crt",
-                RSA_SECOND_PRIME_CRT,
-                "rsa_first_crt_coefficient",
-                RSA_FIRST_CRT_COEFFICIENT
-            );
-            optionalRSAParameters.forEach(
-                (param, variable) -> Optional.ofNullable(settings.get(param))
-                    .ifPresentOrElse(v -> jwk.setProperty(variable, v), () -> rsaMissingSettings.add(param))
-            );
-
-            if (!rsaMissingSettings.isEmpty() && rsaMissingSettings.size() != 5) {
-                // incorrect optional settings
-                throw new IllegalArgumentException(
-                    "Settings for RSA key is missing, missing properties: " + String.join(", ", rsaMissingSettings)
-                );
-            }
-        }
-        return jwk;
-    }
-
-    private static JsonWebKey getECSigningJWK(String algorithm, Settings settings) {
-        JsonWebKey jwk = new JsonWebKey();
-        jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-        jwk.setKeyType(KeyType.EC);
-        jwk.setAlgorithm(algorithm);
-        jwk.setProperty(EC_CURVE, calcCurve(algorithm));
-        // try to load key from file
-        if (settings.get("ec_private_key") != null) {
-            try {
-                StringReader rdr = new StringReader(settings.get("ec_private_key"));
-                Object parsed = new org.bouncycastle.openssl.PEMParser(rdr).readObject();
-                ECPrivateKey privateKey = (ECPrivateKey) new org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter().getKeyPair(
-                    (org.bouncycastle.openssl.PEMKeyPair) parsed
-                ).getPrivate();
-                jwk.setProperty(EC_PRIVATE_KEY, Base64.getUrlEncoder().encodeToString(privateKey.getS().toByteArray()));
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Unable to read EC private key.", e);
-            }
-        } else {
-            jwk.setProperty(
-                EC_PRIVATE_KEY,
-                Optional.ofNullable(settings.get("ec_private"))
-                    .orElseThrow(
-                        () -> new IllegalArgumentException(
-                            "Settings for EC private key is missing. Please specify ec_private with required x and y coordinates."
-                        )
-                    )
-            );
-            jwk.setProperty(
-                EC_X_COORDINATE,
-                Optional.ofNullable(settings.get("ec_x"))
-                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC x coordinate is missing."))
-            );
-            jwk.setProperty(
-                EC_Y_COORDINATE,
-                Optional.ofNullable(settings.get("ec_y"))
-                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC y coordinate is missing."))
-            );
-        }
-        return jwk;
-    }
-
-    public static String calcCurve(String algorithm) {
-        switch (algorithm) {
-            case ES_SHA_256_ALGO:
-                return EC_CURVE_P256;
-            case ES_SHA_384_ALGO:
-                return EC_CURVE_P384;
-            case ES_SHA_512_ALGO:
-                return EC_CURVE_P521;
-            default:
-                throw new IllegalArgumentException("Not recognized Elliptic Curve algorithm: " + algorithm);
         }
     }
 

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -11,14 +11,28 @@
 
 package org.opensearch.security.authtoken.jwt;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-import com.google.common.base.Strings;
+import io.jsonwebtoken.io.Decoders;
 import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
+import org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
+import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
 import org.apache.cxf.rs.security.jose.jwk.KeyType;
 import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
 import org.apache.cxf.rs.security.jose.jws.JwsUtils;
@@ -31,6 +45,24 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.ExceptionUtils;
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_256_ALGO;
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_384_ALGO;
+import static org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils.ES_SHA_512_ALGO;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P256;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P384;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P521;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_PRIVATE_KEY;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_X_COORDINATE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_Y_COORDINATE;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_CRT_COEFFICIENT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_CRT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_FIRST_PRIME_FACTOR;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_MODULUS;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PRIVATE_EXP;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_PUBLIC_EXP;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_CRT;
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.RSA_SECOND_PRIME_FACTOR;
 
 public class JwtVendor {
     private static final Logger logger = LogManager.getLogger(JwtVendor.class);
@@ -72,28 +104,13 @@ public class JwtVendor {
      *   PublicKeyUse: SIGN
      *   Encryption Algorithm: HS512
      * */
-    static JsonWebKey createJwkFromSettings(Settings settings) throws Exception {
-        String signingKey = settings.get("signing_key");
+    static JsonWebKey createJwkFromSettings(Settings settings) {
+        String algorithm = settings.get("algorithm");
+        Settings jwkSettings = settings.getAsSettings("jwt").getAsSettings("key");
 
-        if (!Strings.isNullOrEmpty(signingKey)) {
-
-            JsonWebKey jwk = new JsonWebKey();
-
-            jwk.setKeyType(KeyType.OCTET);
-            jwk.setAlgorithm("HS512");
-            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-            jwk.setProperty("k", signingKey);
-
-            return jwk;
-        } else {
-            Settings jwkSettings = settings.getAsSettings("jwt").getAsSettings("key");
-
-            if (jwkSettings.isEmpty()) {
-                throw new Exception(
-                    "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret."
-                );
-            }
-
+        if (algorithm != null) {
+            return getSigningJwk(algorithm.toUpperCase(Locale.ROOT), settings);
+        } else if (!jwkSettings.isEmpty()) {
             JsonWebKey jwk = new JsonWebKey();
 
             for (String key : jwkSettings.keySet()) {
@@ -101,6 +118,163 @@ public class JwtVendor {
             }
 
             return jwk;
+        } else {
+            // try default
+            return getSigningJwk("HS512", settings);
+        }
+    }
+
+    private static JsonWebKey getSigningJwk(String algorithm, Settings settings) throws IllegalArgumentException {
+        JsonWebKey jwk;
+
+        if (AlgorithmUtils.isOctet(algorithm)) {
+            jwk = new JsonWebKey();
+            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+            jwk.setKeyType(KeyType.OCTET);
+            String signingKey = Optional.ofNullable(settings.get("signing_key"))
+                .orElseThrow(
+                    () -> new IllegalArgumentException(
+                        "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret."
+                    )
+                );
+            jwk.setProperty("k", signingKey);
+            jwk.setAlgorithm(algorithm);
+        } else if (AlgorithmUtils.isEcDsaSign(algorithm)) {
+            jwk = getECSigningJWK(algorithm, settings);
+        } else if (AlgorithmUtils.isRsaSign(algorithm)) {
+            jwk = getRsaSigningJWK(algorithm, settings);
+        } else {
+            throw new IllegalArgumentException("Signing algorithm not recognized: " + algorithm);
+        }
+        return jwk;
+    }
+
+    private static JsonWebKey getRsaSigningJWK(String algorithm, Settings settings) {
+        JsonWebKey jwk;
+        // try load private key
+        if (settings.get("rsa_private_key") != null) {
+            try {
+                String privateKey = settings.get("rsa_private_key")
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replaceAll("\n|\r\n", "")
+                    .replace("-----END PRIVATE KEY-----", "");
+
+                byte[] decoded = Decoders.BASE64.decode(privateKey);
+
+                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+                RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) keyFactory.generatePrivate(keySpec);
+                jwk = JwkUtils.fromRSAPrivateKey(rsaPrivateKey, algorithm);
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new RuntimeException("Unable to read RSA private key.", e);
+            }
+        } else {
+            jwk = new JsonWebKey();
+            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+            jwk.setKeyType(KeyType.RSA);
+            jwk.setAlgorithm(algorithm);
+
+            jwk.setProperty(
+                RSA_MODULUS,
+                Optional.ofNullable(settings.get("rsa_modulus"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for RSA modulus is missing. Please specify rsa_modulus."))
+            );
+            jwk.setProperty(
+                RSA_PUBLIC_EXP,
+                Optional.ofNullable(settings.get("rsa_public_exp"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException("Settings for RSA public exponent is missing. Please specify rsa_public_exp.")
+                    )
+            );
+            jwk.setProperty(
+                RSA_PRIVATE_EXP,
+                Optional.ofNullable(settings.get("rsa_private_exp"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException("Settings for RSA private exponent is missing. Please specify rsa_private_exp.")
+                    )
+            );
+
+            // optional settings, we need either none, or all of those
+            List<String> rsaMissingSettings = new ArrayList<>();
+            Map<String, String> optionalRSAParameters = Map.of(
+                "rsa_first_prime_factor",
+                RSA_FIRST_PRIME_FACTOR,
+                "rsa_second_prime_factor",
+                RSA_SECOND_PRIME_FACTOR,
+                "rsa_first_prime_crt",
+                RSA_FIRST_PRIME_CRT,
+                "rsa_second_prime_crt",
+                RSA_SECOND_PRIME_CRT,
+                "rsa_first_crt_coefficient",
+                RSA_FIRST_CRT_COEFFICIENT
+            );
+            optionalRSAParameters.forEach(
+                (param, variable) -> Optional.ofNullable(settings.get(param))
+                    .ifPresentOrElse(v -> jwk.setProperty(variable, v), () -> rsaMissingSettings.add(param))
+            );
+
+            if (!rsaMissingSettings.isEmpty() && rsaMissingSettings.size() != 5) {
+                // incorrect optional settings
+                throw new IllegalArgumentException(
+                    "Settings for RSA key is missing, missing properties: " + String.join(", ", rsaMissingSettings)
+                );
+            }
+        }
+        return jwk;
+    }
+
+    private static JsonWebKey getECSigningJWK(String algorithm, Settings settings) {
+        JsonWebKey jwk = new JsonWebKey();
+        jwk.setPublicKeyUse(PublicKeyUse.SIGN);
+        jwk.setKeyType(KeyType.EC);
+        jwk.setAlgorithm(algorithm);
+        jwk.setProperty(EC_CURVE, calcCurve(algorithm));
+        // try to load key from file
+        if (settings.get("ec_private_key") != null) {
+            try {
+                StringReader rdr = new StringReader(settings.get("ec_private_key"));
+                Object parsed = new org.bouncycastle.openssl.PEMParser(rdr).readObject();
+                ECPrivateKey privateKey = (ECPrivateKey) new org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter().getKeyPair(
+                    (org.bouncycastle.openssl.PEMKeyPair) parsed
+                ).getPrivate();
+                jwk.setProperty(EC_PRIVATE_KEY, Base64.getUrlEncoder().encodeToString(privateKey.getS().toByteArray()));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Unable to read EC private key.", e);
+            }
+        } else {
+            jwk.setProperty(
+                EC_PRIVATE_KEY,
+                Optional.ofNullable(settings.get("ec_private"))
+                    .orElseThrow(
+                        () -> new IllegalArgumentException(
+                            "Settings for EC private key is missing. Please specify ec_private with required x and y coordinates."
+                        )
+                    )
+            );
+            jwk.setProperty(
+                EC_X_COORDINATE,
+                Optional.ofNullable(settings.get("ec_x"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC x coordinate is missing."))
+            );
+            jwk.setProperty(
+                EC_Y_COORDINATE,
+                Optional.ofNullable(settings.get("ec_y"))
+                    .orElseThrow(() -> new IllegalArgumentException("Settings for EC y coordinate is missing."))
+            );
+        }
+        return jwk;
+    }
+
+    public static String calcCurve(String algorithm) {
+        switch (algorithm) {
+            case ES_SHA_256_ALGO:
+                return EC_CURVE_P256;
+            case ES_SHA_384_ALGO:
+                return EC_CURVE_P384;
+            case ES_SHA_512_ALGO:
+                return EC_CURVE_P521;
+            default:
+                throw new IllegalArgumentException("Not recognized Elliptic Curve algorithm: " + algorithm);
         }
     }
 
@@ -114,7 +288,6 @@ public class JwtVendor {
         boolean roleSecurityMode
     ) throws Exception {
         final long nowAsMillis = timeProvider.getAsLong();
-        final Instant nowAsInstant = Instant.ofEpochMilli(timeProvider.getAsLong());
 
         jwtProducer.setSignatureProvider(JwsUtils.getSignatureProvider(signingKey));
         JwtClaims jwtClaims = new JwtClaims();

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -19,7 +19,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -11,26 +11,104 @@
 
 package org.opensearch.security.authtoken.jwt;
 
-import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jws.JwsJwtCompactConsumer;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
-import org.junit.Assert;
-import org.junit.Test;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.security.support.ConfigConstants;
-
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
+import com.google.common.io.BaseEncoding;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.cxf.rs.security.jose.jwa.AlgorithmUtils;
+import org.apache.cxf.rs.security.jose.jwa.SignatureAlgorithm;
+import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
+import org.apache.cxf.rs.security.jose.jwk.KeyType;
+import org.apache.cxf.rs.security.jose.jws.JwsJwtCompactConsumer;
+import org.apache.cxf.rs.security.jose.jws.JwsSignatureVerifier;
+import org.apache.cxf.rs.security.jose.jws.JwsUtils;
+import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.apache.cxf.rs.security.jose.jwk.JsonWebKey.EC_CURVE_P521;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
 public class JwtVendorTest {
 
+    public static final String ENCRYPTION_KEY = "encryption_key";
+    public static final String ALGORITHM = "algorithm";
+    public static final String EC_X = "ec_x";
+    public static final String EC_Y = "ec_y";
+    public static final String EC_PRIVATE = "ec_private";
+    public static final String RSA_MODULUS = "rsa_modulus";
+    public static final String RSA_PUBLIC_EXP = "rsa_public_exp";
+    public static final String RSA_PRIVATE_EXP = "rsa_private_exp";
+    private String issuer = "cluster_0";
+    private String subject = "admin";
+    private String audience = "audience_0";
+    private List<String> roles = List.of("IT", "HR");
+    private List<String> backendRoles = List.of("Sales");
+    private Integer expirySeconds = 300;
+    private LongSupplier currentTime = () -> (int) 100;
+    private Long expectedExp = currentTime.getAsLong() + (expirySeconds);
+    private String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
+    private String expectedRoles = "IT,HR";
+
+    private static PublicKey getPublicKey(String publicKey, SignatureAlgorithm algorithm) throws NoSuchAlgorithmException,
+        InvalidKeySpecException {
+        publicKey = publicKey.replace("-----BEGIN PUBLIC KEY-----", "").replaceAll("\n|\r\n", "").replace("-----END PUBLIC KEY-----", "");
+        if (AlgorithmUtils.isEc(String.valueOf(algorithm))) {
+            byte[] decoded = BaseEncoding.base64().decode(publicKey);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decoded);
+
+            return keyFactory.generatePublic(keySpec);
+        } else {
+            byte[] decoded = BaseEncoding.base64().decode(publicKey);
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decoded);
+
+            return keyFactory.generatePublic(keySpec);
+        }
+    }
+
+    public static boolean validateJWTSignatureUsingPublicKey(String encodedJwt, SignatureAlgorithm algorithm, String publicKey)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
+        PublicKey ecPublicKey = getPublicKey(publicKey, algorithm);
+
+        JwsSignatureVerifier verifier = JwsUtils.getPublicKeySignatureVerifier(ecPublicKey, algorithm);
+        return jwtConsumer.verifySignatureWith(verifier);
+    }
+
+    public static boolean validateJWTSignatureUsingJWK(String encodedJwt, SignatureAlgorithm algorithm, JsonWebKey jsonWebKey) {
+        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
+
+        JwsSignatureVerifier verifier = JwsUtils.getSignatureVerifier(jsonWebKey, algorithm);
+        return jwtConsumer.verifySignatureWith(verifier);
+    }
+
     @Test
-    public void testCreateJwkFromSettings() throws Exception {
+    public void testCreateHMACJwkFromSettings() {
+        // try default algorithm: HS512
         Settings settings = Settings.builder().put("signing_key", "abc123").build();
 
         JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
+        Assert.assertEquals("HS512", jwk.getAlgorithm());
+        Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
+        Assert.assertEquals("abc123", jwk.getProperty("k"));
+
+        settings = Settings.builder().put(ALGORITHM, "HS512").put("signing_key", "abc123").build();
+
+        jwk = JwtVendor.createJwkFromSettings(settings);
         Assert.assertEquals("HS512", jwk.getAlgorithm());
         Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
         Assert.assertEquals("abc123", jwk.getProperty("k"));
@@ -47,7 +125,7 @@ public class JwtVendorTest {
             }
         });
         Assert.assertEquals(
-            "java.lang.Exception: Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
+            "java.lang.IllegalArgumentException: Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
             exception.getMessage()
         );
     }
@@ -124,64 +202,589 @@ public class JwtVendorTest {
     }
 
     @Test
-    public void testCreateJwtWithBadExpiry() {
-        String issuer = "cluster_0";
-        String subject = "admin";
-        String audience = "audience_0";
-        List<String> roles = List.of("admin");
-        Integer expirySeconds = -300;
-        String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
-        JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
+    public void testCreateHMACJwkFromSettingsWithoutProperConfig() {
+        Settings settings = Settings.builder().build();
 
-        Throwable exception = Assert.assertThrows(RuntimeException.class, () -> {
-            try {
-                jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, List.of(), true);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        Assert.assertEquals("java.lang.Exception: The expiration time should be a positive integer", exception.getMessage());
+        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings));
+        assertEquals(
+            "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
+            e.getMessage()
+        );
+
+        e = assertThrows(
+            Exception.class,
+            () -> JwtVendor.createJwkFromSettings(Settings.builder().put(settings).put(ALGORITHM, "HS512").build())
+        );
+        assertEquals(
+            "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
+            e.getMessage()
+        );
+
+        // correct config at this point
+        JwtVendor.createJwkFromSettings(
+            Settings.builder().put(settings).put(ALGORITHM, "HS512").put("signing_key", "secret_signing_key").build()
+        );
     }
 
     @Test
-    public void testCreateJwtWithBadEncryptionKey() {
-        String issuer = "cluster_0";
-        String subject = "admin";
-        String audience = "audience_0";
-        List<String> roles = List.of("admin");
-        Integer expirySeconds = 300;
+    public void testPayloadCreateHMACSignedJWTWithRoles() throws Exception {
+        Settings settings = Settings.builder()
+            .put(ALGORITHM, "HS256")
+            .put("signing_key", "abc123")
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .build();
 
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, true);
+
+        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
+        JwtToken jwt = jwtConsumer.getJwtToken();
+
+        Assert.assertEquals("cluster_0", jwt.getClaim("iss"));
+        Assert.assertEquals("admin", jwt.getClaim("sub"));
+        Assert.assertEquals("audience_0", jwt.getClaim("aud"));
+        Assert.assertNotNull(jwt.getClaim("iat"));
+        Assert.assertNotNull(jwt.getClaim("exp"));
+        Assert.assertEquals(expectedExp, jwt.getClaim("exp"));
+        Assert.assertNotEquals(expectedRoles, jwt.getClaim("er"));
+    }
+
+    @Test(expected = Exception.class)
+    public void testCreateJwtWithBadEncryptionKey() throws Exception {
         Settings settings = Settings.builder().put("signing_key", "abc123").build();
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
 
-        Throwable exception = Assert.assertThrows(RuntimeException.class, () -> {
-            try {
-                new JwtVendor(settings, Optional.empty()).createJwt(issuer, subject, audience, expirySeconds, roles, List.of(), true);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        Assert.assertEquals("java.lang.IllegalArgumentException: encryption_key cannot be null", exception.getMessage());
+        jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, true);
     }
 
     @Test
     public void testCreateJwtWithBadRoles() {
-        String issuer = "cluster_0";
-        String subject = "admin";
-        String audience = "audience_0";
-        List<String> roles = null;
-        Integer expirySeconds = 300;
+        Settings settings = Settings.builder()
+            .put("signing_key", "abc123")
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(ALGORITHM, "HS256")
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
+        Exception e = assertThrows(
+            Exception.class,
+            () -> jwtVendor.createJwt(issuer, subject, audience, expirySeconds, null, backendRoles, false)
+        );
+        Assert.assertEquals("Roles cannot be null", e.getMessage());
+    }
+
+    @Test
+    public void testPayloadECSignedJWT() throws Exception {
+        Settings settings = Settings.builder()
+            .put(ALGORITHM, "ES512")
+            .put(EC_X, RandomStringUtils.randomAlphanumeric(16))
+            .put(EC_Y, RandomStringUtils.randomAlphanumeric(16))
+            .put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88))
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .build();
+
+        JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
+        Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
+        Assert.assertEquals(EC_CURVE_P521, jwk.getProperty("crv"));
+        Assert.assertEquals(KeyType.EC, jwk.getKeyType());
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
+
+        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
+        JwtToken jwt = jwtConsumer.getJwtToken();
+
+        Assert.assertEquals("ES512", jwt.getJwsHeaders().getAlgorithm());
+        Assert.assertEquals("cluster_0", jwt.getClaim("iss"));
+        Assert.assertEquals("admin", jwt.getClaim("sub"));
+        Assert.assertEquals("audience_0", jwt.getClaim("aud"));
+        Assert.assertNotNull(jwt.getClaim("iat"));
+        Assert.assertNotNull(jwt.getClaim("exp"));
+        Assert.assertEquals(expectedExp, jwt.getClaim("exp"));
+        Assert.assertNotEquals(expectedRoles, jwt.getClaim("er"));
+    }
+
+    @Test
+    public void testEC256KeySignedJWT() throws Exception {
+        String privateKey = "-----BEGIN EC PRIVATE KEY-----\n"
+            + "MHcCAQEEIKtPaRgmI5T3Y3q65FywDdn3oU+1eXkmozQSi2dn3g06oAoGCCqGSM49\n"
+            + "AwEHoUQDQgAETRfeqI5k3mAbuRJzu/wNuAMsiT66dr3xdKe/tmVQ85jT73Z7GbAA\n"
+            + "ORUDZpXDP99AizX7U+OdEliSVZoXHHMLKw==\n"
+            + "-----END EC PRIVATE KEY-----";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETRfeqI5k3mAbuRJzu/wNuAMsiT66\n"
+            + "dr3xdKe/tmVQ85jT73Z7GbAAORUDZpXDP99AizX7U+OdEliSVZoXHHMLKw==\n"
+            + "-----END PUBLIC KEY-----";
+        Settings settings = Settings.builder()
+            .put(ALGORITHM, "ES256")
+            .put("ec_private_key", privateKey)
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
+
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.ES256, publicKey));
+    }
+
+    @Test
+    public void testEC384KeySignedJWT() throws Exception {
+        // create keys using openssl: "openssl ecparam -name secp384r1 -genkey -noout -out 384private-key.pem" for private key
+        // "openssl ec -in 384private-key.pem -pubout -out 384public-key.pem" for public key
+        String privateKey = "-----BEGIN EC PRIVATE KEY-----\n"
+            + "MIGkAgEBBDB5WKs0x6dQugmyN3Cn1nzf18AKtPClzgoNeqjdsU5mvg+WSX5btLjk\n"
+            + "Y2s9oRbxqxmgBwYFK4EEACKhZANiAARwnzmM7/HJuISxbvw4Z0zK3rMVej0qsB9G\n"
+            + "Zeb0sL7SZfO89ONX37qNgvzxGOAonFq3uBJDqkf0AGtKlm7e8hfb+vnppIVHsota\n"
+            + "f8hqKLpbYeYueQ7+H7ilCFpqYgRdiao=\n"
+            + "-----END EC PRIVATE KEY-----";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEcJ85jO/xybiEsW78OGdMyt6zFXo9KrAf\n"
+            + "RmXm9LC+0mXzvPTjV9+6jYL88RjgKJxat7gSQ6pH9ABrSpZu3vIX2/r56aSFR7KL\n"
+            + "Wn/Iaii6W2HmLnkO/h+4pQhaamIEXYmq\n"
+            + "-----END PUBLIC KEY-----";
+        Settings settings = Settings.builder()
+            .put(ALGORITHM, "ES384")
+            .put("ec_private_key", privateKey)
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
+
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.ES384, publicKey));
+    }
+
+    @Test
+    public void testEC512KeySignedJWT() throws Exception {
+        // create keys using openssl: "openssl ecparam -name secp521r1 -genkey -noout -out 521private-key.pem" for private key
+        // "openssl ec -in 521private-key.pem -pubout -out 521public-key.pem" for public key
+        String privateKey = "-----BEGIN EC PRIVATE KEY-----\n"
+            + "MIHcAgEBBEIBbsJFVgSOjHSQh8Ma1PhYr0GNMihRI4WydekXZtJVSrinYYINHOj5\n"
+            + "qD9v10nq7WNg85Fu9KV9xRyN2SYlYI+zByCgBwYFK4EEACOhgYkDgYYABABXzFZp\n"
+            + "VE8C0G39Q8clamzs8zW9pX1cKNuTqz8XcSr6PyWl24EBqTnoea+tMPS0np0MW19r\n"
+            + "/Exb+QzlKuy4XTkgwQBziwDspBgsOepT67BHCeuDcwkNJHisSs0NbAw5eu2u/eKc\n"
+            + "1TjQCu6DI/HchRewpx5P4pdEm50oKXoEq3ngne8VUA==\n"
+            + "-----END EC PRIVATE KEY-----\n";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAV8xWaVRPAtBt/UPHJWps7PM1vaV9\n"
+            + "XCjbk6s/F3Eq+j8lpduBAak56HmvrTD0tJ6dDFtfa/xMW/kM5SrsuF05IMEAc4sA\n"
+            + "7KQYLDnqU+uwRwnrg3MJDSR4rErNDWwMOXrtrv3inNU40ArugyPx3IUXsKceT+KX\n"
+            + "RJudKCl6BKt54J3vFVA=\n"
+            + "-----END PUBLIC KEY-----";
+        Settings settings = Settings.builder()
+            .put(ALGORITHM, "ES512")
+            .put("ec_private_key", privateKey)
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
+
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.ES512, publicKey));
+    }
+
+    @Test
+    public void testCreateECJwkFromSettingsWithoutProperConfig() {
+        String privateKey = "-----BEGIN EC PRIVATE KEY-----\n" + "INCORRECT KEY" + "-----END EC PRIVATE KEY-----\n";
+
+        Settings keyBasedSettings = Settings.builder().put(ALGORITHM, "ES256").put("ec_private_key", privateKey).build();
+        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(keyBasedSettings));
+        assertEquals("Unable to read EC private key.", e.getMessage());
+
+        Settings settings = Settings.builder().put(ALGORITHM, "ES256").build();
+        e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings));
+        assertEquals(
+            "Settings for EC private key is missing. Please specify ec_private with required x and y coordinates.",
+            e.getMessage()
+        );
+
+        e = assertThrows(
+            Exception.class,
+            () -> JwtVendor.createJwkFromSettings(
+                Settings.builder().put(settings).put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88)).build()
+            )
+        );
+        assertEquals("Settings for EC x coordinate is missing.", e.getMessage());
+
+        e = assertThrows(
+            Exception.class,
+            () -> JwtVendor.createJwkFromSettings(
+                Settings.builder()
+                    .put(settings)
+                    .put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88))
+                    .put(EC_X, RandomStringUtils.randomAlphanumeric(10))
+                    .build()
+            )
+        );
+        assertEquals("Settings for EC y coordinate is missing.", e.getMessage());
+
+        // correct config at this point
+        JwtVendor.createJwkFromSettings(
+            Settings.builder()
+                .put(settings)
+                .put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88))
+                .put(EC_X, RandomStringUtils.randomAlphanumeric(10))
+                .put(EC_Y, RandomStringUtils.randomAlphanumeric(10))
+                .build()
+        );
+    }
+
+    @Test
+    public void testCreateRSASignedJWTFromSettings() throws Exception {
+        String kty = "jwt.key.kty";
+        String alg = "jwt.key.alg";
+        String rsaN = "jwt.key.n";
+        String rsaE = "jwt.key.e";
+        String rsaD = "jwt.key.d";
+        String rsaP = "jwt.key.p";
+        String rsaQ = "jwt.key.q";
+        String rsaDP = "jwt.key.dp";
+        String rsaDQ = "jwt.key.dq";
+        String rsaQI = "jwt.key.qi";
+        Settings settings = Settings.builder()
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(ALGORITHM, "RS256")
+            .put(
+                RSA_MODULUS,
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+            )
+            .put(RSA_PUBLIC_EXP, "AQAB")
+            .put(
+                RSA_PRIVATE_EXP,
+                "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"
+            )
+            .build();
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        String encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        JsonWebKey jsonWebKey = new JsonWebKey(
+            Map.of(
+                "kty",
+                "RSA",
+                "n",
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e",
+                "AQAB"
+            )
+        );
+        Assert.assertTrue(validateJWTSignatureUsingJWK(encodedJwt, SignatureAlgorithm.RS256, jsonWebKey));
+
+        // other way of creating jwk, without pre-defined properties, to check properties mapping look at JsonWebKey.class
+        settings = Settings.builder()
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(kty, "RSA")
+            .put(alg, "RS256")
+            .put(
+                rsaN,
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+            )
+            .put(rsaE, "AQAB")
+            .put(
+                rsaD,
+                "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"
+            )
+            .put(
+                rsaP,
+                "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs"
+            )
+            .put(
+                rsaQ,
+                "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk"
+            )
+            .put(
+                rsaDP,
+                "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0"
+            )
+            .put(
+                rsaDQ,
+                "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk"
+            )
+            .put(
+                rsaQI,
+                "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa - Bk0KWNGDjJHZDdDmFhW3AN7lI - puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU"
+            )
+            .build();
+        jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        jsonWebKey = new JsonWebKey(
+            Map.of(
+                "kty",
+                "RSA",
+                "n",
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e",
+                "AQAB",
+                "p",
+                "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs",
+                "q",
+                "3dfOR9cuYq-0S-mkFLzgItgMEfFzB2q3hWehMuG0oCuqnb3vobLyumqjVZQO1dIrdwgTnCdpYzBcOfW5r370AFXjiWft_NGEiovonizhKpo9VVS78TzFgxkIdrecRezsZ-1kYd_s1qDbxtkDEgfAITAG9LUnADun4vIcb6yelxk",
+                "dp",
+                "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0",
+                "dq",
+                "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk",
+                "qi",
+                "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa - Bk0KWNGDjJHZDdDmFhW3AN7lI - puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU"
+            )
+        );
+        Assert.assertTrue(validateJWTSignatureUsingJWK(encodedJwt, SignatureAlgorithm.RS256, jsonWebKey));
+
+        // only n, e, p is required
+        settings = Settings.builder()
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(kty, "RSA")
+            .put(alg, "RS256")
+            .put(
+                rsaN,
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+            )
+            .put(rsaE, "AQAB")
+            .put(
+                rsaD,
+                "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"
+            )
+            .build();
+
+        jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        jsonWebKey = new JsonWebKey(
+            Map.of(
+                "kty",
+                "RSA",
+                "n",
+                "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e",
+                "AQAB"
+            )
+        );
+        Assert.assertTrue(validateJWTSignatureUsingJWK(encodedJwt, SignatureAlgorithm.RS256, jsonWebKey));
+    }
+
+    @Test
+    public void testRSA256KeySignedJWT() throws Exception {
+        String privateKey = "-----BEGIN PRIVATE KEY-----\n"
+            + "MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDAB1QyTM+i2djr\n"
+            + "mPnbPJ5/NjfielSeR4s1U5hC7wcUMzt2Y65/tvWuOD7b8BlM68bvTWpHaSiAhQVt\n"
+            + "10pLxZAfTbDtRy53MT6CAZKL//EdNDTuIr+YRWMyN9nLhwLD445nSwwJmlrurm61\n"
+            + "/LU57jtvYe393JemkuRzT0KbMASb2L9mebjF4qvBos2qu3JyGD+6oFOPPB7l02Tw\n"
+            + "aqHoZQWcz+CYWLtuUYP3Qz6UlNzoRckr4PbuK+x7Svk/KUBnuPMZCmbj5FJKi/s6\n"
+            + "+r9L9LeljslYJpwfzL+CXLLzKkoaQKZddz7DCE33NK9DMaZdmHxOJqySAL6JBZHB\n"
+            + "oTU5Wy7jAgMBAAECggEAGC/0ItUk+YIPaMw0ezESqmWrEAZQ6TzhY8lQmOxgS7g7\n"
+            + "nv5lnjrujXq9LtklFANwuSIFpygE4idJ10YyWq1FqYO7gNpMl9Z75UaLGGztCGd+\n"
+            + "hpju4XWqox/WJDowbCRvV+25KZkn0f+Q/LBE0slXSCt2yC6ZwBv+1X1gH4miqE8i\n"
+            + "RF4bjuhY4OERRYqwFy3wqWdmnJEQVqtc3tG7RN5z4ppk01oUCXdikvMkWJzg9OMC\n"
+            + "heIbqjmduBpHpXQf5TpO9xmliEQJnxvQ5GToKHatM+qPlth+So0cwByeYQJgpp9Y\n"
+            + "fRR4TteRcWdlAezcZ5cdKxJNiW0Rq5vZZI3lIMCS6QKBgQD+UiBXt5jjpUrHqrk3\n"
+            + "qLJbDoOQCxEx814lNrLHP9nk6FJq+ltdxVhluZYF3WAc3HRDdPT3hsx1s4jQYxDt\n"
+            + "CJafpG8s+TfInThXO/nvYPERH43o1/TMCJX+uMdtf5r2smADpsNzMINNW/0YMSfL\n"
+            + "aBJfPMMELJRdn1dlJGFIcZarmwKBgQDBS+lIa97JPvh3F71KbRWTpcoDNgb0VhVa\n"
+            + "XpyYzmBmkYffE53WIBPgC8l0PvHBs8aqa7P6WUzZHO2Zkj8pp4/QQvEuvqUZL7Qj\n"
+            + "15++GbP2/eyhizon8lk+pf2KH7HyJYRMd1CXQr1Pwq9kirH+LMQpKtChjlsonspm\n"
+            + "gwEn59PyWQKBgQDeDslsrcNSKbYkpt24SpUIyqB3OiKWcb/nUF5DeW4A4BVukREL\n"
+            + "zE9F6wiiMExGhvsBF3L5WfrWXp98DLPvs4sI82ObajOZ+CUEjjrKF+QFJn8bKsz1\n"
+            + "Bh4p3h9LbZraAp+xMIAB6P8MoeBYqjrr8P/xpjVFRMN7B7Egf+ZtgbikNwKBgGB8\n"
+            + "DNkKhy07EnkXz3O8GZ4WjkymBjimU4hFW7NmqHXqRMEUIKAGaQVXvNoapUBEBXGB\n"
+            + "y1e2hYaGSw9yEbcwHbgeAheMMArvZeLSObmBSPSL8Tb9sSzJasS7xF/SzFcLZQtq\n"
+            + "Lz8hoC+VBUmRdaFjJRNLfNJ3pYcUJAGheM07ie8ZAoGBAMLguVp5Kn74GQ0ExtxB\n"
+            + "zHO9AKejR8d3SckQFFcVtH+OYJ+X05ZxRRTvG7PzCziiTSoVf7wNHi0ebxq7YFvd\n"
+            + "2QesN8EgxwXiUOrPeUELpXhfZ7ztri1E/MACw9ETbdyEL5bh4vKDpaJr4FTwVojJ\n"
+            + "E5KVj7rUSwDJJi6NRWTIk12S\n"
+            + "-----END PRIVATE KEY-----";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAwAdUMkzPotnY65j52zye\n"
+            + "fzY34npUnkeLNVOYQu8HFDM7dmOuf7b1rjg+2/AZTOvG701qR2kogIUFbddKS8WQ\n"
+            + "H02w7UcudzE+ggGSi//xHTQ07iK/mEVjMjfZy4cCw+OOZ0sMCZpa7q5utfy1Oe47\n"
+            + "b2Ht/dyXppLkc09CmzAEm9i/Znm4xeKrwaLNqrtychg/uqBTjzwe5dNk8Gqh6GUF\n"
+            + "nM/gmFi7blGD90M+lJTc6EXJK+D27ivse0r5PylAZ7jzGQpm4+RSSov7Ovq/S/S3\n"
+            + "pY7JWCacH8y/glyy8ypKGkCmXXc+wwhN9zSvQzGmXZh8TiaskgC+iQWRwaE1OVsu\n"
+            + "4wIDAQAB\n"
+            + "-----END PUBLIC KEY-----\n";
+
+        Settings settings = Settings.builder()
+            .put(ENCRYPTION_KEY, RandomStringUtils.randomAlphanumeric(16))
+            .put(ALGORITHM, "RS256")
+            .put("rsa_private_key", privateKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        String encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.RS256, publicKey));
+    }
+
+    @Test
+    public void testRSA384KeySignedJWT() throws Exception {
+        String privateKey = "-----BEGIN PRIVATE KEY-----\n"
+            + "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrHDjPwb+DKEKh\n"
+            + "ZD/5fity+yOtEvX5yNuR9QMNUiDjBOdeM5Q+JBcCydeGUYpDibAr3R1BaOpzK9XZ\n"
+            + "oRI4jehP0RiwS9n0yRvvOdomX5sYz1Azzxle8FQ00hmPSks5JGGfmN7H/q8yLR+X\n"
+            + "5assB545tmJgDGi8kDABUzMZPrn8zR2zkUKvIqGXXn4Xet34WM8AXrgpHYFR6qht\n"
+            + "EKAIUYRn4O08EF/NdXxyAWHCepOIvbI+C73KmRIFQSmexrxfINs8zpZnEJqlXYiP\n"
+            + "A/UJafS18eEc4ivh2pcIEOLgGA3ix3PdaNhj3Cjo2lNFN9SVoHRKzOullJfA9Q3v\n"
+            + "PIW+3bqfAgMBAAECggEAA4RufzLL4C3ShM/Ikt/Zk8updZQnXe2XjzNapIpKJnCC\n"
+            + "MwkGD0BIVXnXBin57h56nRmL/D1kXbQKeXvv9x1Pp7MJegztG4o2Gp+f+4bz62Qj\n"
+            + "kWpnP/DabPA0BKKHKP21oLAQmvWCHhrDBKkncMhtTmFl5J83WJzxfQLRUOpdrLPK\n"
+            + "vaA7YePnWPRC/zgPSHQgGJlIPdxHy6LGCQdMTqDvdMckLJ7z1R7aWxOsygi5/Z17\n"
+            + "Ihx2k/7cXaLjnZEn77TO8jdyupTKm3Ixb62DpYbYxWrOJL9foXYgtRSTG7AUKJcr\n"
+            + "HO2LjsXpKBm5e1yJcvM3UJ5wu7nUUtnTu4vHkMZgGQKBgQDeMzbrn9syUmUBlFw+\n"
+            + "wl8njtH0pQ4R8Ox5LzNVQulbYJj901NrrPYjo/eWe7nj1zE5uqRmSrKW1CQCW4TU\n"
+            + "xm1QPn5eojEYOmaI4Hx04K6XtuVnnqnnb43aU4uJzoDS/F9Qzx9N9a2j9sk1iasO\n"
+            + "A88L78/8/zj8Mj7ABszeFOmyCQKBgQDFI39cxNw2ouQmLfnh+L14DV1ZrLDFci1n\n"
+            + "4EaBCcVigNE9ZczcjK70GmRmVOAJSlZD8/IO6qUC108FCMWoN2xxfkEW21seavB/\n"
+            + "LweU3Uq2/OmHi4zaaQjFFxeSFzly1Mx3B7OEGVcKV+m7oUJSDY75WMktdE4bMM82\n"
+            + "v6Qc/wCRZwKBgB8r/CZuFKgomvbvw0kip4q7JIU3qpOlwub1UjRB4M7q7Eufm/Jd\n"
+            + "H2K8m/1GejuWctdwcaPQEuHJ/Qs/n5DiDW/WdI/+HPkTKFNHeu5Cnvu1stUokxle\n"
+            + "sv3P/qFkkPoIYa7Kf8/GCYgZFP0nxRGAQ0mfaQRLIclvmxIBYjg9otNRAoGAEsd9\n"
+            + "43VxUNcVirmIe0k5q00Cnn8/258zyhhoPvSSU/7Xb9TZvgy8wc4d0E23hcsKCrEb\n"
+            + "VuZtT6b5BQ6/3XViJDGVu7qrpGsle8gcHccyzdmr2Vim00t8JWI8wZLqyxCQZapb\n"
+            + "JHNRgk+7mT8UVUKrYv9dMrJImnh81MdOt+BmynMCgYEAnqCnZHD9LnKIhOLnSKAI\n"
+            + "VsDhaFHrDWbedG9WsIbI7pb7majW+wxUWFCx9pMOVDzS8ykoixPS3NggkCtxF10i\n"
+            + "YPhHfx0DhvPQsv4VzR6jhWGpnL4OS3H+piZbTDKip5swIsM5IV2YLBE569y1eTmJ\n"
+            + "xzoZ1r2eLYjHOEhZx28887Q=\n"
+            + "-----END PRIVATE KEY-----";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxw4z8G/gyhCoWQ/+X4r\n"
+            + "cvsjrRL1+cjbkfUDDVIg4wTnXjOUPiQXAsnXhlGKQ4mwK90dQWjqcyvV2aESOI3o\n"
+            + "T9EYsEvZ9Mkb7znaJl+bGM9QM88ZXvBUNNIZj0pLOSRhn5jex/6vMi0fl+WrLAee\n"
+            + "ObZiYAxovJAwAVMzGT65/M0ds5FCryKhl15+F3rd+FjPAF64KR2BUeqobRCgCFGE\n"
+            + "Z+DtPBBfzXV8cgFhwnqTiL2yPgu9ypkSBUEpnsa8XyDbPM6WZxCapV2IjwP1CWn0\n"
+            + "tfHhHOIr4dqXCBDi4BgN4sdz3WjYY9wo6NpTRTfUlaB0SszrpZSXwPUN7zyFvt26\n"
+            + "nwIDAQAB\n"
+            + "-----END PUBLIC KEY-----\n";
+
+        Settings settings = Settings.builder()
+            .put(ENCRYPTION_KEY, RandomStringUtils.randomAlphanumeric(16))
+            .put(ALGORITHM, "RS384")
+            .put("rsa_private_key", privateKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        String encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.RS384, publicKey));
+    }
+
+    @Test
+    public void testRSA512KeySignedJWT() throws Exception {
+        String privateKey = "-----BEGIN PRIVATE KEY-----\n"
+            + "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrHDjPwb+DKEKh\n"
+            + "ZD/5fity+yOtEvX5yNuR9QMNUiDjBOdeM5Q+JBcCydeGUYpDibAr3R1BaOpzK9XZ\n"
+            + "oRI4jehP0RiwS9n0yRvvOdomX5sYz1Azzxle8FQ00hmPSks5JGGfmN7H/q8yLR+X\n"
+            + "5assB545tmJgDGi8kDABUzMZPrn8zR2zkUKvIqGXXn4Xet34WM8AXrgpHYFR6qht\n"
+            + "EKAIUYRn4O08EF/NdXxyAWHCepOIvbI+C73KmRIFQSmexrxfINs8zpZnEJqlXYiP\n"
+            + "A/UJafS18eEc4ivh2pcIEOLgGA3ix3PdaNhj3Cjo2lNFN9SVoHRKzOullJfA9Q3v\n"
+            + "PIW+3bqfAgMBAAECggEAA4RufzLL4C3ShM/Ikt/Zk8updZQnXe2XjzNapIpKJnCC\n"
+            + "MwkGD0BIVXnXBin57h56nRmL/D1kXbQKeXvv9x1Pp7MJegztG4o2Gp+f+4bz62Qj\n"
+            + "kWpnP/DabPA0BKKHKP21oLAQmvWCHhrDBKkncMhtTmFl5J83WJzxfQLRUOpdrLPK\n"
+            + "vaA7YePnWPRC/zgPSHQgGJlIPdxHy6LGCQdMTqDvdMckLJ7z1R7aWxOsygi5/Z17\n"
+            + "Ihx2k/7cXaLjnZEn77TO8jdyupTKm3Ixb62DpYbYxWrOJL9foXYgtRSTG7AUKJcr\n"
+            + "HO2LjsXpKBm5e1yJcvM3UJ5wu7nUUtnTu4vHkMZgGQKBgQDeMzbrn9syUmUBlFw+\n"
+            + "wl8njtH0pQ4R8Ox5LzNVQulbYJj901NrrPYjo/eWe7nj1zE5uqRmSrKW1CQCW4TU\n"
+            + "xm1QPn5eojEYOmaI4Hx04K6XtuVnnqnnb43aU4uJzoDS/F9Qzx9N9a2j9sk1iasO\n"
+            + "A88L78/8/zj8Mj7ABszeFOmyCQKBgQDFI39cxNw2ouQmLfnh+L14DV1ZrLDFci1n\n"
+            + "4EaBCcVigNE9ZczcjK70GmRmVOAJSlZD8/IO6qUC108FCMWoN2xxfkEW21seavB/\n"
+            + "LweU3Uq2/OmHi4zaaQjFFxeSFzly1Mx3B7OEGVcKV+m7oUJSDY75WMktdE4bMM82\n"
+            + "v6Qc/wCRZwKBgB8r/CZuFKgomvbvw0kip4q7JIU3qpOlwub1UjRB4M7q7Eufm/Jd\n"
+            + "H2K8m/1GejuWctdwcaPQEuHJ/Qs/n5DiDW/WdI/+HPkTKFNHeu5Cnvu1stUokxle\n"
+            + "sv3P/qFkkPoIYa7Kf8/GCYgZFP0nxRGAQ0mfaQRLIclvmxIBYjg9otNRAoGAEsd9\n"
+            + "43VxUNcVirmIe0k5q00Cnn8/258zyhhoPvSSU/7Xb9TZvgy8wc4d0E23hcsKCrEb\n"
+            + "VuZtT6b5BQ6/3XViJDGVu7qrpGsle8gcHccyzdmr2Vim00t8JWI8wZLqyxCQZapb\n"
+            + "JHNRgk+7mT8UVUKrYv9dMrJImnh81MdOt+BmynMCgYEAnqCnZHD9LnKIhOLnSKAI\n"
+            + "VsDhaFHrDWbedG9WsIbI7pb7majW+wxUWFCx9pMOVDzS8ykoixPS3NggkCtxF10i\n"
+            + "YPhHfx0DhvPQsv4VzR6jhWGpnL4OS3H+piZbTDKip5swIsM5IV2YLBE569y1eTmJ\n"
+            + "xzoZ1r2eLYjHOEhZx28887Q=\n"
+            + "-----END PRIVATE KEY-----";
+        String publicKey = "-----BEGIN PUBLIC KEY-----\n"
+            + "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqxw4z8G/gyhCoWQ/+X4r\n"
+            + "cvsjrRL1+cjbkfUDDVIg4wTnXjOUPiQXAsnXhlGKQ4mwK90dQWjqcyvV2aESOI3o\n"
+            + "T9EYsEvZ9Mkb7znaJl+bGM9QM88ZXvBUNNIZj0pLOSRhn5jex/6vMi0fl+WrLAee\n"
+            + "ObZiYAxovJAwAVMzGT65/M0ds5FCryKhl15+F3rd+FjPAF64KR2BUeqobRCgCFGE\n"
+            + "Z+DtPBBfzXV8cgFhwnqTiL2yPgu9ypkSBUEpnsa8XyDbPM6WZxCapV2IjwP1CWn0\n"
+            + "tfHhHOIr4dqXCBDi4BgN4sdz3WjYY9wo6NpTRTfUlaB0SszrpZSXwPUN7zyFvt26\n"
+            + "nwIDAQAB\n"
+            + "-----END PUBLIC KEY-----\n";
+
+        Settings settings = Settings.builder()
+            .put(ENCRYPTION_KEY, RandomStringUtils.randomAlphanumeric(16))
+            .put(ALGORITHM, "RS512")
+            .put("rsa_private_key", privateKey)
+            .build();
+
+        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(() -> 100));
+        String encodedJwt = jwtVendor.createJwt("issuer", "subject", "audience", 200, List.of("IT", "HR"), backendRoles, false);
+        Assert.assertTrue(validateJWTSignatureUsingPublicKey(encodedJwt, SignatureAlgorithm.RS512, publicKey));
+    }
+
+    @Test
+    public void testCreateRSAJwkFromSettingsWithoutProperConfig() {
+        String privateKey = "-----BEGIN PRIVATE KEY-----\n" + "incorrectKey" + "-----END PRIVATE KEY-----";
         String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
+
+        Settings settings1 = Settings.builder()
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(ALGORITHM, "RS256")
+            .put("rsa_private_key", privateKey)
+            .build();
+        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings1));
+        assertEquals("Unable to read RSA private key.", e.getMessage());
+
+        Settings settings2 = Settings.builder()
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(ALGORITHM, "RS256")
+            .put(RSA_PUBLIC_EXP, "AQAB")
+            .put(
+                RSA_PRIVATE_EXP,
+                "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"
+            )
+            .build();
+        e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings2));
+        assertEquals("Settings for RSA modulus is missing. Please specify rsa_modulus.", e.getMessage());
+
+        final Exception finalE = assertThrows(
+            Exception.class,
+            () -> JwtVendor.createJwkFromSettings(
+                Settings.builder()
+                    .put(settings2)
+                    .put(RSA_MODULUS, "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R")
+                    .put("rsa_first_prime_factor", "some_prime")
+                    .build()
+            )
+        );
+        List<String> expectedList = List.of(
+            "Settings for RSA key is missing, missing properties:",
+            "rsa_second_prime_factor",
+            "rsa_first_prime_crt",
+            "rsa_second_prime_crt",
+            "rsa_first_crt_coefficient"
+        );
+        expectedList.forEach(v -> Assert.assertTrue(finalE.getMessage().contains(v)));
+
+    }
+
+    @Test
+    public void testIncorrectAlgorithmName() {
+        Settings settings = Settings.builder()
+            .put("signing_key", "abc123")
+            .put(ENCRYPTION_KEY, claimsEncryptionKey)
+            .put(ALGORITHM, "NON EXISTING SIGNING ALGO")
+            .build();
+
+        Exception e = assertThrows(Exception.class, () -> new JwtVendor(settings, Optional.empty()));
+        Assert.assertEquals(
+            "An error occurred during the creation of Jwk: Signing algorithm not recognized: NON EXISTING SIGNING ALGO",
+            e.getMessage()
+        );
+    }
+
+    @Test
+    public void testCreateJwtWithBadExpiry() {
+        Integer expirySeconds = -300;
+        String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
+
         Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
         JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
 
-        Throwable exception = Assert.assertThrows(RuntimeException.class, () -> {
-            try {
-                jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, List.of(), true);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        Assert.assertEquals("java.lang.Exception: Roles cannot be null", exception.getMessage());
+        Exception e = assertThrows(
+            Exception.class,
+            () -> jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false)
+        );
+        Assert.assertEquals("The expiration time should be a positive integer", e.getMessage());
     }
+
 }

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -101,14 +101,14 @@ public class JwtVendorTest {
         // try default algorithm: HS512
         Settings settings = Settings.builder().put("signing_key", "abc123").build();
 
-        JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
+        JsonWebKey jwk = JwkUtil.createJwkFromSettings(settings);
         Assert.assertEquals("HS512", jwk.getAlgorithm());
         Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
         Assert.assertEquals("abc123", jwk.getProperty("k"));
 
         settings = Settings.builder().put(ALGORITHM, "HS512").put("signing_key", "abc123").build();
 
-        jwk = JwtVendor.createJwkFromSettings(settings);
+        jwk = JwkUtil.createJwkFromSettings(settings);
         Assert.assertEquals("HS512", jwk.getAlgorithm());
         Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
         Assert.assertEquals("abc123", jwk.getProperty("k"));
@@ -119,7 +119,7 @@ public class JwtVendorTest {
         Settings settings = Settings.builder().put("jwt", "").build();
         Throwable exception = Assert.assertThrows(RuntimeException.class, () -> {
             try {
-                JwtVendor.createJwkFromSettings(settings);
+                JwkUtil.createJwkFromSettings(settings);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
@@ -205,7 +205,7 @@ public class JwtVendorTest {
     public void testCreateHMACJwkFromSettingsWithoutProperConfig() {
         Settings settings = Settings.builder().build();
 
-        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings));
+        Exception e = assertThrows(Exception.class, () -> JwkUtil.createJwkFromSettings(settings));
         assertEquals(
             "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
             e.getMessage()
@@ -213,7 +213,7 @@ public class JwtVendorTest {
 
         e = assertThrows(
             Exception.class,
-            () -> JwtVendor.createJwkFromSettings(Settings.builder().put(settings).put(ALGORITHM, "HS512").build())
+            () -> JwkUtil.createJwkFromSettings(Settings.builder().put(settings).put(ALGORITHM, "HS512").build())
         );
         assertEquals(
             "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
@@ -221,7 +221,7 @@ public class JwtVendorTest {
         );
 
         // correct config at this point
-        JwtVendor.createJwkFromSettings(
+        JwkUtil.createJwkFromSettings(
             Settings.builder().put(settings).put(ALGORITHM, "HS512").put("signing_key", "secret_signing_key").build()
         );
     }
@@ -283,7 +283,7 @@ public class JwtVendorTest {
             .put(ENCRYPTION_KEY, claimsEncryptionKey)
             .build();
 
-        JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
+        JsonWebKey jwk = JwkUtil.createJwkFromSettings(settings);
         Assert.assertEquals("sig", jwk.getPublicKeyUse().toString());
         Assert.assertEquals(EC_CURVE_P521, jwk.getProperty("crv"));
         Assert.assertEquals(KeyType.EC, jwk.getKeyType());
@@ -388,11 +388,11 @@ public class JwtVendorTest {
         String privateKey = "-----BEGIN EC PRIVATE KEY-----\n" + "INCORRECT KEY" + "-----END EC PRIVATE KEY-----\n";
 
         Settings keyBasedSettings = Settings.builder().put(ALGORITHM, "ES256").put("ec_private_key", privateKey).build();
-        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(keyBasedSettings));
+        Exception e = assertThrows(Exception.class, () -> JwkUtil.createJwkFromSettings(keyBasedSettings));
         assertEquals("Unable to read EC private key.", e.getMessage());
 
         Settings settings = Settings.builder().put(ALGORITHM, "ES256").build();
-        e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings));
+        e = assertThrows(Exception.class, () -> JwkUtil.createJwkFromSettings(settings));
         assertEquals(
             "Settings for EC private key is missing. Please specify ec_private with required x and y coordinates.",
             e.getMessage()
@@ -400,7 +400,7 @@ public class JwtVendorTest {
 
         e = assertThrows(
             Exception.class,
-            () -> JwtVendor.createJwkFromSettings(
+            () -> JwkUtil.createJwkFromSettings(
                 Settings.builder().put(settings).put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88)).build()
             )
         );
@@ -408,7 +408,7 @@ public class JwtVendorTest {
 
         e = assertThrows(
             Exception.class,
-            () -> JwtVendor.createJwkFromSettings(
+            () -> JwkUtil.createJwkFromSettings(
                 Settings.builder()
                     .put(settings)
                     .put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88))
@@ -419,7 +419,7 @@ public class JwtVendorTest {
         assertEquals("Settings for EC y coordinate is missing.", e.getMessage());
 
         // correct config at this point
-        JwtVendor.createJwkFromSettings(
+        JwkUtil.createJwkFromSettings(
             Settings.builder()
                 .put(settings)
                 .put(EC_PRIVATE, RandomStringUtils.randomAlphanumeric(88))
@@ -721,7 +721,7 @@ public class JwtVendorTest {
             .put(ALGORITHM, "RS256")
             .put("rsa_private_key", privateKey)
             .build();
-        Exception e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings1));
+        Exception e = assertThrows(Exception.class, () -> JwkUtil.createJwkFromSettings(settings1));
         assertEquals("Unable to read RSA private key.", e.getMessage());
 
         Settings settings2 = Settings.builder()
@@ -733,12 +733,12 @@ public class JwtVendorTest {
                 "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q"
             )
             .build();
-        e = assertThrows(Exception.class, () -> JwtVendor.createJwkFromSettings(settings2));
+        e = assertThrows(Exception.class, () -> JwkUtil.createJwkFromSettings(settings2));
         assertEquals("Settings for RSA modulus is missing. Please specify rsa_modulus.", e.getMessage());
 
         final Exception finalE = assertThrows(
             Exception.class,
-            () -> JwtVendor.createJwkFromSettings(
+            () -> JwkUtil.createJwkFromSettings(
                 Settings.builder()
                     .put(settings2)
                     .put(RSA_MODULUS, "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R")


### PR DESCRIPTION
### Description

Previously, the application was limited to HMAC-based algorithms (HS256, HS384, HS512). With this update, RSA and Elliptic Curve algorithms are now supported as well.

Supported Algorithms:
- HMAC: HS256, HS384, HS512
- RSA: RS256, RS384, RS512
- Elliptic Curve: ES256, ES384, ES512

The new feature enables users to configure the signing method by specifying JSON Web Keys (JWK) in the configuration, modeled after their JSON structure, or by directly using private RSA/EC keys. This aligns with the algorithms specified in [RFC 7518 Section 3.1](https://www.rfc-editor.org/rfc/rfc7518#section-3.1).

### Issues Resolved
https://github.com/opensearch-project/security/issues/2680


### Testing
Unit tests prepared with focus on EC and SHA JWT creation

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
