### PR TITLE
[Backport 2.x] Separate config option to enable restapi: permissions (#2605)

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -360,9 +360,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
             final List<String> files = AccessController.doPrivileged(new PrivilegedAction<List<String>>() {
                 @Override
                 public List<String> run() {
-
                     final Path confPath = new Environment(settings, configPath).configFile().toAbsolutePath();
-
                     if(Files.isDirectory(confPath, LinkOption.NOFOLLOW_LINKS)) {
                         try (Stream<Path> s = Files.walk(confPath)) {
                             return s.distinct().map(p -> sha256(p)).collect(Collectors.toList());
@@ -1040,6 +1038,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
             // OpenSearch Security - REST API
             settings.add(Setting.listSetting(ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED, Collections.emptyList(), Function.identity(), Property.NodeScope)); //not filtered here
             settings.add(Setting.groupSetting(ConfigConstants.SECURITY_RESTAPI_ENDPOINTS_DISABLED + ".", Property.NodeScope));
+            settings.add(Setting.boolSetting(ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED, false, Property.NodeScope, Property.Filtered));
 
             settings.add(Setting.simpleString(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, Property.NodeScope, Property.Filtered));
             settings.add(Setting.simpleString(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE, Property.NodeScope, Property.Filtered));
@@ -1192,6 +1191,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin 
         private static RepositoriesService repositoriesService;
         private static RemoteClusterService remoteClusterService;
         private static IndicesService indicesService;
+
         private static PitService pitService;
 
         private static ExtensionsManager extensionsManager;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -66,6 +66,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+
 public abstract class AbstractApiAction extends BaseRestHandler {
 
 	protected final Logger log = LogManager.getLogger(this.getClass());
@@ -94,7 +96,9 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 		this.restApiPrivilegesEvaluator = new RestApiPrivilegesEvaluator(settings, adminDNs, evaluator,
 				principalExtractor, configPath, threadPool);
 		this.restApiAdminPrivilegesEvaluator =
-				new RestApiAdminPrivilegesEvaluator(threadPool.getThreadContext(), evaluator, adminDNs);
+				new RestApiAdminPrivilegesEvaluator(
+						threadPool.getThreadContext(), evaluator, adminDNs,
+						settings.getAsBoolean(SECURITY_RESTAPI_ADMIN_ENABLED, false));
 		this.auditLog = auditLog;
 	}
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsAction.java
@@ -72,8 +72,6 @@ public class SecuritySSLCertsAction extends AbstractApiAction {
 
     private final boolean certificatesReloadEnabled;
 
-    private final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator;
-
     private final boolean httpsEnabled;
 
     public SecuritySSLCertsAction(final Settings settings,
@@ -91,8 +89,6 @@ public class SecuritySSLCertsAction extends AbstractApiAction {
                                   final boolean certificatesReloadEnabled) {
         super(settings, configPath, controller, client, adminDNs, cl, cs, principalExtractor, privilegesEvaluator, threadPool, auditLog);
         this.securityKeyStore = securityKeyStore;
-        this.restApiAdminPrivilegesEvaluator =
-                new RestApiAdminPrivilegesEvaluator(threadPool.getThreadContext(), privilegesEvaluator, adminDNs);
         this.certificatesReloadEnabled = certificatesReloadEnabled;
         this.httpsEnabled = settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED, true);
     }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -250,13 +250,13 @@ public class ConfigConstants {
     public static final String SECURITY_DLS_MODE = "plugins.security.dls.mode";
     // REST API
     public static final String SECURITY_RESTAPI_ROLES_ENABLED = "plugins.security.restapi.roles_enabled";
+    public static final String SECURITY_RESTAPI_ADMIN_ENABLED = "plugins.security.restapi.admin.enabled";
     public static final String SECURITY_RESTAPI_ENDPOINTS_DISABLED = "plugins.security.restapi.endpoints_disabled";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX = "plugins.security.restapi.password_validation_regex";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE = "plugins.security.restapi.password_validation_error_message";
     public static final String SECURITY_RESTAPI_PASSWORD_MIN_LENGTH = "plugins.security.restapi.password_min_length";
     public static final String SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH = "plugins.security.restapi.password_score_based_validation_strength";
 
-    // Illegal Opcodes from here on
     public static final String SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY = "plugins.security.unsupported.disable_rest_auth_initially";
     public static final String SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY = "plugins.security.unsupported.disable_intertransport_auth_initially";
     public static final String SECURITY_UNSUPPORTED_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY = "plugins.security.unsupported.passive_intertransport_auth_initially";

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiTest.java
@@ -29,6 +29,7 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
     private final String ENDPOINT; 
@@ -363,7 +364,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testActionGroupsApiForRestAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
         // create index
         setupStarfleetIndex();
@@ -381,7 +382,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testActionGroupsApiForActionGroupsRestApiAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
         // create index
         setupStarfleetIndex();
@@ -399,7 +400,7 @@ public class ActionGroupsApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testCreateActionGroupWithRestAdminPermissionsForbidden() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
         final Header restApiAdminActionGroupsHeader = encodeBasicHeader("rest_api_admin_actiongroups", "rest_api_admin_actiongroups");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
@@ -37,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 /**
  * Testing class to verify that {@link AllowlistApiAction} works correctly.
@@ -158,7 +159,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testAllowlistApiWithPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
         final Header restApiAllowlistHeader = encodeBasicHeader("rest_api_admin_allowlist", "rest_api_admin_allowlist");
@@ -170,7 +171,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testAllowlistApiWithAllowListPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
 
         final Header restApiAllowlistHeader = encodeBasicHeader("rest_api_admin_allowlist", "rest_api_admin_allowlist");
         final Header restApiUserHeader = encodeBasicHeader("test", "test");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -37,6 +37,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class NodesDnApiTest extends AbstractRestApiUnitTest {
     private HttpResponse response;
@@ -184,7 +185,10 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testNodesDnApiWithPermissions() throws Exception {
-        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, true)
+        Settings settings =
+                Settings.builder()
+                        .put(ConfigConstants.SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, true)
+                        .put(SECURITY_RESTAPI_ADMIN_ENABLED, true)
                 .build();
         setupWithRestRoles(settings);
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
@@ -31,6 +31,7 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class RolesApiTest extends AbstractRestApiUnitTest {
     private final String ENDPOINT;
@@ -77,15 +78,17 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testAllRolesForRestAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
+        rh.sendAdminCertificate = false;
         checkSuperAdminRoles(new Header[]{restApiAdminHeader});
     }
 
     @Test
     public void testAllRolesForRolesRestAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         final Header restApiAdminRolesHeader = encodeBasicHeader("rest_api_admin_roles", "rest_api_admin_roles");
+        rh.sendAdminCertificate = false;
         checkSuperAdminRoles(new Header[]{restApiAdminRolesHeader});
     }
 
@@ -520,7 +523,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testRolesApiWithAllRestApiPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
 
@@ -540,7 +543,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testRolesApiWithRestApiRolePermission() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
 
         final Header restApiRolesHeader = encodeBasicHeader("rest_api_admin_roles", "rest_api_admin_roles");
 
@@ -561,7 +564,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testCreateOrUpdateRestApiAdminRoleForbiddenForNonSuperAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
@@ -633,7 +636,7 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testDeleteRestApiAdminRoleForbiddenForNonSuperAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiTest.java
@@ -29,6 +29,7 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class RolesMappingApiTest extends AbstractRestApiUnitTest {
     private final String ENDPOINT; 
@@ -98,7 +99,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testRolesMappingApiWithFullPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
@@ -466,7 +467,7 @@ public class RolesMappingApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testChangeRestApiAdminRoleMappingForbiddenForNonSuperAdmin() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
 
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
@@ -28,6 +28,7 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class SslCertsApiTest extends AbstractRestApiUnitTest {
 
@@ -83,9 +84,7 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
         return String.format("%s/api/ssl/%s/reloadcerts", PLUGINS_PREFIX, certType);
     }
 
-    @Test
-    public void testCertsInfo() throws Exception {
-        setupWithRestRoles();
+    private void verifyHasNoAccess() throws Exception {
         final Header adminCredsHeader = encodeBasicHeader("admin", "admin");
         // No creds, no admin certificate - UNAUTHORIZED
         rh.sendAdminCertificate = false;
@@ -96,17 +95,28 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
         response = rh.executeGetRequest(certsInfoEndpoint(), adminCredsHeader);
         Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+        response = rh.executeGetRequest(certsInfoEndpoint(), restApiHeader);
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    public void testCertsInfo() throws Exception {
+        setup();
+        verifyHasNoAccess();
         sendAdminCert();
-        response = rh.executeGetRequest(certsInfoEndpoint());
+        HttpResponse response = rh.executeGetRequest(certsInfoEndpoint());
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertEquals(EXPECTED_CERTIFICATES_BY_TYPE, response.getBody());
 
+    }
+
+    @Test
+    public void testCertsInfoRestAdmin() throws Exception {
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
+        verifyHasNoAccess();
         rh.sendAdminCertificate = false;
         Assert.assertEquals(EXPECTED_CERTIFICATES_BY_TYPE, loadCerts(restApiAdminHeader));
         Assert.assertEquals(EXPECTED_CERTIFICATES_BY_TYPE, loadCerts(restApiCertsInfoAdminHeader));
-
-        response = rh.executeGetRequest(certsInfoEndpoint(), restApiHeader);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
     }
 
     private String loadCerts(final Header... header) throws Exception {
@@ -120,23 +130,18 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
         setupWithRestRoles();
 
         sendAdminCert();
-        verifyReloadCertsNotAvailable();
+        verifyReloadCertsNotAvailable(HttpStatus.SC_BAD_REQUEST);
 
         rh.sendAdminCertificate = false;
-        verifyReloadCertsNotAvailable(restApiAdminHeader);
-        verifyReloadCertsNotAvailable(restApiReloadCertsAdminHeader);
-
-        HttpResponse response = rh.executePutRequest(certsReloadEndpoint(HTTP_CERTS), "{}", restApiHeader);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        response = rh.executePutRequest(certsReloadEndpoint(TRANSPORT_CERTS), "{}", restApiHeader);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        verifyReloadCertsNotAvailable(HttpStatus.SC_FORBIDDEN, restApiAdminHeader);
+        verifyReloadCertsNotAvailable(HttpStatus.SC_FORBIDDEN, restApiReloadCertsAdminHeader);
     }
 
-    private void verifyReloadCertsNotAvailable(final Header... header) {
+    private void verifyReloadCertsNotAvailable(final int expectedStatus, final Header... header) {
         HttpResponse response = rh.executePutRequest(certsReloadEndpoint(HTTP_CERTS), "{}", header);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(response.getBody(), expectedStatus, response.getStatusCode());
         response = rh.executePutRequest(certsReloadEndpoint(TRANSPORT_CERTS), "{}", header);
-        Assert.assertEquals(response.getBody(), HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals(response.getBody(), expectedStatus, response.getStatusCode());
     }
 
     @Test
@@ -153,12 +158,6 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
     }
-
-    @Test
-    public void testReloadCerts() throws Exception {
-        setupWithRestRoles(reloadEnabled());
-    }
-
 
     private void sendAdminCert() {
         rh.keystore = "restapi/kirk-keystore.jks";

--- a/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.dlic.rest.api.InternalUsersApiAction.RESTRICTED_FROM_USERNAME;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class UserApiTest extends AbstractRestApiUnitTest {
     private final String ENDPOINT;
@@ -528,7 +529,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testUserApiWithRestAdminPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
         final Header restApiAdminHeader = encodeBasicHeader("rest_api_admin_user", "rest_api_admin_user");
         // initial configuration
@@ -546,7 +547,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
 
     @Test
     public void testUserApiWithRestInternalUsersAdminPermissions() throws Exception {
-        setupWithRestRoles();
+        setupWithRestRoles(Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build());
         rh.sendAdminCertificate = false;
         final Header restApiInternalUsersAdminHeader = encodeBasicHeader("rest_api_admin_internalusers", "rest_api_admin_internalusers");
         // initial configuration


### PR DESCRIPTION
Backports #2605 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
