### PR TITLE
add search model group permission to ml_read_access role

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -262,6 +262,7 @@ ml_read_access:
     - 'cluster:admin/opensearch/ml/models/search'
     - 'cluster:admin/opensearch/ml/tasks/get'
     - 'cluster:admin/opensearch/ml/tasks/search'
+    - 'cluster:admin/opensearch/ml/model_groups/search'
 
 # Allows users to use all ML functionality
 ml_full_access:

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -258,11 +258,11 @@ ml_read_access:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opensearch/ml/stats/nodes'
+    - 'cluster:admin/opensearch/ml/model_groups/search'
     - 'cluster:admin/opensearch/ml/models/get'
     - 'cluster:admin/opensearch/ml/models/search'
     - 'cluster:admin/opensearch/ml/tasks/get'
     - 'cluster:admin/opensearch/ml/tasks/search'
-    - 'cluster:admin/opensearch/ml/model_groups/search'
 
 # Allows users to use all ML functionality
 ml_full_access:


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
ML-commons has a new index "model group" added in 2.8 release. This PR adds the search model group permission to the "ml_read_access" role.

* What is the old behavior before changes and new behavior after changes?
We want a user with "ml_read_access" role to be able to search the model group index.  Before this change, user is not given that permission which is contrary to the expected behaviour. 
This change allows any user with "ml_read_access" role to search the model group index.

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
