### PR TITLE
Fix JwtAuthenticationTests.shouldAuthenticateWithJwtToken_positive assertion

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
@@ -141,7 +141,7 @@ public class JwtAuthenticationTests {
 
 			response.assertStatusCode(200);
 			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(username));
+			assertThat(username, equalTo(USER_SUPERHERO));
 		}
 	}
 


### PR DESCRIPTION
### Description

Changes an assertion in `JwtAuthenticationTests.shouldAuthenticateWithJwtToken_positive` that was not testing the code correctly. It was checking if a variable was equal to itself instead of the actual expected value.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Testing

```
./gradlew integrationTest --tests JwtAuthenticationTests -i
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
