### PR TITLE
Re-adds jakarta dep that was removed due to stale artifact issue with CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -289,6 +289,7 @@ configurations.all {
 }
 
 dependencies {
+    implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation 'com.google.guava:guava:30.0-jre'


### PR DESCRIPTION
Re-adds jakarta dependency that was removed due to stale artifact issue with CI for 2.8 branch.

Category: Maintenance

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
