### PR TITLE
[opendistro-1.13] Fix compilation errors on opendistro-1.13

### DIFF
--- a/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/com/amazon/opendistroforelasticsearch/security/resolver/IndexResolverReplacer.java
@@ -43,10 +43,6 @@ import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
-import org.opensearch.action.admin.indices.datastream.CreateDataStreamAction;
-import org.opensearch.action.admin.indices.resolve.ResolveIndexAction;
-import org.opensearch.action.admin.indices.template.put.PutComponentTemplateAction;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -61,6 +57,7 @@ import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest.AliasA
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.action.admin.indices.resolve.ResolveIndexAction;
+import org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkShardRequest;
 import org.elasticsearch.action.delete.DeleteRequest;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -36,10 +36,10 @@ public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest{
         }
         @Test
         public void testPutIndexTemplateByNonPrivilegedUser() throws Exception {
-            String expectedFailureResponse = getFailureResponseReason("ds3");
+            String expectedFailureResponse = getFailureResponseReason("user_with_no_roles");
 
-            // should fail, as user `ds3` doesn't have correct permissions
-            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("ds3", "nagilum"));
+            // should fail, as user `user_with_no_roles` doesn't have correct permissions
+            HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("user_with_no_roles", "nagilum"));
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
             Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
         }

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -16,9 +16,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.opensearch.security.test.SingleClusterTest;
-import org.opensearch.security.test.helper.rest.RestHelper;
-import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+import com.amazon.opendistroforelasticsearch.security.test.SingleClusterTest;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest{
         private RestHelper rh;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.security;
+package com.amazon.opendistroforelasticsearch.security;
 
 import org.apache.http.HttpStatus;
 import org.junit.Assert;

--- a/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/com/amazon/opendistroforelasticsearch/security/test/helper/rest/RestHelper.java
@@ -75,9 +75,9 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.security.DefaultObjectMapper;
-import org.opensearch.security.test.helper.cluster.ClusterInfo;
-import org.opensearch.security.test.helper.file.FileHelper;
+import com.amazon.opendistroforelasticsearch.security.DefaultObjectMapper;
+import com.amazon.opendistroforelasticsearch.security.test.helper.cluster.ClusterInfo;
+import com.amazon.opendistroforelasticsearch.security.test.helper.file.FileHelper;
 
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/src/test/resources/internal_users.yml
+++ b/src/test/resources/internal_users.yml
@@ -337,7 +337,10 @@ bulk_test_user:
 hidden_test:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   opendistro_security_roles:
-  - hidden_test
+    - hidden_test
+user_with_no_roles:
+  hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
+  #password is: nagilum
 sem-user:
   hash: $2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m
   #password is: nagilum

--- a/src/test/resources/roles.yml
+++ b/src/test/resources/roles.yml
@@ -1069,10 +1069,6 @@ xyz_sr_reserved:
         - "*"
   tenant_permissions: []
 
-hidden_test:
-  cluster_permissions:
-    - SGS_CLUSTER_COMPOSITE_OPS
-
 index_template_perm:
   reserved: true
   hidden: false


### PR DESCRIPTION
### Description

One of the [PRs into opendistro-1.13](https://github.com/opensearch-project/security/commit/0b772a8089160372db1abfc4056f0fd18b318f11) introduced imports to org.opensearch which does not exist on the branch. This PR replaces the imports with their respective classnames in elasticsearch or the correct package name for opendistro-1.13

### Testing

Tested by running `mvn compile`.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
