### PR TITLE
[Enhancement] Parallel test jobs for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       separateTestsNames: ${{ steps.set-matrix.outputs.separateTestsNames }}
-      testsNamesExclude: ${{ steps.set-matrix.outputs.testsNamesExclude }}
     steps:
     - name: Set up JDK for build and test
       uses: actions/setup-java@v2
@@ -26,58 +25,15 @@ jobs:
       run: |
         echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
 
-  tests:
-    name: tests
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ["windows-latest", "ubuntu-latest"]
-        jdk: [11, 17]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - name: Set up JDK for build and test
-      uses: actions/setup-java@v2
-      with:
-        distribution: temurin
-        java-version: ${{ matrix.jdk }}
-
-    - name: Checkout security
-      uses: actions/checkout@v2
-
-    - name: Build and Test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: |
-          citest -Dbuild.snapshot=false
-          -x test
-
-    - name: Coverage
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml
-
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
-        path: |
-          ./build/reports/
-
-    - name: check archive for debugging
-      if: always()
-      run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
-
   test:
     name: test
     needs: generate-test-list
     strategy:
       fail-fast: false
       matrix:
-        platform: ["windows-latest", "ubuntu-latest"]
-        jdk: [11, 17]
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
+        platform: [windows-latest, ubuntu-latest]
+        jdk: [11, 17]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -120,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [17]
-        platform: ["ubuntu-latest", "windows-latest"]
+        platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -149,7 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest"]
+        platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
       id: set-matrix
       run: |
         echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
-        echo "testsNamesExclude=$(./gradlew listTasksAsParam -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
 
   build:
     name: build
@@ -51,7 +50,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build citest ${{ needs.generate-test-list.outputs.testsNamesExclude }} -Dbuild.snapshot=false
+          build citest -Dbuild.snapshot=false
           -x integrationTest
           -x spotlessCheck
           -x checkstyleMain
@@ -111,7 +110,6 @@ jobs:
           -x spotbugsMain
           -x spotbugsIntegrationTest
           -x checkstyleIntegrationTest
-          -x citest
           -x test
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Generate list of tasks
       id: set-matrix
       run: |
-        echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
+        echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | head -n 1)" >> $GITHUB_OUTPUT
 
   build:
     name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,30 @@ env:
   GRADLE_OPTS: -Dhttp.keepAlive=false
 
 jobs:
+  generate-test-list:
+    runs-on: ubuntu-latest
+    outputs:
+      separateTestsNames: ${{ steps.set-matrix.outputs.separateTestsNames }}
+      testsNamesExclude: ${{ steps.set-matrix.outputs.testsNamesExclude }}
+    steps:
+    - name: Set up JDK for build and test
+      uses: actions/setup-java@v2
+      with:
+        distribution: temurin # Temurin is a distribution of adoptium
+        java-version: 17
+
+    - name: Checkout security
+      uses: actions/checkout@v2
+
+    - name: Generate list of tasks
+      id: set-matrix
+      run: |
+        echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
+        echo "testsNamesExclude=$(./gradlew listTasksAsParam -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
+
   build:
     name: build
+    needs: generate-test-list
     strategy:
       fail-fast: false
       matrix:
@@ -29,18 +51,66 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build test -Dbuild.snapshot=false
+          build test ${{ needs.generate-test-list.outputs.testsNamesExclude }} -Dbuild.snapshot=false
           -x integrationTest
           -x spotlessCheck
           -x checkstyleMain
           -x checkstyleTest
           -x spotbugsMain
+          -x spotbugsIntegrationTest
+          -x checkstyleIntegrationTest
 
     - name: Coverage
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/reports/jacoco/test/jacocoTestReport.xml
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
+        path: |
+          ./build/reports/
+
+    - name: check archive for debugging
+      if: always()
+      run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
+
+  build-test:
+    name: build-test
+    needs: generate-test-list
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest"]
+        gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Set up JDK for build and test
+      uses: actions/setup-java@v2
+      with:
+        distribution: temurin # Temurin is a distribution of adoptium
+        java-version: ${{ matrix.jdk }}
+
+    - name: Checkout security
+      uses: actions/checkout@v2
+
+    - name: Build and Test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          build ${{ matrix.gradle_task }} -Dbuild.snapshot=false
+          -x integrationTest
+          -x spotlessCheck
+          -x checkstyleMain
+          -x checkstyleTest
+          -x spotbugsMain
+          -x spotbugsIntegrationTest
+          -x checkstyleIntegrationTest
+          -x test
 
     - uses: actions/upload-artifact@v3
       if: always()
@@ -84,7 +154,6 @@ jobs:
           -x spotbugsMain
 
   backward-compatibility:
-
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Generate list of tasks
       id: set-matrix
       run: |
-        echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | head -n 1)" >> $GITHUB_OUTPUT
+        echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
 
   build:
     name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,57 +34,6 @@ jobs:
       matrix:
         jdk: [11, 17]
         platform: ["ubuntu-latest", "windows-latest"]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-    - name: Set up JDK for build and test
-      uses: actions/setup-java@v2
-      with:
-        distribution: temurin # Temurin is a distribution of adoptium
-        java-version: ${{ matrix.jdk }}
-
-    - name: Checkout security
-      uses: actions/checkout@v2
-
-    - name: Build and Test
-      uses: gradle/gradle-build-action@v2
-      with:
-        arguments: |
-          build citest -Dbuild.snapshot=false
-          -x integrationTest
-          -x spotlessCheck
-          -x checkstyleMain
-          -x checkstyleTest
-          -x spotbugsMain
-          -x spotbugsIntegrationTest
-          -x checkstyleIntegrationTest
-          -x test
-
-    - name: Coverage
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml
-
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
-        path: |
-          ./build/reports/
-
-    - name: check archive for debugging
-      if: always()
-      run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
-
-  build-test:
-    name: build-test
-    needs: generate-test-list
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest"]
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
     runs-on: ${{ matrix.platform }}
 
@@ -102,14 +51,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build ${{ matrix.gradle_task }} -Dbuild.snapshot=false
-          -x integrationTest
-          -x spotlessCheck
-          -x checkstyleMain
-          -x checkstyleTest
-          -x spotbugsMain
-          -x spotbugsIntegrationTest
-          -x checkstyleIntegrationTest
+          ${{ matrix.gradle_task }} -Dbuild.snapshot=false
           -x test
 
     - name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,13 @@ jobs:
       run: |
         echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
 
-  test:
-    name: citest
+  tests:
+    name: tests
     strategy:
       fail-fast: false
       matrix:
+        platform: ["windows-latest", "ubuntu-latest"]
         jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -69,14 +69,14 @@ jobs:
       if: always()
       run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
 
-  build:
-    name: build
+  test:
+    name: test
     needs: generate-test-list
     strategy:
       fail-fast: false
       matrix:
+        platform: ["windows-latest", "ubuntu-latest"]
         jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest"]
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,49 @@ jobs:
       run: |
         echo "separateTestsNames=$(./gradlew listTasksAsJSON -q --console=plain | tail -n 1)" >> $GITHUB_OUTPUT
 
+  test:
+    name: citest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest"]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+    - name: Set up JDK for build and test
+      uses: actions/setup-java@v2
+      with:
+        distribution: temurin
+        java-version: ${{ matrix.jdk }}
+
+    - name: Checkout security
+      uses: actions/checkout@v2
+
+    - name: Build and Test
+      uses: gradle/gradle-build-action@v2
+      with:
+        arguments: |
+          citest -Dbuild.snapshot=false
+          -x test
+
+    - name: Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
+        path: |
+          ./build/reports/
+
+    - name: check archive for debugging
+      if: always()
+      run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
+
   build:
     name: build
     needs: generate-test-list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       uses: gradle/gradle-build-action@v2
       with:
         arguments: |
-          build test ${{ needs.generate-test-list.outputs.testsNamesExclude }} -Dbuild.snapshot=false
+          build citest ${{ needs.generate-test-list.outputs.testsNamesExclude }} -Dbuild.snapshot=false
           -x integrationTest
           -x spotlessCheck
           -x checkstyleMain
@@ -59,6 +59,7 @@ jobs:
           -x spotbugsMain
           -x spotbugsIntegrationTest
           -x checkstyleIntegrationTest
+          -x test
 
     - name: Coverage
       uses: codecov/codecov-action@v1
@@ -110,6 +111,7 @@ jobs:
           -x spotbugsMain
           -x spotbugsIntegrationTest
           -x checkstyleIntegrationTest
+          -x citest
           -x test
 
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
           -x checkstyleIntegrationTest
           -x test
 
+    - name: Coverage
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./build/reports/jacoco/test/jacocoTestReport.xml
+
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,6 @@ jobs:
       with:
         arguments: |
           integrationTest -Dbuild.snapshot=false
-          -x spotlessCheck
-          -x checkstyleMain
-          -x checkstyleTest
-          -x spotbugsMain
 
   backward-compatibility:
     strategy:

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,25 @@ tasks.whenTaskAdded {task ->
 }
 
 def splitTestConfig = [
+    ciSecurityIntegrationTest: [
+        description: "Runs integration tests from all classes.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.*Integ*"
+            ],
+            excludeTestsMatching: [
+                "org.opensearch.security.sanity.tests.*"
+            ]
+        ]
+    ],
+    crossClusterTest: [
+        description: "Runs cross-cluster tests.",
+        filters: [
+            includeTestsMatching: [
+                    "org.opensearch.security.ccstest.*"
+            ]
+        ]
+    ],
     dlicDlsflsTest: [
         description: "Runs Document- and Field-Level Security tests.",
         filters: [
@@ -123,13 +142,20 @@ def splitTestConfig = [
             ]
         ]
     ],
-    crossClusterTest: [
-        description: "Runs cross-cluster tests.",
+    indicesTest: [
+        description: "Runs indices tests from all classes.",
         filters: [
             includeTestsMatching: [
-                    "org.opensearch.security.ccstest.*"
+                "org.opensearch.security.*indices*"
+            ],
+            excludeTestsMatching: [
+                "org.opensearch.security.sanity.tests.*"
             ]
         ]
+    ],
+    opensslCITest: [
+        description: "Runs portion of SSL tests related to OpenSSL. Explained in https://github.com/opensearch-project/security/pull/2301",
+        include: '**/OpenSSL*.class'
     ],
     sslTest: [
         description: "Runs most of the SSL tests.",
@@ -139,32 +165,6 @@ def splitTestConfig = [
             ],
             excludeTestsMatching: [
                 "org.opensearch.security.ssl.OpenSSL*"
-            ]
-        ]
-    ],
-    opensslCiTest: [
-        description: "Runs portion of SSL tests related to OpenSSL. Explained in https://github.com/opensearch-project/security/pull/2301",
-        include: '**/OpenSSL*.class'
-    ],
-    securityIntegrationTest: [
-        description: "Runs integration tests from all classes.",
-        filters: [
-            includeTestsMatching: [
-                "org.opensearch.security.*Integ*"
-            ],
-            excludeTestsMatching: [
-                "org.opensearch.security.sanity.tests.*"
-            ]
-        ]
-    ],
-    indicesTest: [
-        description: "Runs indices tests from all classes.",
-        filters: [
-            includeTestsMatching: [
-                "org.opensearch.security.*indices*"
-            ],
-            excludeTestsMatching: [
-                "org.opensearch.security.sanity.tests.*"
             ]
         ]
     ]
@@ -177,7 +177,7 @@ task listTasksAsJSON {
     // want this action to be started. Without it the output
     // is not shown at all or can be mixed with other outputs.
     doLast {
-        System.out.println(new JsonBuilder(taskNames))
+        System.out.println(new JsonBuilder(["citest"] + taskNames))
     }
 }
 
@@ -269,7 +269,7 @@ task citest(type: Test) {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
         excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
         splitTestConfig.each { entry ->
-            entry.value.each{ test ->
+            entry.value.filters.each{ test ->
                 if (test.key == "includeTestsMatching") {
                     test.value.each{
                         excludeTestsMatching "${it}"

--- a/build.gradle
+++ b/build.gradle
@@ -298,6 +298,7 @@ task citest(type: Test) {
         ]
     }
     dependsOn copyExtraTestResources
+    finalizedBy jacocoTestReport
 }
 
 splitTestConfig.each{ testName, testCfg ->
@@ -337,6 +338,7 @@ splitTestConfig.each{ testName, testCfg ->
             ]
         }
         dependsOn copyExtraTestResources
+        finalizedBy jacocoTestReport
     }
 }
 
@@ -347,6 +349,7 @@ jacoco {
 }
 
 jacocoTestReport {
+    getExecutionData().setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
     reports {
         xml.required = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@
 
 import com.diffplug.gradle.spotless.JavaExtension
 import org.opensearch.gradle.test.RestIntegTestTask
+import groovy.json.JsonBuilder
 
 buildscript {
     ext {
@@ -105,12 +106,79 @@ tasks.whenTaskAdded {task ->
     }
 }
 
+def splitTestConfig = [
+    dlicDlsflsTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.dlic.dlsfls.*"
+        ]
+    ],
+    dlicRestApiTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.dlic.rest.*"
+        ]
+    ],
+    crossClusterTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.ccstest.*"
+        ]
+    ],
+    sslTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.ssl.*"
+        ]
+    ],
+    securityIntegrationTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.*Integ*"
+        ],
+        excludeTestsMatching: [
+            "org.opensearch.security.sanity.tests.*",
+            "org.opensearch.security.ssl.OpenSSL*",
+        ]
+    ],
+    indicesTest: [
+        includeTestsMatching: [
+            "org.opensearch.security.*indices*"
+        ],
+        excludeTestsMatching: [
+            "org.opensearch.security.sanity.tests.*",
+            "org.opensearch.security.ssl.OpenSSL*",
+        ]
+    ]
+] as ConfigObject
+
+List<String> taskNames = splitTestConfig.keySet() as List
+
+task listTasksAsJSON {
+    doLast {
+        System.out.println(new JsonBuilder(taskNames))
+    }
+}
+
+task listTasksAsParam {
+    doLast {
+        System.out.println('-x ' + (taskNames).join(' -x '))
+    }
+}
 
 test {
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
         excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
+        splitTestConfig.each { entry ->
+            entry.value.each{ test ->
+                if (test.key == "includeTestsMatching") {
+                    test.value.each{ 
+                        excludeTestsMatching "${it}"
+                    }
+                } else if (test.key == "includeTest") {
+                    test.value.each{
+                        excludeTest "${it}"
+                    }
+                }
+            }
+        }
     }
     maxParallelForks = 8
     jvmArgs += "-Xmx3072m"
@@ -162,13 +230,50 @@ task opensslTest(type: Test) {
     }
 }
 
+splitTestConfig.each{ testName, filterCfg ->
+    task "${testName}"(type: Test) {
+        include '**/*.class'
+        filter {
+            filterCfg.each{ filter, values ->
+                values.each{ value ->
+                    "${filter}" "${value}"
+                }
+            }
+        }
+        maxParallelForks = 8
+        jvmArgs += "-Xmx3072m"
+        if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+            jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+        }
+        retry {
+            failOnPassedAfterRetry = false
+            maxRetries = 5
+        }
+        jacoco {
+            excludes = [
+                "com.sun.jndi.dns.*",
+                "com.sun.security.sasl.gsskerb.*",
+                "java.sql.*",
+                "javax.script.*",
+                "org.jcp.xml.dsig.internal.dom.*",
+                "sun.nio.cs.ext.*",
+                "sun.security.ec.*",
+                "sun.security.jgss.*",
+                "sun.security.pkcs11.*",
+                "sun.security.smartcardio.*",
+                "sun.util.resources.provider.*"
+            ]
+        }
+    }
+}
+
 task copyExtraTestResources(dependsOn: testClasses) {
     copy {
         from 'src/test/resources'
         into 'build/testrun/test/src/test/resources'
     }
 }
-tasks.test.dependsOn(copyExtraTestResources, opensslTest)
+tasks.test.dependsOn(copyExtraTestResources, opensslTest, taskNames)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,9 @@ def splitTestConfig = [
 List<String> taskNames = splitTestConfig.keySet() as List
 
 task listTasksAsJSON {
-    System.out.println(new JsonBuilder(taskNames))
+    doLast {
+        System.out.println(new JsonBuilder(taskNames))
+    }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -163,12 +163,37 @@ test {
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
+        excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
     }
     maxParallelForks = 8
     jvmArgs += "-Xmx3072m"
     if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
         jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
     }
+    retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 5
+    }
+    jacoco {
+        excludes = [
+                "com.sun.jndi.dns.*",
+                "com.sun.security.sasl.gsskerb.*",
+                "java.sql.*",
+                "javax.script.*",
+                "org.jcp.xml.dsig.internal.dom.*",
+                "sun.nio.cs.ext.*",
+                "sun.security.ec.*",
+                "sun.security.jgss.*",
+                "sun.security.pkcs11.*",
+                "sun.security.smartcardio.*",
+                "sun.util.resources.provider.*"
+        ]
+    }
+}
+
+//add new task that runs OpenSSL tests
+task opensslTest(type: Test) {
+    include '**/OpenSSL*.class'
     retry {
         failOnPassedAfterRetry = false
         maxRetries = 5
@@ -294,7 +319,7 @@ splitTestConfig.each{ testName, filterCfg ->
     }
 }
 
-tasks.test.dependsOn(copyExtraTestResources)
+tasks.test.dependsOn(copyExtraTestResources, opensslTest)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")

--- a/build.gradle
+++ b/build.gradle
@@ -173,9 +173,7 @@ def splitTestConfig = [
 List<String> taskNames = splitTestConfig.keySet() as List
 
 task listTasksAsJSON {
-    doLast {
-        System.out.println(new JsonBuilder(taskNames))
-    }
+    System.out.println(new JsonBuilder(taskNames))
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -163,7 +163,38 @@ test {
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
-        excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
+    }
+    maxParallelForks = 8
+    jvmArgs += "-Xmx3072m"
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    }
+    retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 5
+    }
+    jacoco {
+        excludes = [
+                "com.sun.jndi.dns.*",
+                "com.sun.security.sasl.gsskerb.*",
+                "java.sql.*",
+                "javax.script.*",
+                "org.jcp.xml.dsig.internal.dom.*",
+                "sun.nio.cs.ext.*",
+                "sun.security.ec.*",
+                "sun.security.jgss.*",
+                "sun.security.pkcs11.*",
+                "sun.security.smartcardio.*",
+                "sun.util.resources.provider.*"
+        ]
+    }
+}
+
+task citest(type: Test) {
+//    onlyIf { !project.gradle.taskGraph.hasTask(':test') }
+    include '**/*.class'
+    filter {
+        excludeTestsMatching "org.opensearch.security.sanity.tests.*"
         splitTestConfig.each { entry ->
             entry.value.each{ test ->
                 if (test.key == "includeTestsMatching") {
@@ -247,7 +278,8 @@ task copyExtraTestResources(dependsOn: testClasses) {
         into 'build/testrun/test/src/test/resources'
     }
 }
-tasks.test.dependsOn(copyExtraTestResources, taskNames)
+tasks.test.dependsOn(copyExtraTestResources)
+tasks.citest.dependsOn(copyExtraTestResources, taskNames)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")

--- a/build.gradle
+++ b/build.gradle
@@ -190,6 +190,26 @@ test {
     }
 }
 
+task copyExtraTestResources(dependsOn: testClasses) {
+
+    copy {
+        from 'src/test/resources'
+        into 'build/testrun/test/src/test/resources'
+    }
+
+    taskNames.each { testName ->
+        copy {
+            from 'src/test/resources'
+            into "build/testrun/${testName}/src/test/resources"
+        }
+    }
+
+    copy {
+        from 'src/test/resources'
+        into 'build/testrun/citest/src/test/resources'
+    }
+}
+
 task citest(type: Test) {
 //    onlyIf { !project.gradle.taskGraph.hasTask(':test') }
     include '**/*.class'
@@ -233,6 +253,7 @@ task citest(type: Test) {
                 "sun.util.resources.provider.*"
         ]
     }
+    dependsOn copyExtraTestResources
 }
 
 splitTestConfig.each{ testName, filterCfg ->
@@ -269,17 +290,11 @@ splitTestConfig.each{ testName, filterCfg ->
                 "sun.util.resources.provider.*"
             ]
         }
+        dependsOn copyExtraTestResources
     }
 }
 
-task copyExtraTestResources(dependsOn: testClasses) {
-    copy {
-        from 'src/test/resources'
-        into 'build/testrun/test/src/test/resources'
-    }
-}
 tasks.test.dependsOn(copyExtraTestResources)
-tasks.citest.dependsOn(copyExtraTestResources, taskNames)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")

--- a/build.gradle
+++ b/build.gradle
@@ -173,6 +173,9 @@ def splitTestConfig = [
 List<String> taskNames = splitTestConfig.keySet() as List
 
 task listTasksAsJSON {
+    // We are using `doLast` to explicitly specify when we
+    // want this action to be started. Without it the output
+    // is not shown at all or can be mixed with other outputs.
     doLast {
         System.out.println(new JsonBuilder(taskNames))
     }

--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,35 @@ task copyExtraTestResources(dependsOn: testClasses) {
     }
 }
 
+def setCommonTestConfig(Test task) {
+    task.maxParallelForks = 8
+    task.jvmArgs += "-Xmx3072m"
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        task.jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    }
+    task.retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 5
+    }
+    task.jacoco {
+        excludes = [
+                "com.sun.jndi.dns.*",
+                "com.sun.security.sasl.gsskerb.*",
+                "java.sql.*",
+                "javax.script.*",
+                "org.jcp.xml.dsig.internal.dom.*",
+                "sun.nio.cs.ext.*",
+                "sun.security.ec.*",
+                "sun.security.jgss.*",
+                "sun.security.pkcs11.*",
+                "sun.security.smartcardio.*",
+                "sun.util.resources.provider.*"
+        ]
+    }
+    task.dependsOn copyExtraTestResources
+    task.finalizedBy jacocoTestReport
+}
+
 task citest(type: Test) {
     group = "Github Actions tests"
     description = "Runs the test suite on classes not covered by rest of the task in this group."
@@ -281,32 +310,7 @@ task citest(type: Test) {
             }
         }
     }
-    maxParallelForks = 8
-    jvmArgs += "-Xmx3072m"
-    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
-    }
-    retry {
-        failOnPassedAfterRetry = false
-        maxRetries = 5
-    }
-    jacoco {
-        excludes = [
-                "com.sun.jndi.dns.*",
-                "com.sun.security.sasl.gsskerb.*",
-                "java.sql.*",
-                "javax.script.*",
-                "org.jcp.xml.dsig.internal.dom.*",
-                "sun.nio.cs.ext.*",
-                "sun.security.ec.*",
-                "sun.security.jgss.*",
-                "sun.security.pkcs11.*",
-                "sun.security.smartcardio.*",
-                "sun.util.resources.provider.*"
-        ]
-    }
-    dependsOn copyExtraTestResources
-    finalizedBy jacocoTestReport
+    setCommonTestConfig(it)
 }
 
 splitTestConfig.each{ testName, testCfg ->
@@ -321,32 +325,7 @@ splitTestConfig.each{ testName, testCfg ->
                 }
             }
         }
-        maxParallelForks = 8
-        jvmArgs += "-Xmx3072m"
-        if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-            jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
-        }
-        retry {
-            failOnPassedAfterRetry = false
-            maxRetries = 5
-        }
-        jacoco {
-            excludes = [
-                "com.sun.jndi.dns.*",
-                "com.sun.security.sasl.gsskerb.*",
-                "java.sql.*",
-                "javax.script.*",
-                "org.jcp.xml.dsig.internal.dom.*",
-                "sun.nio.cs.ext.*",
-                "sun.security.ec.*",
-                "sun.security.jgss.*",
-                "sun.security.pkcs11.*",
-                "sun.security.smartcardio.*",
-                "sun.util.resources.provider.*"
-            ]
-        }
-        dependsOn copyExtraTestResources
-        finalizedBy jacocoTestReport
+        setCommonTestConfig(it)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ List<String> taskNames = splitTestConfig.keySet() as List
 
 task listTasksAsJSON {
     doLast {
-        System.out.println(new JsonBuilder(taskNames))
+        System.out.println(new JsonBuilder(["citest"] + taskNames))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,8 +132,7 @@ def splitTestConfig = [
             "org.opensearch.security.*Integ*"
         ],
         excludeTestsMatching: [
-            "org.opensearch.security.sanity.tests.*",
-            "org.opensearch.security.ssl.OpenSSL*",
+            "org.opensearch.security.sanity.tests.*"
         ]
     ],
     indicesTest: [
@@ -141,8 +140,7 @@ def splitTestConfig = [
             "org.opensearch.security.*indices*"
         ],
         excludeTestsMatching: [
-            "org.opensearch.security.sanity.tests.*",
-            "org.opensearch.security.ssl.OpenSSL*",
+            "org.opensearch.security.sanity.tests.*"
         ]
     ]
 ] as ConfigObject
@@ -185,30 +183,6 @@ test {
     if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
         jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
     }
-    retry {
-        failOnPassedAfterRetry = false
-        maxRetries = 5
-    }
-    jacoco {
-        excludes = [
-                "com.sun.jndi.dns.*",
-                "com.sun.security.sasl.gsskerb.*",
-                "java.sql.*",
-                "javax.script.*",
-                "org.jcp.xml.dsig.internal.dom.*",
-                "sun.nio.cs.ext.*",
-                "sun.security.ec.*",
-                "sun.security.jgss.*",
-                "sun.security.pkcs11.*",
-                "sun.security.smartcardio.*",
-                "sun.util.resources.provider.*"
-        ]
-    }
-}
-
-//add new task that runs OpenSSL tests
-task opensslTest(type: Test) {
-    include '**/OpenSSL*.class'
     retry {
         failOnPassedAfterRetry = false
         maxRetries = 5
@@ -273,7 +247,7 @@ task copyExtraTestResources(dependsOn: testClasses) {
         into 'build/testrun/test/src/test/resources'
     }
 }
-tasks.test.dependsOn(copyExtraTestResources, opensslTest, taskNames)
+tasks.test.dependsOn(copyExtraTestResources, taskNames)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")

--- a/build.gradle
+++ b/build.gradle
@@ -108,39 +108,57 @@ tasks.whenTaskAdded {task ->
 
 def splitTestConfig = [
     dlicDlsflsTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.dlic.dlsfls.*"
+        description: "Runs Document- and Field-Level Security tests.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.dlic.dlsfls.*"
+            ]
         ]
     ],
     dlicRestApiTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.dlic.rest.*"
+        description: "Runs REST Management API tests.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.dlic.rest.*"
+            ]
         ]
     ],
     crossClusterTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.ccstest.*"
+        description: "Runs cross-cluster tests.",
+        filters: [
+            includeTestsMatching: [
+                    "org.opensearch.security.ccstest.*"
+            ]
         ]
     ],
     sslTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.ssl.*"
+        description: "Runs all SSL tests.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.ssl.*"
+            ]
         ]
     ],
     securityIntegrationTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.*Integ*"
-        ],
-        excludeTestsMatching: [
-            "org.opensearch.security.sanity.tests.*"
+        description: "Runs integration tests from all classes.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.*Integ*"
+            ],
+            excludeTestsMatching: [
+                "org.opensearch.security.sanity.tests.*"
+            ]
         ]
     ],
     indicesTest: [
-        includeTestsMatching: [
-            "org.opensearch.security.*indices*"
-        ],
-        excludeTestsMatching: [
-            "org.opensearch.security.sanity.tests.*"
+        description: "Runs indices tests from all classes.",
+        filters: [
+            includeTestsMatching: [
+                "org.opensearch.security.*indices*"
+            ],
+            excludeTestsMatching: [
+                "org.opensearch.security.sanity.tests.*"
+            ]
         ]
     ]
 ] as ConfigObject
@@ -236,7 +254,8 @@ task copyExtraTestResources(dependsOn: testClasses) {
 }
 
 task citest(type: Test) {
-//    onlyIf { !project.gradle.taskGraph.hasTask(':test') }
+    group = "Github Actions tests"
+    description = "Runs the test suite on classes not covered by rest of the task in this group."
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
@@ -281,11 +300,13 @@ task citest(type: Test) {
     dependsOn copyExtraTestResources
 }
 
-splitTestConfig.each{ testName, filterCfg ->
+splitTestConfig.each{ testName, testCfg ->
     task "${testName}"(type: Test) {
-        include '**/*.class'
+        group = testCfg.group ?: "Github Actions tests"
+        description = testCfg.description
+        include testCfg.include ?: '**/*.class'
         filter {
-            filterCfg.each{ filter, values ->
+            testCfg.filters.each{ filter, values ->
                 values.each{ value ->
                     "${filter}" "${value}"
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -132,12 +132,19 @@ def splitTestConfig = [
         ]
     ],
     sslTest: [
-        description: "Runs all SSL tests.",
+        description: "Runs most of the SSL tests.",
         filters: [
             includeTestsMatching: [
                 "org.opensearch.security.ssl.*"
+            ],
+            excludeTestsMatching: [
+                "org.opensearch.security.ssl.OpenSSL*"
             ]
         ]
+    ],
+    opensslCiTest: [
+        description: "Runs portion of SSL tests related to OpenSSL. Explained in https://github.com/opensearch-project/security/pull/2301",
+        include: '**/OpenSSL*.class'
     ],
     securityIntegrationTest: [
         description: "Runs integration tests from all classes.",
@@ -259,6 +266,7 @@ task citest(type: Test) {
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
+        excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
         splitTestConfig.each { entry ->
             entry.value.each{ test ->
                 if (test.key == "includeTestsMatching") {

--- a/build.gradle
+++ b/build.gradle
@@ -178,12 +178,6 @@ task listTasksAsJSON {
     }
 }
 
-task listTasksAsParam {
-    doLast {
-        System.out.println('-x ' + (taskNames).join(' -x '))
-    }
-}
-
 test {
     include '**/*.class'
     filter {

--- a/build.gradle
+++ b/build.gradle
@@ -174,7 +174,7 @@ List<String> taskNames = splitTestConfig.keySet() as List
 
 task listTasksAsJSON {
     doLast {
-        System.out.println(new JsonBuilder(["citest"] + taskNames))
+        System.out.println(new JsonBuilder(taskNames))
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ test {
         splitTestConfig.each { entry ->
             entry.value.each{ test ->
                 if (test.key == "includeTestsMatching") {
-                    test.value.each{ 
+                    test.value.each{
                         excludeTestsMatching "${it}"
                     }
                 } else if (test.key == "includeTest") {

--- a/build.gradle
+++ b/build.gradle
@@ -188,37 +188,12 @@ test {
     include '**/*.class'
     filter {
         excludeTestsMatching "org.opensearch.security.sanity.tests.*"
-        excludeTestsMatching "org.opensearch.security.ssl.OpenSSL*"
     }
     maxParallelForks = 8
     jvmArgs += "-Xmx3072m"
     if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
         jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
     }
-    retry {
-        failOnPassedAfterRetry = false
-        maxRetries = 5
-    }
-    jacoco {
-        excludes = [
-                "com.sun.jndi.dns.*",
-                "com.sun.security.sasl.gsskerb.*",
-                "java.sql.*",
-                "javax.script.*",
-                "org.jcp.xml.dsig.internal.dom.*",
-                "sun.nio.cs.ext.*",
-                "sun.security.ec.*",
-                "sun.security.jgss.*",
-                "sun.security.pkcs11.*",
-                "sun.security.smartcardio.*",
-                "sun.util.resources.provider.*"
-        ]
-    }
-}
-
-//add new task that runs OpenSSL tests
-task opensslTest(type: Test) {
-    include '**/OpenSSL*.class'
     retry {
         failOnPassedAfterRetry = false
         maxRetries = 5
@@ -329,7 +304,7 @@ splitTestConfig.each{ testName, testCfg ->
     }
 }
 
-tasks.test.dependsOn(copyExtraTestResources, opensslTest)
+tasks.test.dependsOn(copyExtraTestResources)
 
 jacoco {
     reportsDirectory = file("$buildDir/reports/jacoco")


### PR DESCRIPTION
### Description
Currently "build" job in Github Actions runs for around 60-80 minutes on average. Long time for tests to be done can slow down development process. Easiest way to make this situation little better is to split tests into separate task and reconfigure Github Actions to run tests in parallel. This change allows to cut run of CI from 60-80 minutes to around 28-30 minutes.

We've determined which tests run are the longest and moved them into separate tasks (defined in `build.gradle` file). We do not want to break test on Developers side so running `gradle test` command would run full test suite (`test` task depends on new ones). This also allows new test to be added run automatically.

### Issues Resolved
#2798 

### Testing
There's no changes in test themselves.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
