### PR TITLE
Match version of zstd-jni from core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -338,6 +338,7 @@ configurations {
             force "io.netty:netty-transport:${versions.netty}"
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
             force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+            force "com.github.luben:zstd-jni:${versions.zstd}"
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -460,7 +460,7 @@ dependencies {
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
-    runtimeOnly 'com.github.luben:zstd-jni:1.5.2-1'
+    runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
 


### PR DESCRIPTION
### Description

Currently `./gradlew assemble` is failing for the security plugin due to the addition of `zstd-jni` in core which the security plugin already has a runtime dependency on. This PR uses the version from core's version.properties to ensure there is a matching version.

Related PR: https://github.com/opensearch-project/OpenSearch/pull/2996

`./gradlew assemble` is failing with the following error:

```
Execution failed for task ':bundlePlugin'.
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Conflict(s) found for the following module(s):
       - com.github.luben:zstd-jni between versions 1.5.5-3 and ${versions.zstd}
     Run with:
         --scan or
         :dependencyInsight --configuration runtimeClasspath --dependency com.github.luben:zstd-jni
     to get more insight on how to solve the conflict.
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
