### PR TITLE
[FEATURE] usage of JWKS with JWT (w/o OpenID connect)

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -55,6 +55,8 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final String jwtUrlParameter;
     private final String subjectKey;
     private final String rolesKey;
+    private final String requiredAudience;
+    private final String requiredIssuer;
 
     public static final int DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS = 30;
     private final int clockSkewToleranceSeconds ;
@@ -66,10 +68,12 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
+        requiredAudience = settings.get("required_audience");
+        requiredIssuer = settings.get("required_issuer");
 
         try {
             this.keyProvider = this.initKeyProvider(settings, configPath);
-            jwtVerifier = new JwtVerifier(keyProvider, clockSkewToleranceSeconds );
+            jwtVerifier = new JwtVerifier(keyProvider, clockSkewToleranceSeconds, requiredIssuer, requiredAudience);
 
         } catch (Exception e) {
             log.error("Error creating JWT authenticator. JWT authentication will not work", e);
@@ -231,6 +235,14 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         wwwAuthenticateResponse.addHeader("WWW-Authenticate", "Bearer realm=\"OpenSearch Security\"");
         channel.sendResponse(wwwAuthenticateResponse);
         return true;
+    }
+
+    public String getRequiredAudience() {
+        return requiredAudience;
+    }
+
+    public String getRequiredIssuer() {
+        return requiredIssuer;
     }
 
 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
@@ -32,9 +32,15 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticator extends AbstractHTTPJwtAuthe
 
 		int refreshRateLimitTimeWindowMs = settings.getAsInt("refresh_rate_limit_time_window_ms", 10000);
 		int refreshRateLimitCount = settings.getAsInt("refresh_rate_limit_count", 10);
+		var jwksUri = settings.get("jwks_uri");
 
-		KeySetRetriever keySetRetriever = new KeySetRetriever(settings.get("openid_connect_url"),
-				getSSLConfig(settings, configPath), settings.getAsBoolean("cache_jwks_endpoint", false));
+		KeySetRetriever keySetRetriever;
+		if(jwksUri != null && !jwksUri.isBlank()) {
+			keySetRetriever =
+				new KeySetRetriever(getSSLConfig(settings, configPath), settings.getAsBoolean("cache_jwks_endpoint", false), jwksUri);
+		} else {
+			keySetRetriever = new KeySetRetriever(settings.get("openid_connect_url"), getSSLConfig(settings, configPath), settings.getAsBoolean("cache_jwks_endpoint", false));
+		}
 
 		keySetRetriever.setRequestTimeoutMs(idpRequestTimeoutMs);
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
@@ -13,8 +13,6 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.nio.file.Path;
 
-import joptsimple.internal.Strings;
-
 import com.amazon.dlic.auth.http.jwt.AbstractHTTPJwtAuthenticator;
 import com.amazon.dlic.util.SettingsBasedSSLConfigurator;
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
@@ -13,6 +13,8 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.nio.file.Path;
 
+import joptsimple.internal.Strings;
+
 import com.amazon.dlic.auth.http.jwt.AbstractHTTPJwtAuthenticator;
 import com.amazon.dlic.util.SettingsBasedSSLConfigurator;
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticator.java
@@ -32,7 +32,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticator extends AbstractHTTPJwtAuthe
 
 		int refreshRateLimitTimeWindowMs = settings.getAsInt("refresh_rate_limit_time_window_ms", 10000);
 		int refreshRateLimitCount = settings.getAsInt("refresh_rate_limit_count", 10);
-		var jwksUri = settings.get("jwks_uri");
+		String jwksUri = settings.get("jwks_uri");
 
 		KeySetRetriever keySetRetriever;
 		if(jwksUri != null && !jwksUri.isBlank()) {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -110,7 +110,7 @@ public class JwtVerifier {
 		}
 	}
 
-	private void validateClaims(JwtToken jwt) throws BadCredentialsException, JwtException {
+	private void validateClaims(JwtToken jwt) throws JwtException {
 		JwtClaims claims = jwt.getClaims();
 
 		if (claims != null) {
@@ -125,7 +125,7 @@ public class JwtVerifier {
 		String issuer = claims.getIssuer();
 
 		if (!audience.equals(requiredAudience)) {
-			throw new JwtException("Invalid issuer");
+			throw new JwtException("Invalid audience");
 		}
 
 		if (!issuer.equals(requiredIssuer)) {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -33,10 +33,14 @@ public class JwtVerifier {
 
 	private final KeyProvider keyProvider;
 	private final int clockSkewToleranceSeconds;
-
-	public JwtVerifier(KeyProvider keyProvider, int clockSkewToleranceSeconds ) {
+	private final String requiredIssuer;
+	private final String requiredAudience;
+	
+	public JwtVerifier(KeyProvider keyProvider, int clockSkewToleranceSeconds, String requiredIssuer, String requiredAudience) {
 		this.keyProvider = keyProvider;
 		this.clockSkewToleranceSeconds = clockSkewToleranceSeconds;
+		this.requiredIssuer = requiredIssuer;
+		this.requiredAudience = requiredAudience;
 	}
 
 	public JwtToken getVerifiedJwtToken(String encodedJwt) throws BadCredentialsException {
@@ -112,6 +116,20 @@ public class JwtVerifier {
 		if (claims != null) {
 			JwtUtils.validateJwtExpiry(claims, clockSkewToleranceSeconds, false);
 			JwtUtils.validateJwtNotBefore(claims, clockSkewToleranceSeconds, false);
+			validateRequiredAudienceAndIssuer(claims);
+		}
+	}
+
+	private void validateRequiredAudienceAndIssuer(JwtClaims claims) {
+		String audience = claims.getAudience();
+		String issuer = claims.getIssuer();
+
+		if (!audience.equals(requiredAudience)) {
+			throw new JwtException("Invalid issuer");
+		}
+
+		if (!issuer.equals(requiredIssuer)) {
+			throw new JwtException("Invalid issuer");
 		}
 	}
 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -124,11 +124,11 @@ public class JwtVerifier {
 		String audience = claims.getAudience();
 		String issuer = claims.getIssuer();
 
-		if (!audience.equals(requiredAudience)) {
+		if (!Strings.isNullOrEmpty(requiredAudience) && !audience.equals(requiredAudience)) {
 			throw new JwtException("Invalid audience");
 		}
 
-		if (!issuer.equals(requiredIssuer)) {
+		if (!Strings.isNullOrEmpty(requiredAudience)  && !issuer.equals(requiredIssuer)) {
 			throw new JwtException("Invalid issuer");
 		}
 	}

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -124,11 +124,11 @@ public class JwtVerifier {
 		String audience = claims.getAudience();
 		String issuer = claims.getIssuer();
 
-		if (!Strings.isNullOrEmpty(requiredAudience) && !audience.equals(requiredAudience)) {
+		if (!Strings.isNullOrEmpty(requiredAudience) && !requiredAudience.equals(audience)) {
 			throw new JwtException("Invalid audience");
 		}
 
-		if (!Strings.isNullOrEmpty(requiredAudience)  && !issuer.equals(requiredIssuer)) {
+		if (!Strings.isNullOrEmpty(requiredIssuer)  && !requiredIssuer.equals(issuer)) {
 			throw new JwtException("Invalid issuer");
 		}
 	}

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -14,6 +14,7 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import joptsimple.internal.Strings;
 import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
 import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
 import org.apache.hc.client5.http.cache.HttpCacheContext;
@@ -106,8 +107,12 @@ public class KeySetRetriever implements KeySetProvider {
 
 	String getJwksUri() throws AuthenticatorUnavailableException {
 
-		if (jwksUri != null && !jwksUri.isBlank()) {
+		if (!Strings.isNullOrEmpty(jwksUri)) {
 			return jwksUri;
+		}
+
+		if (Strings.isNullOrEmpty(openIdConnectEndpoint)) {
+			throw new AuthenticatorUnavailableException("Either openid_connect_url or jwks_uri must be configured for OIDC Authentication backend");
 		}
 
 		try (CloseableHttpClient httpClient = createHttpClient(oidcHttpCacheStorage)) {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -118,7 +118,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 	public void jwksMissingRequiredAudienceInClaimTest() {
 		Settings settings = Settings.builder()
 			.put("jwks_uri", mockIdpServer.getJwksUri())
-			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
 			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -18,6 +18,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
@@ -44,7 +45,11 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
 	@Test
 	public void basicTest() {
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -55,12 +60,110 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 		Assert.assertEquals(0, creds.getBackendRoles().size());
-		Assert.assertEquals(3, creds.getAttributes().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
+	}
+
+
+	@Test
+	public void jwksUriTest() {
+		Settings settings = Settings.builder()
+			.put("jwks_uri", mockIdpServer.getJwksUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+
+		Assert.assertNotNull(creds);
+		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
+		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+		Assert.assertEquals(0, creds.getBackendRoles().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
+	}
+
+	@Test
+	public void jwksMissingRequiredIssuerInClaimTest() {
+		Settings settings = Settings.builder()
+			.put("jwks_uri", mockIdpServer.getJwksUri())
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+
+		Assert.assertNull(creds);
+	}
+
+	@Test
+	public void jwksNotMatchingRequiredIssuerInClaimTest() {
+		Settings settings = Settings.builder()
+			.put("jwks_uri", mockIdpServer.getJwksUri())
+			.put("required_issuer", "Wrong Issuer")
+			.build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+
+		Assert.assertNull(creds);
+	}
+
+	@Test
+	public void jwksMissingRequiredAudienceInClaimTest() {
+		Settings settings = Settings.builder()
+			.put("jwks_uri", mockIdpServer.getJwksUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+
+		Assert.assertNull(creds);
+	}
+
+	@Test
+	public void jwksNotMatchingRequiredAudienceInClaimTest() {
+		Settings settings = Settings.builder()
+			.put("jwks_uri", mockIdpServer.getJwksUri())
+			.put("required_audience", "Wrong Audience")
+			.build();
+
+		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+
+		Assert.assertNull(creds);
+	}
+
+	@Test
+	public void jwksUriMissingTest() {
+		var exception = Assert.assertThrows(Exception.class, () -> {
+			HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(Settings.builder().build(), null);
+			jwtAuth.extractCredentials(
+				new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_1), new HashMap<>()),
+				null);
+		});
+
+		Assert.assertEquals("Authentication backend failed", exception.getMessage());
+		Assert.assertEquals(OpenSearchSecurityException.class, exception.getClass());
 	}
 
 	@Test
 	public void testEscapeKid() {
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -71,12 +174,16 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 		Assert.assertEquals(0, creds.getBackendRoles().size());
-		Assert.assertEquals(3, creds.getAttributes().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
 	}
 
 	@Test
 	public void bearerTest() {
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -89,13 +196,17 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 		Assert.assertEquals(0, creds.getBackendRoles().size());
-		Assert.assertEquals(3, creds.getAttributes().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
 	}
 
 	@Test
 	public void testRoles() throws Exception {
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri())
-				.put("roles_key", TestJwts.ROLES_CLAIM).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("roles_key", TestJwts.ROLES_CLAIM)
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -126,6 +237,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Settings settings = Settings.builder()
 			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
 			.put("jwt_clock_skew_tolerance_seconds", "10")
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
 			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
@@ -149,6 +262,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Settings settings = Settings.builder()
 			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
 			.put("jwt_clock_skew_tolerance_seconds", "0")
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
 			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
@@ -172,6 +287,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Settings settings = Settings.builder()
 			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
 			.put("jwt_clock_skew_tolerance_seconds", "10")
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
 			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
@@ -192,7 +309,11 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 	@Test
 	public void testRS256() throws Exception {
 
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -203,7 +324,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 		Assert.assertEquals(0, creds.getBackendRoles().size());
-		Assert.assertEquals(3, creds.getAttributes().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
 	}
 
 	@Test
@@ -221,7 +342,11 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
 	@Test
 	public void testPeculiarJsonEscaping() {
-		Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
+		Settings settings = Settings.builder()
+			.put("openid_connect_url", mockIdpServer.getDiscoverUri())
+			.put("required_issuer", TestJwts.TEST_ISSUER)
+			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
@@ -233,7 +358,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 		Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 		Assert.assertEquals(0, creds.getBackendRoles().size());
-		Assert.assertEquals(3, creds.getAttributes().size());
+		Assert.assertEquals(4, creds.getAttributes().size());
 	}
 
 }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -88,13 +88,13 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 	public void jwksMissingRequiredIssuerInClaimTest() {
 		Settings settings = Settings.builder()
 			.put("jwks_uri", mockIdpServer.getJwksUri())
-			.put("required_audience", TestJwts.TEST_AUDIENCE)
+			.put("required_issuer", TestJwts.TEST_ISSUER)
 			.build();
 
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
 		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
-			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_NO_ISSUER_OCT_1), new HashMap<>()), null);
 
 		Assert.assertNull(creds);
 	}
@@ -124,7 +124,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 		HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
 		AuthCredentials creds = jwtAuth.extractCredentials(new FakeRestRequest(
-			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_2), new HashMap<>()), null);
+			ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_NO_AUDIENCE_OCT_1), new HashMap<>()), null);
 
 		Assert.assertNull(creds);
 	}

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
@@ -118,6 +118,10 @@ class MockIpdServer implements Closeable {
 		return uri + CTX_DISCOVER;
 	}
 
+	public String getJwksUri() {
+		return uri + CTX_KEYS;
+	}
+
 	public int getPort() {
 		return port;
 	}

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -40,7 +40,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 			Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 			Assert.assertEquals(0, creds.getBackendRoles().size());
-			Assert.assertEquals(3, creds.getAttributes().size());
+			Assert.assertEquals(4, creds.getAttributes().size());
 
 		} finally {
 			try {
@@ -92,7 +92,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 			Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 			Assert.assertEquals(0, creds.getBackendRoles().size());
-			Assert.assertEquals(3, creds.getAttributes().size());
+			Assert.assertEquals(4, creds.getAttributes().size());
 		} finally {
 			try {
 				mockIdpServer.close();
@@ -145,7 +145,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 			Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 			Assert.assertEquals(0, creds.getBackendRoles().size());
-			Assert.assertEquals(3, creds.getAttributes().size());
+			Assert.assertEquals(4, creds.getAttributes().size());
 
 			creds = jwtAuth.extractCredentials(
 					new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.NoKid.MC_COY_SIGNED_RSA_2),
@@ -170,7 +170,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 			Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 			Assert.assertEquals(0, creds.getBackendRoles().size());
-			Assert.assertEquals(3, creds.getAttributes().size());
+			Assert.assertEquals(4, creds.getAttributes().size());
 
 		} finally {
 			try {
@@ -194,7 +194,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 			Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
 			Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
 			Assert.assertEquals(0, creds.getBackendRoles().size());
-			Assert.assertEquals(3, creds.getAttributes().size());
+			Assert.assertEquals(4, creds.getAttributes().size());
 
 		} finally {
 			try {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -33,11 +33,17 @@ class TestJwts {
 
 	static final String MCCOY_SUBJECT = "Leonard McCoy";
 
-	static final JwtToken MC_COY = create(MCCOY_SUBJECT, TEST_AUDIENCE, ROLES_CLAIM, TEST_ROLES_STRING);
+	static final String TEST_ISSUER = "TestIssuer";
 
-    static final JwtToken MC_COY_EXPIRED = create(MCCOY_SUBJECT, TEST_AUDIENCE, ROLES_CLAIM, TEST_ROLES_STRING, JwtConstants.CLAIM_EXPIRY, 10);
+	static final JwtToken MC_COY = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+
+	static final JwtToken MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+
+    static final JwtToken MC_COY_EXPIRED = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING, JwtConstants.CLAIM_EXPIRY, 10);
 
 	static final String MC_COY_SIGNED_OCT_1 = createSigned(MC_COY, TestJwk.OCT_1);
+
+	static final String MC_COY_SIGNED_OCT_2 = createSigned(MC_COY_2, TestJwk.OCT_1);
 
 	static final String MC_COY_SIGNED_OCT_1_INVALID_KID = createSigned(MC_COY, TestJwk.FORWARD_SLASH_KID_OCT_1);
 
@@ -57,11 +63,12 @@ class TestJwts {
 		static final String MC_COY_SIGNED_RSA_1 = createSignedWithPeculiarEscaping(MC_COY, TestJwk.RSA_1);
 	}
 
-	static JwtToken create(String subject, String audience, Object... moreClaims) {
+	static JwtToken create(String subject, String audience, String issuer, Object... moreClaims) {
 		JwtClaims claims = new JwtClaims();
 
 		claims.setSubject(subject);
 		claims.setAudience(audience);
+		claims.setIssuer(issuer);
 
 		if (moreClaims != null) {
 			for (int i = 0; i < moreClaims.length; i += 2) {
@@ -108,8 +115,8 @@ class TestJwts {
 	static String createMcCoySignedOct1(long nbf, long exp)
 	{
 		JwtToken jwt_token = create(
-			MCCOY_SUBJECT, TEST_AUDIENCE, 
-			ROLES_CLAIM, TEST_ROLES_STRING, 
+			MCCOY_SUBJECT, TEST_AUDIENCE,
+			TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING,
 			JwtConstants.CLAIM_NOT_BEFORE, nbf, 
 			JwtConstants.CLAIM_EXPIRY, exp);
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -39,11 +39,18 @@ class TestJwts {
 
 	static final JwtToken MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
 
+	static final JwtToken MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, null, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+
+	static final JwtToken MC_COY_NO_ISSUER = create(MCCOY_SUBJECT, TEST_AUDIENCE, null, ROLES_CLAIM, TEST_ROLES_STRING);
+
     static final JwtToken MC_COY_EXPIRED = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING, JwtConstants.CLAIM_EXPIRY, 10);
 
 	static final String MC_COY_SIGNED_OCT_1 = createSigned(MC_COY, TestJwk.OCT_1);
 
 	static final String MC_COY_SIGNED_OCT_2 = createSigned(MC_COY_2, TestJwk.OCT_2);
+
+	static final String MC_COY_SIGNED_NO_AUDIENCE_OCT_1 = createSigned(MC_COY_NO_AUDIENCE, TestJwk.OCT_1);
+	static final String MC_COY_SIGNED_NO_ISSUER_OCT_1 = createSigned(MC_COY_NO_ISSUER, TestJwk.OCT_1);
 
 	static final String MC_COY_SIGNED_OCT_1_INVALID_KID = createSigned(MC_COY, TestJwk.FORWARD_SLASH_KID_OCT_1);
 
@@ -67,8 +74,12 @@ class TestJwts {
 		JwtClaims claims = new JwtClaims();
 
 		claims.setSubject(subject);
-		claims.setAudience(audience);
-		claims.setIssuer(issuer);
+		if (audience != null) {
+			claims.setAudience(audience);
+		}
+		if (issuer != null) {
+			claims.setIssuer(issuer);
+		}
 
 		if (moreClaims != null) {
 			for (int i = 0; i < moreClaims.length; i += 2) {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -43,7 +43,7 @@ class TestJwts {
 
 	static final String MC_COY_SIGNED_OCT_1 = createSigned(MC_COY, TestJwk.OCT_1);
 
-	static final String MC_COY_SIGNED_OCT_2 = createSigned(MC_COY_2, TestJwk.OCT_1);
+	static final String MC_COY_SIGNED_OCT_2 = createSigned(MC_COY_2, TestJwk.OCT_2);
 
 	static final String MC_COY_SIGNED_OCT_1_INVALID_KID = createSigned(MC_COY, TestJwk.FORWARD_SLASH_KID_OCT_1);
 


### PR DESCRIPTION
Re-creating https://github.com/opensearch-project/security/pull/2708 with the jar hell fix merged into main and addressing 2 minor comments from the PR. 

### Description
Extending auth with jwks_uri parameter to omit passing openid_connect_url with openid-configuration
* Category: feature
* Why these changes are required?  To add possibility to define a JWKS endpoint for JWT-based authentication
* What is the old behavior before changes and new behavior after changes? Old behavior remains the same, new one omits the part with calling openid-configuration endpoint of IdP

### Issues Resolved
https://github.com/opensearch-project/security/issues/1858

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
