### PR TITLE
[Backport 2.x] Match version of zstd-jni from core

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -3,7 +3,7 @@ name: Plugin Install
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  OPENSEARCH_VERSION: 2.8.0
+  OPENSEARCH_VERSION: 2.9.0
   PLUGIN_NAME: opensearch-security
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.16.0'
+    id 'com.diffplug.spotless' version '6.19.0'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage'  version "11.0.0"
     id "org.gradle.test-retry" version "1.5.2"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ import org.opensearch.gradle.test.RestIntegTestTask
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.8.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.9.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 

--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,7 @@ configurations.all {
         force "io.netty:netty-transport:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+        force "com.github.luben:zstd-jni:${versions.zstd}"
     }
 }
 
@@ -365,7 +366,7 @@ dependencies {
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
-    runtimeOnly 'com.github.luben:zstd-jni:1.5.2-1'
+    runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
 

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 
-String bwcVersion = "2.8.0.0";
+String bwcVersion = "2.6.0.0";
 String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
 String projectVersion = "2.9.0.0"
@@ -82,7 +82,7 @@ String projectVersion = "2.9.0.0"
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["2.8.0","2.9.0"]
+            versions = ["2.6.0","2.9.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -47,7 +47,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.8.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.9.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
     }
     repositories {
@@ -73,16 +73,16 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
 }
 
-String bwcVersion = "2.6.0.0";
+String bwcVersion = "2.8.0.0";
 String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
-String projectVersion = "2.8.0.0"
+String projectVersion = "2.9.0.0"
 
 2.times {i ->
     testClusters {
         "${baseName}$i" {
             testDistribution = "ARCHIVE"
-            versions = ["2.6.0","2.8.0"]
+            versions = ["2.8.0","2.9.0"]
             numberOfNodes = 3
             plugin(provider(new Callable<RegularFile>() {
                 @Override


### PR DESCRIPTION
Backport #2832 to 2.x

Depends on https://github.com/opensearch-project/OpenSearch/pull/7906