### PR TITLE
Update formatting of all *.java files under **/integrationTest 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ spotless {
         target '**/com/amazon/dlic/**/*.java'
         target '**/com/amazon/security/**/*.java'
         target '**/test/**/*.java'
+        target '**/integrationTest/**/*.java'
 
         removeUnusedImports()
         eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
@@ -113,6 +114,7 @@ spotless {
         targetExclude '**/com/amazon/dlic/**/*.java'
         targetExclude '**/com/amazon/security/**/*.java'
         targetExclude '**/test/**/*.java'
+        targetExclude '**/integrationTest/**/*.java'
 
         trimTrailingWhitespace()
         endWithNewline();

--- a/src/integrationTest/java/org/opensearch/common/logging/NodeAndClusterIdConverter.java
+++ b/src/integrationTest/java/org/opensearch/common/logging/NodeAndClusterIdConverter.java
@@ -21,13 +21,9 @@ import org.apache.logging.log4j.core.LogEvent;
 
 class NodeAndClusterIdConverter {
 
+    public NodeAndClusterIdConverter() {}
 
-	public NodeAndClusterIdConverter() {
-	}
+    public static void setNodeIdAndClusterId(String nodeId, String clusterUUID) {}
 
-	public static void setNodeIdAndClusterId(String nodeId, String clusterUUID) {
-	}
-
-	public void format(LogEvent event, StringBuilder toAppendTo) {
-	}
+    public void format(LogEvent event, StringBuilder toAppendTo) {}
 }

--- a/src/integrationTest/java/org/opensearch/node/PluginAwareNode.java
+++ b/src/integrationTest/java/org/opensearch/node/PluginAwareNode.java
@@ -34,16 +34,19 @@ import org.opensearch.plugins.Plugin;
 
 public class PluginAwareNode extends Node {
 
-	private final boolean clusterManagerEligible;
+    private final boolean clusterManagerEligible;
 
-	@SafeVarargs
-	public PluginAwareNode(boolean clusterManagerEligible, final Settings preparedSettings, final Class<? extends Plugin>... plugins) {
-		super(InternalSettingsPreparer.prepareEnvironment(preparedSettings, Collections.emptyMap(), null, () -> System.getenv("HOSTNAME")), Arrays.asList(plugins), true);
-		this.clusterManagerEligible = clusterManagerEligible;
-	}
+    @SafeVarargs
+    public PluginAwareNode(boolean clusterManagerEligible, final Settings preparedSettings, final Class<? extends Plugin>... plugins) {
+        super(
+            InternalSettingsPreparer.prepareEnvironment(preparedSettings, Collections.emptyMap(), null, () -> System.getenv("HOSTNAME")),
+            Arrays.asList(plugins),
+            true
+        );
+        this.clusterManagerEligible = clusterManagerEligible;
+    }
 
-
-	public boolean isClusterManagerEligible() {
-		return clusterManagerEligible;
-	}
+    public boolean isClusterManagerEligible() {
+        return clusterManagerEligible;
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
+++ b/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
@@ -20,42 +20,41 @@ import java.util.Objects;
 
 class ConfigurationFiles {
 
-	public static void createRoleMappingFile(File destination) {
-		String resource = "roles_mapping.yml";
-		copyResourceToFile(resource, destination);
-	}
+    public static void createRoleMappingFile(File destination) {
+        String resource = "roles_mapping.yml";
+        copyResourceToFile(resource, destination);
+    }
 
-	public static Path createConfigurationDirectory()  {
-		try {
-			Path tempDirectory = Files.createTempDirectory("test-security-config");
-			String[] configurationFiles = {
-				"config.yml",
-				"action_groups.yml",
-				"config.yml",
-				"internal_users.yml",
-				"roles.yml",
-				"roles_mapping.yml",
-				"security_tenants.yml",
-				"tenants.yml"
-			};
-			for (String fileName : configurationFiles) {
-				Path configFileDestination = tempDirectory.resolve(fileName);
-				copyResourceToFile(fileName, configFileDestination.toFile());
-			}
-			return tempDirectory.toAbsolutePath();
-		} catch (IOException ex) {
-		throw new RuntimeException("Cannot create directory with security plugin configuration.", ex);
-		}
-	}
+    public static Path createConfigurationDirectory() {
+        try {
+            Path tempDirectory = Files.createTempDirectory("test-security-config");
+            String[] configurationFiles = {
+                "config.yml",
+                "action_groups.yml",
+                "config.yml",
+                "internal_users.yml",
+                "roles.yml",
+                "roles_mapping.yml",
+                "security_tenants.yml",
+                "tenants.yml" };
+            for (String fileName : configurationFiles) {
+                Path configFileDestination = tempDirectory.resolve(fileName);
+                copyResourceToFile(fileName, configFileDestination.toFile());
+            }
+            return tempDirectory.toAbsolutePath();
+        } catch (IOException ex) {
+            throw new RuntimeException("Cannot create directory with security plugin configuration.", ex);
+        }
+    }
 
-	private static void copyResourceToFile(String resource, File destination) {
-		try(InputStream input = ConfigurationFiles.class.getClassLoader().getResourceAsStream(resource)) {
-			Objects.requireNonNull(input, "Cannot find source resource " + resource);
-			try(OutputStream output = new FileOutputStream(destination)) {
-				input.transferTo(output);
-			}
-		} catch (IOException e) {
-			throw new RuntimeException("Cannot create file with security plugin configuration", e);
-		}
-	}
+    private static void copyResourceToFile(String resource, File destination) {
+        try (InputStream input = ConfigurationFiles.class.getClassLoader().getResourceAsStream(resource)) {
+            Objects.requireNonNull(input, "Cannot find source resource " + resource);
+            try (OutputStream output = new FileOutputStream(destination)) {
+                input.transferTo(output);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot create file with security plugin configuration", e);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
+++ b/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
@@ -68,368 +68,388 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class CrossClusterSearchTests {
 
-	private static final String SONG_INDEX_NAME = "song_lyrics";
-
-	private static final String PROHIBITED_SONG_INDEX_NAME = "prohibited_song_lyrics";
-
-	public static final String REMOTE_CLUSTER_NAME = "ccsRemote";
-	public static final String REMOTE_SONG_INDEX = REMOTE_CLUSTER_NAME + ":" + SONG_INDEX_NAME;
-
-	public static final String SONG_ID_1R = "remote-00001";
-	public static final String SONG_ID_2L = "local-00002";
-	public static final String SONG_ID_3R = "remote-00003";
-	public static final String SONG_ID_4L = "local-00004";
-	public static final String SONG_ID_5R = "remote-00005";
-	public static final String SONG_ID_6R = "remote-00006";
-
-	private static final Role LIMITED_ROLE = new Role("limited_role")
-		.indexPermissions("indices:data/read/search", "indices:admin/shards/search_shards")
-		.on(SONG_INDEX_NAME, "user-${user.name}-${attr.internal.type}");
-
-	private static final Role DLS_ROLE_ROCK = new Role("dls_role_rock")
-		.indexPermissions("indices:data/read/search", "indices:data/read/get", "indices:admin/shards/search_shards")
-		.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_GENRE, GENRE_ROCK))
-		.on(SONG_INDEX_NAME);
-
-	private static final Role DLS_ROLE_JAZZ = new Role("dls_role_jazz")
-		.indexPermissions("indices:data/read/search", "indices:data/read/get", "indices:admin/shards/search_shards")
-		.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_GENRE, GENRE_JAZZ))
-		.on(SONG_INDEX_NAME);
-
-	private static final Role FLS_EXCLUDE_LYRICS_ROLE = new Role("fls_exclude_lyrics_role")
-		.indexPermissions("indices:data/read/search", "indices:data/read/get", "indices:admin/shards/search_shards")
-		.fls("~" + FIELD_LYRICS)
-		.on(SONG_INDEX_NAME);
-
-	private static final Role FLS_INCLUDE_TITLE_ROLE = new Role("fls_include_title_role")
-		.indexPermissions("indices:data/read/search", "indices:data/read/get", "indices:admin/shards/search_shards")
-		.fls(FIELD_TITLE)
-		.on(SONG_INDEX_NAME);
-
-	public static final String TYPE_ATTRIBUTE = "type";
-
-	private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS).attr(TYPE_ATTRIBUTE, "administrative");
-	private static final User LIMITED_USER = new User("limited_user").attr(TYPE_ATTRIBUTE, "personal");
-
-	private static final User FLS_INCLUDE_TITLE_USER = new User("fls_include_title_user");
-
-	private static final User FLS_EXCLUDE_LYRICS_USER = new User("fls_exclude_lyrics_user");
-
-	private static final User DLS_USER_ROCK = new User("dls-user-rock");
-
-	private static final User DLS_USER_JAZZ = new User("dls-user-jazz");
-
-	public static final String LIMITED_USER_INDEX_NAME = "user-" + LIMITED_USER.getName() + "-" + LIMITED_USER.getAttribute(TYPE_ATTRIBUTE);
-	public static final String ADMIN_USER_INDEX_NAME = "user-" + ADMIN_USER.getName() + "-" + ADMIN_USER.getAttribute(TYPE_ATTRIBUTE);
-
-	private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
-
-	private final boolean ccsMinimizeRoundtrips;
-
-	public static final String PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED = "plugins.security.restapi.roles_enabled";
-	@ClassRule
-	public static final LocalCluster remoteCluster = new LocalCluster.Builder().certificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false).clusterName(REMOTE_CLUSTER_NAME)
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.roles(LIMITED_ROLE, DLS_ROLE_ROCK, DLS_ROLE_JAZZ, FLS_EXCLUDE_LYRICS_ROLE, FLS_INCLUDE_TITLE_ROLE).users(ADMIN_USER)
-		.build();
-
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder().certificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLE_REMOTE_CLIENT).anonymousAuth(false).clusterName("ccsLocal")
-		.nodeSettings(Map.of(PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_" + ADMIN_USER.getName()  +"__" + ALL_ACCESS.getName())))
-		.remote(REMOTE_CLUSTER_NAME, remoteCluster)
-		.roles(LIMITED_ROLE, DLS_ROLE_ROCK, DLS_ROLE_JAZZ, FLS_EXCLUDE_LYRICS_ROLE, FLS_INCLUDE_TITLE_ROLE).authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER, LIMITED_USER, DLS_USER_ROCK, DLS_USER_JAZZ, FLS_INCLUDE_TITLE_USER, FLS_EXCLUDE_LYRICS_USER)
-		.build();
-
-	@ParametersFactory(shuffle = false)
-	public static Iterable<Object[]> parameters() {
-		return List.of(new Object[] { true }, new Object[] { false });
-	}
-
-	public CrossClusterSearchTests(Boolean ccsMinimizeRoundtrips) {
-		this.ccsMinimizeRoundtrips = ccsMinimizeRoundtrips;
-	}
-
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = remoteCluster.getInternalNodeClient()){
-			client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_1R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
-			client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_6R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[5].asMap()).get();
-			client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(SONG_ID_3R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
-			client.prepareIndex(LIMITED_USER_INDEX_NAME).setId(SONG_ID_5R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[4].asMap()).get();
-		}
-		try(Client client = cluster.getInternalNodeClient()){
-			client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_2L).setRefreshPolicy(IMMEDIATE).setSource(SONGS[2].asMap()).get();
-			client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(SONG_ID_4L).setRefreshPolicy(IMMEDIATE).setSource(SONGS[3].asMap()).get();
-		}
-		try(TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
-			client.assignRoleToUser(LIMITED_USER.getName(), LIMITED_ROLE.getName()).assertStatusCode(200);
-			client.assignRoleToUser(DLS_USER_ROCK.getName(), DLS_ROLE_ROCK.getName()).assertStatusCode(200);
-			client.assignRoleToUser(DLS_USER_JAZZ.getName(), DLS_ROLE_JAZZ.getName()).assertStatusCode(200);
-			client.assignRoleToUser(FLS_INCLUDE_TITLE_USER.getName(), FLS_INCLUDE_TITLE_ROLE.getName()).assertStatusCode(200);
-			client.assignRoleToUser(FLS_EXCLUDE_LYRICS_USER.getName(), FLS_EXCLUDE_LYRICS_ROLE.getName()).assertStatusCode(200);
-		}
-	}
-
-	@Test
-	public void shouldFindDocumentOnRemoteCluster_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(2));
-			assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
-			assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
-		}
-	}
-
-	private SearchRequest searchAll(String indexName) {
-		SearchRequest searchRequest = SearchRequestFactory.searchAll(indexName);
-		searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-		return searchRequest;
-	}
-
-	@Test
-	public void shouldFindDocumentOnRemoteCluster_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll("*" + ":" + SONG_INDEX_NAME);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			//only remote documents are found
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(2));
-			assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
-			assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
-		}
-	}
-
-	@Test
-	public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll("*" + ":" + PROHIBITED_SONG_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
-			searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(3));
-			assertThat(response, searchHitsContainDocumentsInAnyOrder(
-				Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-				Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
-				Pair.of(SONG_INDEX_NAME, SONG_ID_6R))
-			);
-		}
-	}
-
-	@Test
-	public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfLocalAccess() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			var searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, PROHIBITED_SONG_INDEX_NAME);
-			searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-
-			assertThatThrownBy(() ->  restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfRemoteAccess() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			String remoteIndex = REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME;
-			SearchRequest searchRequest = SearchRequestFactory.searchAll(remoteIndex, SONG_INDEX_NAME);
-			searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-
-			assertThatThrownBy(() ->  restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchViaAllAliasOnRemoteCluster_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(4));
-			assertThat(response, searchHitsContainDocumentsInAnyOrder(
-				Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-				Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-				Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-				Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R))
-			);
-		}
-	}
-
-	@Test
-	public void shouldSearchViaAllAliasOnRemoteCluster_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(4));
-			assertThat(response, searchHitsContainDocumentsInAnyOrder(
-				Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-				Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-				Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-				Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R))
-			);
-		}
-	}
-
-	@Test
-	public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldResolveUserNameExpressionInRoleIndexPattern_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + LIMITED_USER_INDEX_NAME);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-		}
-	}
-
-	@Test
-	public void shouldResolveUserNameExpressionInRoleIndexPattern_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + ADMIN_USER_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldSearchInIndexWithPrefix_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":song*");
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(2));
-			assertThat(response, searchHitsContainDocumentsInAnyOrder(
-					Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-					Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
-				));
-		}
-	}
-
-	@Test
-	public void shouldSearchInIndexWithPrefix_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":prohibited*");
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseRock() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_ROCK)) {
-			SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			//searching for all documents, so is it important that result contain only one document with id SONG_ID_1
-			// and document with SONG_ID_6 is excluded from result set by DLS
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-			assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
-		}
-	}
-
-	@Test
-	public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseJazz() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_JAZZ)) {
-			SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			//searching for all documents, so is it important that result contain only one document with id SONG_ID_6
-			// and document with SONG_ID_1 is excluded from result set by DLS
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-			assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_6R));
-		}
-	}
-
-	@Test
-	public void shouldHaveAccessOnlyToSpecificField() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_INCLUDE_TITLE_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
-			searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-			//document should contain only title field
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(response, searchHitDoesNotContainField(0, FIELD_ARTIST));
-			assertThat(response, searchHitDoesNotContainField(0, FIELD_LYRICS));
-			assertThat(response, searchHitDoesNotContainField(0, FIELD_STARS));
-			assertThat(response, searchHitDoesNotContainField(0, FIELD_GENRE));
-		}
-	}
-
-	@Test
-	public void shouldLackAccessToSpecificField() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_EXCLUDE_LYRICS_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
-			searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-
-			SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-			//document should not contain lyrics field
-			assertThat(response, searchHitDoesNotContainField(0, FIELD_LYRICS));
-
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_STARS, 1));
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_GENRE, GENRE_ROCK));
-		}
-	}
+    private static final String SONG_INDEX_NAME = "song_lyrics";
+
+    private static final String PROHIBITED_SONG_INDEX_NAME = "prohibited_song_lyrics";
+
+    public static final String REMOTE_CLUSTER_NAME = "ccsRemote";
+    public static final String REMOTE_SONG_INDEX = REMOTE_CLUSTER_NAME + ":" + SONG_INDEX_NAME;
+
+    public static final String SONG_ID_1R = "remote-00001";
+    public static final String SONG_ID_2L = "local-00002";
+    public static final String SONG_ID_3R = "remote-00003";
+    public static final String SONG_ID_4L = "local-00004";
+    public static final String SONG_ID_5R = "remote-00005";
+    public static final String SONG_ID_6R = "remote-00006";
+
+    private static final Role LIMITED_ROLE = new Role("limited_role").indexPermissions(
+        "indices:data/read/search",
+        "indices:admin/shards/search_shards"
+    ).on(SONG_INDEX_NAME, "user-${user.name}-${attr.internal.type}");
+
+    private static final Role DLS_ROLE_ROCK = new Role("dls_role_rock").indexPermissions(
+        "indices:data/read/search",
+        "indices:data/read/get",
+        "indices:admin/shards/search_shards"
+    ).dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_GENRE, GENRE_ROCK)).on(SONG_INDEX_NAME);
+
+    private static final Role DLS_ROLE_JAZZ = new Role("dls_role_jazz").indexPermissions(
+        "indices:data/read/search",
+        "indices:data/read/get",
+        "indices:admin/shards/search_shards"
+    ).dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_GENRE, GENRE_JAZZ)).on(SONG_INDEX_NAME);
+
+    private static final Role FLS_EXCLUDE_LYRICS_ROLE = new Role("fls_exclude_lyrics_role").indexPermissions(
+        "indices:data/read/search",
+        "indices:data/read/get",
+        "indices:admin/shards/search_shards"
+    ).fls("~" + FIELD_LYRICS).on(SONG_INDEX_NAME);
+
+    private static final Role FLS_INCLUDE_TITLE_ROLE = new Role("fls_include_title_role").indexPermissions(
+        "indices:data/read/search",
+        "indices:data/read/get",
+        "indices:admin/shards/search_shards"
+    ).fls(FIELD_TITLE).on(SONG_INDEX_NAME);
+
+    public static final String TYPE_ATTRIBUTE = "type";
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS).attr(TYPE_ATTRIBUTE, "administrative");
+    private static final User LIMITED_USER = new User("limited_user").attr(TYPE_ATTRIBUTE, "personal");
+
+    private static final User FLS_INCLUDE_TITLE_USER = new User("fls_include_title_user");
+
+    private static final User FLS_EXCLUDE_LYRICS_USER = new User("fls_exclude_lyrics_user");
+
+    private static final User DLS_USER_ROCK = new User("dls-user-rock");
+
+    private static final User DLS_USER_JAZZ = new User("dls-user-jazz");
+
+    public static final String LIMITED_USER_INDEX_NAME = "user-" + LIMITED_USER.getName() + "-" + LIMITED_USER.getAttribute(TYPE_ATTRIBUTE);
+    public static final String ADMIN_USER_INDEX_NAME = "user-" + ADMIN_USER.getName() + "-" + ADMIN_USER.getAttribute(TYPE_ATTRIBUTE);
+
+    private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+
+    private final boolean ccsMinimizeRoundtrips;
+
+    public static final String PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED = "plugins.security.restapi.roles_enabled";
+    @ClassRule
+    public static final LocalCluster remoteCluster = new LocalCluster.Builder().certificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .clusterName(REMOTE_CLUSTER_NAME)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .roles(LIMITED_ROLE, DLS_ROLE_ROCK, DLS_ROLE_JAZZ, FLS_EXCLUDE_LYRICS_ROLE, FLS_INCLUDE_TITLE_ROLE)
+        .users(ADMIN_USER)
+        .build();
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().certificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLE_REMOTE_CLIENT)
+        .anonymousAuth(false)
+        .clusterName("ccsLocal")
+        .nodeSettings(Map.of(PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName())))
+        .remote(REMOTE_CLUSTER_NAME, remoteCluster)
+        .roles(LIMITED_ROLE, DLS_ROLE_ROCK, DLS_ROLE_JAZZ, FLS_EXCLUDE_LYRICS_ROLE, FLS_INCLUDE_TITLE_ROLE)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, LIMITED_USER, DLS_USER_ROCK, DLS_USER_JAZZ, FLS_INCLUDE_TITLE_USER, FLS_EXCLUDE_LYRICS_USER)
+        .build();
+
+    @ParametersFactory(shuffle = false)
+    public static Iterable<Object[]> parameters() {
+        return List.of(new Object[] { true }, new Object[] { false });
+    }
+
+    public CrossClusterSearchTests(Boolean ccsMinimizeRoundtrips) {
+        this.ccsMinimizeRoundtrips = ccsMinimizeRoundtrips;
+    }
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = remoteCluster.getInternalNodeClient()) {
+            client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_1R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+            client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_6R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[5].asMap()).get();
+            client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(SONG_ID_3R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
+            client.prepareIndex(LIMITED_USER_INDEX_NAME).setId(SONG_ID_5R).setRefreshPolicy(IMMEDIATE).setSource(SONGS[4].asMap()).get();
+        }
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_2L).setRefreshPolicy(IMMEDIATE).setSource(SONGS[2].asMap()).get();
+            client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(SONG_ID_4L).setRefreshPolicy(IMMEDIATE).setSource(SONGS[3].asMap()).get();
+        }
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            client.assignRoleToUser(LIMITED_USER.getName(), LIMITED_ROLE.getName()).assertStatusCode(200);
+            client.assignRoleToUser(DLS_USER_ROCK.getName(), DLS_ROLE_ROCK.getName()).assertStatusCode(200);
+            client.assignRoleToUser(DLS_USER_JAZZ.getName(), DLS_ROLE_JAZZ.getName()).assertStatusCode(200);
+            client.assignRoleToUser(FLS_INCLUDE_TITLE_USER.getName(), FLS_INCLUDE_TITLE_ROLE.getName()).assertStatusCode(200);
+            client.assignRoleToUser(FLS_EXCLUDE_LYRICS_USER.getName(), FLS_EXCLUDE_LYRICS_ROLE.getName()).assertStatusCode(200);
+        }
+    }
+
+    @Test
+    public void shouldFindDocumentOnRemoteCluster_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(2));
+            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
+            assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
+        }
+    }
+
+    private SearchRequest searchAll(String indexName) {
+        SearchRequest searchRequest = SearchRequestFactory.searchAll(indexName);
+        searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+        return searchRequest;
+    }
+
+    @Test
+    public void shouldFindDocumentOnRemoteCluster_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll("*" + ":" + SONG_INDEX_NAME);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            // only remote documents are found
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(2));
+            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
+            assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
+        }
+    }
+
+    @Test
+    public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll("*" + ":" + PROHIBITED_SONG_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
+            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(3));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
+                )
+            );
+        }
+    }
+
+    @Test
+    public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfLocalAccess() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            var searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, PROHIBITED_SONG_INDEX_NAME);
+            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfRemoteAccess() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            String remoteIndex = REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME;
+            SearchRequest searchRequest = SearchRequestFactory.searchAll(remoteIndex, SONG_INDEX_NAME);
+            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchViaAllAliasOnRemoteCluster_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(4));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                )
+            );
+        }
+    }
+
+    @Test
+    public void shouldSearchViaAllAliasOnRemoteCluster_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(4));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                )
+            );
+        }
+    }
+
+    @Test
+    public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldResolveUserNameExpressionInRoleIndexPattern_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + LIMITED_USER_INDEX_NAME);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+        }
+    }
+
+    @Test
+    public void shouldResolveUserNameExpressionInRoleIndexPattern_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + ADMIN_USER_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldSearchInIndexWithPrefix_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":song*");
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(2));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(Pair.of(SONG_INDEX_NAME, SONG_ID_1R), Pair.of(SONG_INDEX_NAME, SONG_ID_6R))
+            );
+        }
+    }
+
+    @Test
+    public void shouldSearchInIndexWithPrefix_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":prohibited*");
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseRock() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_ROCK)) {
+            SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            // searching for all documents, so is it important that result contain only one document with id SONG_ID_1
+            // and document with SONG_ID_6 is excluded from result set by DLS
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
+        }
+    }
+
+    @Test
+    public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseJazz() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_JAZZ)) {
+            SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            // searching for all documents, so is it important that result contain only one document with id SONG_ID_6
+            // and document with SONG_ID_1 is excluded from result set by DLS
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_6R));
+        }
+    }
+
+    @Test
+    public void shouldHaveAccessOnlyToSpecificField() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_INCLUDE_TITLE_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
+            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+            // document should contain only title field
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(response, searchHitDoesNotContainField(0, FIELD_ARTIST));
+            assertThat(response, searchHitDoesNotContainField(0, FIELD_LYRICS));
+            assertThat(response, searchHitDoesNotContainField(0, FIELD_STARS));
+            assertThat(response, searchHitDoesNotContainField(0, FIELD_GENRE));
+        }
+    }
+
+    @Test
+    public void shouldLackAccessToSpecificField() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_EXCLUDE_LYRICS_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
+            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+
+            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+            // document should not contain lyrics field
+            assertThat(response, searchHitDoesNotContainField(0, FIELD_LYRICS));
+
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_STARS, 1));
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_GENRE, GENRE_ROCK));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationTests.java
@@ -37,44 +37,42 @@ import static org.hamcrest.Matchers.hasKey;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DefaultConfigurationTests {
 
-	private final static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
-	public static final String ADMIN_USER_NAME = "admin";
-	public static final String DEFAULT_PASSWORD = "secret";
-	public static final String NEW_USER = "new-user";
-	public static final String LIMITED_USER = "limited-user";
+    private final static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
+    public static final String ADMIN_USER_NAME = "admin";
+    public static final String DEFAULT_PASSWORD = "secret";
+    public static final String NEW_USER = "new-user";
+    public static final String LIMITED_USER = "limited-user";
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE)
-		.nodeSettings(Map.of(
-			"plugins.security.allow_default_init_securityindex", true,
-			"plugins.security.restapi.roles_enabled", List.of("user_admin__all_access")
-		))
-		.defaultConfigurationInitDirectory(configurationFolder.toString())
-		.loadConfigurationIntoIndex(false)
-		.build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.allow_default_init_securityindex",
+                true,
+                "plugins.security.restapi.roles_enabled",
+                List.of("user_admin__all_access")
+            )
+        )
+        .defaultConfigurationInitDirectory(configurationFolder.toString())
+        .loadConfigurationIntoIndex(false)
+        .build();
 
-	@AfterClass
-	public static void cleanConfigurationDirectory() throws IOException {
-		FileUtils.deleteDirectory(configurationFolder.toFile());
-	}
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
 
-	@Test
-	public void shouldLoadDefaultConfiguration()  {
-		try(TestRestClient client = cluster.getRestClient(NEW_USER, DEFAULT_PASSWORD)) {
-			Awaitility.await().alias("Load default configuration")
-				.until(() -> client.getAuthInfo().getStatusCode(), equalTo(200));
-		}
-		try(TestRestClient client = cluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)){
-			client.assertCorrectCredentials(ADMIN_USER_NAME);
-			HttpResponse response = client.get("/_plugins/_security/api/internalusers");
-			response.assertStatusCode(200);
-			Map<String, Object> users = response.getBodyAs(Map.class);
-			assertThat(users, allOf(
-				aMapWithSize(3),
-				hasKey(ADMIN_USER_NAME),
-				hasKey(NEW_USER),
-				hasKey(LIMITED_USER)));
-		}
-	}
+    @Test
+    public void shouldLoadDefaultConfiguration() {
+        try (TestRestClient client = cluster.getRestClient(NEW_USER, DEFAULT_PASSWORD)) {
+            Awaitility.await().alias("Load default configuration").until(() -> client.getAuthInfo().getStatusCode(), equalTo(200));
+        }
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
+            client.assertCorrectCredentials(ADMIN_USER_NAME);
+            HttpResponse response = client.get("/_plugins/_security/api/internalusers");
+            response.assertStatusCode(200);
+            Map<String, Object> users = response.getBodyAs(Map.class);
+            assertThat(users, allOf(aMapWithSize(3), hasKey(ADMIN_USER_NAME), hasKey(NEW_USER), hasKey(LIMITED_USER)));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -61,419 +61,456 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DlsIntegrationTests {
 
-	static final String FIRST_INDEX_ID_SONG_1 = "INDEX_1_S1";
-	static final String FIRST_INDEX_ID_SONG_2 = "INDEX_1_S2";
-	static final String FIRST_INDEX_ID_SONG_3 = "INDEX_1_S3";
-	static final String FIRST_INDEX_ID_SONG_4 = "INDEX_1_S4";
-	static final String FIRST_INDEX_ID_SONG_5 = "INDEX_1_S5";
-	static final String FIRST_INDEX_ID_SONG_6 = "INDEX_1_S6";
-	static final String SECOND_INDEX_ID_SONG_1 = "INDEX_2_S1";
-	static final String SECOND_INDEX_ID_SONG_2 = "INDEX_2_S2";
-	static final String SECOND_INDEX_ID_SONG_3 = "INDEX_2_S3";
-	static final String SECOND_INDEX_ID_SONG_4 = "INDEX_2_S4";
-
-	static final String INDEX_NAME_SUFFIX = "-test-index";
-	static final String FIRST_INDEX_NAME = "first".concat(INDEX_NAME_SUFFIX);
-	static final String SECOND_INDEX_NAME = "second".concat(INDEX_NAME_SUFFIX);
-	static final String FIRST_INDEX_ALIAS = FIRST_INDEX_NAME.concat("-alias");
-	static final String SECOND_INDEX_ALIAS = SECOND_INDEX_NAME.concat("-alias");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE = FIRST_INDEX_NAME.concat("-filtered-by-next-song-title");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-twins-artist");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-first-artist");
-	static final String ALL_INDICES_ALIAS = "_all";
-
-
-	static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
-
-	/**
-	* User who is allowed to read all indices.
-	*/
-	static final TestSecurityConfig.User READ_ALL_USER = new TestSecurityConfig.User("read_all_user")
-			.roles(
-					new TestSecurityConfig.Role("read_all_user")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.on("*")
-			);
-
-	/**
-	* User who is allowed to see all fields on indices {@link #FIRST_INDEX_NAME} and {@link #SECOND_INDEX_NAME}.
-	*/
-	static final TestSecurityConfig.User READ_FIRST_AND_SECOND_USER = new TestSecurityConfig.User("read_first_and_second_user")
-			.roles(
-					new TestSecurityConfig.Role("first_index_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.on(FIRST_INDEX_NAME),
-					new TestSecurityConfig.Role("second_index_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.on(SECOND_INDEX_NAME)
-			);
-
-	/**
-	* User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_STRING}.
-	*/
-	static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING = new TestSecurityConfig.User("read_where_field_artist_matches_artist_string")
-			.roles(
-					new TestSecurityConfig.Role("read_where_field_artist_matches_artist_string")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_STRING))
-							.on("*")
-			);
-
-	/**
-	 * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS} OR {@link Song#FIELD_STARS} is greater than five.
-	 */
-	static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE = new TestSecurityConfig.User("read_where_field_artist_matches_artist_twins_or_field_stars_greater_than_five")
-			.roles(
-					new TestSecurityConfig.Role("read_where_field_artist_matches_artist_twins")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
-							.on("*"),
-					new TestSecurityConfig.Role("read_where_field_stars_greater_than_five")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"range\":{\"%s\":{\"gt\":%d}}}", FIELD_STARS, 5))
-							.on("*")
-			);
-
-
-	/**
-	* User who is allowed to see documents on indices where value of {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS} or {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_FIRST}:
-	*/
-	static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST = new TestSecurityConfig.User("read_where_field_artist_matches_artist_twins_or_artist_first")
-			.roles(
-					new TestSecurityConfig.Role("read_where_field_artist_matches_artist_twins")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
-							.on(FIRST_INDEX_NAME),
-					new TestSecurityConfig.Role("read_where_field_artist_matches_artist_first")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_FIRST))
-							.on(SECOND_INDEX_NAME)
-			);
-
-	/**
-	* User who is allowed to see documents on all indices where value of the {@link Song#FIELD_STARS} is less than three.
-	*/
-	static final TestSecurityConfig.User READ_WHERE_STARS_LESS_THAN_THREE = new TestSecurityConfig.User("read_where_stars_less_than_three")
-			.roles(
-					new TestSecurityConfig.Role("read_where_stars_less_than_three")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"range\":{\"%s\":{\"lt\":%d}}}", FIELD_STARS, 3))
-							.on("*")
-			);
-
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-			.nodeSettings(Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName()  +"__" + ALL_ACCESS.getName())))
-			.authc(AUTHC_HTTPBASIC_INTERNAL)
-			.users(
-					ADMIN_USER, READ_ALL_USER, READ_FIRST_AND_SECOND_USER, READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING,
-					READ_WHERE_STARS_LESS_THAN_THREE, READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE,
-					READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
-			)
-			.build();
-
-	/**
-	* Function that returns id assigned to song with title equal to given title or throws {@link RuntimeException}
-	* when no song matches.
-	*/
-	static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_TITLE = (map, title) -> map.entrySet()
-			.stream().filter(entry -> title.equals(entry.getValue().getTitle()))
-			.findAny()
-			.map(Map.Entry::getKey)
-			.orElseThrow(() -> new RuntimeException("Cannot find id of song with title: " + title));
-
-	/**
-	* Function that returns id assigned to song with artist equal to given artist or throws {@link RuntimeException}
-	* when no song matches.
-	*/
-	static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_ARTIST = (map, artist) -> map.entrySet()
-			.stream().filter(entry -> artist.equals(entry.getValue().getArtist()))
-			.findAny()
-			.map(Map.Entry::getKey)
-			.orElseThrow(() -> new RuntimeException("Cannot find id of song with artist: " + artist));
-
-	static final TreeMap<String, Song> FIRST_INDEX_SONGS_BY_ID = new TreeMap<>() {{ // SONG = (String artist, String title, String lyrics, Integer stars, String genre)
-		put(FIRST_INDEX_ID_SONG_1, SONGS[0]); // (ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1,  GENRE_ROCK)
-		put(FIRST_INDEX_ID_SONG_2, SONGS[1]); // (ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2,  2,  GENRE_BLUES),
-		put(FIRST_INDEX_ID_SONG_3, SONGS[2]); // (ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3,  3, GENRE_JAZZ),
-		put(FIRST_INDEX_ID_SONG_4, SONGS[3]); // (ARTIST_NO, TITLE_POISON, LYRICS_4,  4,  GENRE_ROCK),
-		put(FIRST_INDEX_ID_SONG_5, SONGS[4]); // (ARTIST_YES, TITLE_AFFIRMATIVE,LYRICS_5,  5,  GENRE_BLUES),
-		put(FIRST_INDEX_ID_SONG_6, SONGS[5]); // (ARTIST_UNKNOWN, TITLE_CONFIDENTIAL, LYRICS_6,  6,  GENRE_JAZZ)
-	}};
-
-	static final TreeMap<String, Song> SECOND_INDEX_SONGS_BY_ID = new TreeMap<>() {{
-		put(SECOND_INDEX_ID_SONG_1, SONGS[3]); // (ARTIST_NO, TITLE_POISON, LYRICS_4,  4,  GENRE_ROCK),
-		put(SECOND_INDEX_ID_SONG_2, SONGS[2]); // (ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3,  3, GENRE_JAZZ),
-		put(SECOND_INDEX_ID_SONG_3, SONGS[1]); // (ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2,  2,  GENRE_BLUES),
-		put(SECOND_INDEX_ID_SONG_4, SONGS[0]); // (ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1,  GENRE_ROCK)
-	}};
-
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()){
-			FIRST_INDEX_SONGS_BY_ID.forEach((id, song) -> {
-				client.prepareIndex(FIRST_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
-			});
-
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.indices(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS)
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE)
-					.filter(QueryBuilders.queryStringQuery(QUERY_TITLE_NEXT_SONG))
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST)
-					.filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_TWINS)))
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST)
-					.filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_FIRST)))
-			)).actionGet();
-
-			SECOND_INDEX_SONGS_BY_ID.forEach((id, song) -> {
-				client.prepareIndex(SECOND_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
-			});
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.indices(SECOND_INDEX_NAME)
-					.alias(SECOND_INDEX_ALIAS)
-			)).actionGet();
-		}
-	}
-
-	@Test
-	public void testShouldSearchAll() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
-		}
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_FIRST_AND_SECOND_USER)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
-		}
-	}
-
-	@Test
-	public void testShouldSearchI1_S2I2_S3() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
-		}
-	}
-
-	public void testShouldSearchI1_S3I1_S6I2_S2() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_UNKNOWN));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
-		}
-	}
-
-	public void testShouldSearchI1_S1I1_S3I2_S2I2_S4() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
-		}
-	}
-
-	public void testShouldSearchStarsLessThanThree() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
-
-			searchRequest = new SearchRequest(SECOND_INDEX_NAME);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
-		}
-	}
-
-
-	@Test
-	public void testSearchForAllDocumentsWithIndexPattern() throws IOException {
-
-		//DLS
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
-			SearchRequest searchRequest = new SearchRequest("*".concat(FIRST_INDEX_NAME));
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
-
-			searchRequest = new SearchRequest("*".concat(SECOND_INDEX_NAME));
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
-		}
-	}
-
-	@Test
-	public void testSearchForAllDocumentsWithAlias() throws IOException {
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_ALIAS);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
-
-			searchRequest = new SearchRequest("*".concat(SECOND_INDEX_NAME));
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
-		}
-	}
-
-	@Test
-	public void testAggregateAndComputeStarRatings() throws IOException {
-
-		//DLS
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST)) {
-			String aggregationName = "averageStars";
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(FIND_ID_OF_SONG_WITH_ARTIST.apply(FIRST_INDEX_SONGS_BY_ID, ARTIST_TWINS));
-
-			SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-			Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-			assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-			assertThat(((ParsedAvg) actualAggregation).getValue(), is(song.getStars()*1.0));
-		}
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE)) {
-			String aggregationName = "averageStars";
-			SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-			Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-			assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-			assertThat(((ParsedAvg) actualAggregation).getValue(), is(4.5));
-		}
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
-			String aggregationName = "averageStars";
-			SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-			Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-			assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-			assertThat(((ParsedAvg) actualAggregation).getValue(), is(1.5));
-		}
-	}
+    static final String FIRST_INDEX_ID_SONG_1 = "INDEX_1_S1";
+    static final String FIRST_INDEX_ID_SONG_2 = "INDEX_1_S2";
+    static final String FIRST_INDEX_ID_SONG_3 = "INDEX_1_S3";
+    static final String FIRST_INDEX_ID_SONG_4 = "INDEX_1_S4";
+    static final String FIRST_INDEX_ID_SONG_5 = "INDEX_1_S5";
+    static final String FIRST_INDEX_ID_SONG_6 = "INDEX_1_S6";
+    static final String SECOND_INDEX_ID_SONG_1 = "INDEX_2_S1";
+    static final String SECOND_INDEX_ID_SONG_2 = "INDEX_2_S2";
+    static final String SECOND_INDEX_ID_SONG_3 = "INDEX_2_S3";
+    static final String SECOND_INDEX_ID_SONG_4 = "INDEX_2_S4";
+
+    static final String INDEX_NAME_SUFFIX = "-test-index";
+    static final String FIRST_INDEX_NAME = "first".concat(INDEX_NAME_SUFFIX);
+    static final String SECOND_INDEX_NAME = "second".concat(INDEX_NAME_SUFFIX);
+    static final String FIRST_INDEX_ALIAS = FIRST_INDEX_NAME.concat("-alias");
+    static final String SECOND_INDEX_ALIAS = SECOND_INDEX_NAME.concat("-alias");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE = FIRST_INDEX_NAME.concat("-filtered-by-next-song-title");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-twins-artist");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-first-artist");
+    static final String ALL_INDICES_ALIAS = "_all";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    /**
+    * User who is allowed to read all indices.
+    */
+    static final TestSecurityConfig.User READ_ALL_USER = new TestSecurityConfig.User("read_all_user").roles(
+        new TestSecurityConfig.Role("read_all_user").clusterPermissions("cluster_composite_ops_ro").indexPermissions("read").on("*")
+    );
+
+    /**
+    * User who is allowed to see all fields on indices {@link #FIRST_INDEX_NAME} and {@link #SECOND_INDEX_NAME}.
+    */
+    static final TestSecurityConfig.User READ_FIRST_AND_SECOND_USER = new TestSecurityConfig.User("read_first_and_second_user").roles(
+        new TestSecurityConfig.Role("first_index_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .on(FIRST_INDEX_NAME),
+        new TestSecurityConfig.Role("second_index_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .on(SECOND_INDEX_NAME)
+    );
+
+    /**
+    * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_STRING}.
+    */
+    static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING = new TestSecurityConfig.User(
+        "read_where_field_artist_matches_artist_string"
+    ).roles(
+        new TestSecurityConfig.Role("read_where_field_artist_matches_artist_string").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_STRING))
+            .on("*")
+    );
+
+    /**
+     * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS} OR {@link Song#FIELD_STARS} is greater than five.
+     */
+    static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE =
+        new TestSecurityConfig.User("read_where_field_artist_matches_artist_twins_or_field_stars_greater_than_five").roles(
+            new TestSecurityConfig.Role("read_where_field_artist_matches_artist_twins").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
+                .on("*"),
+            new TestSecurityConfig.Role("read_where_field_stars_greater_than_five").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .dls(String.format("{\"range\":{\"%s\":{\"gt\":%d}}}", FIELD_STARS, 5))
+                .on("*")
+        );
+
+    /**
+    * User who is allowed to see documents on indices where value of {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS} or {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_FIRST}:
+    */
+    static final TestSecurityConfig.User READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST = new TestSecurityConfig.User(
+        "read_where_field_artist_matches_artist_twins_or_artist_first"
+    ).roles(
+        new TestSecurityConfig.Role("read_where_field_artist_matches_artist_twins").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
+            .on(FIRST_INDEX_NAME),
+        new TestSecurityConfig.Role("read_where_field_artist_matches_artist_first").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_FIRST))
+            .on(SECOND_INDEX_NAME)
+    );
+
+    /**
+    * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_STARS} is less than three.
+    */
+    static final TestSecurityConfig.User READ_WHERE_STARS_LESS_THAN_THREE = new TestSecurityConfig.User("read_where_stars_less_than_three")
+        .roles(
+            new TestSecurityConfig.Role("read_where_stars_less_than_three").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .dls(String.format("{\"range\":{\"%s\":{\"lt\":%d}}}", FIELD_STARS, 3))
+                .on("*")
+        );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .nodeSettings(
+            Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()))
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(
+            ADMIN_USER,
+            READ_ALL_USER,
+            READ_FIRST_AND_SECOND_USER,
+            READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING,
+            READ_WHERE_STARS_LESS_THAN_THREE,
+            READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE,
+            READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
+        )
+        .build();
+
+    /**
+    * Function that returns id assigned to song with title equal to given title or throws {@link RuntimeException}
+    * when no song matches.
+    */
+    static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_TITLE = (map, title) -> map.entrySet()
+        .stream()
+        .filter(entry -> title.equals(entry.getValue().getTitle()))
+        .findAny()
+        .map(Map.Entry::getKey)
+        .orElseThrow(() -> new RuntimeException("Cannot find id of song with title: " + title));
+
+    /**
+    * Function that returns id assigned to song with artist equal to given artist or throws {@link RuntimeException}
+    * when no song matches.
+    */
+    static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_ARTIST = (map, artist) -> map.entrySet()
+        .stream()
+        .filter(entry -> artist.equals(entry.getValue().getArtist()))
+        .findAny()
+        .map(Map.Entry::getKey)
+        .orElseThrow(() -> new RuntimeException("Cannot find id of song with artist: " + artist));
+
+    static final TreeMap<String, Song> FIRST_INDEX_SONGS_BY_ID = new TreeMap<>() {
+        { // SONG = (String artist, String title, String lyrics, Integer stars, String genre)
+            put(FIRST_INDEX_ID_SONG_1, SONGS[0]); // (ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1, GENRE_ROCK)
+            put(FIRST_INDEX_ID_SONG_2, SONGS[1]); // (ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2, 2, GENRE_BLUES),
+            put(FIRST_INDEX_ID_SONG_3, SONGS[2]); // (ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3, 3, GENRE_JAZZ),
+            put(FIRST_INDEX_ID_SONG_4, SONGS[3]); // (ARTIST_NO, TITLE_POISON, LYRICS_4, 4, GENRE_ROCK),
+            put(FIRST_INDEX_ID_SONG_5, SONGS[4]); // (ARTIST_YES, TITLE_AFFIRMATIVE,LYRICS_5, 5, GENRE_BLUES),
+            put(FIRST_INDEX_ID_SONG_6, SONGS[5]); // (ARTIST_UNKNOWN, TITLE_CONFIDENTIAL, LYRICS_6, 6, GENRE_JAZZ)
+        }
+    };
+
+    static final TreeMap<String, Song> SECOND_INDEX_SONGS_BY_ID = new TreeMap<>() {
+        {
+            put(SECOND_INDEX_ID_SONG_1, SONGS[3]); // (ARTIST_NO, TITLE_POISON, LYRICS_4, 4, GENRE_ROCK),
+            put(SECOND_INDEX_ID_SONG_2, SONGS[2]); // (ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3, 3, GENRE_JAZZ),
+            put(SECOND_INDEX_ID_SONG_3, SONGS[1]); // (ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2, 2, GENRE_BLUES),
+            put(SECOND_INDEX_ID_SONG_4, SONGS[0]); // (ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1, GENRE_ROCK)
+        }
+    };
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            FIRST_INDEX_SONGS_BY_ID.forEach((id, song) -> {
+                client.prepareIndex(FIRST_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
+            });
+
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(FIRST_INDEX_NAME).alias(FIRST_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE)
+                            .filter(QueryBuilders.queryStringQuery(QUERY_TITLE_NEXT_SONG))
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST)
+                            .filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_TWINS)))
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST)
+                            .filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_FIRST)))
+                    )
+                )
+                .actionGet();
+
+            SECOND_INDEX_SONGS_BY_ID.forEach((id, song) -> {
+                client.prepareIndex(SECOND_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
+            });
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(SECOND_INDEX_NAME).alias(SECOND_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+        }
+    }
+
+    @Test
+    public void testShouldSearchAll() throws IOException {
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
+        }
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_FIRST_AND_SECOND_USER)) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
+        }
+    }
+
+    @Test
+    public void testShouldSearchI1_S2I2_S3() throws IOException {
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING)) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
+        }
+    }
+
+    public void testShouldSearchI1_S3I1_S6I2_S2() throws IOException {
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE
+            )
+        ) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_UNKNOWN));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
+        }
+    }
+
+    public void testShouldSearchI1_S1I1_S3I2_S2I2_S4() throws IOException {
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
+            )
+        ) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
+        }
+    }
+
+    public void testShouldSearchStarsLessThanThree() throws IOException {
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
+
+            searchRequest = new SearchRequest(SECOND_INDEX_NAME);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
+        }
+    }
+
+    @Test
+    public void testSearchForAllDocumentsWithIndexPattern() throws IOException {
+
+        // DLS
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+            SearchRequest searchRequest = new SearchRequest("*".concat(FIRST_INDEX_NAME));
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
+
+            searchRequest = new SearchRequest("*".concat(SECOND_INDEX_NAME));
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
+        }
+    }
+
+    @Test
+    public void testSearchForAllDocumentsWithAlias() throws IOException {
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_ALIAS);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_FIRST));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(2, FIELD_ARTIST, ARTIST_TWINS));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(3, FIELD_ARTIST, ARTIST_NO));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(4, FIELD_ARTIST, ARTIST_YES));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
+
+            searchRequest = new SearchRequest("*".concat(SECOND_INDEX_NAME));
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
+        }
+    }
+
+    @Test
+    public void testAggregateAndComputeStarRatings() throws IOException {
+
+        // DLS
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
+            )
+        ) {
+            String aggregationName = "averageStars";
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(FIND_ID_OF_SONG_WITH_ARTIST.apply(FIRST_INDEX_SONGS_BY_ID, ARTIST_TWINS));
+
+            SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
+            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
+            assertThat(((ParsedAvg) actualAggregation).getValue(), is(song.getStars() * 1.0));
+        }
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE
+            )
+        ) {
+            String aggregationName = "averageStars";
+            SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
+            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
+            assertThat(((ParsedAvg) actualAggregation).getValue(), is(4.5));
+        }
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
+            String aggregationName = "averageStars";
+            SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
+            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
+            assertThat(((ParsedAvg) actualAggregation).getValue(), is(1.5));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -80,301 +80,332 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DoNotFailOnForbiddenTests {
 
-	/**
-	* Songs accessible for {@link #LIMITED_USER}
-	*/
-	private static final String MARVELOUS_SONGS = "marvelous_songs";
+    /**
+    * Songs accessible for {@link #LIMITED_USER}
+    */
+    private static final String MARVELOUS_SONGS = "marvelous_songs";
 
-	/**
-	* Songs inaccessible for {@link #LIMITED_USER}
-	*/
-	private static final String HORRIBLE_SONGS = "horrible_songs";
+    /**
+    * Songs inaccessible for {@link #LIMITED_USER}
+    */
+    private static final String HORRIBLE_SONGS = "horrible_songs";
 
-	private static final String BOTH_INDEX_PATTERN = "*songs";
+    private static final String BOTH_INDEX_PATTERN = "*songs";
 
-	private static final String ID_1 = "1";
-	private static final String ID_2 = "2";
-	private static final String ID_3 = "3";
-	private static final String ID_4 = "4";
+    private static final String ID_1 = "1";
+    private static final String ID_2 = "2";
+    private static final String ID_3 = "3";
+    private static final String ID_4 = "4";
 
-	private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
-	private static final User LIMITED_USER = new User("limited_user")
-		.roles(new TestSecurityConfig.Role("limited-role")
-			.clusterPermissions("indices:data/read/mget", "indices:data/read/msearch", "indices:data/read/scroll")
-			.indexPermissions("indices:data/read/search", "indices:data/read/mget*", "indices:data/read/field_caps", "indices:data/read/field_caps*", "indices:data/read/msearch", "indices:data/read/scroll")
-			.on(MARVELOUS_SONGS));
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+    private static final User LIMITED_USER = new User("limited_user").roles(
+        new TestSecurityConfig.Role("limited-role").clusterPermissions(
+            "indices:data/read/mget",
+            "indices:data/read/msearch",
+            "indices:data/read/scroll"
+        )
+            .indexPermissions(
+                "indices:data/read/search",
+                "indices:data/read/mget*",
+                "indices:data/read/field_caps",
+                "indices:data/read/field_caps*",
+                "indices:data/read/msearch",
+                "indices:data/read/scroll"
+            )
+            .on(MARVELOUS_SONGS)
+    );
 
-	private static final String BOTH_INDEX_ALIAS = "both-indices";
-	private static final String FORBIDDEN_INDEX_ALIAS = "forbidden-index";
+    private static final String BOTH_INDEX_ALIAS = "both-indices";
+    private static final String FORBIDDEN_INDEX_ALIAS = "forbidden-index";
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER, LIMITED_USER).anonymousAuth(false).doNotFailOnForbidden(true).build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, LIMITED_USER)
+        .anonymousAuth(false)
+        .doNotFailOnForbidden(true)
+        .build();
 
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()) {
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_1).source(SONGS[0].asMap())).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_2).source(SONGS[1].asMap())).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_3).source(SONGS[2].asMap())).actionGet();
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_1).source(SONGS[0].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_2).source(SONGS[1].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_3).source(SONGS[2].asMap()))
+                .actionGet();
 
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(HORRIBLE_SONGS).id(ID_4).source(SONGS[3].asMap())).actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(HORRIBLE_SONGS).id(ID_4).source(SONGS[3].asMap()))
+                .actionGet();
 
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD).indices(
-				MARVELOUS_SONGS, HORRIBLE_SONGS).alias(BOTH_INDEX_ALIAS))).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD).indices(
-				HORRIBLE_SONGS).alias(FORBIDDEN_INDEX_ALIAS))).actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(MARVELOUS_SONGS, HORRIBLE_SONGS).alias(BOTH_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(HORRIBLE_SONGS).alias(FORBIDDEN_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
 
-		}
-	}
+        }
+    }
 
-	@Test
-	public void shouldPerformSimpleSearch_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(new String[]{MARVELOUS_SONGS, HORRIBLE_SONGS}, QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldPerformSimpleSearch_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(
+                new String[] { MARVELOUS_SONGS, HORRIBLE_SONGS },
+                QUERY_TITLE_MAGNUM_OPUS
+            );
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
-		}
-	}
+            assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
+        }
+    }
 
-	private static void assertThatContainOneSong(SearchResponse searchResponse, String documentId, String title) {
-		assertThat(searchResponse, isSuccessfulSearchResponse());
-		assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-		assertThat(searchResponse, searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, documentId));
-		assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, title));
-	}
+    private static void assertThatContainOneSong(SearchResponse searchResponse, String documentId, String title) {
+        assertThat(searchResponse, isSuccessfulSearchResponse());
+        assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+        assertThat(searchResponse, searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, documentId));
+        assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, title));
+    }
 
-	@Test
-	public void shouldPerformSimpleSearch_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
+    @Test
+    public void shouldPerformSimpleSearch_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaIndexPattern_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldSearchForDocumentsViaIndexPattern_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
-		}
-	}
+            assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaIndexPattern_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
+    @Test
+    public void shouldSearchForDocumentsViaIndexPattern_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
-		}
-	}
+            assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON);
+    @Test
+    public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON);
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaAll_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldSearchForDocumentsViaAll_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
-		}
-	}
+            assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
+        }
+    }
 
-	@Test
-	public void shouldSearchForDocumentsViaAll_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_POISON);
+    @Test
+    public void shouldSearchForDocumentsViaAll_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_POISON);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(0));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(0));
+        }
+    }
 
-	@Test
-	public void shouldMGetDocument_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			MultiGetRequest request = new MultiGetRequest()
-				.add(BOTH_INDEX_PATTERN, ID_1)
-				.add(BOTH_INDEX_PATTERN, ID_4);
+    @Test
+    public void shouldMGetDocument_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            MultiGetRequest request = new MultiGetRequest().add(BOTH_INDEX_PATTERN, ID_1).add(BOTH_INDEX_PATTERN, ID_4);
 
-			MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
 
-			MultiGetItemResponse[] responses = response.getResponses();
-			assertThat(responses, arrayWithSize(2));
-			MultiGetItemResponse firstResult = responses[0];
-			MultiGetItemResponse secondResult = responses[1];
-			assertThat(firstResult.getFailure(), nullValue());
-			assertThat(secondResult.getFailure(), nullValue());
-			assertThat(firstResult.getResponse(), allOf(
-				containDocument(MARVELOUS_SONGS, ID_1),
-				documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
-			);
-			assertThat(secondResult.getResponse(), containOnlyDocumentId(MARVELOUS_SONGS, ID_4));
-		}
-	}
+            MultiGetItemResponse[] responses = response.getResponses();
+            assertThat(responses, arrayWithSize(2));
+            MultiGetItemResponse firstResult = responses[0];
+            MultiGetItemResponse secondResult = responses[1];
+            assertThat(firstResult.getFailure(), nullValue());
+            assertThat(secondResult.getFailure(), nullValue());
+            assertThat(
+                firstResult.getResponse(),
+                allOf(containDocument(MARVELOUS_SONGS, ID_1), documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
+            );
+            assertThat(secondResult.getResponse(), containOnlyDocumentId(MARVELOUS_SONGS, ID_4));
+        }
+    }
 
-	@Test
-	public void shouldMGetDocument_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			MultiGetRequest request = new MultiGetRequest().add(HORRIBLE_SONGS, ID_4);
+    @Test
+    public void shouldMGetDocument_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            MultiGetRequest request = new MultiGetRequest().add(HORRIBLE_SONGS, ID_4);
 
-			assertThatThrownBy(() -> restHighLevelClient.mget(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.mget(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldMSearchDocument_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			MultiSearchRequest request = new MultiSearchRequest();
-			request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS));
-			request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_NEXT_SONG));
+    @Test
+    public void shouldMSearchDocument_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS));
+            request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_NEXT_SONG));
 
-			MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
 
-			MultiSearchResponse.Item[] responses = response.getResponses();
-			assertThat(responses, Matchers.arrayWithSize(2));
-			assertThat(responses[0].getFailure(), nullValue());
-			assertThat(responses[1].getFailure(), nullValue());
+            MultiSearchResponse.Item[] responses = response.getResponses();
+            assertThat(responses, Matchers.arrayWithSize(2));
+            assertThat(responses[0].getFailure(), nullValue());
+            assertThat(responses[1].getFailure(), nullValue());
 
-			assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_1));
-			assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-			assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_3));
-		}
-	}
+            assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_1));
+            assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+            assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_3));
+        }
+    }
 
-	@Test
-	public void shouldMSearchDocument_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			MultiSearchRequest request = new MultiSearchRequest();
-			request.add(queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON));
+    @Test
+    public void shouldMSearchDocument_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.add(queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON));
 
-			assertThatThrownBy(() -> restHighLevelClient.msearch(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.msearch(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldGetFieldCapabilities_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(MARVELOUS_SONGS, HORRIBLE_SONGS).fields(FIELD_TITLE);
+    @Test
+    public void shouldGetFieldCapabilities_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(MARVELOUS_SONGS, HORRIBLE_SONGS).fields(FIELD_TITLE);
 
-			FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
 
-			assertThat(response.get(), aMapWithSize(1));
-			assertThat(response.getIndices(), arrayWithSize(1));
-			assertThat(response.getField(FIELD_TITLE), hasKey("text"));
-			assertThat(response.getIndices(), arrayContainingInAnyOrder(MARVELOUS_SONGS));
-		}
-	}
+            assertThat(response.get(), aMapWithSize(1));
+            assertThat(response.getIndices(), arrayWithSize(1));
+            assertThat(response.getField(FIELD_TITLE), hasKey("text"));
+            assertThat(response.getIndices(), arrayContainingInAnyOrder(MARVELOUS_SONGS));
+        }
+    }
 
-	@Test
-	public void shouldGetFieldCapabilities_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(HORRIBLE_SONGS).fields(FIELD_TITLE);
+    @Test
+    public void shouldGetFieldCapabilities_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(HORRIBLE_SONGS).fields(FIELD_TITLE);
 
-			assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldScrollOverSearchResults_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchRequestWithScroll(BOTH_INDEX_PATTERN, 2);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containNotEmptyScrollingId());
+    @Test
+    public void shouldScrollOverSearchResults_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchRequestWithScroll(BOTH_INDEX_PATTERN, 2);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containNotEmptyScrollingId());
 
-			SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
 
-			SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
-			assertThat(scrollResponse, isSuccessfulSearchResponse());
-			assertThat(scrollResponse, containNotEmptyScrollingId());
-			assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
-			assertThat(scrollResponse, numberOfHitsInPageIsEqualTo(1));
-		}
-	}
+            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            assertThat(scrollResponse, isSuccessfulSearchResponse());
+            assertThat(scrollResponse, containNotEmptyScrollingId());
+            assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
+            assertThat(scrollResponse, numberOfHitsInPageIsEqualTo(1));
+        }
+    }
 
-	@Test
-	public void shouldScrollOverSearchResults_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			SearchRequest searchRequest = searchRequestWithScroll(HORRIBLE_SONGS, 2);
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+    @Test
+    public void shouldScrollOverSearchResults_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchRequestWithScroll(HORRIBLE_SONGS, 2);
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldPerformAggregation_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			final String aggregationName = "averageStars";
-			SearchRequest searchRequest = averageAggregationRequest(BOTH_INDEX_PATTERN, aggregationName, FIELD_STARS);
+    @Test
+    public void shouldPerformAggregation_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            final String aggregationName = "averageStars";
+            SearchRequest searchRequest = averageAggregationRequest(BOTH_INDEX_PATTERN, aggregationName, FIELD_STARS);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+        }
+    }
 
-	@Test
-	public void shouldPerformAggregation_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			final String aggregationName = "averageStars";
-			SearchRequest searchRequest = averageAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
+    @Test
+    public void shouldPerformAggregation_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            final String aggregationName = "averageStars";
+            SearchRequest searchRequest = averageAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
 
-			assertThatThrownBy( () -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldPerformStatAggregation_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			final String aggregationName = "statsStars";
-			SearchRequest searchRequest = statsAggregationRequest(BOTH_INDEX_ALIAS, aggregationName, FIELD_STARS);
+    @Test
+    public void shouldPerformStatAggregation_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            final String aggregationName = "statsStars";
+            SearchRequest searchRequest = statsAggregationRequest(BOTH_INDEX_ALIAS, aggregationName, FIELD_STARS);
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
+        }
+    }
 
-	@Test
-	public void shouldPerformStatAggregation_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-			final String aggregationName = "statsStars";
-			SearchRequest searchRequest = statsAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
+    @Test
+    public void shouldPerformStatAggregation_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            final String aggregationName = "statsStars";
+            SearchRequest searchRequest = statsAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -101,671 +101,714 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class FlsAndFieldMaskingTests {
 
-	static final String FIRST_INDEX_ID_SONG_1 = "INDEX_1_S1";
-	static final String FIRST_INDEX_ID_SONG_2 = "INDEX_1_S2";
-	static final String FIRST_INDEX_ID_SONG_3 = "INDEX_1_S3";
-	static final String FIRST_INDEX_ID_SONG_4 = "INDEX_1_S4";
-	static final String SECOND_INDEX_ID_SONG_1 = "INDEX_2_S1";
-	static final String SECOND_INDEX_ID_SONG_2 = "INDEX_2_S2";
-	static final String SECOND_INDEX_ID_SONG_3 = "INDEX_2_S3";
-	static final String SECOND_INDEX_ID_SONG_4 = "INDEX_2_S4";
-
-	static final String INDEX_NAME_SUFFIX = "-test-index";
-	static final String FIRST_INDEX_NAME = "first".concat(INDEX_NAME_SUFFIX);
-	static final String SECOND_INDEX_NAME = "second".concat(INDEX_NAME_SUFFIX);
-	static final String FIRST_INDEX_ALIAS = FIRST_INDEX_NAME.concat("-alias");
-	static final String SECOND_INDEX_ALIAS = SECOND_INDEX_NAME.concat("-alias");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE = FIRST_INDEX_NAME.concat("-filtered-by-next-song-title");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-twins-artist");
-	static final String FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-first-artist");
-	static final String ALL_INDICES_ALIAS = "_all";
-
-	static final String MASK_VALUE = "*";
-
-	static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
-
-	/**
-	* User who is allowed to see all fields on all indices. Values of the title and artist fields should be masked.
-	*/
-	static final TestSecurityConfig.User ALL_INDICES_MASKED_TITLE_ARTIST_READER = new TestSecurityConfig.User("masked_artist_title_reader")
-			.roles(
-					new TestSecurityConfig.Role("masked_artist_title_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.maskedFields(
-									FIELD_TITLE.concat("::/(?<=.{1})./::").concat(MASK_VALUE),
-									FIELD_ARTIST.concat("::/(?<=.{1})./::").concat(MASK_VALUE)
-							)
-							.on("*")
-			);
-
-	/**
-	* User who is allowed to see all fields on indices {@link #FIRST_INDEX_NAME} and {@link #SECOND_INDEX_NAME}.
-	* <ul>
-	*     <li>values of the artist and lyrics fields should be masked on index {@link #FIRST_INDEX_NAME}</li>
-	*     <li>values of the lyrics field should be masked on index {@link #SECOND_INDEX_NAME}</li>
-	* </ul>
-	*/
-	static final TestSecurityConfig.User MASKED_ARTIST_LYRICS_READER = new TestSecurityConfig.User("masked_title_artist_lyrics_reader")
-			.roles(
-					new TestSecurityConfig.Role("masked_title_artist_lyrics_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.maskedFields(
-									FIELD_ARTIST.concat("::/(?<=.{1})./::").concat(MASK_VALUE),
-									FIELD_LYRICS.concat("::/(?<=.{1})./::").concat(MASK_VALUE)
-							)
-							.on(FIRST_INDEX_NAME),
-					new TestSecurityConfig.Role("masked_lyrics_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.maskedFields(FIELD_LYRICS.concat("::/(?<=.{1})./::").concat(MASK_VALUE))
-							.on(SECOND_INDEX_NAME)
-			);
-
-	/**
-	* Function that converts field value to value masked with {@link #MASK_VALUE}
-	*/
-	static final Function<String, String> VALUE_TO_MASKED_VALUE = value -> value.substring(0, 1)
-			.concat(MASK_VALUE.repeat(value.length() - 1));
-
-	/**
-	* User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_STRING}.
-	*/
-	static final TestSecurityConfig.User ALL_INDICES_STRING_ARTIST_READER = new TestSecurityConfig.User("string_artist_reader")
-			.roles(
-					new TestSecurityConfig.Role("string_artist_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_STRING))
-							.on("*")
-			);
-
-	/**
-	* User who is allowed to see documents on index:
-	* <ul>
-	*     <li>{@link #FIRST_INDEX_NAME} where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS}</li>
-	*     <li>{@link #SECOND_INDEX_NAME} where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_FIRST}</li>
-	* </ul>
-	*/
-	static final TestSecurityConfig.User TWINS_FIRST_ARTIST_READER = new TestSecurityConfig.User("twins_first_artist_reader")
-			.roles(
-					new TestSecurityConfig.Role("twins_artist_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
-							.on(FIRST_INDEX_NAME),
-					new TestSecurityConfig.Role("first_artist_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_FIRST))
-							.on(SECOND_INDEX_NAME)
-			);
-
-	/**
-	* User who is allowed to see documents on all indices where value of the {@link Song#FIELD_STARS} is less than zero.
-	*/
-	static final TestSecurityConfig.User ALL_INDICES_STARS_LESS_THAN_ZERO_READER = new TestSecurityConfig.User("stars_less_than_zero_reader")
-			.roles(
-					new TestSecurityConfig.Role("stars_less_than_zero_reader")
-							.clusterPermissions("cluster_composite_ops_ro")
-							.indexPermissions("read")
-							.dls(String.format("{\"range\":{\"%s\":{\"lt\":%d}}}", FIELD_STARS, 0))
-							.on("*")
-			);
-
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-			.nodeSettings(Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName()  +"__" + ALL_ACCESS.getName())))
-			.authc(AUTHC_HTTPBASIC_INTERNAL)
-			.users(
-					ADMIN_USER,
-					ALL_INDICES_MASKED_TITLE_ARTIST_READER, MASKED_ARTIST_LYRICS_READER,
-					ALL_INDICES_STRING_ARTIST_READER, ALL_INDICES_STARS_LESS_THAN_ZERO_READER, TWINS_FIRST_ARTIST_READER
-			)
-			.build();
-
-	/**
-	* Function that returns id assigned to song with title equal to given title or throws {@link RuntimeException}
-	* when no song matches.
-	*/
-	static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_TITLE = (map, title) -> map.entrySet()
-			.stream().filter(entry -> title.equals(entry.getValue().getTitle()))
-			.findAny()
-			.map(Map.Entry::getKey)
-			.orElseThrow(() -> new RuntimeException("Cannot find id of song with title: " + title));
-
-	/**
-	* Function that returns id assigned to song with artist equal to given artist or throws {@link RuntimeException}
-	* when no song matches.
-	*/
-	static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_ARTIST = (map, artist) -> map.entrySet()
-			.stream().filter(entry -> artist.equals(entry.getValue().getArtist()))
-			.findAny()
-			.map(Map.Entry::getKey)
-			.orElseThrow(() -> new RuntimeException("Cannot find id of song with artist: " + artist));
-
-	static final TreeMap<String, Song> FIRST_INDEX_SONGS_BY_ID = new TreeMap<>() {{
-		put(FIRST_INDEX_ID_SONG_1, SONGS[0]);
-		put(FIRST_INDEX_ID_SONG_2, SONGS[1]);
-		put(FIRST_INDEX_ID_SONG_3, SONGS[2]);
-		put(FIRST_INDEX_ID_SONG_4, SONGS[3]);
-	}};
-
-	static final TreeMap<String, Song> SECOND_INDEX_SONGS_BY_ID = new TreeMap<>() {{
-		put(SECOND_INDEX_ID_SONG_1, SONGS[3]);
-		put(SECOND_INDEX_ID_SONG_2, SONGS[2]);
-		put(SECOND_INDEX_ID_SONG_3, SONGS[1]);
-		put(SECOND_INDEX_ID_SONG_4, SONGS[0]);
-	}};
-
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()){
-			FIRST_INDEX_SONGS_BY_ID.forEach((id, song) -> {
-				client.prepareIndex(FIRST_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
-			});
-
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.indices(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS)
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE)
-					.filter(QueryBuilders.queryStringQuery(QUERY_TITLE_NEXT_SONG))
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST)
-					.filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_TWINS)))
-			)).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.index(FIRST_INDEX_NAME)
-					.alias(FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST)
-					.filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_FIRST)))
-			)).actionGet();
-
-			SECOND_INDEX_SONGS_BY_ID.forEach((id, song) -> {
-				client.prepareIndex(SECOND_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
-			});
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-					.indices(SECOND_INDEX_NAME)
-					.alias(SECOND_INDEX_ALIAS)
-			)).actionGet();
-		}
-	}
-
-	@Test
-	public void flsEnabledFieldsAreHiddenForNormalUsers() throws IOException {
-		String indexName = "fls_index";
-		String indexAlias = "fls_index_alias";
-		String indexFilteredAlias = "fls_index_filtered_alias";
-		TestSecurityConfig.Role userRole = new TestSecurityConfig.Role("fls_exclude_stars_reader")
-				.clusterPermissions("cluster_composite_ops_ro")
-				.indexPermissions("read")
-				.fls("~".concat(FIELD_STARS))
-				.on("*");
-		TestSecurityConfig.User user = createUserWithRole("fls_user", userRole);
-		List<String> docIds = createIndexWithDocs(indexName, SONGS[0], SONGS[1]);
-		addAliasToIndex(indexName, indexAlias);
-		addAliasToIndex(indexName, indexFilteredAlias, QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, SONGS[0].getArtist())));
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(user)) {
-			//search
-			SearchResponse searchResponse = restHighLevelClient.search(new SearchRequest(indexName), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			//search with index pattern
-			searchResponse = restHighLevelClient.search(new SearchRequest("*".concat(indexName)), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			//search via alias
-			searchResponse = restHighLevelClient.search(new SearchRequest(indexAlias), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			//search via filtered alias
-			searchResponse = restHighLevelClient.search(new SearchRequest(indexFilteredAlias), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			//search via all indices alias
-			searchResponse = restHighLevelClient.search(new SearchRequest(ALL_INDICES_ALIAS), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			//scroll
-			searchResponse = restHighLevelClient.search(searchRequestWithScroll(indexName, 1), DEFAULT);
-
-			assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
-
-			SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
-			SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
-
-			assertSearchHitsDoNotContainField(scrollResponse, FIELD_STARS);
-
-			//aggregate data and compute avg
-			String aggregationName = "averageStars";
-			searchResponse = restHighLevelClient.search(averageAggregationRequest(indexName, aggregationName, FIELD_STARS), DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-			Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-			assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-			assertThat(((ParsedAvg) actualAggregation).getValue(), is(Double.POSITIVE_INFINITY)); //user cannot see the STARS field
-
-			//get document
-			GetResponse getResponse = restHighLevelClient.get(new GetRequest(indexName, docIds.get(0)), DEFAULT);
-
-			assertThat(getResponse, documentDoesNotContainField(FIELD_STARS));
-
-			//multi get
-			for (String index: List.of(indexName, indexAlias)) {
-				MultiGetRequest multiGetRequest = new MultiGetRequest();
-				docIds.forEach(id -> multiGetRequest.add(new MultiGetRequest.Item(index, id)));
-
-				MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-
-				List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-						.map(MultiGetItemResponse::getResponse)
-						.collect(Collectors.toList());
-				assertThat(getResponses, everyItem(documentDoesNotContainField(FIELD_STARS)));
-			}
-
-			//multi search
-			for (String index: List.of(indexName, indexAlias)) {
-				MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
-				docIds.forEach(id -> multiSearchRequest.add(queryByIdsRequest(index, id)));
-				MultiSearchResponse multiSearchResponse = restHighLevelClient.msearch(multiSearchRequest, DEFAULT);
-
-				assertThat(multiSearchResponse, isSuccessfulMultiSearchResponse());
-				List<MultiSearchResponse.Item> itemResponses = List.of(multiSearchResponse.getResponses());
-				itemResponses.forEach(item -> assertSearchHitsDoNotContainField(item.getResponse(), FIELD_STARS));
-			}
-
-			//field capabilities
-			FieldCapabilitiesResponse fieldCapsResponse = restHighLevelClient.fieldCaps(
-					new FieldCapabilitiesRequest().indices(indexName).fields(FIELD_TITLE, FIELD_STARS), DEFAULT
-			);
-			assertThat(fieldCapsResponse.getField(FIELD_STARS), nullValue());
-		}
-	}
-
-	private static List<String> createIndexWithDocs(String indexName, Song... songs) {
-		try(Client client = cluster.getInternalNodeClient()){
-			return Stream.of(songs).map(song -> {
-				IndexResponse response = client.index(
-						new IndexRequest(indexName).setRefreshPolicy(IMMEDIATE).source(song.asMap())
-				).actionGet();
-				return response.getId();
-			}).collect(Collectors.toList());
-		}
-	}
-
-	private static void addAliasToIndex(String indexName, String alias) {
-		addAliasToIndex(indexName, alias, QueryBuilders.matchAllQuery());
-	}
-
-	private static void addAliasToIndex(String indexName, String alias, QueryBuilder filterQuery) {
-		try(Client client = cluster.getInternalNodeClient()){
-			client.admin().indices()
-					.aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD)
-							.indices(indexName)
-							.alias(alias)
-							.filter(filterQuery)
-			)).actionGet();
-		}
-	}
-
-	private static TestSecurityConfig.User createUserWithRole(String userName, TestSecurityConfig.Role role) {
-		TestSecurityConfig.User user = new TestSecurityConfig.User(userName);
-		try(TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
-			client.createRole(role.getName(), role).assertStatusCode(201);
-			client.createUser(user.getName(), user).assertStatusCode(201);
-			client.assignRoleToUser(user.getName(), role.getName()).assertStatusCode(200);
-		}
-		return user;
-	}
-
-	private static void assertSearchHitsDoNotContainField(SearchResponse response, String excludedField) {
-		assertThat(response, isSuccessfulSearchResponse());
-		assertThat(response.getHits().getHits().length, greaterThan(0));
-		IntStream.range(0, response.getHits().getHits().length).boxed()
-				.forEach(index -> assertThat(response, searchHitDoesNotContainField(index, excludedField)));
-	}
-
-	@Test
-	public void searchForDocuments() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIRST_INDEX_ID_SONG_1;
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest =  queryByIdsRequest(FIRST_INDEX_NAME, songId);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-
-			songId = SECOND_INDEX_ID_SONG_2;
-			song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-
-			searchRequest =  queryByIdsRequest(SECOND_INDEX_NAME, songId);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void searchForDocumentsWithIndexPattern() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIRST_INDEX_ID_SONG_2;
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest =  queryByIdsRequest("*".concat(FIRST_INDEX_NAME), songId);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-
-
-			songId = SECOND_INDEX_ID_SONG_3;
-			song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-
-			searchRequest =  queryByIdsRequest("*".concat(SECOND_INDEX_NAME), songId);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void searchForDocumentsViaAlias() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIRST_INDEX_ID_SONG_3;
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest =  queryByIdsRequest(FIRST_INDEX_ALIAS, songId);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-
-			songId = SECOND_INDEX_ID_SONG_4;
-			song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-
-			searchRequest =  queryByIdsRequest("*".concat(SECOND_INDEX_ALIAS), songId);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void searchForDocumentsViaFilteredAlias() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIND_ID_OF_SONG_WITH_TITLE.apply(FIRST_INDEX_SONGS_BY_ID, TITLE_NEXT_SONG);
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void searchForDocumentsViaAllIndicesAlias() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ALL_INDICES_MASKED_TITLE_ARTIST_READER)) {
-			String songId = FIRST_INDEX_ID_SONG_4;
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, VALUE_TO_MASKED_VALUE.apply(song.getTitle())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, song.getLyrics()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-
-
-			songId = SECOND_INDEX_ID_SONG_1;
-			song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-
-			searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
-			searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, VALUE_TO_MASKED_VALUE.apply(song.getTitle())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, song.getLyrics()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void scrollOverSearchResults() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIRST_INDEX_SONGS_BY_ID.firstKey();
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-
-			SearchRequest searchRequest = searchRequestWithScroll(FIRST_INDEX_NAME, 1);
-			searchRequest.source().sort("_id", SortOrder.ASC);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containNotEmptyScrollingId());
-
-			SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
-
-			SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
-			assertThat(scrollResponse, isSuccessfulSearchResponse());
-			assertThat(scrollResponse, containNotEmptyScrollingId());
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void aggregateDataAndComputeAverage() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String aggregationName = "averageStars";
-			Double expectedValue = FIRST_INDEX_SONGS_BY_ID.values()
-					.stream()
-					.mapToDouble(Song::getStars)
-					.average().orElseThrow(() -> new RuntimeException("Cannot compute average stars - list of docs is empty"));
-			SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-			Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-			assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-			assertThat(((ParsedAvg) actualAggregation).getValue(), is(expectedValue));
-		}
-	}
-
-	@Test
-	public void getDocument() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			String songId = FIRST_INDEX_ID_SONG_4;
-			Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-			GetResponse response = restHighLevelClient.get(new GetRequest(FIRST_INDEX_NAME, songId), DEFAULT);
-
-			assertThat(response, containDocument(FIRST_INDEX_NAME, songId));
-			assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
-			assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(response, documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-			assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
-
-			songId = SECOND_INDEX_ID_SONG_1;
-			song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-			response = restHighLevelClient.get(new GetRequest(SECOND_INDEX_NAME, songId), DEFAULT);
-
-			assertThat(response, containDocument(SECOND_INDEX_NAME, songId));
-			assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
-			assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-			assertThat(response, documentContainField(FIELD_ARTIST, song.getArtist()));
-			assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
-		}
-	}
-
-	@Test
-	public void multiGetDocuments() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			List<List<String>> indicesToCheck = List.of(
-					List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
-					List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
-			);
-			String firstSongId = FIRST_INDEX_ID_SONG_1;
-			Song firstSong = FIRST_INDEX_SONGS_BY_ID.get(firstSongId);
-			String secondSongId = SECOND_INDEX_ID_SONG_2;
-			Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
-
-			for (List<String> indices : indicesToCheck) {
-				MultiGetRequest request = new MultiGetRequest();
-				request.add(new MultiGetRequest.Item(indices.get(0), firstSongId));
-				request.add(new MultiGetRequest.Item(indices.get(1), secondSongId));
-				MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
-
-				assertThat(response, isSuccessfulMultiGetResponse());
-				assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
-
-				MultiGetItemResponse[] responses = response.getResponses();
-				assertThat(responses[0].getResponse(), allOf(
-						containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1),
-						documentContainField(FIELD_TITLE, firstSong.getTitle()),
-						documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
-						documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
-						documentContainField(FIELD_STARS, firstSong.getStars())
-				));
-				assertThat(responses[1].getResponse(), allOf(
-						containDocument(SECOND_INDEX_NAME, secondSongId),
-						documentContainField(FIELD_TITLE, secondSong.getTitle()),
-						documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
-						documentContainField(FIELD_ARTIST, secondSong.getArtist()),
-						documentContainField(FIELD_STARS, secondSong.getStars())
-				));
-			}
-		}
-	}
-
-	@Test
-	public void multiSearchDocuments() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			List<List<String>> indicesToCheck = List.of(
-					List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
-					List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
-			);
-			String firstSongId = FIRST_INDEX_ID_SONG_3;
-			Song firstSong = FIRST_INDEX_SONGS_BY_ID.get(firstSongId);
-			String secondSongId = SECOND_INDEX_ID_SONG_4;
-			Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
-
-			for (List<String> indices : indicesToCheck) {
-				MultiSearchRequest request = new MultiSearchRequest();
-				request.add(queryByIdsRequest(indices.get(0), firstSongId));
-				request.add(queryByIdsRequest(indices.get(1), secondSongId));
-				MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
-
-				assertThat(response, isSuccessfulMultiSearchResponse());
-				assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
-
-				MultiSearchResponse.Item[] responses = response.getResponses();
-
-				assertThat(responses[0].getResponse(), allOf(
-						searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, firstSongId),
-						searchHitContainsFieldWithValue(0, FIELD_TITLE, firstSong.getTitle()),
-						searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
-						searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
-						searchHitContainsFieldWithValue(0, FIELD_STARS, firstSong.getStars())
-				));
-				assertThat(responses[1].getResponse(), allOf(
-						searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, secondSongId),
-						searchHitContainsFieldWithValue(0, FIELD_TITLE, secondSong.getTitle()),
-						searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
-						searchHitContainsFieldWithValue(0, FIELD_ARTIST, secondSong.getArtist()),
-						searchHitContainsFieldWithValue(0, FIELD_STARS, secondSong.getStars())
-				));
-			}
-		}
-	}
-
-	@Test
-	public void getFieldCapabilities() throws IOException {
-		//FIELD MASKING
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(FIRST_INDEX_NAME).fields(FIELD_ARTIST, FIELD_TITLE, FIELD_LYRICS);
-			FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
-
-			assertThat(response, containsExactlyIndices(FIRST_INDEX_NAME));
-			assertThat(response, numberOfFieldsIsEqualTo(3));
-			assertThat(response, containsFieldWithNameAndType(FIELD_ARTIST, "text"));
-			assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
-			assertThat(response, containsFieldWithNameAndType(FIELD_LYRICS, "text"));
-		}
-	}
+    static final String FIRST_INDEX_ID_SONG_1 = "INDEX_1_S1";
+    static final String FIRST_INDEX_ID_SONG_2 = "INDEX_1_S2";
+    static final String FIRST_INDEX_ID_SONG_3 = "INDEX_1_S3";
+    static final String FIRST_INDEX_ID_SONG_4 = "INDEX_1_S4";
+    static final String SECOND_INDEX_ID_SONG_1 = "INDEX_2_S1";
+    static final String SECOND_INDEX_ID_SONG_2 = "INDEX_2_S2";
+    static final String SECOND_INDEX_ID_SONG_3 = "INDEX_2_S3";
+    static final String SECOND_INDEX_ID_SONG_4 = "INDEX_2_S4";
+
+    static final String INDEX_NAME_SUFFIX = "-test-index";
+    static final String FIRST_INDEX_NAME = "first".concat(INDEX_NAME_SUFFIX);
+    static final String SECOND_INDEX_NAME = "second".concat(INDEX_NAME_SUFFIX);
+    static final String FIRST_INDEX_ALIAS = FIRST_INDEX_NAME.concat("-alias");
+    static final String SECOND_INDEX_ALIAS = SECOND_INDEX_NAME.concat("-alias");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE = FIRST_INDEX_NAME.concat("-filtered-by-next-song-title");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-twins-artist");
+    static final String FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-first-artist");
+    static final String ALL_INDICES_ALIAS = "_all";
+
+    static final String MASK_VALUE = "*";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    /**
+    * User who is allowed to see all fields on all indices. Values of the title and artist fields should be masked.
+    */
+    static final TestSecurityConfig.User ALL_INDICES_MASKED_TITLE_ARTIST_READER = new TestSecurityConfig.User("masked_artist_title_reader")
+        .roles(
+            new TestSecurityConfig.Role("masked_artist_title_reader").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .maskedFields(
+                    FIELD_TITLE.concat("::/(?<=.{1})./::").concat(MASK_VALUE),
+                    FIELD_ARTIST.concat("::/(?<=.{1})./::").concat(MASK_VALUE)
+                )
+                .on("*")
+        );
+
+    /**
+    * User who is allowed to see all fields on indices {@link #FIRST_INDEX_NAME} and {@link #SECOND_INDEX_NAME}.
+    * <ul>
+    *     <li>values of the artist and lyrics fields should be masked on index {@link #FIRST_INDEX_NAME}</li>
+    *     <li>values of the lyrics field should be masked on index {@link #SECOND_INDEX_NAME}</li>
+    * </ul>
+    */
+    static final TestSecurityConfig.User MASKED_ARTIST_LYRICS_READER = new TestSecurityConfig.User("masked_title_artist_lyrics_reader")
+        .roles(
+            new TestSecurityConfig.Role("masked_title_artist_lyrics_reader").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .maskedFields(
+                    FIELD_ARTIST.concat("::/(?<=.{1})./::").concat(MASK_VALUE),
+                    FIELD_LYRICS.concat("::/(?<=.{1})./::").concat(MASK_VALUE)
+                )
+                .on(FIRST_INDEX_NAME),
+            new TestSecurityConfig.Role("masked_lyrics_reader").clusterPermissions("cluster_composite_ops_ro")
+                .indexPermissions("read")
+                .maskedFields(FIELD_LYRICS.concat("::/(?<=.{1})./::").concat(MASK_VALUE))
+                .on(SECOND_INDEX_NAME)
+        );
+
+    /**
+    * Function that converts field value to value masked with {@link #MASK_VALUE}
+    */
+    static final Function<String, String> VALUE_TO_MASKED_VALUE = value -> value.substring(0, 1)
+        .concat(MASK_VALUE.repeat(value.length() - 1));
+
+    /**
+    * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_STRING}.
+    */
+    static final TestSecurityConfig.User ALL_INDICES_STRING_ARTIST_READER = new TestSecurityConfig.User("string_artist_reader").roles(
+        new TestSecurityConfig.Role("string_artist_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_STRING))
+            .on("*")
+    );
+
+    /**
+    * User who is allowed to see documents on index:
+    * <ul>
+    *     <li>{@link #FIRST_INDEX_NAME} where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_TWINS}</li>
+    *     <li>{@link #SECOND_INDEX_NAME} where value of the {@link Song#FIELD_ARTIST} field matches {@link Song#ARTIST_FIRST}</li>
+    * </ul>
+    */
+    static final TestSecurityConfig.User TWINS_FIRST_ARTIST_READER = new TestSecurityConfig.User("twins_first_artist_reader").roles(
+        new TestSecurityConfig.Role("twins_artist_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_TWINS))
+            .on(FIRST_INDEX_NAME),
+        new TestSecurityConfig.Role("first_artist_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_FIRST))
+            .on(SECOND_INDEX_NAME)
+    );
+
+    /**
+    * User who is allowed to see documents on all indices where value of the {@link Song#FIELD_STARS} is less than zero.
+    */
+    static final TestSecurityConfig.User ALL_INDICES_STARS_LESS_THAN_ZERO_READER = new TestSecurityConfig.User(
+        "stars_less_than_zero_reader"
+    ).roles(
+        new TestSecurityConfig.Role("stars_less_than_zero_reader").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"range\":{\"%s\":{\"lt\":%d}}}", FIELD_STARS, 0))
+            .on("*")
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .nodeSettings(
+            Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()))
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(
+            ADMIN_USER,
+            ALL_INDICES_MASKED_TITLE_ARTIST_READER,
+            MASKED_ARTIST_LYRICS_READER,
+            ALL_INDICES_STRING_ARTIST_READER,
+            ALL_INDICES_STARS_LESS_THAN_ZERO_READER,
+            TWINS_FIRST_ARTIST_READER
+        )
+        .build();
+
+    /**
+    * Function that returns id assigned to song with title equal to given title or throws {@link RuntimeException}
+    * when no song matches.
+    */
+    static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_TITLE = (map, title) -> map.entrySet()
+        .stream()
+        .filter(entry -> title.equals(entry.getValue().getTitle()))
+        .findAny()
+        .map(Map.Entry::getKey)
+        .orElseThrow(() -> new RuntimeException("Cannot find id of song with title: " + title));
+
+    /**
+    * Function that returns id assigned to song with artist equal to given artist or throws {@link RuntimeException}
+    * when no song matches.
+    */
+    static final BiFunction<Map<String, Song>, String, String> FIND_ID_OF_SONG_WITH_ARTIST = (map, artist) -> map.entrySet()
+        .stream()
+        .filter(entry -> artist.equals(entry.getValue().getArtist()))
+        .findAny()
+        .map(Map.Entry::getKey)
+        .orElseThrow(() -> new RuntimeException("Cannot find id of song with artist: " + artist));
+
+    static final TreeMap<String, Song> FIRST_INDEX_SONGS_BY_ID = new TreeMap<>() {
+        {
+            put(FIRST_INDEX_ID_SONG_1, SONGS[0]);
+            put(FIRST_INDEX_ID_SONG_2, SONGS[1]);
+            put(FIRST_INDEX_ID_SONG_3, SONGS[2]);
+            put(FIRST_INDEX_ID_SONG_4, SONGS[3]);
+        }
+    };
+
+    static final TreeMap<String, Song> SECOND_INDEX_SONGS_BY_ID = new TreeMap<>() {
+        {
+            put(SECOND_INDEX_ID_SONG_1, SONGS[3]);
+            put(SECOND_INDEX_ID_SONG_2, SONGS[2]);
+            put(SECOND_INDEX_ID_SONG_3, SONGS[1]);
+            put(SECOND_INDEX_ID_SONG_4, SONGS[0]);
+        }
+    };
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            FIRST_INDEX_SONGS_BY_ID.forEach((id, song) -> {
+                client.prepareIndex(FIRST_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
+            });
+
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(FIRST_INDEX_NAME).alias(FIRST_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE)
+                            .filter(QueryBuilders.queryStringQuery(QUERY_TITLE_NEXT_SONG))
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST)
+                            .filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_TWINS)))
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(FIRST_INDEX_NAME)
+                            .alias(FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST)
+                            .filter(QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, ARTIST_FIRST)))
+                    )
+                )
+                .actionGet();
+
+            SECOND_INDEX_SONGS_BY_ID.forEach((id, song) -> {
+                client.prepareIndex(SECOND_INDEX_NAME).setId(id).setRefreshPolicy(IMMEDIATE).setSource(song.asMap()).get();
+            });
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(SECOND_INDEX_NAME).alias(SECOND_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+        }
+    }
+
+    @Test
+    public void flsEnabledFieldsAreHiddenForNormalUsers() throws IOException {
+        String indexName = "fls_index";
+        String indexAlias = "fls_index_alias";
+        String indexFilteredAlias = "fls_index_filtered_alias";
+        TestSecurityConfig.Role userRole = new TestSecurityConfig.Role("fls_exclude_stars_reader").clusterPermissions(
+            "cluster_composite_ops_ro"
+        ).indexPermissions("read").fls("~".concat(FIELD_STARS)).on("*");
+        TestSecurityConfig.User user = createUserWithRole("fls_user", userRole);
+        List<String> docIds = createIndexWithDocs(indexName, SONGS[0], SONGS[1]);
+        addAliasToIndex(indexName, indexAlias);
+        addAliasToIndex(
+            indexName,
+            indexFilteredAlias,
+            QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, SONGS[0].getArtist()))
+        );
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(user)) {
+            // search
+            SearchResponse searchResponse = restHighLevelClient.search(new SearchRequest(indexName), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            // search with index pattern
+            searchResponse = restHighLevelClient.search(new SearchRequest("*".concat(indexName)), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            // search via alias
+            searchResponse = restHighLevelClient.search(new SearchRequest(indexAlias), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            // search via filtered alias
+            searchResponse = restHighLevelClient.search(new SearchRequest(indexFilteredAlias), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            // search via all indices alias
+            searchResponse = restHighLevelClient.search(new SearchRequest(ALL_INDICES_ALIAS), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            // scroll
+            searchResponse = restHighLevelClient.search(searchRequestWithScroll(indexName, 1), DEFAULT);
+
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
+
+            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+
+            assertSearchHitsDoNotContainField(scrollResponse, FIELD_STARS);
+
+            // aggregate data and compute avg
+            String aggregationName = "averageStars";
+            searchResponse = restHighLevelClient.search(averageAggregationRequest(indexName, aggregationName, FIELD_STARS), DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
+            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
+            assertThat(((ParsedAvg) actualAggregation).getValue(), is(Double.POSITIVE_INFINITY)); // user cannot see the STARS field
+
+            // get document
+            GetResponse getResponse = restHighLevelClient.get(new GetRequest(indexName, docIds.get(0)), DEFAULT);
+
+            assertThat(getResponse, documentDoesNotContainField(FIELD_STARS));
+
+            // multi get
+            for (String index : List.of(indexName, indexAlias)) {
+                MultiGetRequest multiGetRequest = new MultiGetRequest();
+                docIds.forEach(id -> multiGetRequest.add(new MultiGetRequest.Item(index, id)));
+
+                MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
+
+                List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
+                    .map(MultiGetItemResponse::getResponse)
+                    .collect(Collectors.toList());
+                assertThat(getResponses, everyItem(documentDoesNotContainField(FIELD_STARS)));
+            }
+
+            // multi search
+            for (String index : List.of(indexName, indexAlias)) {
+                MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
+                docIds.forEach(id -> multiSearchRequest.add(queryByIdsRequest(index, id)));
+                MultiSearchResponse multiSearchResponse = restHighLevelClient.msearch(multiSearchRequest, DEFAULT);
+
+                assertThat(multiSearchResponse, isSuccessfulMultiSearchResponse());
+                List<MultiSearchResponse.Item> itemResponses = List.of(multiSearchResponse.getResponses());
+                itemResponses.forEach(item -> assertSearchHitsDoNotContainField(item.getResponse(), FIELD_STARS));
+            }
+
+            // field capabilities
+            FieldCapabilitiesResponse fieldCapsResponse = restHighLevelClient.fieldCaps(
+                new FieldCapabilitiesRequest().indices(indexName).fields(FIELD_TITLE, FIELD_STARS),
+                DEFAULT
+            );
+            assertThat(fieldCapsResponse.getField(FIELD_STARS), nullValue());
+        }
+    }
+
+    private static List<String> createIndexWithDocs(String indexName, Song... songs) {
+        try (Client client = cluster.getInternalNodeClient()) {
+            return Stream.of(songs).map(song -> {
+                IndexResponse response = client.index(new IndexRequest(indexName).setRefreshPolicy(IMMEDIATE).source(song.asMap()))
+                    .actionGet();
+                return response.getId();
+            }).collect(Collectors.toList());
+        }
+    }
+
+    private static void addAliasToIndex(String indexName, String alias) {
+        addAliasToIndex(indexName, alias, QueryBuilders.matchAllQuery());
+    }
+
+    private static void addAliasToIndex(String indexName, String alias, QueryBuilder filterQuery) {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(indexName).alias(alias).filter(filterQuery)
+                    )
+                )
+                .actionGet();
+        }
+    }
+
+    private static TestSecurityConfig.User createUserWithRole(String userName, TestSecurityConfig.Role role) {
+        TestSecurityConfig.User user = new TestSecurityConfig.User(userName);
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            client.createRole(role.getName(), role).assertStatusCode(201);
+            client.createUser(user.getName(), user).assertStatusCode(201);
+            client.assignRoleToUser(user.getName(), role.getName()).assertStatusCode(200);
+        }
+        return user;
+    }
+
+    private static void assertSearchHitsDoNotContainField(SearchResponse response, String excludedField) {
+        assertThat(response, isSuccessfulSearchResponse());
+        assertThat(response.getHits().getHits().length, greaterThan(0));
+        IntStream.range(0, response.getHits().getHits().length)
+            .boxed()
+            .forEach(index -> assertThat(response, searchHitDoesNotContainField(index, excludedField)));
+    }
+
+    @Test
+    public void searchForDocuments() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIRST_INDEX_ID_SONG_1;
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = queryByIdsRequest(FIRST_INDEX_NAME, songId);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+
+            songId = SECOND_INDEX_ID_SONG_2;
+            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+
+            searchRequest = queryByIdsRequest(SECOND_INDEX_NAME, songId);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void searchForDocumentsWithIndexPattern() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIRST_INDEX_ID_SONG_2;
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = queryByIdsRequest("*".concat(FIRST_INDEX_NAME), songId);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+
+            songId = SECOND_INDEX_ID_SONG_3;
+            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+
+            searchRequest = queryByIdsRequest("*".concat(SECOND_INDEX_NAME), songId);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void searchForDocumentsViaAlias() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIRST_INDEX_ID_SONG_3;
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = queryByIdsRequest(FIRST_INDEX_ALIAS, songId);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+
+            songId = SECOND_INDEX_ID_SONG_4;
+            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+
+            searchRequest = queryByIdsRequest("*".concat(SECOND_INDEX_ALIAS), songId);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, song.getArtist()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void searchForDocumentsViaFilteredAlias() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIND_ID_OF_SONG_WITH_TITLE.apply(FIRST_INDEX_SONGS_BY_ID, TITLE_NEXT_SONG);
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void searchForDocumentsViaAllIndicesAlias() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ALL_INDICES_MASKED_TITLE_ARTIST_READER)) {
+            String songId = FIRST_INDEX_ID_SONG_4;
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, VALUE_TO_MASKED_VALUE.apply(song.getTitle())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, song.getLyrics()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+
+            songId = SECOND_INDEX_ID_SONG_1;
+            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+
+            searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
+            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, VALUE_TO_MASKED_VALUE.apply(song.getTitle())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, song.getLyrics()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void scrollOverSearchResults() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIRST_INDEX_SONGS_BY_ID.firstKey();
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+
+            SearchRequest searchRequest = searchRequestWithScroll(FIRST_INDEX_NAME, 1);
+            searchRequest.source().sort("_id", SortOrder.ASC);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containNotEmptyScrollingId());
+
+            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+
+            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            assertThat(scrollResponse, isSuccessfulSearchResponse());
+            assertThat(scrollResponse, containNotEmptyScrollingId());
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, song.getTitle()));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void aggregateDataAndComputeAverage() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String aggregationName = "averageStars";
+            Double expectedValue = FIRST_INDEX_SONGS_BY_ID.values()
+                .stream()
+                .mapToDouble(Song::getStars)
+                .average()
+                .orElseThrow(() -> new RuntimeException("Cannot compute average stars - list of docs is empty"));
+            SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
+            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
+            assertThat(((ParsedAvg) actualAggregation).getValue(), is(expectedValue));
+        }
+    }
+
+    @Test
+    public void getDocument() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            String songId = FIRST_INDEX_ID_SONG_4;
+            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+            GetResponse response = restHighLevelClient.get(new GetRequest(FIRST_INDEX_NAME, songId), DEFAULT);
+
+            assertThat(response, containDocument(FIRST_INDEX_NAME, songId));
+            assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
+            assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(response, documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+            assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+
+            songId = SECOND_INDEX_ID_SONG_1;
+            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+            response = restHighLevelClient.get(new GetRequest(SECOND_INDEX_NAME, songId), DEFAULT);
+
+            assertThat(response, containDocument(SECOND_INDEX_NAME, songId));
+            assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
+            assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+            assertThat(response, documentContainField(FIELD_ARTIST, song.getArtist()));
+            assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+        }
+    }
+
+    @Test
+    public void multiGetDocuments() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            List<List<String>> indicesToCheck = List.of(
+                List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
+                List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
+            );
+            String firstSongId = FIRST_INDEX_ID_SONG_1;
+            Song firstSong = FIRST_INDEX_SONGS_BY_ID.get(firstSongId);
+            String secondSongId = SECOND_INDEX_ID_SONG_2;
+            Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
+
+            for (List<String> indices : indicesToCheck) {
+                MultiGetRequest request = new MultiGetRequest();
+                request.add(new MultiGetRequest.Item(indices.get(0), firstSongId));
+                request.add(new MultiGetRequest.Item(indices.get(1), secondSongId));
+                MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+
+                assertThat(response, isSuccessfulMultiGetResponse());
+                assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
+
+                MultiGetItemResponse[] responses = response.getResponses();
+                assertThat(
+                    responses[0].getResponse(),
+                    allOf(
+                        containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1),
+                        documentContainField(FIELD_TITLE, firstSong.getTitle()),
+                        documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
+                        documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
+                        documentContainField(FIELD_STARS, firstSong.getStars())
+                    )
+                );
+                assertThat(
+                    responses[1].getResponse(),
+                    allOf(
+                        containDocument(SECOND_INDEX_NAME, secondSongId),
+                        documentContainField(FIELD_TITLE, secondSong.getTitle()),
+                        documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
+                        documentContainField(FIELD_ARTIST, secondSong.getArtist()),
+                        documentContainField(FIELD_STARS, secondSong.getStars())
+                    )
+                );
+            }
+        }
+    }
+
+    @Test
+    public void multiSearchDocuments() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            List<List<String>> indicesToCheck = List.of(
+                List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
+                List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
+            );
+            String firstSongId = FIRST_INDEX_ID_SONG_3;
+            Song firstSong = FIRST_INDEX_SONGS_BY_ID.get(firstSongId);
+            String secondSongId = SECOND_INDEX_ID_SONG_4;
+            Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
+
+            for (List<String> indices : indicesToCheck) {
+                MultiSearchRequest request = new MultiSearchRequest();
+                request.add(queryByIdsRequest(indices.get(0), firstSongId));
+                request.add(queryByIdsRequest(indices.get(1), secondSongId));
+                MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+
+                assertThat(response, isSuccessfulMultiSearchResponse());
+                assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
+
+                MultiSearchResponse.Item[] responses = response.getResponses();
+
+                assertThat(
+                    responses[0].getResponse(),
+                    allOf(
+                        searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, firstSongId),
+                        searchHitContainsFieldWithValue(0, FIELD_TITLE, firstSong.getTitle()),
+                        searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
+                        searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
+                        searchHitContainsFieldWithValue(0, FIELD_STARS, firstSong.getStars())
+                    )
+                );
+                assertThat(
+                    responses[1].getResponse(),
+                    allOf(
+                        searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, secondSongId),
+                        searchHitContainsFieldWithValue(0, FIELD_TITLE, secondSong.getTitle()),
+                        searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
+                        searchHitContainsFieldWithValue(0, FIELD_ARTIST, secondSong.getArtist()),
+                        searchHitContainsFieldWithValue(0, FIELD_STARS, secondSong.getStars())
+                    )
+                );
+            }
+        }
+    }
+
+    @Test
+    public void getFieldCapabilities() throws IOException {
+        // FIELD MASKING
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(FIRST_INDEX_NAME)
+                .fields(FIELD_ARTIST, FIELD_TITLE, FIELD_LYRICS);
+            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+
+            assertThat(response, containsExactlyIndices(FIRST_INDEX_NAME));
+            assertThat(response, numberOfFieldsIsEqualTo(3));
+            assertThat(response, containsFieldWithNameAndType(FIELD_ARTIST, "text"));
+            assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
+            assertThat(response, containsFieldWithNameAndType(FIELD_LYRICS, "text"));
+        }
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/IndexOperationsHelper.java
+++ b/src/integrationTest/java/org/opensearch/security/IndexOperationsHelper.java
@@ -28,39 +28,39 @@ import static org.opensearch.test.framework.matcher.ClusterMatchers.indexStateIs
 
 public class IndexOperationsHelper {
 
-	public static void createIndex(LocalCluster cluster, String indexName) {
-		createIndex(cluster, indexName, Settings.EMPTY);
-	}
+    public static void createIndex(LocalCluster cluster, String indexName) {
+        createIndex(cluster, indexName, Settings.EMPTY);
+    }
 
-	public static void createIndex(LocalCluster cluster, String indexName, Settings settings) {
-		try(Client client = cluster.getInternalNodeClient()) {
-			CreateIndexResponse createIndexResponse = client.admin().indices()
-					.create(new CreateIndexRequest(indexName).settings(settings))
-					.actionGet();
+    public static void createIndex(LocalCluster cluster, String indexName, Settings settings) {
+        try (Client client = cluster.getInternalNodeClient()) {
+            CreateIndexResponse createIndexResponse = client.admin()
+                .indices()
+                .create(new CreateIndexRequest(indexName).settings(settings))
+                .actionGet();
 
-			assertThat(createIndexResponse.isAcknowledged(), is(true));
-			assertThat(createIndexResponse.isShardsAcknowledged(), is(true));
-			assertThat(cluster, indexExists(indexName));
-		}
-	}
+            assertThat(createIndexResponse.isAcknowledged(), is(true));
+            assertThat(createIndexResponse.isShardsAcknowledged(), is(true));
+            assertThat(cluster, indexExists(indexName));
+        }
+    }
 
-	public static void closeIndex(LocalCluster cluster, String indexName) {
-		try(Client client = cluster.getInternalNodeClient()) {
-			CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indexName);
-			CloseIndexResponse response = client.admin().indices().close(closeIndexRequest).actionGet();
+    public static void closeIndex(LocalCluster cluster, String indexName) {
+        try (Client client = cluster.getInternalNodeClient()) {
+            CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indexName);
+            CloseIndexResponse response = client.admin().indices().close(closeIndexRequest).actionGet();
 
-			assertThat(response.isAcknowledged(), is(true));
-			assertThat(response.isShardsAcknowledged(), is(true));
-			assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.CLOSE));
-		}
-	}
+            assertThat(response.isAcknowledged(), is(true));
+            assertThat(response.isShardsAcknowledged(), is(true));
+            assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.CLOSE));
+        }
+    }
 
-	public static void createMapping(LocalCluster cluster, String indexName, Map<String, Object> indexMapping) {
-		try(Client client = cluster.getInternalNodeClient()) {
-			var response = client.admin().indices()
-					.putMapping(new PutMappingRequest(indexName).source(indexMapping)).actionGet();
+    public static void createMapping(LocalCluster cluster, String indexName, Map<String, Object> indexMapping) {
+        try (Client client = cluster.getInternalNodeClient()) {
+            var response = client.admin().indices().putMapping(new PutMappingRequest(indexName).source(indexMapping)).actionGet();
 
-			assertThat(response.isAcknowledged(), is(true));
-		}
-	}
+            assertThat(response.isAcknowledged(), is(true));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/IpBruteForceAttacksPreventionTests.java
+++ b/src/integrationTest/java/org/opensearch/security/IpBruteForceAttacksPreventionTests.java
@@ -36,123 +36,131 @@ import static org.opensearch.test.framework.cluster.TestRestClientConfiguration.
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class IpBruteForceAttacksPreventionTests {
-	private static final User USER_1 = new User("simple-user-1").roles(ALL_ACCESS);
-	private static final User USER_2 = new User("simple-user-2").roles(ALL_ACCESS);
+    private static final User USER_1 = new User("simple-user-1").roles(ALL_ACCESS);
+    private static final User USER_2 = new User("simple-user-2").roles(ALL_ACCESS);
 
-	public static final int ALLOWED_TRIES = 3;
-	public static final int TIME_WINDOW_SECONDS = 3;
+    public static final int ALLOWED_TRIES = 3;
+    public static final int TIME_WINDOW_SECONDS = 3;
 
-	public static final String CLIENT_IP_2 = "127.0.0.2";
-	public static final String CLIENT_IP_3 = "127.0.0.3";
-	public static final String CLIENT_IP_4 = "127.0.0.4";
-	public static final String CLIENT_IP_5 = "127.0.0.5";
-	public static final String CLIENT_IP_6 = "127.0.0.6";
-	public static final String CLIENT_IP_7 = "127.0.0.7";
-	public static final String CLIENT_IP_8 = "127.0.0.8";
-	public static final String CLIENT_IP_9 = "127.0.0.9";
+    public static final String CLIENT_IP_2 = "127.0.0.2";
+    public static final String CLIENT_IP_3 = "127.0.0.3";
+    public static final String CLIENT_IP_4 = "127.0.0.4";
+    public static final String CLIENT_IP_5 = "127.0.0.5";
+    public static final String CLIENT_IP_6 = "127.0.0.6";
+    public static final String CLIENT_IP_7 = "127.0.0.7";
+    public static final String CLIENT_IP_8 = "127.0.0.8";
+    public static final String CLIENT_IP_9 = "127.0.0.9";
 
-	private static final AuthFailureListeners listener = new AuthFailureListeners()
-		.addRateLimit(new RateLimiting("internal_authentication_backend_limiting").type("ip")
-			.allowedTries(ALLOWED_TRIES).timeWindowSeconds(TIME_WINDOW_SECONDS).blockExpirySeconds(2).maxBlockedClients(500)
-			.maxTrackedClients(500));
+    private static final AuthFailureListeners listener = new AuthFailureListeners().addRateLimit(
+        new RateLimiting("internal_authentication_backend_limiting").type("ip")
+            .allowedTries(ALLOWED_TRIES)
+            .timeWindowSeconds(TIME_WINDOW_SECONDS)
+            .blockExpirySeconds(2)
+            .maxBlockedClients(500)
+            .maxTrackedClients(500)
+    );
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false).authFailureListeners(listener)
-		.authc(AUTHC_HTTPBASIC_INTERNAL_WITHOUT_CHALLENGE).users(USER_1, USER_2).build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authFailureListeners(listener)
+        .authc(AUTHC_HTTPBASIC_INTERNAL_WITHOUT_CHALLENGE)
+        .users(USER_1, USER_2)
+        .build();
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("org.opensearch.security.auth.BackendRegistry");
+    @Rule
+    public LogsRule logsRule = new LogsRule("org.opensearch.security.auth.BackendRegistry");
 
-	@Test
-	public void shouldAuthenticateUserWhenBlockadeIsNotActive() {
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_2))) {
+    @Test
+    public void shouldAuthenticateUserWhenBlockadeIsNotActive() {
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_2))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void shouldBlockIpAddress() {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_3, USER_2, ALLOWED_TRIES);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_2, CLIENT_IP_3))) {
+    @Test
+    public void shouldBlockIpAddress() {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_3, USER_2, ALLOWED_TRIES);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_2, CLIENT_IP_3))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_UNAUTHORIZED);
-			logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_3);
-		}
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_3);
+        }
+    }
 
-	@Test
-	public void shouldBlockUsersWhoUseTheSameIpAddress() {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_4, USER_1, ALLOWED_TRIES);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_2, CLIENT_IP_4))) {
+    @Test
+    public void shouldBlockUsersWhoUseTheSameIpAddress() {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_4, USER_1, ALLOWED_TRIES);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_2, CLIENT_IP_4))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_UNAUTHORIZED);
-			logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_4);
-		}
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_4);
+        }
+    }
 
-	@Test
-	public void testUserShouldBeAbleToAuthenticateFromAnotherNotBlockedIpAddress() {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_5, USER_1, ALLOWED_TRIES);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_6))) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void testUserShouldBeAbleToAuthenticateFromAnotherNotBlockedIpAddress() {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_5, USER_1, ALLOWED_TRIES);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_6))) {
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void shouldNotBlockIpWhenFailureAuthenticationCountIsLessThanAllowedTries() {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_7, USER_1, ALLOWED_TRIES - 1);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_7))) {
+    @Test
+    public void shouldNotBlockIpWhenFailureAuthenticationCountIsLessThanAllowedTries() {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_7, USER_1, ALLOWED_TRIES - 1);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_7))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void shouldBlockIpWhenFailureAuthenticationCountIsGreaterThanAllowedTries() {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_8, USER_1, ALLOWED_TRIES * 2);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_8))) {
+    @Test
+    public void shouldBlockIpWhenFailureAuthenticationCountIsGreaterThanAllowedTries() {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_8, USER_1, ALLOWED_TRIES * 2);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_8))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_UNAUTHORIZED);
-			logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_8);
-		}
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_8);
+        }
+    }
 
-	@Test
-	public void shouldReleaseIpAddressLock() throws InterruptedException {
-		authenticateUserWithIncorrectPassword(CLIENT_IP_9, USER_1, ALLOWED_TRIES * 2);
-		TimeUnit.SECONDS.sleep(TIME_WINDOW_SECONDS);
-		try(TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_9))) {
+    @Test
+    public void shouldReleaseIpAddressLock() throws InterruptedException {
+        authenticateUserWithIncorrectPassword(CLIENT_IP_9, USER_1, ALLOWED_TRIES * 2);
+        TimeUnit.SECONDS.sleep(TIME_WINDOW_SECONDS);
+        try (TestRestClient client = cluster.createGenericClientRestClient(userWithSourceIp(USER_1, CLIENT_IP_9))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-			logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_9);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+            logsRule.assertThatContain("Rejecting REST request because of blocked address: /" + CLIENT_IP_9);
+        }
+    }
 
-	private static void authenticateUserWithIncorrectPassword(String sourceIpAddress, User user, int numberOfRequests) {
-		var clientConfiguration = new TestRestClientConfiguration().username(user.getName())
-			.password("incorrect password").sourceInetAddress(sourceIpAddress);
-		try(TestRestClient client = cluster.createGenericClientRestClient(clientConfiguration)) {
-			for(int i = 0; i < numberOfRequests; ++i) {
-				HttpResponse response = client.getAuthInfo();
+    private static void authenticateUserWithIncorrectPassword(String sourceIpAddress, User user, int numberOfRequests) {
+        var clientConfiguration = new TestRestClientConfiguration().username(user.getName())
+            .password("incorrect password")
+            .sourceInetAddress(sourceIpAddress);
+        try (TestRestClient client = cluster.createGenericClientRestClient(clientConfiguration)) {
+            for (int i = 0; i < numberOfRequests; ++i) {
+                HttpResponse response = client.getAuthInfo();
 
-				response.assertStatusCode(SC_UNAUTHORIZED);
-			}
-		}
-	}
+                response.assertStatusCode(SC_UNAUTHORIZED);
+            }
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
@@ -63,333 +63,364 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class PointInTimeOperationTest {
 
-	private static final String FIRST_SONG_INDEX = "song-index-1";
-	private static final String FIRST_INDEX_ALIAS = "song-index-1-alias";
-	private static final String SECOND_SONG_INDEX = "song-index-2";
-	private static final String SECOND_INDEX_ALIAS = "song-index-2-alias";
+    private static final String FIRST_SONG_INDEX = "song-index-1";
+    private static final String FIRST_INDEX_ALIAS = "song-index-1-alias";
+    private static final String SECOND_SONG_INDEX = "song-index-2";
+    private static final String SECOND_INDEX_ALIAS = "song-index-2-alias";
 
-	private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	/**
-	* User who is allowed to perform PIT operations only on the {@link #FIRST_SONG_INDEX}
-	*/
-	private static final TestSecurityConfig.User LIMITED_POINT_IN_TIME_USER = new TestSecurityConfig.User("limited_point_in_time_user")
-			.roles(new TestSecurityConfig.Role("limited_point_in_time_user")
-					.indexPermissions(
-							"indices:data/read/point_in_time/create",
-							"indices:data/read/point_in_time/delete",
-							"indices:data/read/search",
-							"indices:data/read/point_in_time/readall", //anyway user needs the all indexes permission (*) to find all pits
-							"indices:monitor/point_in_time/segments" //anyway user needs the all indexes permission (*) to list all pits segments
-					)
-					.on(FIRST_SONG_INDEX));
-	/**
-	* User who is allowed to perform PIT operations on all indices
-	*/
-	private static final TestSecurityConfig.User POINT_IN_TIME_USER = new TestSecurityConfig.User("point_in_time_user")
-			.roles(new TestSecurityConfig.Role("point_in_time_user")
-					.indexPermissions(
-							"indices:data/read/point_in_time/create",
-							"indices:data/read/point_in_time/delete",
-							"indices:data/read/search",
-							"indices:data/read/point_in_time/readall",
-							"indices:monitor/point_in_time/segments"
-					)
-					.on("*"));
+    /**
+    * User who is allowed to perform PIT operations only on the {@link #FIRST_SONG_INDEX}
+    */
+    private static final TestSecurityConfig.User LIMITED_POINT_IN_TIME_USER = new TestSecurityConfig.User("limited_point_in_time_user")
+        .roles(
+            new TestSecurityConfig.Role("limited_point_in_time_user").indexPermissions(
+                "indices:data/read/point_in_time/create",
+                "indices:data/read/point_in_time/delete",
+                "indices:data/read/search",
+                "indices:data/read/point_in_time/readall", // anyway user needs the all indexes permission (*) to find all pits
+                "indices:monitor/point_in_time/segments" // anyway user needs the all indexes permission (*) to list all pits segments
+            ).on(FIRST_SONG_INDEX)
+        );
+    /**
+    * User who is allowed to perform PIT operations on all indices
+    */
+    private static final TestSecurityConfig.User POINT_IN_TIME_USER = new TestSecurityConfig.User("point_in_time_user").roles(
+        new TestSecurityConfig.Role("point_in_time_user").indexPermissions(
+            "indices:data/read/point_in_time/create",
+            "indices:data/read/point_in_time/delete",
+            "indices:data/read/search",
+            "indices:data/read/point_in_time/readall",
+            "indices:monitor/point_in_time/segments"
+        ).on("*")
+    );
 
-	private static final String ID_1 = "1";
-	private static final String ID_2 = "2";
-	private static final String ID_3 = "3";
-	private static final String ID_4 = "4";
+    private static final String ID_1 = "1";
+    private static final String ID_2 = "2";
+    private static final String ID_3 = "3";
+    private static final String ID_4 = "4";
 
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()) {
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_1).source(SONGS[0].asMap())).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_2).source(SONGS[1].asMap())).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_3).source(SONGS[2].asMap())).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD).indices(
-					FIRST_SONG_INDEX).alias(FIRST_INDEX_ALIAS))).actionGet();
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_1).source(SONGS[0].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_2).source(SONGS[1].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(FIRST_SONG_INDEX).id(ID_3).source(SONGS[2].asMap()))
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(FIRST_SONG_INDEX).alias(FIRST_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
 
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SECOND_SONG_INDEX).id(ID_4).source(SONGS[3].asMap())).actionGet();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new IndicesAliasesRequest.AliasActions(ADD).indices(
-					SECOND_SONG_INDEX).alias(SECOND_INDEX_ALIAS))).actionGet();
-		}
-	}
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SECOND_SONG_INDEX).id(ID_4).source(SONGS[3].asMap()))
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(SECOND_SONG_INDEX).alias(SECOND_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+        }
+    }
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-			.authc(AUTHC_HTTPBASIC_INTERNAL)
-			.users(ADMIN_USER, LIMITED_POINT_IN_TIME_USER, POINT_IN_TIME_USER)
-			.build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, LIMITED_POINT_IN_TIME_USER, POINT_IN_TIME_USER)
+        .build();
 
-	@Test
-	public void createPit_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_SONG_INDEX);
+    @Test
+    public void createPit_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_SONG_INDEX);
 
-			CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
 
-			assertThat(createPitResponse, isSuccessfulCreatePitResponse());
-		}
-	}
+            assertThat(createPitResponse, isSuccessfulCreatePitResponse());
+        }
+    }
 
-	@Test
-	public void createPitWithIndexAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_INDEX_ALIAS);
+    @Test
+    public void createPitWithIndexAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_INDEX_ALIAS);
 
-			CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
 
-			assertThat(createPitResponse, isSuccessfulCreatePitResponse());
-		}
-	}
+            assertThat(createPitResponse, isSuccessfulCreatePitResponse());
+        }
+    }
 
-	@Test
-	public void createPit_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_SONG_INDEX);
+    @Test
+    public void createPit_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_SONG_INDEX);
 
-			assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void createPitWithIndexAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_INDEX_ALIAS);
+    @Test
+    public void createPitWithIndexAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_INDEX_ALIAS);
 
-			assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void listAllPits_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
-			cleanUpPits();
-			String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
-			String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
+    @Test
+    public void listAllPits_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
+            cleanUpPits();
+            String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
+            String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
 
-			GetAllPitNodesResponse getAllPitsResponse = restHighLevelClient.getAllPits(DEFAULT);
+            GetAllPitNodesResponse getAllPitsResponse = restHighLevelClient.getAllPits(DEFAULT);
 
-			assertThat(getAllPitsResponse, getAllResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
-		}
-	}
+            assertThat(getAllPitsResponse, getAllResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
+        }
+    }
 
-	@Test
-	public void listAllPits_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			assertThatThrownBy(() -> restHighLevelClient.getAllPits(DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+    @Test
+    public void listAllPits_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            assertThatThrownBy(() -> restHighLevelClient.getAllPits(DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void deletePit_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
+    @Test
+    public void deletePit_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
 
-			DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
-			assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
-			assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
-		}
-	}
+            DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
+            assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
+            assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
+        }
+    }
 
-	@Test
-	public void deletePitCreatedWithIndexAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
+    @Test
+    public void deletePitCreatedWithIndexAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
 
-			DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
-			assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
-			assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
-		}
-	}
+            DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
+            assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
+            assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
+        }
+    }
 
-	@Test
-	public void deletePit_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
+    @Test
+    public void deletePit_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
 
-			assertThatThrownBy(() -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(
+                () -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
 
-	@Test
-	public void deletePitCreatedWithIndexAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
+    @Test
+    public void deletePitCreatedWithIndexAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
 
-			assertThatThrownBy(() -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(
+                () -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
 
-	@Test
-	public void deleteAllPits_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
-			cleanUpPits();
-			String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
-			String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
+    @Test
+    public void deleteAllPits_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
+            cleanUpPits();
+            String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
+            String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
 
-			DeletePitResponse deletePitResponse = restHighLevelClient.deleteAllPits(DEFAULT);
-			assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
-			assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
-		}
-	}
+            DeletePitResponse deletePitResponse = restHighLevelClient.deleteAllPits(DEFAULT);
+            assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
+            assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
+        }
+    }
 
-	@Test
-	public void deleteAllPits_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			assertThatThrownBy(() -> restHighLevelClient.deleteAllPits(DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+    @Test
+    public void deleteAllPits_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            assertThatThrownBy(() -> restHighLevelClient.deleteAllPits(DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void searchWithPit_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
+    @Test
+    public void searchWithPit_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
 
-			SearchRequest searchRequest = new SearchRequest();
-			searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, searchHitsContainDocumentsInAnyOrder(
-					Pair.of(FIRST_SONG_INDEX, ID_1), Pair.of(FIRST_SONG_INDEX, ID_2), Pair.of(FIRST_SONG_INDEX, ID_3)
-			));
-		}
-	}
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(
+                searchResponse,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(FIRST_SONG_INDEX, ID_1),
+                    Pair.of(FIRST_SONG_INDEX, ID_2),
+                    Pair.of(FIRST_SONG_INDEX, ID_3)
+                )
+            );
+        }
+    }
 
-	@Test
-	public void searchWithPitCreatedWithIndexAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
+    @Test
+    public void searchWithPitCreatedWithIndexAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
 
-			SearchRequest searchRequest = new SearchRequest();
-			searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
 
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, searchHitsContainDocumentsInAnyOrder(
-					Pair.of(FIRST_SONG_INDEX, ID_1), Pair.of(FIRST_SONG_INDEX, ID_2), Pair.of(FIRST_SONG_INDEX, ID_3)
-			));
-		}
-	}
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(
+                searchResponse,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(FIRST_SONG_INDEX, ID_1),
+                    Pair.of(FIRST_SONG_INDEX, ID_2),
+                    Pair.of(FIRST_SONG_INDEX, ID_3)
+                )
+            );
+        }
+    }
 
-	@Test
-	public void searchWithPit_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
+    @Test
+    public void searchWithPit_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
 
-			SearchRequest searchRequest = new SearchRequest();
-			searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void searchWithPitCreatedWithIndexAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
+    @Test
+    public void searchWithPitCreatedWithIndexAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
 
-			SearchRequest searchRequest = new SearchRequest();
-			searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = new SearchRequest();
+            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
 
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void listPitSegments_positive() throws IOException {
-		try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
-			String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
-			HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
+    @Test
+    public void listPitSegments_positive() throws IOException {
+        try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
+            String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
+            HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
 
-			response.assertStatusCode(OK.getStatus());
-		}
-	}
+            response.assertStatusCode(OK.getStatus());
+        }
+    }
 
-	@Test
-	public void listPitSegmentsCreatedWithIndexAlias_positive() throws IOException {
-		try (TestRestClient restClient = cluster.getRestClient(POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
-			String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
-			HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
+    @Test
+    public void listPitSegmentsCreatedWithIndexAlias_positive() throws IOException {
+        try (TestRestClient restClient = cluster.getRestClient(POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
+            String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
+            HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
 
-			response.assertStatusCode(OK.getStatus());
-		}
-	}
+            response.assertStatusCode(OK.getStatus());
+        }
+    }
 
-	@Test
-	public void listPitSegments_negative() throws IOException {
-		try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
-			String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
-			HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
+    @Test
+    public void listPitSegments_negative() throws IOException {
+        try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
+            String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
+            HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
 
-			response.assertStatusCode(FORBIDDEN.getStatus());
-		}
-	}
+            response.assertStatusCode(FORBIDDEN.getStatus());
+        }
+    }
 
-	@Test
-	public void listPitSegmentsCreatedWithIndexAlias_negative() throws IOException {
-		try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
-			String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
-			String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
-			HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
+    @Test
+    public void listPitSegmentsCreatedWithIndexAlias_negative() throws IOException {
+        try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
+            String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
+            String body = String.format("{\"pit_id\":[\"%s\"]}", existingPitId);
+            HttpResponse response = restClient.getWithJsonBody("/_cat/pit_segments", body);
 
-			response.assertStatusCode(FORBIDDEN.getStatus());
-		}
-	}
+            response.assertStatusCode(FORBIDDEN.getStatus());
+        }
+    }
 
-	@Test
-	public void listAllPitSegments_positive() {
-		try (TestRestClient restClient = cluster.getRestClient(POINT_IN_TIME_USER)) {
-			HttpResponse response = restClient.get("/_cat/pit_segments/_all");
+    @Test
+    public void listAllPitSegments_positive() {
+        try (TestRestClient restClient = cluster.getRestClient(POINT_IN_TIME_USER)) {
+            HttpResponse response = restClient.get("/_cat/pit_segments/_all");
 
-			response.assertStatusCode(OK.getStatus());
-		}
-	}
+            response.assertStatusCode(OK.getStatus());
+        }
+    }
 
-	@Test
-	public void listAllPitSegments_negative() {
-		try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
-			HttpResponse response = restClient.get("/_cat/pit_segments/_all");
+    @Test
+    public void listAllPitSegments_negative() {
+        try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
+            HttpResponse response = restClient.get("/_cat/pit_segments/_all");
 
-			response.assertStatusCode(FORBIDDEN.getStatus());
-		}
-	}
+            response.assertStatusCode(FORBIDDEN.getStatus());
+        }
+    }
 
-	/**
-	* Creates PIT for given indices. Returns PIT id.
-	*/
-	private String createPitForIndices(String... indices) throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, indices);
+    /**
+    * Creates PIT for given indices. Returns PIT id.
+    */
+    private String createPitForIndices(String... indices) throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, indices);
 
-			CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
 
-			assertThat(createPitResponse, isSuccessfulCreatePitResponse());
-			return createPitResponse.getId();
-		}
-	}
+            assertThat(createPitResponse, isSuccessfulCreatePitResponse());
+            return createPitResponse.getId();
+        }
+    }
 
-	/**
-	* Deletes all PITs.
-	*/
-	public void cleanUpPits() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			try {
-				restHighLevelClient.deleteAllPits(DEFAULT);
-			} catch (OpenSearchStatusException ex) {
-				if (ex.status() != RestStatus.NOT_FOUND) {
-					throw ex;
-				}
-				//tried to remove pits but no pit exists
-			}
-		}
-	}
+    /**
+    * Deletes all PITs.
+    */
+    public void cleanUpPits() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            try {
+                restHighLevelClient.deleteAllPits(DEFAULT);
+            } catch (OpenSearchStatusException ex) {
+                if (ex.status() != RestStatus.NOT_FOUND) {
+                    throw ex;
+                }
+                // tried to remove pits but no pit exists
+            }
+        }
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -197,2149 +197,2523 @@ import static org.opensearch.test.framework.matcher.UpdateResponseMatchers.isSuc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class SearchOperationTest {
 
-	private static final Logger log = LogManager.getLogger(SearchOperationTest.class);
-
-	public static final String SONG_INDEX_NAME = "song_lyrics";
-	public static final String PROHIBITED_SONG_INDEX_NAME = "prohibited_song_lyrics";
-	public static final String WRITE_SONG_INDEX_NAME = "write_song_index";
-
-	public static final String SONG_LYRICS_ALIAS = "song_lyrics_index_alias";
-	public static final String PROHIBITED_SONG_ALIAS = "prohibited_song_lyrics_index_alias";
-	private static final String COLLECTIVE_INDEX_ALIAS = "collective-index-alias";
-	private static final String TEMPLATE_INDEX_PREFIX = "song-transcription*";
-	public static final String TEMPORARY_ALIAS_NAME = "temporary-alias";
-	public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001 = "alias-used-in-musical-index-template-0001";
-	public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002 = "alias-used-in-musical-index-template-0002";
-	public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003 = "alias-used-in-musical-index-template-0003";
-	public static final String INDEX_NAME_SONG_TRANSCRIPTION_JAZZ = "song-transcription-jazz";
-
-	public static final String MUSICAL_INDEX_TEMPLATE = "musical-index-template";
-	public static final String ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE = "alias_create_index_with_alias_positive";
-	public static final String ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE = "alias_create_index_with_alias_negative";
-
-	public static final String UNDELETABLE_TEMPLATE_NAME = "undeletable-template-name";
-
-	public static final String ALIAS_FROM_UNDELETABLE_TEMPLATE = "alias-from-undeletable-template";
-
-	public static final String TEST_SNAPSHOT_REPOSITORY_NAME = "test-snapshot-repository";
-
-	public static final String UNUSED_SNAPSHOT_REPOSITORY_NAME = "unused-snapshot-repository";
-
-	public static final String RESTORED_SONG_INDEX_NAME = "restored_" + WRITE_SONG_INDEX_NAME;
-
-	public static final String UPDATE_DELETE_OPERATION_INDEX_NAME = "update_delete_index";
-
-	public static final String DOCUMENT_TO_UPDATE_ID = "doc_to_update";
-
-	private static final String ID_P4 = "4";
-	private static final String ID_S3 = "3";
-	private static final String ID_S2 = "2";
-	private static final String ID_S1 = "1";
-
-	static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
-
-	/**
-	* All user read permissions are related to {@link #SONG_INDEX_NAME} index
-	*/
-	static final User LIMITED_READ_USER = new User("limited_read_user")
-		.roles(new Role("limited-song-reader")
-			.clusterPermissions("indices:data/read/mget", "indices:data/read/msearch", "indices:data/read/scroll")
-			.indexPermissions("indices:data/read/search", "indices:data/read/get", "indices:data/read/mget*", "indices:admin/aliases", "indices:data/read/field_caps", "indices:data/read/field_caps*")
-			.on(SONG_INDEX_NAME));
-
-	static final User LIMITED_WRITE_USER = new User("limited_write_user")
-		.roles(new Role("limited-write-role")
-			.clusterPermissions("indices:data/write/bulk", "indices:admin/template/put", "indices:admin/template/delete", "cluster:admin/repository/put", "cluster:admin/repository/delete", "cluster:admin/snapshot/create", "cluster:admin/snapshot/status", "cluster:admin/snapshot/status[nodes]", "cluster:admin/snapshot/delete", "cluster:admin/snapshot/get", "cluster:admin/snapshot/restore")
-			.indexPermissions("indices:data/write/index", "indices:data/write/bulk[s]", "indices:admin/create", "indices:admin/mapping/put",
-			"indices:data/write/update", "indices:data/write/bulk[s]", "indices:data/write/delete", "indices:data/write/bulk[s]")
-			.on(WRITE_SONG_INDEX_NAME),
-			new Role("transcription-role")
-				.indexPermissions("indices:data/write/index", "indices:admin/create", "indices:data/write/bulk[s]", "indices:admin/mapping/put")
-				.on(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ),
-			new Role("limited-write-index-restore-role")
-				.indexPermissions("indices:data/write/index", "indices:admin/create", "indices:data/read/search")
-				.on(RESTORED_SONG_INDEX_NAME));
-
-
-	/**
-	* User who is allowed read both index {@link #SONG_INDEX_NAME} and {@link #PROHIBITED_SONG_INDEX_NAME}
-	*/
-	static final User DOUBLE_READER_USER = new User("double_read_user")
-		.roles(new Role("full-song-reader").indexPermissions("indices:data/read/search")
-			.on(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME));
-
-	static final User REINDEXING_USER = new User("reindexing_user")
-		.roles(new Role("song-reindexing-target-write")
-				.clusterPermissions("indices:data/write/reindex", "indices:data/write/bulk")
-				.indexPermissions("indices:admin/create", "indices:data/write/index", "indices:data/write/bulk[s]", "indices:admin/mapping/put")
-				.on(WRITE_SONG_INDEX_NAME),
-			new Role("song-reindexing-source-read")
-				.clusterPermissions("indices:data/read/scroll")
-				.indexPermissions("indices:data/read/search")
-				.on(SONG_INDEX_NAME));
-
-	private Client internalClient;
-	/**
-	* User who is allowed to update and delete documents on index {@link #UPDATE_DELETE_OPERATION_INDEX_NAME}
-	*/
-	static final User UPDATE_DELETE_USER = new User("update_delete_user")
-			.roles(new Role("document-updater")
-							.clusterPermissions("indices:data/write/bulk")
-							.indexPermissions("indices:data/write/update","indices:data/write/index", "indices:data/write/bulk[s]", "indices:admin/mapping/put")
-							.on(UPDATE_DELETE_OPERATION_INDEX_NAME),
-					new Role("document-remover")
-							.indexPermissions("indices:data/write/delete")
-							.on(UPDATE_DELETE_OPERATION_INDEX_NAME))
-			;
-
-	static final String INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX = "index_operations_";
-
-	/**
-	* User who is allowed to perform index-related operations on
-	* indices with names prefixed by the {@link #INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX}
-	*/
-	static final User USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES = new User("index-operation-tester")
-			.roles(new Role("index-manager")
-					.indexPermissions(
-							"indices:admin/create", "indices:admin/get", "indices:admin/delete", "indices:admin/close",
-							"indices:admin/close*", "indices:admin/open", "indices:admin/resize", "indices:monitor/stats",
-							"indices:monitor/settings/get", "indices:admin/settings/update", "indices:admin/mapping/put",
-							"indices:admin/mappings/get", "indices:admin/cache/clear", "indices:admin/aliases"
-					)
-					.on(INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("*")));
-
-	private static User USER_ALLOWED_TO_CREATE_INDEX = new User("user-allowed-to-create-index")
-		.roles(new Role("create-index-role").indexPermissions("indices:admin/create").on("*"));
-
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER, LIMITED_READ_USER, LIMITED_WRITE_USER, DOUBLE_READER_USER, REINDEXING_USER, UPDATE_DELETE_USER,
-			USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES, USER_ALLOWED_TO_CREATE_INDEX)
-		.audit(new AuditConfiguration(true)
-			.compliance(new AuditCompliance().enabled(true))
-			.filters(new AuditFilters().enabledRest(true).enabledTransport(true))
-		).build();
-
-	@Rule
-	public AuditLogsRule auditLogsRule = new AuditLogsRule();
-
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()) {
-			client.prepareIndex(SONG_INDEX_NAME).setId(ID_S1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
-			client.prepareIndex(UPDATE_DELETE_OPERATION_INDEX_NAME).setId(DOCUMENT_TO_UPDATE_ID).setRefreshPolicy(IMMEDIATE).setSource("field", "value").get();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(SONG_LYRICS_ALIAS))).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S2).source(SONGS[1].asMap())).actionGet();
-			client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S3).source(SONGS[2].asMap())).actionGet();
-
-			client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(ID_P4).setSource(SONGS[3].asMap()).setRefreshPolicy(IMMEDIATE).get();
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new AliasActions(ADD).indices(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS))).actionGet();
-
-			client.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(new AliasActions(ADD).indices(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME).alias(COLLECTIVE_INDEX_ALIAS))).actionGet();
-			var createTemplateRequest = new org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME);
-			createTemplateRequest.patterns(List.of("pattern-does-not-match-to-any-index"));
-			createTemplateRequest.alias(new Alias(ALIAS_FROM_UNDELETABLE_TEMPLATE));
-			client.admin().indices().putTemplate(createTemplateRequest).actionGet();
-
-			client.admin().cluster().putRepository(new PutRepositoryRequest(UNUSED_SNAPSHOT_REPOSITORY_NAME).type("fs").settings(Map.of("location", cluster.getSnapshotDirPath()))).actionGet();
-		}
-	}
-
-	@Before
-	public void retrieveClusterClient() {
-		this.internalClient = cluster.getInternalNodeClient();
-	}
-
-	@After
-	public void cleanData() throws ExecutionException, InterruptedException {
-		Stopwatch stopwatch = Stopwatch.createStarted();
-		IndicesAdminClient indices = internalClient.admin().indices();
-		List<String> indicesToBeDeleted = List.of(
-			WRITE_SONG_INDEX_NAME, INDEX_NAME_SONG_TRANSCRIPTION_JAZZ, RESTORED_SONG_INDEX_NAME,
-			INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("*")
-		);
-		for(String indexToBeDeleted : indicesToBeDeleted) {
-			IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(indexToBeDeleted);
-			var indicesExistsResponse = indices.exists(indicesExistsRequest).get();
-			if (indicesExistsResponse.isExists()) {
-				DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexToBeDeleted);
-				indices.delete(deleteIndexRequest).actionGet();
-				Awaitility.await().ignoreExceptions().until(() -> indices.exists(indicesExistsRequest).get().isExists() == false);
-			}
-		}
-
-		List<String> aliasesToBeDeleted = List.of(TEMPORARY_ALIAS_NAME, ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001,
-			ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE, ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE);
-		for(String aliasToBeDeleted : aliasesToBeDeleted) {
-			if(indices.exists(new IndicesExistsRequest(aliasToBeDeleted)).get().isExists()) {
-				AliasActions aliasAction = new AliasActions(AliasActions.Type.REMOVE).indices(SONG_INDEX_NAME).alias(aliasToBeDeleted);
-				internalClient.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(aliasAction)).get();
-			}
-		}
-
-		GetIndexTemplatesResponse response = indices.getTemplates(new GetIndexTemplatesRequest(MUSICAL_INDEX_TEMPLATE)).get();
-		for(IndexTemplateMetadata metadata : response.getIndexTemplates()) {
-			indices.deleteTemplate(new DeleteIndexTemplateRequest(metadata.getName())).get();
-		}
-
-		ClusterAdminClient clusterClient = internalClient.admin().cluster();
-		try {
-			clusterClient.deleteRepository(new DeleteRepositoryRequest(TEST_SNAPSHOT_REPOSITORY_NAME)).actionGet();
-		} catch (RepositoryMissingException e) {
-			log.debug("Repository '{}' does not exist. This is expected in most of test cases", TEST_SNAPSHOT_REPOSITORY_NAME, e);
-		}
-		internalClient.close();
-		log.debug("Cleaning data after test took {}", stopwatch.stop());
-	}
-
-	@Test
-	public void shouldSearchForDocuments_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldSearchForDocuments_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(SONG_LYRICS_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics_index_alias/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_ALIAS, QUERY_TITLE_POISON);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics_index_alias/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchSongViaMultiIndexAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_NEXT_SONG);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/collective-index-alias/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchSongViaMultiIndexAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_POISON);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/collective-index-alias/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchAllIndexes_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(POST, "/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchAllIndexes_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-	@Test
-	public void shouldBeAbleToSearchSongIndexesWithAsterisk_prohibitedSongIndex_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_POISON);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, PROHIBITED_SONG_INDEX_NAME, ID_P4));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_POISON));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/*song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchSongIndexesWithAsterisk_singIndex_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/*song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAbleToSearchSongIndexesWithAsterisk_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/*song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldFindSongUsingDslQuery_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = new SearchRequest(SONG_INDEX_NAME);
-			SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-			BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-			boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "f.+"));
-			boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			searchSourceBuilder.query(boolQueryBuilder);
-			searchRequest.source(searchSourceBuilder);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldFindSongUsingDslQuery_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = new SearchRequest(PROHIBITED_SONG_INDEX_NAME);
-			SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-			BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-			boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "n.+"));
-			boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_POISON));
-			searchSourceBuilder.query(boolQueryBuilder);
-			searchRequest.source(searchSourceBuilder);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldPerformSearchWithAllIndexAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(POST, "/_all/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldPerformSearchWithAllIndexAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_all/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldScrollOverSearchResults_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containNotEmptyScrollingId());
-
-			SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
-
-			SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
-			assertThat(scrollResponse, isSuccessfulSearchResponse());
-			assertThat(scrollResponse, containNotEmptyScrollingId());
-			assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
-			assertThat(scrollResponse, numberOfHitsInPageIsEqualTo(1));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_search/scroll"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchScrollRequest"));
-	}
-
-	@Test
-	public void shouldScrollOverSearchResults_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containNotEmptyScrollingId());
-
-			SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
-
-			assertThatThrownBy(() -> restHighLevelClient.scroll(scrollRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_search/scroll"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "SearchScrollRequest"));
-	}
-
-	@Test
-	public void shouldGetDocument_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			GetResponse response = restHighLevelClient.get(new GetRequest(SONG_INDEX_NAME, ID_S1), DEFAULT);
-
-			assertThat(response, containDocument(SONG_INDEX_NAME, ID_S1));
-			assertThat(response, documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/song_lyrics/_doc/1"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "GetRequest"));
-	}
-
-	@Test
-	public void shouldGetDocument_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			GetRequest getRequest = new GetRequest(PROHIBITED_SONG_INDEX_NAME, ID_P4);
-			assertThatThrownBy(() -> restHighLevelClient.get(getRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_doc/4"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "GetRequest"));
-	}
-
-	@Test
-	public void shouldPerformMultiGetDocuments_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			MultiGetRequest request = new MultiGetRequest();
-			request.add(new Item(SONG_INDEX_NAME, ID_S1));
-			request.add(new Item(SONG_INDEX_NAME, ID_S2));
-
-			MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
-
-			assertThat(response, is(notNullValue()));
-			assertThat(response, isSuccessfulMultiGetResponse());
-			assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
-
-			MultiGetItemResponse[] responses = response.getResponses();
-			assertThat(responses[0].getResponse(), allOf(
-				containDocument(SONG_INDEX_NAME, ID_S1),
-				documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
-			);
-			assertThat(responses[1].getResponse(),  allOf(
-				containDocument(SONG_INDEX_NAME, ID_S2),
-				documentContainField(FIELD_TITLE, TITLE_SONG_1_PLUS_1))
-			);
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetShardRequest"));
-	}
-
-	@Test
-	public void shouldPerformMultiGetDocuments_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			MultiGetRequest request = new MultiGetRequest();
-			request.add(new Item(SONG_INDEX_NAME, ID_S1));
-
-			assertThatThrownBy(() -> restHighLevelClient.mget(request, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_mget"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "MultiGetRequest"));
-	}
-
-	@Test
-	public void shouldPerformMultiGetDocuments_partiallyPositive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			MultiGetRequest request = new MultiGetRequest();
-			request.add(new Item(SONG_INDEX_NAME, ID_S1));
-			request.add(new Item(PROHIBITED_SONG_INDEX_NAME, ID_P4));
-
-			MultiGetResponse response =  restHighLevelClient.mget(request, DEFAULT);
-
-			assertThat(request, notNullValue());
-			assertThat(response, not(isSuccessfulMultiGetResponse()));
-			assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
-
-			MultiGetItemResponse[] responses = response.getResponses();
-			assertThat(responses, arrayContaining(
-				hasProperty("failure", nullValue()),
-				hasProperty("failure", notNullValue())
-			));
-			assertThat(responses[1].getFailure().getFailure(), statusException(INTERNAL_SERVER_ERROR));
-			assertThat(responses[1].getFailure().getFailure(), errorMessageContain("security_exception"));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetShardRequest").withIndex(SONG_INDEX_NAME));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "MultiGetShardRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldBeAllowedToPerformMulitSearch_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			MultiSearchRequest request = new MultiSearchRequest();
-			request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-			request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
-
-			MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response, isSuccessfulMultiSearchResponse());
-			assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
-
-			MultiSearchResponse.Item[] responses = response.getResponses();
-
-			assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-			assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-			assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldBeAllowedToPerformMulitSearch_partiallyPositive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			MultiSearchRequest request = new MultiSearchRequest();
-			request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-			request.add(queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON));
-
-			MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response, not(isSuccessfulMultiSearchResponse()));
-			assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
-
-			MultiSearchResponse.Item[] responses = response.getResponses();
-			assertThat(responses[0].getFailure(), nullValue());
-			assertThat(responses[1].getFailure(), statusException(INTERNAL_SERVER_ERROR));
-			assertThat(responses[1].getFailure(), errorMessageContain("security_exception"));
-			assertThat(responses[1].getResponse(), nullValue());
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(SONG_INDEX_NAME));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldBeAllowedToPerformMulitSearch_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-			MultiSearchRequest request = new MultiSearchRequest();
-			request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-			request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
-
-			assertThatThrownBy(() -> restHighLevelClient.msearch(request, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_msearch"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "MultiSearchRequest"));
-	}
-
-	@Test
-	public void shouldAggregateDataAndComputeAverage_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			final String aggregationName = "averageStars";
-			SearchRequest searchRequest = averageAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldAggregateDataAndComputeAverage_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = averageAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "averageStars", FIELD_STARS);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldPerformStatAggregation_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			final String aggregationName = "statsStars";
-			SearchRequest searchRequest = statsAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
-
-			SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
-
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldPerformStatAggregation_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SearchRequest searchRequest = statsAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "statsStars", FIELD_STARS);
-
-			assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldIndexDocumentInBulkRequest_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, successBulkResponse());
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one"));
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "two"));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertAtLeast(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));//sometimes 4 or 6
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));//sometimes 2 or 4
-	}
-
-	@Test
-	public void shouldIndexDocumentInBulkRequest_partiallyPositive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, bulkResponseContainExceptions(0, allOf(
-				statusException(INTERNAL_SERVER_ERROR),
-				errorMessageContain("security_exception")
-			)));
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "two"));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldIndexDocumentInBulkRequest_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, allOf(
-				failureBulkResponse(),
-				bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-				bulkResponseContainExceptions(errorMessageContain("security_exception"))
-			));
-			assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "one")));
-			assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "two")));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldUpdateDocumentsInBulk_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			final String titleOne = "shape of my mind";
-			final String titleTwo = "forgiven";
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-			bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
-			bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "two").doc(Map.of(FIELD_TITLE, titleTwo)));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, successBulkResponse());
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, titleTwo));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-
-	}
-
-	@Test
-	public void shouldUpdateDocumentsInBulk_partiallyPositive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			final String titleOne = "shape of my mind";
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-			bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
-			bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, bulkResponseContainExceptions(1, allOf(
-				statusException(INTERNAL_SERVER_ERROR),
-				errorMessageContain("security_exception")
-			)));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
-	}
-
-	@Test
-	public void shouldUpdateDocumentsInBulk_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S1).doc(Map.of(FIELD_TITLE, "shape of my mind")));
-			bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, allOf(
-				failureBulkResponse(),
-				bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-				bulkResponseContainExceptions(errorMessageContain("security_exception"))
-			));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S1, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
-	}
-
-	@Test
-	public void shouldDeleteDocumentInBulk_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("three").source(SONGS[2].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("four").source(SONGS[3].asMap()));
-			assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
-			bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
-			bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "three"));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, successBulkResponse());
-			assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
-			assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "three")));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "four", FIELD_TITLE, TITLE_POISON));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-
-	@Test
-	public void shouldDeleteDocumentInBulk_partiallyPositive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-			assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
-			bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
-			bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-			assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
-
-			assertThat(response, bulkResponseContainExceptions(1, allOf(
-				statusException(INTERNAL_SERVER_ERROR),
-				errorMessageContain("security_exception")
-			)));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S3, FIELD_TITLE, TITLE_NEXT_SONG));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
-	}
-
-	@Test
-	public void shouldDeleteDocumentInBulk_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-			bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S1));
-			bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
-
-			BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			assertThat(response, allOf(
-				failureBulkResponse(),
-				bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-				bulkResponseContainExceptions(errorMessageContain("security_exception"))
-			));
-			assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S1));
-			assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S3));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
-
-	}
-
-	@Test
-	public void shouldReindexDocuments_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-			ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(WRITE_SONG_INDEX_NAME);
-
-			BulkByScrollResponse response = restHighLevelClient.reindex(reindexRequest, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.getBulkFailures(), empty());
-			assertThat(response.getSearchFailures(), empty());
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S1));
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S2));
-			assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S3));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(REINDEXING_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(REINDEXING_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchScrollRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(REINDEXING_USER));
-		auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "ClearScrollRequest"));
-	}
-
-	@Test
-	public void shouldReindexDocuments_negativeSource() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-			ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME).setDestIndex(WRITE_SONG_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_P4)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldReindexDocuments_negativeDestination() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-			ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(PROHIBITED_SONG_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S1)));
-			assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S2)));
-			assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S3)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "BulkRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "BulkShardRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "ClearScrollRequest"));
-	}
-
-	@Test
-	public void shouldReindexDocuments_negativeSourceAndDestination() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-			ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME).setDestIndex(SONG_INDEX_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "SearchRequest"));
-	}
-
-	@Test
-	public void shouldUpdateDocument_positive() throws IOException {
-		String newField = "newField";
-		String newValue = "newValue";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-			UpdateRequest updateRequest = new UpdateRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, DOCUMENT_TO_UPDATE_ID)
-					.doc(newField, newValue).setRefreshPolicy(IMMEDIATE);
-
-			UpdateResponse response = restHighLevelClient.update(updateRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulUpdateResponse());
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(UPDATE_DELETE_OPERATION_INDEX_NAME, DOCUMENT_TO_UPDATE_ID, newField, newValue));
-		}
-	}
-	@Test
-	public void shouldUpdateDocument_negative() throws IOException {
-		String newField = "newField";
-		String newValue = "newValue";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-			UpdateRequest updateRequest = new UpdateRequest(PROHIBITED_SONG_INDEX_NAME, DOCUMENT_TO_UPDATE_ID).doc(newField, newValue).setRefreshPolicy(IMMEDIATE);
-
-			assertThatThrownBy(() -> restHighLevelClient.update(updateRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldDeleteDocument_positive() throws IOException {
-		String docId = "shouldDeleteDocument_positive";
-		try(Client client = cluster.getInternalNodeClient()){
-			client.index(new IndexRequest(UPDATE_DELETE_OPERATION_INDEX_NAME).id(docId).source("field", "value").setRefreshPolicy(IMMEDIATE)).actionGet();
-			assertThat(internalClient, clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId));
-		}
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-			DeleteRequest deleteRequest = new DeleteRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, docId).setRefreshPolicy(IMMEDIATE);
-
-			DeleteResponse response = restHighLevelClient.delete(deleteRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulDeleteResponse());
-			assertThat(internalClient, not(clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId)));
-		}
-	}
-	@Test
-	public void shouldDeleteDocument_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-			DeleteRequest deleteRequest = new DeleteRequest(PROHIBITED_SONG_INDEX_NAME, ID_S1).setRefreshPolicy(IMMEDIATE);
-
-			assertThatThrownBy(() -> restHighLevelClient.delete(deleteRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	public void shouldCreateAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-			IndicesAliasesRequest indicesAliasesRequest =  new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-			var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
-		auditLogsRule.assertExactly(2, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_READ_USER));
-	}
-
-	@Test
-	public void shouldCreateAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			AliasActions aliasAction = new AliasActions(ADD).indices(PROHIBITED_SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-			IndicesAliasesRequest indicesAliasesRequest =  new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT), statusException(FORBIDDEN));
-
-			assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_P4)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
-	}
-
-	@Test
-	public void shouldDeleteAlias_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-			IndicesAliasesRequest indicesAliasesRequest =  new IndicesAliasesRequest().addAliasAction(aliasAction);
-			restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
-			aliasAction = new AliasActions(REMOVE).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-			indicesAliasesRequest =  new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-			var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1)));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
-		auditLogsRule.assertExactly(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_READ_USER));
-	}
-
-	@Test
-	public void shouldDeleteAlias_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			AliasActions aliasAction = new AliasActions(REMOVE).indices(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS);
-			IndicesAliasesRequest indicesAliasesRequest =  new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT), statusException(FORBIDDEN));
-
-			assertThat(internalClient, clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_P4));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
-	}
-
-	@Test
-	public void shouldCreateIndexTemplate_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
-
-			var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE ));
-			String documentId = "0001";
-			IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId).source(SONGS[0].asMap())
-				.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.index(indexRequest, DEFAULT);
-			assertThat(internalClient, clusterContainsDocument(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ, documentId));
-			assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId));
-			assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, documentId));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/song-transcription-jazz/_doc/0001"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "IndexRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(8, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-
-	@Test
-	public void shouldCreateIndexTemplate_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
-			assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE )));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_template/musical-index-template"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutIndexTemplateRequest"));
-	}
-
-	@Test
-	public void shouldDeleteTemplate_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX));
-			restHighLevelClient.indices().putTemplate(request, DEFAULT);
-			assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
-			DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE);
-
-			var response = restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_template/musical-index-template"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteIndexTemplateRequest"));
-		auditLogsRule.assertExactly(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-
-	@Test
-	public void shouldDeleteTemplate_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT), statusException(FORBIDDEN));
-
-			assertThat(internalClient, clusterContainTemplate(UNDELETABLE_TEMPLATE_NAME));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_template/undeletable-template-name"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "DeleteIndexTemplateRequest"));
-	}
-
-	@Test
-	public void shouldUpdateTemplate_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
-			restHighLevelClient.indices().putTemplate(request, DEFAULT);
-			assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
-			request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
-
-			var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			String documentId = "000one";
-			IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId).source(SONGS[0].asMap())
-				.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.index(indexRequest, DEFAULT);
-			assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
-			assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003, documentId));
-			assertThat(internalClient, not(clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId)));
-			assertThat(internalClient, not(clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, documentId)));
-		}
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/song-transcription-jazz/_doc/000one"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "IndexRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(10, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-	@Test
-	public void shouldUpdateTemplate_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			PutIndexTemplateRequest request = new PutIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME)
-				.patterns(List.of(TEMPLATE_INDEX_PREFIX))
-				.alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
-			assertThat(internalClient, clusterContainTemplateWithAlias(UNDELETABLE_TEMPLATE_NAME, ALIAS_FROM_UNDELETABLE_TEMPLATE));
-			assertThat(internalClient, not(clusterContainTemplateWithAlias(UNDELETABLE_TEMPLATE_NAME, ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_template/undeletable-template-name"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutIndexTemplateRequest"));
-	}
-
-	@Test
-	public void shouldGetFieldCapabilitiesForAllIndexes_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
-
-			FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response, containsExactlyIndices(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME, UPDATE_DELETE_OPERATION_INDEX_NAME));
-			assertThat(response, numberOfFieldsIsEqualTo(1));
-			assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(GET, "/_field_caps"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "FieldCapabilitiesRequest"));
-		auditLogsRule.assertExactly(3, grantedPrivilege(ADMIN_USER, "FieldCapabilitiesIndexRequest"));
-	}
-
-	@Test
-	public void shouldGetFieldCapabilitiesForAllIndexes_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
-
-			assertThatThrownBy(() ->  restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/_field_caps"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
-	}
-
-	@Test
-	public void shouldGetFieldCapabilitiesForParticularIndex_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(SONG_INDEX_NAME).fields(FIELD_TITLE);
-
-			FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
-
-			assertThat(response, notNullValue());
-			assertThat(response, containsExactlyIndices(SONG_INDEX_NAME));
-			assertThat(response, numberOfFieldsIsEqualTo(1));
-			assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/song_lyrics/_field_caps"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "FieldCapabilitiesIndexRequest"));
-	}
-
-	@Test
-	public void shouldGetFieldCapabilitiesForParticularIndex_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(PROHIBITED_SONG_INDEX_NAME).fields(FIELD_TITLE);
-
-			assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_field_caps"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
-	}
-
-	@Test
-	public void shouldCreateSnapshotRepository_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			String snapshotDirPath = cluster.getSnapshotDirPath();
-
-			var response = steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotDirPath, "fs");
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-	}
-
-	@Test
-	public void shouldCreateSnapshotRepository_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			String snapshotDirPath = cluster.getSnapshotDirPath();
-
-			assertThatThrownBy(() -> steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotDirPath, "fs"), statusException(FORBIDDEN));
-			assertThat(internalClient, not(clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutRepositoryRequest"));
-	}
-
-	@Test
-	public void shouldDeleteSnapshotRepository_positive() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-			assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
-
-			var response = steps.deleteSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME);
-
-			assertThat(response, notNullValue());
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, not(clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteRepositoryRequest"));
-	}
-
-	@Test
-	public void shouldDeleteSnapshotRepository_negative() throws IOException {
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-
-			assertThatThrownBy(() -> steps.deleteSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME), statusException(FORBIDDEN));
-			assertThat(internalClient, clusterContainsSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_snapshot/unused-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "DeleteRepositoryRequest"));
-	}
-
-	@Test //Bug which can be reproduced with the below test: https://github.com/opensearch-project/security/issues/2169
-	public void shouldCreateSnapshot_positive() throws IOException {
-		final String snapshotName = "snapshot-positive-test";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-
-			CreateSnapshotResponse response = steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
-
-			assertThat(response, notNullValue());
-			assertThat(response.status(), equalTo(RestStatus.ACCEPTED));
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-			assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/snapshot-positive-test"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/snapshot-positive-test"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-	}
-
-	@Test
-	public void shouldCreateSnapshot_negative() throws IOException {
-		final String snapshotName = "snapshot-negative-test";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-
-			assertThatThrownBy(() -> steps.createSnapshot(UNUSED_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME), statusException(FORBIDDEN));
-
-			assertThat(internalClient, snapshotInClusterDoesNotExists(UNUSED_SNAPSHOT_REPOSITORY_NAME, snapshotName));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_snapshot/unused-snapshot-repository/snapshot-negative-test"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "CreateSnapshotRequest"));
-	}
-
-	@Test
-	public void shouldDeleteSnapshot_positive() throws IOException {
-		String snapshotName = "delete-snapshot-positive";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			restHighLevelClient.snapshot();
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-			steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-
-			var response = steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-
-			assertThat(response.isAcknowledged(), equalTo(true));
-			assertThat(internalClient, snapshotInClusterDoesNotExists(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/delete-snapshot-positive"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository/delete-snapshot-positive"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/delete-snapshot-positive"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteSnapshotRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-	}
-
-	@Test
-	public void shouldDeleteSnapshot_negative() throws IOException {
-		String snapshotName = "delete-snapshot-negative";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-			steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-		}
-		try(RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			assertThatThrownBy(() -> steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName), statusException(FORBIDDEN));
-
-			assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/delete-snapshot-negative"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository/delete-snapshot-negative"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/delete-snapshot-negative"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertExactly(1, missingPrivilege(LIMITED_READ_USER, "DeleteSnapshotRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-	}
-
-	@Test
-	public void shouldRestoreSnapshot_positive() throws IOException {
-		final String snapshotName = "restore-snapshot-positive";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			// 1. create some documents
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			//2. create snapshot repository
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-
-			// 3. create snapshot
-			steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME) ;
-
-			// 4. wait till snapshot is ready
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-
-			// 5. introduce some changes
-			bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Drei").source(SONGS[2].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Vier").source(SONGS[3].asMap()));
-			bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "Eins"));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			// 6. restore the snapshot
-			var response = steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1");
-
-			assertThat(response, notNullValue());
-			assertThat(response.status(), equalTo(ACCEPTED));
-
-			// 7. wait until snapshot is restored
-			CountRequest countRequest = new CountRequest(RESTORED_SONG_INDEX_NAME);
-			Awaitility.await().ignoreExceptions().alias("Index contains proper number of documents restored from snapshot.")
-				.until(() -> restHighLevelClient.count(countRequest, DEFAULT).getCount() == 2);
-
-			//8. verify that document are present in restored index
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(RESTORED_SONG_INDEX_NAME, "Eins", FIELD_TITLE, TITLE_MAGNUM_OPUS));
-			assertThat(internalClient, clusterContainsDocumentWithFieldValue(RESTORED_SONG_INDEX_NAME, "Zwei", FIELD_TITLE, TITLE_SONG_1_PLUS_1));
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Drei")));
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Vier")));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/restore-snapshot-positive"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_snapshot/test-snapshot-repository/restore-snapshot-positive/_restore"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/restored_write_song_index/_count"));
-		auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/restore-snapshot-positive"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "SearchRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-
-	@Test
-	public void shouldRestoreSnapshot_failureForbiddenIndex() throws IOException {
-		final String snapshotName = "restore-snapshot-negative-forbidden-index";
-		String restoreToIndex = "forbidden_index";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			// 1. create some documents
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			//2. create snapshot repository
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-
-			// 3. create snapshot
-			steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME);
-
-			// 4. wait till snapshot is ready
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-
-			// 5. restore the snapshot
-			assertThatThrownBy(() -> steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", restoreToIndex),
-				statusException(FORBIDDEN));
-
-
-			//6. verify that document are not present in restored index
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Eins")));
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Zwei")));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index/_restore"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-		auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
-	}
-
-	@Test
-	public void shouldRestoreSnapshot_failureOperationForbidden() throws IOException {
-		String snapshotName = "restore-snapshot-negative-forbidden-operation";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			// 1. create some documents
-			BulkRequest bulkRequest = new BulkRequest();
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-			bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-			bulkRequest.setRefreshPolicy(IMMEDIATE);
-			restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-			//2. create snapshot repository
-			steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
-
-			// 3. create snapshot
-			steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME);
-
-			// 4. wait till snapshot is ready
-			steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
-		}
-		// 5. restore the snapshot
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-			SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-			assertThatThrownBy( () -> steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1"),
-				statusException(FORBIDDEN));
-
-			// 6. verify that documents does not exist
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Eins")));
-			assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Zwei")));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation/_restore"));
-		auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
-		auditLogsRule.assertAtLeast(1, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
-		auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
-		auditLogsRule.assertExactly(1, missingPrivilege(LIMITED_READ_USER, "RestoreSnapshotRequest"));
-		auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
-		auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
-	}
-
-	@Test
-	//required permissions: "indices:admin/create"
-	public void createIndex_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_positive");
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
-			CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
-
-			assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
-			assertThat(cluster, indexExists(indexName));
-		}
-	}
-
-	@Test
-	public void createIndex_negative() throws IOException {
-		String indexName = "create_index_negative";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(indexName)));
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/get"
-	public void checkIfIndexExists_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("index_exists_positive");
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			boolean exists = restHighLevelClient.indices().exists(new GetIndexRequest(indexName), DEFAULT);
-
-			assertThat(exists, is(false));
-		}
-	}
-
-	@Test
-	public void checkIfIndexExists_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "index_exists_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().exists(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().exists(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().exists(new GetIndexRequest("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/delete"
-	public void deleteIndex_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
-			var response = restHighLevelClient.indices().delete(deleteIndexRequest, DEFAULT);
-
-			assertThat(response.isAcknowledged(), is(true));
-			assertThat(cluster, not(indexExists(indexName)));
-		}
-	}
-
-	@Test
-	public void deleteIndex_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "delete_index_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().delete(new DeleteIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().delete(new DeleteIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-					restHighLevelClient.indices().delete(new DeleteIndexRequest("*"), DEFAULT), statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: indices:admin/aliases, indices:admin/delete
-	public void shouldDeleteIndexByAliasRequest_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_by_alias_request_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
-
-			var response = restHighLevelClient.indices().updateAliases(request, DEFAULT);
-
-			assertThat(response.isAcknowledged(), is(true));
-			assertThat(cluster, not(indexExists(indexName)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES).withRestRequest(POST, "/_aliases"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES, "IndicesAliasesRequest"));
-		auditLogsRule.assertExactly(2, auditPredicate(INDEX_EVENT).withEffectiveUser(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES));
-	}
-
-	@Test
-	public void shouldDeleteIndexByAliasRequest_negative() throws IOException {
-		String indexName = "delete_index_by_alias_request_negative";
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().updateAliases(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/get"
-	public void getIndex_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			GetIndexRequest getIndexRequest = new GetIndexRequest(indexName);
-			GetIndexResponse response = restHighLevelClient.indices().get(getIndexRequest, DEFAULT);
-
-			assertThat(response, getIndexResponseContainsIndices(indexName));
-		}
-	}
-
-	@Test
-	public void getIndex_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "get_index_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().get(new GetIndexRequest("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/close", "indices:admin/close*"
-	public void closeIndex_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("close_index_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indexName);
-			CloseIndexResponse response = restHighLevelClient.indices().close(closeIndexRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulCloseIndexResponse());
-			assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.CLOSE));
-		}
-	}
-
-	@Test
-	public void closeIndex_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "close_index_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().close(new CloseIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().close(new CloseIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().close(new CloseIndexRequest("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/open"
-	public void openIndex_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("open_index_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-		IndexOperationsHelper.closeIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			OpenIndexRequest closeIndexRequest = new OpenIndexRequest(indexName);
-			OpenIndexResponse response = restHighLevelClient.indices().open(closeIndexRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulOpenIndexResponse());
-			assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.OPEN));
-		}
-	}
-
-	@Test
-	public void openIndex_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "open_index_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().open(new OpenIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().open(new OpenIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().open(new OpenIndexRequest("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	@Ignore
-	//required permissions: "indices:admin/resize", "indices:monitor/stats
-	// todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
-	//  Issue: https://github.com/opensearch-project/security/issues/2141
-	public void shrinkIndex_positive() throws IOException {
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_positive_source");
-		Settings sourceIndexSettings = Settings.builder()
-				.put("index.blocks.write", true)
-				.put("index.number_of_shards", 2)
-				.build();
-		String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_positive_target");
-		IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-			ResizeResponse response = restHighLevelClient.indices().shrink(resizeRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulResizeResponse(targetIndexName));
-			assertThat(cluster, indexExists(targetIndexName));
-		}
-	}
-
-	@Test
-	public void shrinkIndex_negative() throws IOException {
-		//user cannot access target index
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_source");
-		String targetIndexName = "shrink_index_negative_target";
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-
-		//user cannot access source index
-		sourceIndexName = "shrink_index_negative_source";
-		targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_target");
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-	}
-
-	@Test
-	@Ignore
-	//required permissions: "indices:admin/resize", "indices:monitor/stats
-	// todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
-	//  Issue: https://github.com/opensearch-project/security/issues/2141
-	public void cloneIndex_positive() throws IOException {
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_positive_source");
-		Settings sourceIndexSettings = Settings.builder()
-				.put("index.blocks.write", true)
-				.build();
-		String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_positive_target");
-		IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-			ResizeResponse response = restHighLevelClient.indices().clone(resizeRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulResizeResponse(targetIndexName));
-			assertThat(cluster, indexExists(targetIndexName));
-		}
-	}
-
-	@Test
-	public void cloneIndex_negative() throws IOException {
-		//user cannot access target index
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_source");
-		String targetIndexName = "clone_index_negative_target";
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-
-		//user cannot access source index
-		sourceIndexName = "clone_index_negative_source";
-		targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_target");
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-	}
-
-	@Test
-	@Ignore
-	//required permissions: "indices:admin/resize", "indices:monitor/stats
-	// todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
-	//  Issue: https://github.com/opensearch-project/security/issues/2141
-	public void splitIndex_positive() throws IOException {
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_positive_source");
-		Settings sourceIndexSettings = Settings.builder()
-				.put("index.blocks.write", true)
-				.build();
-		String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_positive_target");
-		IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-			resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
-			ResizeResponse response = restHighLevelClient.indices().split(resizeRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulResizeResponse(targetIndexName));
-			assertThat(cluster, indexExists(targetIndexName));
-		}
-	}
-
-	@Test
-	public void splitIndex_negative() throws IOException {
-		//user cannot access target index
-		String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_source");
-		String targetIndexName = "split_index_negative_target";
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-			resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-
-		//user cannot access source index
-		sourceIndexName = "split_index_negative_source";
-		targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_target");
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-			resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
-			assertThat(cluster, not(indexExists(targetIndexName)));
-		}
-	}
-
-	@Test
-	//required permissions: "indices:monitor/settings/get"
-	public void getIndexSettings_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_settings_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			GetSettingsRequest getSettingsRequest = new GetSettingsRequest().indices(indexName);
-			GetSettingsResponse response = restHighLevelClient.indices().getSettings(getSettingsRequest, DEFAULT);
-
-			assertThat(response, getSettingsResponseContainsIndices(indexName));
-		}
-	}
-
-	@Test
-	public void getIndexSettings_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "get_index_settings_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/settings/update"
-	public void updateIndexSettings_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("update_index_settings_positive");
-		Settings initialSettings = Settings.builder().put("index.number_of_replicas", "2").build();
-		Settings updatedSettings = Settings.builder().put("index.number_of_replicas", "4").build();
-		IndexOperationsHelper.createIndex(cluster, indexName, initialSettings);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indexName)
-					.settings(updatedSettings);
-			var response = restHighLevelClient.indices().putSettings(updateSettingsRequest, DEFAULT);
-
-			assertThat(response.isAcknowledged(), is(true));
-			assertThat(cluster, indexSettingsContainValues(indexName, updatedSettings));
-		}
-	}
-
-	@Test
-	public void updateIndexSettings_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "update_index_settings_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		Settings settingsToUpdate = Settings.builder().put("index.number_of_replicas", 2).build();
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putSettings(new UpdateSettingsRequest(indexThatUserHasNoAccessTo).settings(settingsToUpdate), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putSettings(new UpdateSettingsRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).settings(settingsToUpdate), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putSettings(new UpdateSettingsRequest("*").settings(settingsToUpdate), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: indices:admin/mapping/put
-	public void createIndexMappings_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_mappings_positive");
-		Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			PutMappingRequest putMappingRequest = new PutMappingRequest(indexName).source(indexMapping);
-			var response = restHighLevelClient.indices().putMapping(putMappingRequest, DEFAULT);
-
-			assertThat(response.isAcknowledged(), is(true));
-			assertThat(cluster, indexMappingIsEqualTo(indexName, indexMapping));
-		}
-	}
-
-	@Test
-	public void createIndexMappings_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "create_index_mappings_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putMapping(new PutMappingRequest(indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putMapping(new PutMappingRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().putMapping(new PutMappingRequest("*").source(indexMapping), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: indices:admin/mappings/get
-	public void getIndexMappings_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_mappings_positive");
-		Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
-		IndexOperationsHelper.createIndex(cluster, indexName);
-		IndexOperationsHelper.createMapping(cluster, indexName, indexMapping);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(indexName);
-			GetMappingsResponse response = restHighLevelClient.indices().getMapping(getMappingsRequest, DEFAULT);
-
-			assertThat(response, getMappingsResponseContainsIndices(indexName));
-		}
-	}
-
-	@Test
-	public void getIndexMappings_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "get_index_mappings_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/cache/clear"
-	public void clearIndexCache_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clear_index_cache_positive");
-		IndexOperationsHelper.createIndex(cluster, indexName);
-
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(indexName);
-			ClearIndicesCacheResponse response = restHighLevelClient.indices().clearCache(clearIndicesCacheRequest, DEFAULT);
-
-			assertThat(response, isSuccessfulClearIndicesCacheResponse());
-		}
-	}
-
-	@Test
-	public void clearIndexCache_negative() throws IOException {
-		String indexThatUserHasNoAccessTo = "clear_index_cache_negative";
-		String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest(indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-			assertThatThrownBy(() ->
-							restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest("*"), DEFAULT),
-					statusException(FORBIDDEN)
-			);
-		}
-	}
-
-	@Test
-	//required permissions: "indices:admin/create", "indices:admin/aliases"
-	public void shouldCreateIndexWithAlias_positive() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_positive");
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
-			CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName)
-				.alias(new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE));
-
-			CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
-
-			assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
-			assertThat(cluster, indexExists(indexName));
-			assertThat(internalClient, aliasExists(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES).withRestRequest(PUT, "/index_operations_create_index_with_alias_positive"));
-		auditLogsRule.assertExactly(2, grantedPrivilege(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES, "CreateIndexRequest"));
-		auditLogsRule.assertExactly(2, auditPredicate(INDEX_EVENT).withEffectiveUser(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES));
-	}
-
-	@Test
-	public void shouldCreateIndexWithAlias_negative() throws IOException {
-		String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_negative");
-		try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_CREATE_INDEX)) {
-			CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName)
-				.alias(new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE));
-
-			assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
-
-			assertThat(internalClient, not(aliasExists(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE)));
-		}
-		auditLogsRule.assertExactlyOne(userAuthenticated(USER_ALLOWED_TO_CREATE_INDEX).withRestRequest(PUT, "/index_operations_create_index_with_alias_negative"));
-		auditLogsRule.assertExactlyOne(missingPrivilege(USER_ALLOWED_TO_CREATE_INDEX, "CreateIndexRequest"));
-	}
+    private static final Logger log = LogManager.getLogger(SearchOperationTest.class);
+
+    public static final String SONG_INDEX_NAME = "song_lyrics";
+    public static final String PROHIBITED_SONG_INDEX_NAME = "prohibited_song_lyrics";
+    public static final String WRITE_SONG_INDEX_NAME = "write_song_index";
+
+    public static final String SONG_LYRICS_ALIAS = "song_lyrics_index_alias";
+    public static final String PROHIBITED_SONG_ALIAS = "prohibited_song_lyrics_index_alias";
+    private static final String COLLECTIVE_INDEX_ALIAS = "collective-index-alias";
+    private static final String TEMPLATE_INDEX_PREFIX = "song-transcription*";
+    public static final String TEMPORARY_ALIAS_NAME = "temporary-alias";
+    public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001 = "alias-used-in-musical-index-template-0001";
+    public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002 = "alias-used-in-musical-index-template-0002";
+    public static final String ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003 = "alias-used-in-musical-index-template-0003";
+    public static final String INDEX_NAME_SONG_TRANSCRIPTION_JAZZ = "song-transcription-jazz";
+
+    public static final String MUSICAL_INDEX_TEMPLATE = "musical-index-template";
+    public static final String ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE = "alias_create_index_with_alias_positive";
+    public static final String ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE = "alias_create_index_with_alias_negative";
+
+    public static final String UNDELETABLE_TEMPLATE_NAME = "undeletable-template-name";
+
+    public static final String ALIAS_FROM_UNDELETABLE_TEMPLATE = "alias-from-undeletable-template";
+
+    public static final String TEST_SNAPSHOT_REPOSITORY_NAME = "test-snapshot-repository";
+
+    public static final String UNUSED_SNAPSHOT_REPOSITORY_NAME = "unused-snapshot-repository";
+
+    public static final String RESTORED_SONG_INDEX_NAME = "restored_" + WRITE_SONG_INDEX_NAME;
+
+    public static final String UPDATE_DELETE_OPERATION_INDEX_NAME = "update_delete_index";
+
+    public static final String DOCUMENT_TO_UPDATE_ID = "doc_to_update";
+
+    private static final String ID_P4 = "4";
+    private static final String ID_S3 = "3";
+    private static final String ID_S2 = "2";
+    private static final String ID_S1 = "1";
+
+    static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+
+    /**
+    * All user read permissions are related to {@link #SONG_INDEX_NAME} index
+    */
+    static final User LIMITED_READ_USER = new User("limited_read_user").roles(
+        new Role("limited-song-reader").clusterPermissions(
+            "indices:data/read/mget",
+            "indices:data/read/msearch",
+            "indices:data/read/scroll"
+        )
+            .indexPermissions(
+                "indices:data/read/search",
+                "indices:data/read/get",
+                "indices:data/read/mget*",
+                "indices:admin/aliases",
+                "indices:data/read/field_caps",
+                "indices:data/read/field_caps*"
+            )
+            .on(SONG_INDEX_NAME)
+    );
+
+    static final User LIMITED_WRITE_USER = new User("limited_write_user").roles(
+        new Role("limited-write-role").clusterPermissions(
+            "indices:data/write/bulk",
+            "indices:admin/template/put",
+            "indices:admin/template/delete",
+            "cluster:admin/repository/put",
+            "cluster:admin/repository/delete",
+            "cluster:admin/snapshot/create",
+            "cluster:admin/snapshot/status",
+            "cluster:admin/snapshot/status[nodes]",
+            "cluster:admin/snapshot/delete",
+            "cluster:admin/snapshot/get",
+            "cluster:admin/snapshot/restore"
+        )
+            .indexPermissions(
+                "indices:data/write/index",
+                "indices:data/write/bulk[s]",
+                "indices:admin/create",
+                "indices:admin/mapping/put",
+                "indices:data/write/update",
+                "indices:data/write/bulk[s]",
+                "indices:data/write/delete",
+                "indices:data/write/bulk[s]"
+            )
+            .on(WRITE_SONG_INDEX_NAME),
+        new Role("transcription-role").indexPermissions(
+            "indices:data/write/index",
+            "indices:admin/create",
+            "indices:data/write/bulk[s]",
+            "indices:admin/mapping/put"
+        ).on(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ),
+        new Role("limited-write-index-restore-role").indexPermissions(
+            "indices:data/write/index",
+            "indices:admin/create",
+            "indices:data/read/search"
+        ).on(RESTORED_SONG_INDEX_NAME)
+    );
+
+    /**
+    * User who is allowed read both index {@link #SONG_INDEX_NAME} and {@link #PROHIBITED_SONG_INDEX_NAME}
+    */
+    static final User DOUBLE_READER_USER = new User("double_read_user").roles(
+        new Role("full-song-reader").indexPermissions("indices:data/read/search").on(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME)
+    );
+
+    static final User REINDEXING_USER = new User("reindexing_user").roles(
+        new Role("song-reindexing-target-write").clusterPermissions("indices:data/write/reindex", "indices:data/write/bulk")
+            .indexPermissions("indices:admin/create", "indices:data/write/index", "indices:data/write/bulk[s]", "indices:admin/mapping/put")
+            .on(WRITE_SONG_INDEX_NAME),
+        new Role("song-reindexing-source-read").clusterPermissions("indices:data/read/scroll")
+            .indexPermissions("indices:data/read/search")
+            .on(SONG_INDEX_NAME)
+    );
+
+    private Client internalClient;
+    /**
+    * User who is allowed to update and delete documents on index {@link #UPDATE_DELETE_OPERATION_INDEX_NAME}
+    */
+    static final User UPDATE_DELETE_USER = new User("update_delete_user").roles(
+        new Role("document-updater").clusterPermissions("indices:data/write/bulk")
+            .indexPermissions(
+                "indices:data/write/update",
+                "indices:data/write/index",
+                "indices:data/write/bulk[s]",
+                "indices:admin/mapping/put"
+            )
+            .on(UPDATE_DELETE_OPERATION_INDEX_NAME),
+        new Role("document-remover").indexPermissions("indices:data/write/delete").on(UPDATE_DELETE_OPERATION_INDEX_NAME)
+    );
+
+    static final String INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX = "index_operations_";
+
+    /**
+    * User who is allowed to perform index-related operations on
+    * indices with names prefixed by the {@link #INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX}
+    */
+    static final User USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES = new User("index-operation-tester").roles(
+        new Role("index-manager").indexPermissions(
+            "indices:admin/create",
+            "indices:admin/get",
+            "indices:admin/delete",
+            "indices:admin/close",
+            "indices:admin/close*",
+            "indices:admin/open",
+            "indices:admin/resize",
+            "indices:monitor/stats",
+            "indices:monitor/settings/get",
+            "indices:admin/settings/update",
+            "indices:admin/mapping/put",
+            "indices:admin/mappings/get",
+            "indices:admin/cache/clear",
+            "indices:admin/aliases"
+        ).on(INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("*"))
+    );
+
+    private static User USER_ALLOWED_TO_CREATE_INDEX = new User("user-allowed-to-create-index").roles(
+        new Role("create-index-role").indexPermissions("indices:admin/create").on("*")
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(
+            ADMIN_USER,
+            LIMITED_READ_USER,
+            LIMITED_WRITE_USER,
+            DOUBLE_READER_USER,
+            REINDEXING_USER,
+            UPDATE_DELETE_USER,
+            USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES,
+            USER_ALLOWED_TO_CREATE_INDEX
+        )
+        .audit(
+            new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))
+                .filters(new AuditFilters().enabledRest(true).enabledTransport(true))
+        )
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(SONG_INDEX_NAME).setId(ID_S1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+            client.prepareIndex(UPDATE_DELETE_OPERATION_INDEX_NAME)
+                .setId(DOCUMENT_TO_UPDATE_ID)
+                .setRefreshPolicy(IMMEDIATE)
+                .setSource("field", "value")
+                .get();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(SONG_LYRICS_ALIAS))
+                )
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S2).source(SONGS[1].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S3).source(SONGS[2].asMap()))
+                .actionGet();
+
+            client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(ID_P4).setSource(SONGS[3].asMap()).setRefreshPolicy(IMMEDIATE).get();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new AliasActions(ADD).indices(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS)
+                    )
+                )
+                .actionGet();
+
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new AliasActions(ADD).indices(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME).alias(COLLECTIVE_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+            var createTemplateRequest = new org.opensearch.action.admin.indices.template.put.PutIndexTemplateRequest(
+                UNDELETABLE_TEMPLATE_NAME
+            );
+            createTemplateRequest.patterns(List.of("pattern-does-not-match-to-any-index"));
+            createTemplateRequest.alias(new Alias(ALIAS_FROM_UNDELETABLE_TEMPLATE));
+            client.admin().indices().putTemplate(createTemplateRequest).actionGet();
+
+            client.admin()
+                .cluster()
+                .putRepository(
+                    new PutRepositoryRequest(UNUSED_SNAPSHOT_REPOSITORY_NAME).type("fs")
+                        .settings(Map.of("location", cluster.getSnapshotDirPath()))
+                )
+                .actionGet();
+        }
+    }
+
+    @Before
+    public void retrieveClusterClient() {
+        this.internalClient = cluster.getInternalNodeClient();
+    }
+
+    @After
+    public void cleanData() throws ExecutionException, InterruptedException {
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        IndicesAdminClient indices = internalClient.admin().indices();
+        List<String> indicesToBeDeleted = List.of(
+            WRITE_SONG_INDEX_NAME,
+            INDEX_NAME_SONG_TRANSCRIPTION_JAZZ,
+            RESTORED_SONG_INDEX_NAME,
+            INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("*")
+        );
+        for (String indexToBeDeleted : indicesToBeDeleted) {
+            IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(indexToBeDeleted);
+            var indicesExistsResponse = indices.exists(indicesExistsRequest).get();
+            if (indicesExistsResponse.isExists()) {
+                DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexToBeDeleted);
+                indices.delete(deleteIndexRequest).actionGet();
+                Awaitility.await().ignoreExceptions().until(() -> indices.exists(indicesExistsRequest).get().isExists() == false);
+            }
+        }
+
+        List<String> aliasesToBeDeleted = List.of(
+            TEMPORARY_ALIAS_NAME,
+            ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001,
+            ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002,
+            ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE,
+            ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE
+        );
+        for (String aliasToBeDeleted : aliasesToBeDeleted) {
+            if (indices.exists(new IndicesExistsRequest(aliasToBeDeleted)).get().isExists()) {
+                AliasActions aliasAction = new AliasActions(AliasActions.Type.REMOVE).indices(SONG_INDEX_NAME).alias(aliasToBeDeleted);
+                internalClient.admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(aliasAction)).get();
+            }
+        }
+
+        GetIndexTemplatesResponse response = indices.getTemplates(new GetIndexTemplatesRequest(MUSICAL_INDEX_TEMPLATE)).get();
+        for (IndexTemplateMetadata metadata : response.getIndexTemplates()) {
+            indices.deleteTemplate(new DeleteIndexTemplateRequest(metadata.getName())).get();
+        }
+
+        ClusterAdminClient clusterClient = internalClient.admin().cluster();
+        try {
+            clusterClient.deleteRepository(new DeleteRepositoryRequest(TEST_SNAPSHOT_REPOSITORY_NAME)).actionGet();
+        } catch (RepositoryMissingException e) {
+            log.debug("Repository '{}' does not exist. This is expected in most of test cases", TEST_SNAPSHOT_REPOSITORY_NAME, e);
+        }
+        internalClient.close();
+        log.debug("Cleaning data after test took {}", stopwatch.stop());
+    }
+
+    @Test
+    public void shouldSearchForDocuments_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldSearchForDocuments_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(SONG_LYRICS_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics_index_alias/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_ALIAS, QUERY_TITLE_POISON);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics_index_alias/_search")
+        );
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchSongViaMultiIndexAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_NEXT_SONG);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/collective-index-alias/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchSongViaMultiIndexAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_POISON);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/collective-index-alias/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchAllIndexes_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(POST, "/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchAllIndexes_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchSongIndexesWithAsterisk_prohibitedSongIndex_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_POISON);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, PROHIBITED_SONG_INDEX_NAME, ID_P4));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_POISON));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/*song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchSongIndexesWithAsterisk_singIndex_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/*song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAbleToSearchSongIndexesWithAsterisk_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/*song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldFindSongUsingDslQuery_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = new SearchRequest(SONG_INDEX_NAME);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+            boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "f.+"));
+            boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            searchSourceBuilder.query(boolQueryBuilder);
+            searchRequest.source(searchSourceBuilder);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldFindSongUsingDslQuery_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = new SearchRequest(PROHIBITED_SONG_INDEX_NAME);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+            boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "n.+"));
+            boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_POISON));
+            searchSourceBuilder.query(boolQueryBuilder);
+            searchRequest.source(searchSourceBuilder);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldPerformSearchWithAllIndexAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(POST, "/_all/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldPerformSearchWithAllIndexAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_all/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldScrollOverSearchResults_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containNotEmptyScrollingId());
+
+            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+
+            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            assertThat(scrollResponse, isSuccessfulSearchResponse());
+            assertThat(scrollResponse, containNotEmptyScrollingId());
+            assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
+            assertThat(scrollResponse, numberOfHitsInPageIsEqualTo(1));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_search/scroll"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchScrollRequest"));
+    }
+
+    @Test
+    public void shouldScrollOverSearchResults_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containNotEmptyScrollingId());
+
+            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+
+            assertThatThrownBy(() -> restHighLevelClient.scroll(scrollRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_search/scroll"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "SearchScrollRequest"));
+    }
+
+    @Test
+    public void shouldGetDocument_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            GetResponse response = restHighLevelClient.get(new GetRequest(SONG_INDEX_NAME, ID_S1), DEFAULT);
+
+            assertThat(response, containDocument(SONG_INDEX_NAME, ID_S1));
+            assertThat(response, documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/song_lyrics/_doc/1"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "GetRequest"));
+    }
+
+    @Test
+    public void shouldGetDocument_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            GetRequest getRequest = new GetRequest(PROHIBITED_SONG_INDEX_NAME, ID_P4);
+            assertThatThrownBy(() -> restHighLevelClient.get(getRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_doc/4"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "GetRequest"));
+    }
+
+    @Test
+    public void shouldPerformMultiGetDocuments_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            MultiGetRequest request = new MultiGetRequest();
+            request.add(new Item(SONG_INDEX_NAME, ID_S1));
+            request.add(new Item(SONG_INDEX_NAME, ID_S2));
+
+            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+
+            assertThat(response, is(notNullValue()));
+            assertThat(response, isSuccessfulMultiGetResponse());
+            assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
+
+            MultiGetItemResponse[] responses = response.getResponses();
+            assertThat(
+                responses[0].getResponse(),
+                allOf(containDocument(SONG_INDEX_NAME, ID_S1), documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
+            );
+            assertThat(
+                responses[1].getResponse(),
+                allOf(containDocument(SONG_INDEX_NAME, ID_S2), documentContainField(FIELD_TITLE, TITLE_SONG_1_PLUS_1))
+            );
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetShardRequest"));
+    }
+
+    @Test
+    public void shouldPerformMultiGetDocuments_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            MultiGetRequest request = new MultiGetRequest();
+            request.add(new Item(SONG_INDEX_NAME, ID_S1));
+
+            assertThatThrownBy(() -> restHighLevelClient.mget(request, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_mget"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "MultiGetRequest"));
+    }
+
+    @Test
+    public void shouldPerformMultiGetDocuments_partiallyPositive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            MultiGetRequest request = new MultiGetRequest();
+            request.add(new Item(SONG_INDEX_NAME, ID_S1));
+            request.add(new Item(PROHIBITED_SONG_INDEX_NAME, ID_P4));
+
+            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+
+            assertThat(request, notNullValue());
+            assertThat(response, not(isSuccessfulMultiGetResponse()));
+            assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
+
+            MultiGetItemResponse[] responses = response.getResponses();
+            assertThat(responses, arrayContaining(hasProperty("failure", nullValue()), hasProperty("failure", notNullValue())));
+            assertThat(responses[1].getFailure().getFailure(), statusException(INTERNAL_SERVER_ERROR));
+            assertThat(responses[1].getFailure().getFailure(), errorMessageContain("security_exception"));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetShardRequest").withIndex(SONG_INDEX_NAME));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "MultiGetShardRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldBeAllowedToPerformMulitSearch_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
+            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
+
+            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response, isSuccessfulMultiSearchResponse());
+            assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
+
+            MultiSearchResponse.Item[] responses = response.getResponses();
+
+            assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+            assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldBeAllowedToPerformMulitSearch_partiallyPositive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
+            request.add(queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON));
+
+            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response, not(isSuccessfulMultiSearchResponse()));
+            assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
+
+            MultiSearchResponse.Item[] responses = response.getResponses();
+            assertThat(responses[0].getFailure(), nullValue());
+            assertThat(responses[1].getFailure(), statusException(INTERNAL_SERVER_ERROR));
+            assertThat(responses[1].getFailure(), errorMessageContain("security_exception"));
+            assertThat(responses[1].getResponse(), nullValue());
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(SONG_INDEX_NAME));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldBeAllowedToPerformMulitSearch_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+            MultiSearchRequest request = new MultiSearchRequest();
+            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
+            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
+
+            assertThatThrownBy(() -> restHighLevelClient.msearch(request, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_msearch"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "MultiSearchRequest"));
+    }
+
+    @Test
+    public void shouldAggregateDataAndComputeAverage_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            final String aggregationName = "averageStars";
+            SearchRequest searchRequest = averageAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldAggregateDataAndComputeAverage_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = averageAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "averageStars", FIELD_STARS);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldPerformStatAggregation_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            final String aggregationName = "statsStars";
+            SearchRequest searchRequest = statsAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
+
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldPerformStatAggregation_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = statsAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "statsStars", FIELD_STARS);
+
+            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldIndexDocumentInBulkRequest_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(response, successBulkResponse());
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one"));
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "two"));
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+            );
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertAtLeast(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));// sometimes 4 or 6
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));// sometimes 2 or 4
+    }
+
+    @Test
+    public void shouldIndexDocumentInBulkRequest_partiallyPositive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(
+                response,
+                bulkResponseContainExceptions(0, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
+            );
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "two"));
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+            );
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldIndexDocumentInBulkRequest_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(
+                response,
+                allOf(
+                    failureBulkResponse(),
+                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
+                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
+                )
+            );
+            assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "one")));
+            assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "two")));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldUpdateDocumentsInBulk_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            final String titleOne = "shape of my mind";
+            final String titleTwo = "forgiven";
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
+            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "two").doc(Map.of(FIELD_TITLE, titleTwo)));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(response, successBulkResponse());
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, titleTwo));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+
+    }
+
+    @Test
+    public void shouldUpdateDocumentsInBulk_partiallyPositive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            final String titleOne = "shape of my mind";
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
+            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(
+                response,
+                bulkResponseContainExceptions(1, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
+            );
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest").withIndex(SONG_INDEX_NAME));
+    }
+
+    @Test
+    public void shouldUpdateDocumentsInBulk_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S1).doc(Map.of(FIELD_TITLE, "shape of my mind")));
+            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(
+                response,
+                allOf(
+                    failureBulkResponse(),
+                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
+                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
+                )
+            );
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S1, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
+    }
+
+    @Test
+    public void shouldDeleteDocumentInBulk_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("three").source(SONGS[2].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("four").source(SONGS[3].asMap()));
+            assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
+            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
+            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "three"));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(response, successBulkResponse());
+            assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
+            assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "three")));
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+            );
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "four", FIELD_TITLE, TITLE_POISON));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    public void shouldDeleteDocumentInBulk_partiallyPositive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
+            assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
+            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
+            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
+
+            assertThat(
+                response,
+                bulkResponseContainExceptions(1, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
+            );
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+            );
+            assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S3, FIELD_TITLE, TITLE_NEXT_SONG));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
+    }
+
+    @Test
+    public void shouldDeleteDocumentInBulk_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
+            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S1));
+            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
+
+            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            assertThat(
+                response,
+                allOf(
+                    failureBulkResponse(),
+                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
+                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
+                )
+            );
+            assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S1));
+            assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S3));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "BulkShardRequest"));
+
+    }
+
+    @Test
+    public void shouldReindexDocuments_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(WRITE_SONG_INDEX_NAME);
+
+            BulkByScrollResponse response = restHighLevelClient.reindex(reindexRequest, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.getBulkFailures(), empty());
+            assertThat(response.getSearchFailures(), empty());
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S1));
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S2));
+            assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S3));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(REINDEXING_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(REINDEXING_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchScrollRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(REINDEXING_USER));
+        auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "ClearScrollRequest"));
+    }
+
+    @Test
+    public void shouldReindexDocuments_negativeSource() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME)
+                .setDestIndex(WRITE_SONG_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_P4)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldReindexDocuments_negativeDestination() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(PROHIBITED_SONG_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S1)));
+            assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S2)));
+            assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S3)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "SearchRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "BulkRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "BulkShardRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "ClearScrollRequest"));
+    }
+
+    @Test
+    public void shouldReindexDocuments_negativeSourceAndDestination() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME).setDestIndex(SONG_INDEX_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(REINDEXING_USER, "SearchRequest"));
+    }
+
+    @Test
+    public void shouldUpdateDocument_positive() throws IOException {
+        String newField = "newField";
+        String newValue = "newValue";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
+            UpdateRequest updateRequest = new UpdateRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, DOCUMENT_TO_UPDATE_ID).doc(
+                newField,
+                newValue
+            ).setRefreshPolicy(IMMEDIATE);
+
+            UpdateResponse response = restHighLevelClient.update(updateRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulUpdateResponse());
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(UPDATE_DELETE_OPERATION_INDEX_NAME, DOCUMENT_TO_UPDATE_ID, newField, newValue)
+            );
+        }
+    }
+
+    @Test
+    public void shouldUpdateDocument_negative() throws IOException {
+        String newField = "newField";
+        String newValue = "newValue";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
+            UpdateRequest updateRequest = new UpdateRequest(PROHIBITED_SONG_INDEX_NAME, DOCUMENT_TO_UPDATE_ID).doc(newField, newValue)
+                .setRefreshPolicy(IMMEDIATE);
+
+            assertThatThrownBy(() -> restHighLevelClient.update(updateRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldDeleteDocument_positive() throws IOException {
+        String docId = "shouldDeleteDocument_positive";
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.index(
+                new IndexRequest(UPDATE_DELETE_OPERATION_INDEX_NAME).id(docId).source("field", "value").setRefreshPolicy(IMMEDIATE)
+            ).actionGet();
+            assertThat(internalClient, clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId));
+        }
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
+            DeleteRequest deleteRequest = new DeleteRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, docId).setRefreshPolicy(IMMEDIATE);
+
+            DeleteResponse response = restHighLevelClient.delete(deleteRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulDeleteResponse());
+            assertThat(internalClient, not(clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId)));
+        }
+    }
+
+    @Test
+    public void shouldDeleteDocument_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
+            DeleteRequest deleteRequest = new DeleteRequest(PROHIBITED_SONG_INDEX_NAME, ID_S1).setRefreshPolicy(IMMEDIATE);
+
+            assertThatThrownBy(() -> restHighLevelClient.delete(deleteRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void shouldCreateAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
+            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+
+            var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
+        auditLogsRule.assertExactly(2, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_READ_USER));
+    }
+
+    @Test
+    public void shouldCreateAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            AliasActions aliasAction = new AliasActions(ADD).indices(PROHIBITED_SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
+            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT),
+                statusException(FORBIDDEN)
+            );
+
+            assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_P4)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
+    }
+
+    @Test
+    public void shouldDeleteAlias_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
+            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+            restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
+            aliasAction = new AliasActions(REMOVE).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
+            indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+
+            var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1)));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
+        auditLogsRule.assertExactly(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_READ_USER));
+    }
+
+    @Test
+    public void shouldDeleteAlias_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            AliasActions aliasAction = new AliasActions(REMOVE).indices(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS);
+            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT),
+                statusException(FORBIDDEN)
+            );
+
+            assertThat(internalClient, clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_P4));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "IndicesAliasesRequest"));
+    }
+
+    @Test
+    public void shouldCreateIndexTemplate_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
+
+            var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+            String documentId = "0001";
+            IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId)
+                .source(SONGS[0].asMap())
+                .setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.index(indexRequest, DEFAULT);
+            assertThat(internalClient, clusterContainsDocument(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ, documentId));
+            assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId));
+            assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, documentId));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/song-transcription-jazz/_doc/0001"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "IndexRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(8, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    public void shouldCreateIndexTemplate_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
+            assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_template/musical-index-template"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutIndexTemplateRequest"));
+    }
+
+    @Test
+    public void shouldDeleteTemplate_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX));
+            restHighLevelClient.indices().putTemplate(request, DEFAULT);
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+            DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE);
+
+            var response = restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_template/musical-index-template"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteIndexTemplateRequest"));
+        auditLogsRule.assertExactly(4, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    public void shouldDeleteTemplate_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT), statusException(FORBIDDEN));
+
+            assertThat(internalClient, clusterContainTemplate(UNDELETABLE_TEMPLATE_NAME));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_template/undeletable-template-name")
+        );
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "DeleteIndexTemplateRequest"));
+    }
+
+    @Test
+    public void shouldUpdateTemplate_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
+            restHighLevelClient.indices().putTemplate(request, DEFAULT);
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+            request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
+                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
+
+            var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            String documentId = "000one";
+            IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId)
+                .source(SONGS[0].asMap())
+                .setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.index(indexRequest, DEFAULT);
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+            assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003, documentId));
+            assertThat(internalClient, not(clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId)));
+            assertThat(internalClient, not(clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, documentId)));
+        }
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/song-transcription-jazz/_doc/000one"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutIndexTemplateRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "IndexRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(10, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    public void shouldUpdateTemplate_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            PutIndexTemplateRequest request = new PutIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME).patterns(
+                List.of(TEMPLATE_INDEX_PREFIX)
+            ).alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
+            assertThat(internalClient, clusterContainTemplateWithAlias(UNDELETABLE_TEMPLATE_NAME, ALIAS_FROM_UNDELETABLE_TEMPLATE));
+            assertThat(
+                internalClient,
+                not(clusterContainTemplateWithAlias(UNDELETABLE_TEMPLATE_NAME, ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003))
+            );
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_template/undeletable-template-name"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutIndexTemplateRequest"));
+    }
+
+    @Test
+    public void shouldGetFieldCapabilitiesForAllIndexes_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
+
+            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response, containsExactlyIndices(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME, UPDATE_DELETE_OPERATION_INDEX_NAME));
+            assertThat(response, numberOfFieldsIsEqualTo(1));
+            assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(ADMIN_USER).withRestRequest(GET, "/_field_caps"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(ADMIN_USER, "FieldCapabilitiesRequest"));
+        auditLogsRule.assertExactly(3, grantedPrivilege(ADMIN_USER, "FieldCapabilitiesIndexRequest"));
+    }
+
+    @Test
+    public void shouldGetFieldCapabilitiesForAllIndexes_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
+
+            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/_field_caps"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
+    }
+
+    @Test
+    public void shouldGetFieldCapabilitiesForParticularIndex_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(SONG_INDEX_NAME).fields(FIELD_TITLE);
+
+            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+
+            assertThat(response, notNullValue());
+            assertThat(response, containsExactlyIndices(SONG_INDEX_NAME));
+            assertThat(response, numberOfFieldsIsEqualTo(1));
+            assertThat(response, containsFieldWithNameAndType(FIELD_TITLE, "text"));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/song_lyrics/_field_caps"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "FieldCapabilitiesIndexRequest"));
+    }
+
+    @Test
+    public void shouldGetFieldCapabilitiesForParticularIndex_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(PROHIBITED_SONG_INDEX_NAME).fields(FIELD_TITLE);
+
+            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_field_caps"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
+    }
+
+    @Test
+    public void shouldCreateSnapshotRepository_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            String snapshotDirPath = cluster.getSnapshotDirPath();
+
+            var response = steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotDirPath, "fs");
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+    }
+
+    @Test
+    public void shouldCreateSnapshotRepository_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            String snapshotDirPath = cluster.getSnapshotDirPath();
+
+            assertThatThrownBy(
+                () -> steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotDirPath, "fs"),
+                statusException(FORBIDDEN)
+            );
+            assertThat(internalClient, not(clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "PutRepositoryRequest"));
+    }
+
+    @Test
+    public void shouldDeleteSnapshotRepository_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+            assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
+
+            var response = steps.deleteSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME);
+
+            assertThat(response, notNullValue());
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, not(clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME)));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository")
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteRepositoryRequest"));
+    }
+
+    @Test
+    public void shouldDeleteSnapshotRepository_negative() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+
+            assertThatThrownBy(() -> steps.deleteSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME), statusException(FORBIDDEN));
+            assertThat(internalClient, clusterContainsSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_snapshot/unused-snapshot-repository")
+        );
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "DeleteRepositoryRequest"));
+    }
+
+    @Test // Bug which can be reproduced with the below test: https://github.com/opensearch-project/security/issues/2169
+    public void shouldCreateSnapshot_positive() throws IOException {
+        final String snapshotName = "snapshot-positive-test";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+
+            CreateSnapshotResponse response = steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
+
+            assertThat(response, notNullValue());
+            assertThat(response.status(), equalTo(RestStatus.ACCEPTED));
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+            assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/snapshot-positive-test")
+        );
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/snapshot-positive-test")
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+    }
+
+    @Test
+    public void shouldCreateSnapshot_negative() throws IOException {
+        final String snapshotName = "snapshot-negative-test";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+
+            assertThatThrownBy(
+                () -> steps.createSnapshot(UNUSED_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME),
+                statusException(FORBIDDEN)
+            );
+
+            assertThat(internalClient, snapshotInClusterDoesNotExists(UNUSED_SNAPSHOT_REPOSITORY_NAME, snapshotName));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_snapshot/unused-snapshot-repository/snapshot-negative-test")
+        );
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "CreateSnapshotRequest"));
+    }
+
+    @Test
+    public void shouldDeleteSnapshot_positive() throws IOException {
+        String snapshotName = "delete-snapshot-positive";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            restHighLevelClient.snapshot();
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+            steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+
+            var response = steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+
+            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(internalClient, snapshotInClusterDoesNotExists(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/delete-snapshot-positive")
+        );
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository/delete-snapshot-positive")
+        );
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/delete-snapshot-positive")
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "DeleteSnapshotRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+    }
+
+    @Test
+    public void shouldDeleteSnapshot_negative() throws IOException {
+        String snapshotName = "delete-snapshot-negative";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+            steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+        }
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            assertThatThrownBy(() -> steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName), statusException(FORBIDDEN));
+
+            assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/delete-snapshot-negative")
+        );
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(DELETE, "/_snapshot/test-snapshot-repository/delete-snapshot-negative")
+        );
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/delete-snapshot-negative")
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertExactly(1, missingPrivilege(LIMITED_READ_USER, "DeleteSnapshotRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+    }
+
+    @Test
+    public void shouldRestoreSnapshot_positive() throws IOException {
+        final String snapshotName = "restore-snapshot-positive";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            // 1. create some documents
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            // 2. create snapshot repository
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+
+            // 3. create snapshot
+            steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME);
+
+            // 4. wait till snapshot is ready
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+
+            // 5. introduce some changes
+            bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Drei").source(SONGS[2].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Vier").source(SONGS[3].asMap()));
+            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "Eins"));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            // 6. restore the snapshot
+            var response = steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1");
+
+            assertThat(response, notNullValue());
+            assertThat(response.status(), equalTo(ACCEPTED));
+
+            // 7. wait until snapshot is restored
+            CountRequest countRequest = new CountRequest(RESTORED_SONG_INDEX_NAME);
+            Awaitility.await()
+                .ignoreExceptions()
+                .alias("Index contains proper number of documents restored from snapshot.")
+                .until(() -> restHighLevelClient.count(countRequest, DEFAULT).getCount() == 2);
+
+            // 8. verify that document are present in restored index
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(RESTORED_SONG_INDEX_NAME, "Eins", FIELD_TITLE, TITLE_MAGNUM_OPUS)
+            );
+            assertThat(
+                internalClient,
+                clusterContainsDocumentWithFieldValue(RESTORED_SONG_INDEX_NAME, "Zwei", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+            );
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Drei")));
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Vier")));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository/restore-snapshot-positive")
+        );
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                POST,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-positive/_restore"
+            )
+        );
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/restored_write_song_index/_count"));
+        auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(GET, "/_snapshot/test-snapshot-repository/restore-snapshot-positive")
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "SearchRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    public void shouldRestoreSnapshot_failureForbiddenIndex() throws IOException {
+        final String snapshotName = "restore-snapshot-negative-forbidden-index";
+        String restoreToIndex = "forbidden_index";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            // 1. create some documents
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            // 2. create snapshot repository
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+
+            // 3. create snapshot
+            steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME);
+
+            // 4. wait till snapshot is ready
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+
+            // 5. restore the snapshot
+            assertThatThrownBy(
+                () -> steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", restoreToIndex),
+                statusException(FORBIDDEN)
+            );
+
+            // 6. verify that document are not present in restored index
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Eins")));
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Zwei")));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                PUT,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index"
+            )
+        );
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                POST,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index/_restore"
+            )
+        );
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                GET,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-index"
+            )
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+        auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_WRITE_USER, "RestoreSnapshotRequest"));
+    }
+
+    @Test
+    public void shouldRestoreSnapshot_failureOperationForbidden() throws IOException {
+        String snapshotName = "restore-snapshot-negative-forbidden-operation";
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            // 1. create some documents
+            BulkRequest bulkRequest = new BulkRequest();
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
+            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
+            bulkRequest.setRefreshPolicy(IMMEDIATE);
+            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+
+            // 2. create snapshot repository
+            steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
+
+            // 3. create snapshot
+            steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, WRITE_SONG_INDEX_NAME);
+
+            // 4. wait till snapshot is ready
+            steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
+        }
+        // 5. restore the snapshot
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            assertThatThrownBy(
+                () -> steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1"),
+                statusException(FORBIDDEN)
+            );
+
+            // 6. verify that documents does not exist
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Eins")));
+            assertThat(internalClient, not(clusterContainsDocument(RESTORED_SONG_INDEX_NAME, "Zwei")));
+        }
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                PUT,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation"
+            )
+        );
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(LIMITED_READ_USER).withRestRequest(
+                POST,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation/_restore"
+            )
+        );
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(POST, "/_bulk"));
+        auditLogsRule.assertAtLeast(
+            1,
+            userAuthenticated(LIMITED_WRITE_USER).withRestRequest(
+                GET,
+                "/_snapshot/test-snapshot-repository/restore-snapshot-negative-forbidden-operation"
+            )
+        );
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "PutRepositoryRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateSnapshotRequest"));
+        auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_WRITE_USER, "BulkRequest"));
+        auditLogsRule.assertExactly(2, grantedPrivilege(LIMITED_WRITE_USER, "CreateIndexRequest"));
+        auditLogsRule.assertExactly(4, grantedPrivilege(LIMITED_WRITE_USER, "PutMappingRequest"));
+        auditLogsRule.assertExactly(1, missingPrivilege(LIMITED_READ_USER, "RestoreSnapshotRequest"));
+        auditLogsRule.assertAtLeast(2, grantedPrivilege(LIMITED_WRITE_USER, "GetSnapshotsRequest"));
+        auditLogsRule.assertExactly(6, auditPredicate(INDEX_EVENT).withEffectiveUser(LIMITED_WRITE_USER));
+    }
+
+    @Test
+    // required permissions: "indices:admin/create"
+    public void createIndex_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_positive");
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+            CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
+
+            assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
+            assertThat(cluster, indexExists(indexName));
+        }
+    }
+
+    @Test
+    public void createIndex_negative() throws IOException {
+        String indexName = "create_index_negative";
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(indexName)));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/get"
+    public void checkIfIndexExists_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("index_exists_positive");
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            boolean exists = restHighLevelClient.indices().exists(new GetIndexRequest(indexName), DEFAULT);
+
+            assertThat(exists, is(false));
+        }
+    }
+
+    @Test
+    public void checkIfIndexExists_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "index_exists_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().exists(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .exists(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(() -> restHighLevelClient.indices().exists(new GetIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/delete"
+    public void deleteIndex_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
+            var response = restHighLevelClient.indices().delete(deleteIndexRequest, DEFAULT);
+
+            assertThat(response.isAcknowledged(), is(true));
+            assertThat(cluster, not(indexExists(indexName)));
+        }
+    }
+
+    @Test
+    public void deleteIndex_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "delete_index_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().delete(new DeleteIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .delete(new DeleteIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().delete(new DeleteIndexRequest("*"), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: indices:admin/aliases, indices:admin/delete
+    public void shouldDeleteIndexByAliasRequest_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_by_alias_request_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
+
+            var response = restHighLevelClient.indices().updateAliases(request, DEFAULT);
+
+            assertThat(response.isAcknowledged(), is(true));
+            assertThat(cluster, not(indexExists(indexName)));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES).withRestRequest(POST, "/_aliases")
+        );
+        auditLogsRule.assertExactly(
+            2,
+            grantedPrivilege(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES, "IndicesAliasesRequest")
+        );
+        auditLogsRule.assertExactly(
+            2,
+            auditPredicate(INDEX_EVENT).withEffectiveUser(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)
+        );
+    }
+
+    @Test
+    public void shouldDeleteIndexByAliasRequest_negative() throws IOException {
+        String indexName = "delete_index_by_alias_request_negative";
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().updateAliases(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/get"
+    public void getIndex_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            GetIndexRequest getIndexRequest = new GetIndexRequest(indexName);
+            GetIndexResponse response = restHighLevelClient.indices().get(getIndexRequest, DEFAULT);
+
+            assertThat(response, getIndexResponseContainsIndices(indexName));
+        }
+    }
+
+    @Test
+    public void getIndex_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "get_index_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(() -> restHighLevelClient.indices().get(new GetIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/close", "indices:admin/close*"
+    public void closeIndex_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("close_index_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indexName);
+            CloseIndexResponse response = restHighLevelClient.indices().close(closeIndexRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulCloseIndexResponse());
+            assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.CLOSE));
+        }
+    }
+
+    @Test
+    public void closeIndex_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "close_index_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().close(new CloseIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .close(new CloseIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(() -> restHighLevelClient.indices().close(new CloseIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/open"
+    public void openIndex_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("open_index_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+        IndexOperationsHelper.closeIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            OpenIndexRequest closeIndexRequest = new OpenIndexRequest(indexName);
+            OpenIndexResponse response = restHighLevelClient.indices().open(closeIndexRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulOpenIndexResponse());
+            assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.OPEN));
+        }
+    }
+
+    @Test
+    public void openIndex_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "open_index_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().open(new OpenIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .open(new OpenIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(() -> restHighLevelClient.indices().open(new OpenIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    @Ignore
+    // required permissions: "indices:admin/resize", "indices:monitor/stats
+    // todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
+    // Issue: https://github.com/opensearch-project/security/issues/2141
+    public void shrinkIndex_positive() throws IOException {
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_positive_source");
+        Settings sourceIndexSettings = Settings.builder().put("index.blocks.write", true).put("index.number_of_shards", 2).build();
+        String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_positive_target");
+        IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            ResizeResponse response = restHighLevelClient.indices().shrink(resizeRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulResizeResponse(targetIndexName));
+            assertThat(cluster, indexExists(targetIndexName));
+        }
+    }
+
+    @Test
+    public void shrinkIndex_negative() throws IOException {
+        // user cannot access target index
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_source");
+        String targetIndexName = "shrink_index_negative_target";
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+
+        // user cannot access source index
+        sourceIndexName = "shrink_index_negative_source";
+        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_target");
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+    }
+
+    @Test
+    @Ignore
+    // required permissions: "indices:admin/resize", "indices:monitor/stats
+    // todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
+    // Issue: https://github.com/opensearch-project/security/issues/2141
+    public void cloneIndex_positive() throws IOException {
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_positive_source");
+        Settings sourceIndexSettings = Settings.builder().put("index.blocks.write", true).build();
+        String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_positive_target");
+        IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            ResizeResponse response = restHighLevelClient.indices().clone(resizeRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulResizeResponse(targetIndexName));
+            assertThat(cluster, indexExists(targetIndexName));
+        }
+    }
+
+    @Test
+    public void cloneIndex_negative() throws IOException {
+        // user cannot access target index
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_source");
+        String targetIndexName = "clone_index_negative_target";
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+
+        // user cannot access source index
+        sourceIndexName = "clone_index_negative_source";
+        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_target");
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+    }
+
+    @Test
+    @Ignore
+    // required permissions: "indices:admin/resize", "indices:monitor/stats
+    // todo even when I assign the `indices:admin/resize` and `indices:monitor/stats` permissions to test user, this test fails.
+    // Issue: https://github.com/opensearch-project/security/issues/2141
+    public void splitIndex_positive() throws IOException {
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_positive_source");
+        Settings sourceIndexSettings = Settings.builder().put("index.blocks.write", true).build();
+        String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_positive_target");
+        IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+            ResizeResponse response = restHighLevelClient.indices().split(resizeRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulResizeResponse(targetIndexName));
+            assertThat(cluster, indexExists(targetIndexName));
+        }
+    }
+
+    @Test
+    public void splitIndex_negative() throws IOException {
+        // user cannot access target index
+        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_source");
+        String targetIndexName = "split_index_negative_target";
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+
+        // user cannot access source index
+        sourceIndexName = "split_index_negative_source";
+        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_target");
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThat(cluster, not(indexExists(targetIndexName)));
+        }
+    }
+
+    @Test
+    // required permissions: "indices:monitor/settings/get"
+    public void getIndexSettings_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_settings_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            GetSettingsRequest getSettingsRequest = new GetSettingsRequest().indices(indexName);
+            GetSettingsResponse response = restHighLevelClient.indices().getSettings(getSettingsRequest, DEFAULT);
+
+            assertThat(response, getSettingsResponseContainsIndices(indexName));
+        }
+    }
+
+    @Test
+    public void getIndexSettings_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "get_index_settings_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .getSettings(new GetSettingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices("*"), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/settings/update"
+    public void updateIndexSettings_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("update_index_settings_positive");
+        Settings initialSettings = Settings.builder().put("index.number_of_replicas", "2").build();
+        Settings updatedSettings = Settings.builder().put("index.number_of_replicas", "4").build();
+        IndexOperationsHelper.createIndex(cluster, indexName, initialSettings);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indexName).settings(updatedSettings);
+            var response = restHighLevelClient.indices().putSettings(updateSettingsRequest, DEFAULT);
+
+            assertThat(response.isAcknowledged(), is(true));
+            assertThat(cluster, indexSettingsContainValues(indexName, updatedSettings));
+        }
+    }
+
+    @Test
+    public void updateIndexSettings_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "update_index_settings_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        Settings settingsToUpdate = Settings.builder().put("index.number_of_replicas", 2).build();
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .putSettings(new UpdateSettingsRequest(indexThatUserHasNoAccessTo).settings(settingsToUpdate), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .putSettings(
+                        new UpdateSettingsRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).settings(settingsToUpdate),
+                        DEFAULT
+                    ),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().putSettings(new UpdateSettingsRequest("*").settings(settingsToUpdate), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: indices:admin/mapping/put
+    public void createIndexMappings_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_mappings_positive");
+        Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            PutMappingRequest putMappingRequest = new PutMappingRequest(indexName).source(indexMapping);
+            var response = restHighLevelClient.indices().putMapping(putMappingRequest, DEFAULT);
+
+            assertThat(response.isAcknowledged(), is(true));
+            assertThat(cluster, indexMappingIsEqualTo(indexName, indexMapping));
+        }
+    }
+
+    @Test
+    public void createIndexMappings_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "create_index_mappings_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .putMapping(new PutMappingRequest(indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .putMapping(new PutMappingRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().putMapping(new PutMappingRequest("*").source(indexMapping), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: indices:admin/mappings/get
+    public void getIndexMappings_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_mappings_positive");
+        Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
+        IndexOperationsHelper.createIndex(cluster, indexName);
+        IndexOperationsHelper.createMapping(cluster, indexName, indexMapping);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(indexName);
+            GetMappingsResponse response = restHighLevelClient.indices().getMapping(getMappingsRequest, DEFAULT);
+
+            assertThat(response, getMappingsResponseContainsIndices(indexName));
+        }
+    }
+
+    @Test
+    public void getIndexMappings_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "get_index_mappings_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .getMapping(new GetMappingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices("*"), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/cache/clear"
+    public void clearIndexCache_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clear_index_cache_positive");
+        IndexOperationsHelper.createIndex(cluster, indexName);
+
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(indexName);
+            ClearIndicesCacheResponse response = restHighLevelClient.indices().clearCache(clearIndicesCacheRequest, DEFAULT);
+
+            assertThat(response, isSuccessfulClearIndicesCacheResponse());
+        }
+    }
+
+    @Test
+    public void clearIndexCache_negative() throws IOException {
+        String indexThatUserHasNoAccessTo = "clear_index_cache_negative";
+        String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices()
+                    .clearCache(new ClearIndicesCacheRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+            assertThatThrownBy(
+                () -> restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest("*"), DEFAULT),
+                statusException(FORBIDDEN)
+            );
+        }
+    }
+
+    @Test
+    // required permissions: "indices:admin/create", "indices:admin/aliases"
+    public void shouldCreateIndexWithAlias_positive() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_positive");
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
+            )
+        ) {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).alias(
+                new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE)
+            );
+
+            CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
+
+            assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
+            assertThat(cluster, indexExists(indexName));
+            assertThat(internalClient, aliasExists(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES).withRestRequest(
+                PUT,
+                "/index_operations_create_index_with_alias_positive"
+            )
+        );
+        auditLogsRule.assertExactly(
+            2,
+            grantedPrivilege(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES, "CreateIndexRequest")
+        );
+        auditLogsRule.assertExactly(
+            2,
+            auditPredicate(INDEX_EVENT).withEffectiveUser(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)
+        );
+    }
+
+    @Test
+    public void shouldCreateIndexWithAlias_negative() throws IOException {
+        String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_negative");
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_CREATE_INDEX)) {
+            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).alias(
+                new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE)
+            );
+
+            assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
+
+            assertThat(internalClient, not(aliasExists(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE)));
+        }
+        auditLogsRule.assertExactlyOne(
+            userAuthenticated(USER_ALLOWED_TO_CREATE_INDEX).withRestRequest(PUT, "/index_operations_create_index_with_alias_negative")
+        );
+        auditLogsRule.assertExactlyOne(missingPrivilege(USER_ALLOWED_TO_CREATE_INDEX, "CreateIndexRequest"));
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/SecurityAdminLauncher.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityAdminLauncher.java
@@ -18,24 +18,30 @@ import static java.util.Objects.requireNonNull;
 
 class SecurityAdminLauncher {
 
-	private final TestCertificates certificates;
-	private int port;
+    private final TestCertificates certificates;
+    private int port;
 
-	public SecurityAdminLauncher(int port, TestCertificates certificates) {
-		this.port = port;
-		this.certificates = requireNonNull(certificates, "Certificates are required to communicate with cluster.");
-	}
+    public SecurityAdminLauncher(int port, TestCertificates certificates) {
+        this.port = port;
+        this.certificates = requireNonNull(certificates, "Certificates are required to communicate with cluster.");
+    }
 
-	public int updateRoleMappings(File roleMappingsConfigurationFile) throws Exception {
-		String[] commandLineArguments = {"-cacert", certificates.getRootCertificate().getAbsolutePath(),
-			"-cert", certificates.getAdminCertificate().getAbsolutePath(),
-			"-key", certificates.getAdminKey(null).getAbsolutePath(),
-			"-nhnv",
-			"-p", String.valueOf(port),
-			"-f", roleMappingsConfigurationFile.getAbsolutePath(),
-			"-t", "rolesmapping"
-		};
+    public int updateRoleMappings(File roleMappingsConfigurationFile) throws Exception {
+        String[] commandLineArguments = {
+            "-cacert",
+            certificates.getRootCertificate().getAbsolutePath(),
+            "-cert",
+            certificates.getAdminCertificate().getAbsolutePath(),
+            "-key",
+            certificates.getAdminKey(null).getAbsolutePath(),
+            "-nhnv",
+            "-p",
+            String.valueOf(port),
+            "-f",
+            roleMappingsConfigurationFile.getAbsolutePath(),
+            "-t",
+            "rolesmapping" };
 
-		return SecurityAdmin.execute(commandLineArguments);
-	}
+        return SecurityAdmin.execute(commandLineArguments);
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
@@ -44,172 +44,189 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class SecurityConfigurationTests {
 
-	private static final User USER_ADMIN = new User("admin").roles(ALL_ACCESS);
-	private static final User LIMITED_USER = new User("limited-user")
-		.roles(new Role("limited-role").indexPermissions("indices:data/read/search", "indices:data/read/get").on("user-${user.name}"));
-	public static final String LIMITED_USER_INDEX = "user-" + LIMITED_USER.getName();
-	public static final String ADDITIONAL_USER_1 = "additional00001";
-	public static final String ADDITIONAL_PASSWORD_1 = "user 1 fair password";
+    private static final User USER_ADMIN = new User("admin").roles(ALL_ACCESS);
+    private static final User LIMITED_USER = new User("limited-user").roles(
+        new Role("limited-role").indexPermissions("indices:data/read/search", "indices:data/read/get").on("user-${user.name}")
+    );
+    public static final String LIMITED_USER_INDEX = "user-" + LIMITED_USER.getName();
+    public static final String ADDITIONAL_USER_1 = "additional00001";
+    public static final String ADDITIONAL_PASSWORD_1 = "user 1 fair password";
 
-	public static final String ADDITIONAL_USER_2 = "additional2";
-	public static final String ADDITIONAL_PASSWORD_2 = "user 2 fair password";
-	public static final String CREATE_USER_BODY = "{\"password\": \"%s\",\"opendistro_security_roles\": []}";
-	public static final String INTERNAL_USERS_RESOURCE = "_plugins/_security/api/internalusers/";
-	public static final String ID_1 = "one";
-	public static final String PROHIBITED_INDEX = "prohibited";
-	public static final String ID_2 = "two";
+    public static final String ADDITIONAL_USER_2 = "additional2";
+    public static final String ADDITIONAL_PASSWORD_2 = "user 2 fair password";
+    public static final String CREATE_USER_BODY = "{\"password\": \"%s\",\"opendistro_security_roles\": []}";
+    public static final String INTERNAL_USERS_RESOURCE = "_plugins/_security/api/internalusers/";
+    public static final String ID_1 = "one";
+    public static final String PROHIBITED_INDEX = "prohibited";
+    public static final String ID_2 = "two";
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_ADMIN, LIMITED_USER).anonymousAuth(false)
-		.nodeSettings(Map.of(SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_" + USER_ADMIN.getName()  +"__" + ALL_ACCESS.getName()),
-			SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, true))
-		.build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_ADMIN, LIMITED_USER)
+        .anonymousAuth(false)
+        .nodeSettings(
+            Map.of(
+                SECURITY_RESTAPI_ROLES_ENABLED,
+                List.of("user_" + USER_ADMIN.getName() + "__" + ALL_ACCESS.getName()),
+                SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST,
+                true
+            )
+        )
+        .build();
 
-	@Rule
-	public TemporaryFolder configurationDirectory = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder configurationDirectory = new TemporaryFolder();
 
-	@BeforeClass
-	public static void initData() {
-		try(Client client = cluster.getInternalNodeClient()){
-			client.prepareIndex(LIMITED_USER_INDEX).setId(ID_1).setRefreshPolicy(IMMEDIATE).setSource("foo", "bar").get();
-			client.prepareIndex(PROHIBITED_INDEX).setId(ID_2).setRefreshPolicy(IMMEDIATE).setSource("three", "four").get();
-		}
-	}
+    @BeforeClass
+    public static void initData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(LIMITED_USER_INDEX).setId(ID_1).setRefreshPolicy(IMMEDIATE).setSource("foo", "bar").get();
+            client.prepareIndex(PROHIBITED_INDEX).setId(ID_2).setRefreshPolicy(IMMEDIATE).setSource("three", "four").get();
+        }
+    }
 
-	@Test
-	public void shouldCreateUserViaRestApi_success() {
-		try(TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
-			HttpResponse httpResponse = client.putJson(INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_1, String.format(CREATE_USER_BODY,
-				ADDITIONAL_PASSWORD_1));
+    @Test
+    public void shouldCreateUserViaRestApi_success() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            HttpResponse httpResponse = client.putJson(
+                INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_1,
+                String.format(CREATE_USER_BODY, ADDITIONAL_PASSWORD_1)
+            );
 
-			assertThat(httpResponse.getStatusCode(), equalTo(201));
-		}
-		try(TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
-			client.assertCorrectCredentials(USER_ADMIN.getName());
-		}
-		try(TestRestClient client = cluster.getRestClient(ADDITIONAL_USER_1, ADDITIONAL_PASSWORD_1)) {
-			client.assertCorrectCredentials(ADDITIONAL_USER_1);
-		}
-	}
+            assertThat(httpResponse.getStatusCode(), equalTo(201));
+        }
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            client.assertCorrectCredentials(USER_ADMIN.getName());
+        }
+        try (TestRestClient client = cluster.getRestClient(ADDITIONAL_USER_1, ADDITIONAL_PASSWORD_1)) {
+            client.assertCorrectCredentials(ADDITIONAL_USER_1);
+        }
+    }
 
-	@Test
-	public void shouldCreateUserViaRestApi_failure() {
-		try(TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
-			HttpResponse httpResponse = client.putJson(INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_1, String.format(CREATE_USER_BODY,
-				ADDITIONAL_PASSWORD_1));
+    @Test
+    public void shouldCreateUserViaRestApi_failure() {
+        try (TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
+            HttpResponse httpResponse = client.putJson(
+                INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_1,
+                String.format(CREATE_USER_BODY, ADDITIONAL_PASSWORD_1)
+            );
 
-			httpResponse.assertStatusCode(403);
-		}
-	}
+            httpResponse.assertStatusCode(403);
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateAsAdminWithCertificate_positive() {
-		try(TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
-			HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+    @Test
+    public void shouldAuthenticateAsAdminWithCertificate_positive() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
 
-			httpResponse.assertStatusCode(200);
-			assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("true"));
-		}
-	}
+            httpResponse.assertStatusCode(200);
+            assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("true"));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateAsAdminWithCertificate_negativeSelfSignedCertificate() {
-		TestCertificates testCertificates = cluster.getTestCertificates();
-		try(TestRestClient client = cluster.getRestClient(testCertificates.createSelfSignedCertificate("CN=bond"))) {
-			HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+    @Test
+    public void shouldAuthenticateAsAdminWithCertificate_negativeSelfSignedCertificate() {
+        TestCertificates testCertificates = cluster.getTestCertificates();
+        try (TestRestClient client = cluster.getRestClient(testCertificates.createSelfSignedCertificate("CN=bond"))) {
+            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
 
-			httpResponse.assertStatusCode(200);
-			assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
-		}
-	}
+            httpResponse.assertStatusCode(200);
+            assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateAsAdminWithCertificate_negativeIncorrectDn() {
-		TestCertificates testCertificates = cluster.getTestCertificates();
-		try(TestRestClient client = cluster.getRestClient(testCertificates.createAdminCertificate("CN=non_admin"))) {
-			HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+    @Test
+    public void shouldAuthenticateAsAdminWithCertificate_negativeIncorrectDn() {
+        TestCertificates testCertificates = cluster.getTestCertificates();
+        try (TestRestClient client = cluster.getRestClient(testCertificates.createAdminCertificate("CN=non_admin"))) {
+            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
 
-			httpResponse.assertStatusCode(200);
-			assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
-		}
-	}
+            httpResponse.assertStatusCode(200);
+            assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
+        }
+    }
 
-	@Test
-	public void shouldCreateUserViaRestApiWhenAdminIsAuthenticatedViaCertificate_positive() {
-		try(TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+    @Test
+    public void shouldCreateUserViaRestApiWhenAdminIsAuthenticatedViaCertificate_positive() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
 
-			HttpResponse httpResponse = client.putJson(INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_2, String.format(CREATE_USER_BODY,
-				ADDITIONAL_PASSWORD_2));
+            HttpResponse httpResponse = client.putJson(
+                INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_2,
+                String.format(CREATE_USER_BODY, ADDITIONAL_PASSWORD_2)
+            );
 
-			httpResponse.assertStatusCode(201);
-		}
-		try(TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
-			client.assertCorrectCredentials(USER_ADMIN.getName());
-		}
-		try(TestRestClient client = cluster.getRestClient(ADDITIONAL_USER_2, ADDITIONAL_PASSWORD_2)) {
-			client.assertCorrectCredentials(ADDITIONAL_USER_2);
-		}
-	}
+            httpResponse.assertStatusCode(201);
+        }
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            client.assertCorrectCredentials(USER_ADMIN.getName());
+        }
+        try (TestRestClient client = cluster.getRestClient(ADDITIONAL_USER_2, ADDITIONAL_PASSWORD_2)) {
+            client.assertCorrectCredentials(ADDITIONAL_USER_2);
+        }
+    }
 
-	@Test
-	public void shouldCreateUserViaRestApiWhenAdminIsAuthenticatedViaCertificate_negative() {
-		TestCertificates testCertificates = cluster.getTestCertificates();
-		try(TestRestClient client = cluster.getRestClient(testCertificates.createSelfSignedCertificate("CN=attacker"))) {
-			HttpResponse httpResponse = client.putJson(INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_2, String.format(CREATE_USER_BODY,
-				ADDITIONAL_PASSWORD_2));
+    @Test
+    public void shouldCreateUserViaRestApiWhenAdminIsAuthenticatedViaCertificate_negative() {
+        TestCertificates testCertificates = cluster.getTestCertificates();
+        try (TestRestClient client = cluster.getRestClient(testCertificates.createSelfSignedCertificate("CN=attacker"))) {
+            HttpResponse httpResponse = client.putJson(
+                INTERNAL_USERS_RESOURCE + ADDITIONAL_USER_2,
+                String.format(CREATE_USER_BODY, ADDITIONAL_PASSWORD_2)
+            );
 
-			httpResponse.assertStatusCode(401);
-		}
-	}
+            httpResponse.assertStatusCode(401);
+        }
+    }
 
-	@Test
-	public void shouldStillWorkAfterUpdateOfSecurityConfig() {
-		List<User> users = new ArrayList<>(cluster.getConfiguredUsers());
-		User newUser = new User("new-user");
-		users.add(newUser);
+    @Test
+    public void shouldStillWorkAfterUpdateOfSecurityConfig() {
+        List<User> users = new ArrayList<>(cluster.getConfiguredUsers());
+        User newUser = new User("new-user");
+        users.add(newUser);
 
-		cluster.updateUserConfiguration(users);
+        cluster.updateUserConfiguration(users);
 
-		try(TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
-			client.assertCorrectCredentials(USER_ADMIN.getName());
-		}
-		try(TestRestClient client = cluster.getRestClient(newUser)) {
-			client.assertCorrectCredentials(newUser.getName());
-		}
-	}
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            client.assertCorrectCredentials(USER_ADMIN.getName());
+        }
+        try (TestRestClient client = cluster.getRestClient(newUser)) {
+            client.assertCorrectCredentials(newUser.getName());
+        }
+    }
 
-	@Test
-	public void shouldAccessIndexWithPlaceholder_positive() {
-		try(TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
-			HttpResponse httpResponse = client.get("/" + LIMITED_USER_INDEX + "/_doc/" + ID_1);
+    @Test
+    public void shouldAccessIndexWithPlaceholder_positive() {
+        try (TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
+            HttpResponse httpResponse = client.get("/" + LIMITED_USER_INDEX + "/_doc/" + ID_1);
 
-			httpResponse.assertStatusCode(200);
-		}
-	}
+            httpResponse.assertStatusCode(200);
+        }
+    }
 
-	@Test
-	public void shouldAccessIndexWithPlaceholder_negative() {
-		try(TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
-			HttpResponse httpResponse = client.get("/" + PROHIBITED_INDEX + "/_doc/" + ID_2);
+    @Test
+    public void shouldAccessIndexWithPlaceholder_negative() {
+        try (TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
+            HttpResponse httpResponse = client.get("/" + PROHIBITED_INDEX + "/_doc/" + ID_2);
 
-			httpResponse.assertStatusCode(403);
-		}
-	}
+            httpResponse.assertStatusCode(403);
+        }
+    }
 
-	@Test
-	public void shouldUseSecurityAdminTool() throws Exception {
-		SecurityAdminLauncher securityAdminLauncher = new SecurityAdminLauncher(cluster.getHttpPort(), cluster.getTestCertificates());
-		File rolesMapping = configurationDirectory.newFile("roles_mapping.yml");
-		ConfigurationFiles.createRoleMappingFile(rolesMapping);
+    @Test
+    public void shouldUseSecurityAdminTool() throws Exception {
+        SecurityAdminLauncher securityAdminLauncher = new SecurityAdminLauncher(cluster.getHttpPort(), cluster.getTestCertificates());
+        File rolesMapping = configurationDirectory.newFile("roles_mapping.yml");
+        ConfigurationFiles.createRoleMappingFile(rolesMapping);
 
-		int exitCode = securityAdminLauncher.updateRoleMappings(rolesMapping);
+        int exitCode = securityAdminLauncher.updateRoleMappings(rolesMapping);
 
-		assertThat(exitCode, equalTo(0));
-		try(TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
-			Awaitility.await().alias("Waiting for rolemapping 'readall' availability.")
-				.until(() -> client.get("_plugins/_security/api/rolesmapping/readall").getStatusCode(), equalTo(200));
-		}
-	}
+        assertThat(exitCode, equalTo(0));
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            Awaitility.await()
+                .alias("Waiting for rolemapping 'readall' availability.")
+                .until(() -> client.get("_plugins/_security/api/rolesmapping/readall").getStatusCode(), equalTo(200));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/SecurityRolesTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityRolesTests.java
@@ -32,29 +32,32 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class SecurityRolesTests {
 
-	protected final static TestSecurityConfig.User USER_SR = new TestSecurityConfig.User("sr_user").roles(
-			new Role("abc_ber").indexPermissions("*").on("*").clusterPermissions("*"),
-			new Role("def_efg").indexPermissions("*").on("*").clusterPermissions("*"));
+    protected final static TestSecurityConfig.User USER_SR = new TestSecurityConfig.User("sr_user").roles(
+        new Role("abc_ber").indexPermissions("*").on("*").clusterPermissions("*"),
+        new Role("def_efg").indexPermissions("*").on("*").clusterPermissions("*")
+    );
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(true)
-			.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_SR).build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(true)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_SR)
+        .build();
 
-	@Test
-	public void testSecurityRoles() throws Exception {
-		try (TestRestClient client = cluster.getRestClient(USER_SR)) {
-			HttpResponse response = client.getAuthInfo();
-			response.assertStatusCode(HttpStatus.SC_OK);
+    @Test
+    public void testSecurityRoles() throws Exception {
+        try (TestRestClient client = cluster.getRestClient(USER_SR)) {
+            HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(HttpStatus.SC_OK);
 
-			// Check username
-			assertThat(response.getTextFromJsonBody("/user_name"), equalTo("sr_user"));
+            // Check username
+            assertThat(response.getTextFromJsonBody("/user_name"), equalTo("sr_user"));
 
-			// Check security roles
-			assertThat(response.getTextFromJsonBody("/roles/0"), equalTo("user_sr_user__abc_ber"));
-			assertThat(response.getTextFromJsonBody("/roles/1"), equalTo("user_sr_user__def_efg"));
+            // Check security roles
+            assertThat(response.getTextFromJsonBody("/roles/0"), equalTo("user_sr_user__abc_ber"));
+            assertThat(response.getTextFromJsonBody("/roles/1"), equalTo("user_sr_user__def_efg"));
 
-		}
-	}
+        }
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/SnapshotSteps.java
+++ b/src/integrationTest/java/org/opensearch/security/SnapshotSteps.java
@@ -33,55 +33,63 @@ import static org.opensearch.client.RequestOptions.DEFAULT;
 
 class SnapshotSteps {
 
-	private final SnapshotClient snapshotClient;
+    private final SnapshotClient snapshotClient;
 
-	public SnapshotSteps(RestHighLevelClient restHighLevelClient) {
-		this.snapshotClient = requireNonNull(restHighLevelClient, "Rest high level client is required.").snapshot();
-	}
+    public SnapshotSteps(RestHighLevelClient restHighLevelClient) {
+        this.snapshotClient = requireNonNull(restHighLevelClient, "Rest high level client is required.").snapshot();
+    }
 
-	// CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
-	public org.opensearch.action.support.master.AcknowledgedResponse createSnapshotRepository(String repositoryName, String snapshotDirPath, String type)
-	// CS-ENFORCE-SINGLE
-		throws IOException {
-		PutRepositoryRequest createRepositoryRequest = new PutRepositoryRequest().name(repositoryName).type(type)
-			.settings(Map.of("location", snapshotDirPath));
-		return snapshotClient.createRepository(createRepositoryRequest, DEFAULT);
-	}
+    // CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
+    public org.opensearch.action.support.master.AcknowledgedResponse createSnapshotRepository(
+        String repositoryName,
+        String snapshotDirPath,
+        String type
+    )
+        // CS-ENFORCE-SINGLE
+        throws IOException {
+        PutRepositoryRequest createRepositoryRequest = new PutRepositoryRequest().name(repositoryName)
+            .type(type)
+            .settings(Map.of("location", snapshotDirPath));
+        return snapshotClient.createRepository(createRepositoryRequest, DEFAULT);
+    }
 
-	public CreateSnapshotResponse createSnapshot(String repositoryName, String snapshotName, String...indices) throws IOException {
-		CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest(repositoryName, snapshotName)
-			.indices(indices);
-		return snapshotClient.create(createSnapshotRequest, DEFAULT);
-	}
+    public CreateSnapshotResponse createSnapshot(String repositoryName, String snapshotName, String... indices) throws IOException {
+        CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest(repositoryName, snapshotName).indices(indices);
+        return snapshotClient.create(createSnapshotRequest, DEFAULT);
+    }
 
-	public void waitForSnapshotCreation(String repositoryName, String snapshotName) {
-		GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest(repositoryName, new String[] { snapshotName });
-		Awaitility.await().alias("wait for snapshot creation").ignoreExceptions().until(() -> {
-			GetSnapshotsResponse snapshotsResponse = snapshotClient.get(getSnapshotsRequest, DEFAULT);
-			SnapshotInfo snapshotInfo = snapshotsResponse.getSnapshots().get(0);
-			return SnapshotState.SUCCESS.equals(snapshotInfo.state());
-		});
-	}
+    public void waitForSnapshotCreation(String repositoryName, String snapshotName) {
+        GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest(repositoryName, new String[] { snapshotName });
+        Awaitility.await().alias("wait for snapshot creation").ignoreExceptions().until(() -> {
+            GetSnapshotsResponse snapshotsResponse = snapshotClient.get(getSnapshotsRequest, DEFAULT);
+            SnapshotInfo snapshotInfo = snapshotsResponse.getSnapshots().get(0);
+            return SnapshotState.SUCCESS.equals(snapshotInfo.state());
+        });
+    }
 
-	//CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
-	public org.opensearch.action.support.master.AcknowledgedResponse deleteSnapshotRepository(String repositoryName) throws IOException {
-	//CS-ENFORCE-SINGLE
-		DeleteRepositoryRequest request = new DeleteRepositoryRequest(repositoryName);
-		return snapshotClient.deleteRepository(request, DEFAULT);
-	}
+    // CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
+    public org.opensearch.action.support.master.AcknowledgedResponse deleteSnapshotRepository(String repositoryName) throws IOException {
+        // CS-ENFORCE-SINGLE
+        DeleteRepositoryRequest request = new DeleteRepositoryRequest(repositoryName);
+        return snapshotClient.deleteRepository(request, DEFAULT);
+    }
 
-	//CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
-	public org.opensearch.action.support.master.AcknowledgedResponse deleteSnapshot(String repositoryName, String snapshotName) throws IOException {
-	//CS-ENFORCE-SINGLE
-		return snapshotClient.delete(new DeleteSnapshotRequest(repositoryName, snapshotName), DEFAULT);
-	}
+    // CS-SUPPRESS-SINGLE: RegexpSingleline It is not possible to use phrase "cluster manager" instead of master here
+    public org.opensearch.action.support.master.AcknowledgedResponse deleteSnapshot(String repositoryName, String snapshotName)
+        throws IOException {
+        // CS-ENFORCE-SINGLE
+        return snapshotClient.delete(new DeleteSnapshotRequest(repositoryName, snapshotName), DEFAULT);
+    }
 
-	public RestoreSnapshotResponse restoreSnapshot(
-		String repositoryName, String snapshotName, String renamePattern,
-		String renameReplacement) throws IOException {
-		RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repositoryName, snapshotName)
-			.renamePattern(renamePattern)
-			.renameReplacement(renameReplacement);
-		return snapshotClient.restore(restoreSnapshotRequest, DEFAULT);
-	}
+    public RestoreSnapshotResponse restoreSnapshot(
+        String repositoryName,
+        String snapshotName,
+        String renamePattern,
+        String renameReplacement
+    ) throws IOException {
+        RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repositoryName, snapshotName).renamePattern(
+            renamePattern
+        ).renameReplacement(renameReplacement);
+        return snapshotClient.restore(restoreSnapshotRequest, DEFAULT);
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/Song.java
+++ b/src/integrationTest/java/org/opensearch/security/Song.java
@@ -14,90 +14,85 @@ import java.util.Objects;
 
 public class Song {
 
-	public static final String FIELD_TITLE = "title";
-	public static final String FIELD_ARTIST = "artist";
-	public static final String FIELD_LYRICS = "lyrics";
-	public static final String FIELD_STARS = "stars";
-	public static final String FIELD_GENRE = "genre";
-	public static final String ARTIST_FIRST = "First artist";
-	public static final String ARTIST_STRING = "String";
-	public static final String ARTIST_TWINS = "Twins";
-	public static final String TITLE_MAGNUM_OPUS = "Magnum Opus";
-	public static final String TITLE_SONG_1_PLUS_1 = "Song 1+1";
-	public static final String TITLE_NEXT_SONG = "Next song";
-	public static final String ARTIST_NO = "No!";
-	public static final String TITLE_POISON = "Poison";
+    public static final String FIELD_TITLE = "title";
+    public static final String FIELD_ARTIST = "artist";
+    public static final String FIELD_LYRICS = "lyrics";
+    public static final String FIELD_STARS = "stars";
+    public static final String FIELD_GENRE = "genre";
+    public static final String ARTIST_FIRST = "First artist";
+    public static final String ARTIST_STRING = "String";
+    public static final String ARTIST_TWINS = "Twins";
+    public static final String TITLE_MAGNUM_OPUS = "Magnum Opus";
+    public static final String TITLE_SONG_1_PLUS_1 = "Song 1+1";
+    public static final String TITLE_NEXT_SONG = "Next song";
+    public static final String ARTIST_NO = "No!";
+    public static final String TITLE_POISON = "Poison";
 
-	public static final String ARTIST_YES = "yes";
+    public static final String ARTIST_YES = "yes";
 
-	public static final String TITLE_AFFIRMATIVE = "Affirmative";
+    public static final String TITLE_AFFIRMATIVE = "Affirmative";
 
-	public static final String ARTIST_UNKNOWN = "unknown";
-	public static final String TITLE_CONFIDENTIAL = "confidential";
+    public static final String ARTIST_UNKNOWN = "unknown";
+    public static final String TITLE_CONFIDENTIAL = "confidential";
 
-	public static final String LYRICS_1 = "Very deep subject";
-	public static final String LYRICS_2 = "Once upon a time";
-	public static final String LYRICS_3 = "giant nonsense";
-	public static final String LYRICS_4 = "Much too much";
-	public static final String LYRICS_5 = "Little to little";
-	public static final String LYRICS_6 = "confidential secret classified";
+    public static final String LYRICS_1 = "Very deep subject";
+    public static final String LYRICS_2 = "Once upon a time";
+    public static final String LYRICS_3 = "giant nonsense";
+    public static final String LYRICS_4 = "Much too much";
+    public static final String LYRICS_5 = "Little to little";
+    public static final String LYRICS_6 = "confidential secret classified";
 
-	public static final String GENRE_ROCK = "rock";
-	public static final String GENRE_JAZZ = "jazz";
-	public static final String GENRE_BLUES = "blues";
+    public static final String GENRE_ROCK = "rock";
+    public static final String GENRE_JAZZ = "jazz";
+    public static final String GENRE_BLUES = "blues";
 
-	public static final String QUERY_TITLE_NEXT_SONG = FIELD_TITLE + ":" + "\"" + TITLE_NEXT_SONG + "\"";
-	public static final String QUERY_TITLE_POISON = FIELD_TITLE + ":" + TITLE_POISON;
-	public static final String QUERY_TITLE_MAGNUM_OPUS = FIELD_TITLE + ":" + TITLE_MAGNUM_OPUS;
+    public static final String QUERY_TITLE_NEXT_SONG = FIELD_TITLE + ":" + "\"" + TITLE_NEXT_SONG + "\"";
+    public static final String QUERY_TITLE_POISON = FIELD_TITLE + ":" + TITLE_POISON;
+    public static final String QUERY_TITLE_MAGNUM_OPUS = FIELD_TITLE + ":" + TITLE_MAGNUM_OPUS;
 
-	public static final Song[] SONGS = {
-		new Song(ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1,  GENRE_ROCK),
-		new Song(ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2,  2,  GENRE_BLUES),
-		new Song(ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3,  3, GENRE_JAZZ),
-		new Song(ARTIST_NO, TITLE_POISON, LYRICS_4,  4,  GENRE_ROCK),
-		new Song(ARTIST_YES, TITLE_AFFIRMATIVE,LYRICS_5,  5,  GENRE_BLUES),
-		new Song(ARTIST_UNKNOWN, TITLE_CONFIDENTIAL, LYRICS_6,  6,  GENRE_JAZZ)
-	};
+    public static final Song[] SONGS = {
+        new Song(ARTIST_FIRST, TITLE_MAGNUM_OPUS, LYRICS_1, 1, GENRE_ROCK),
+        new Song(ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2, 2, GENRE_BLUES),
+        new Song(ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3, 3, GENRE_JAZZ),
+        new Song(ARTIST_NO, TITLE_POISON, LYRICS_4, 4, GENRE_ROCK),
+        new Song(ARTIST_YES, TITLE_AFFIRMATIVE, LYRICS_5, 5, GENRE_BLUES),
+        new Song(ARTIST_UNKNOWN, TITLE_CONFIDENTIAL, LYRICS_6, 6, GENRE_JAZZ) };
 
-	private final String artist;
-	private final String title;
-	private final String lyrics;
-	private final Integer stars;
-	private final String genre;
+    private final String artist;
+    private final String title;
+    private final String lyrics;
+    private final Integer stars;
+    private final String genre;
 
-	public Song(String artist, String title, String lyrics, Integer stars, String genre) {
-		this.artist = Objects.requireNonNull(artist, "Artist is required");
-		this.title = Objects.requireNonNull(title, "Title is required");
-		this.lyrics = Objects.requireNonNull(lyrics, "Lyrics is required");
-		this.stars = Objects.requireNonNull(stars, "Stars field is required");
-		this.genre = Objects.requireNonNull(genre, "Genre field is required");
-	}
+    public Song(String artist, String title, String lyrics, Integer stars, String genre) {
+        this.artist = Objects.requireNonNull(artist, "Artist is required");
+        this.title = Objects.requireNonNull(title, "Title is required");
+        this.lyrics = Objects.requireNonNull(lyrics, "Lyrics is required");
+        this.stars = Objects.requireNonNull(stars, "Stars field is required");
+        this.genre = Objects.requireNonNull(genre, "Genre field is required");
+    }
 
-	public String getArtist() {
-		return artist;
-	}
+    public String getArtist() {
+        return artist;
+    }
 
-	public String getTitle() {
-		return title;
-	}
+    public String getTitle() {
+        return title;
+    }
 
-	public String getLyrics() {
-		return lyrics;
-	}
+    public String getLyrics() {
+        return lyrics;
+    }
 
-	public Integer getStars() {
-		return stars;
-	}
+    public Integer getStars() {
+        return stars;
+    }
 
-	public String getGenre() {
-		return genre;
-	}
+    public String getGenre() {
+        return genre;
+    }
 
-	public Map<String, Object> asMap() {
-		return Map.of(FIELD_ARTIST, artist,
-			FIELD_TITLE, title,
-			FIELD_LYRICS, lyrics,
-			FIELD_STARS, stars,
-			FIELD_GENRE, genre);
-	}
+    public Map<String, Object> asMap() {
+        return Map.of(FIELD_ARTIST, artist, FIELD_TITLE, title, FIELD_LYRICS, lyrics, FIELD_STARS, stars, FIELD_GENRE, genre);
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/SslOnlyTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SslOnlyTests.java
@@ -33,37 +33,37 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class SslOnlyTests {
 
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true))
+        .sslOnly(true)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .build();
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-		.loadConfigurationIntoIndex(false)
-		.nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true))
-		.sslOnly(true)
-		.authc(AUTHC_HTTPBASIC_INTERNAL).build();
+    @Test
+    public void shouldNotLoadSecurityPluginResources() {
+        try (TestRestClient client = cluster.getRestClient()) {
 
-	@Test
-	public void shouldNotLoadSecurityPluginResources() {
-		try(TestRestClient client = cluster.getRestClient()) {
+            HttpResponse response = client.getAuthInfo();
 
-			HttpResponse response = client.getAuthInfo();
+            // in SSL only mode the security plugin does not register a handler for resource /_plugins/_security/whoami. Therefore error
+            // response is returned.
+            response.assertStatusCode(400);
+        }
+    }
 
-			// in SSL only mode the security plugin does not register a handler for resource /_plugins/_security/whoami. Therefore error
-			// response is returned.
-			response.assertStatusCode(400);
-		}
-	}
+    @Test
+    public void shouldGetIndicesWithoutAuthentication() {
+        try (TestRestClient client = cluster.getRestClient()) {
 
-	@Test
-	public void shouldGetIndicesWithoutAuthentication() {
-		try(TestRestClient client = cluster.getRestClient()) {
+            // request does not contains credential
+            HttpResponse response = client.get("/_cat/indices");
 
-			// request does not contains credential
-			HttpResponse response = client.get("/_cat/indices");
-
-			// successful response is returned because the security plugin in SSL only mode
-			// does not perform authentication and authorization
-			response.assertStatusCode(200);
-		}
-	}
+            // successful response is returned because the security plugin in SSL only mode
+            // does not perform authentication and authorization
+            response.assertStatusCode(200);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/TlsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/TlsTests.java
@@ -50,55 +50,57 @@ import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.asser
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class TlsTests {
 
-	private static final User USER_ADMIN = new User("admin").roles(ALL_ACCESS);
+    private static final User USER_ADMIN = new User("admin").roles(ALL_ACCESS);
 
-	public static final String SUPPORTED_CIPHER_SUIT = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
-	public static final String NOT_SUPPORTED_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_CBC_SHA";
-	public static final String AUTH_INFO_ENDPOINT = "/_opendistro/_security/authinfo?pretty";
+    public static final String SUPPORTED_CIPHER_SUIT = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256";
+    public static final String NOT_SUPPORTED_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_CBC_SHA";
+    public static final String AUTH_INFO_ENDPOINT = "/_opendistro/_security/authinfo?pretty";
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).anonymousAuth(false)
-		.nodeSettings(Map.of(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of(SUPPORTED_CIPHER_SUIT)))
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_ADMIN)
-		.audit(new AuditConfiguration(true)
-			.compliance(new AuditCompliance().enabled(true))
-			.filters(new AuditFilters().enabledRest(true).enabledTransport(true))
-		).build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .nodeSettings(Map.of(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of(SUPPORTED_CIPHER_SUIT)))
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_ADMIN)
+        .audit(
+            new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))
+                .filters(new AuditFilters().enabledRest(true).enabledTransport(true))
+        )
+        .build();
 
-	@Rule
-	public AuditLogsRule auditLogsRule = new AuditLogsRule();
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
 
-	@Test
-	public void shouldCreateAuditOnIncomingNonTlsConnection() throws IOException {
-		try(CloseableHttpClient httpClient = HttpClients.createDefault()) {
-			HttpGet request = new HttpGet("http://localhost:" + cluster.getHttpPort());
+    @Test
+    public void shouldCreateAuditOnIncomingNonTlsConnection() throws IOException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet request = new HttpGet("http://localhost:" + cluster.getHttpPort());
 
-			assertThatThrownBy(() -> httpClient.execute(request), instanceOf(NoHttpResponseException.class));
-		}
-		auditLogsRule.assertAtLeast(1, auditPredicate(AuditCategory.SSL_EXCEPTION).withLayer(REST));
-	}
+            assertThatThrownBy(() -> httpClient.execute(request), instanceOf(NoHttpResponseException.class));
+        }
+        auditLogsRule.assertAtLeast(1, auditPredicate(AuditCategory.SSL_EXCEPTION).withLayer(REST));
+    }
 
-	@Test
-	public void shouldSupportClientCipherSuite_positive() throws IOException {
-		try(CloseableHttpClient client = cluster.getClosableHttpClient(new String[] { SUPPORTED_CIPHER_SUIT })) {
-			HttpGet httpGet = new HttpGet("https://localhost:" + cluster.getHttpPort() + AUTH_INFO_ENDPOINT);
-			httpGet.addHeader(getBasicAuthHeader(USER_ADMIN.getName(), USER_ADMIN.getPassword()));
+    @Test
+    public void shouldSupportClientCipherSuite_positive() throws IOException {
+        try (CloseableHttpClient client = cluster.getClosableHttpClient(new String[] { SUPPORTED_CIPHER_SUIT })) {
+            HttpGet httpGet = new HttpGet("https://localhost:" + cluster.getHttpPort() + AUTH_INFO_ENDPOINT);
+            httpGet.addHeader(getBasicAuthHeader(USER_ADMIN.getName(), USER_ADMIN.getPassword()));
 
-			try(CloseableHttpResponse response = client.execute(httpGet)) {
+            try (CloseableHttpResponse response = client.execute(httpGet)) {
 
-				int responseStatusCode = response.getCode();
-				assertThat(responseStatusCode, equalTo(200));
-			}
-		}
-	}
+                int responseStatusCode = response.getCode();
+                assertThat(responseStatusCode, equalTo(200));
+            }
+        }
+    }
 
-	@Test
-	public void shouldSupportClientCipherSuite_negative() throws IOException {
-		try(CloseableHttpClient client = cluster.getClosableHttpClient(new String[]{ NOT_SUPPORTED_CIPHER_SUITE })) {
-			HttpGet httpGet = new HttpGet("https://localhost:" + cluster.getHttpPort() + AUTH_INFO_ENDPOINT);
+    @Test
+    public void shouldSupportClientCipherSuite_negative() throws IOException {
+        try (CloseableHttpClient client = cluster.getClosableHttpClient(new String[] { NOT_SUPPORTED_CIPHER_SUITE })) {
+            HttpGet httpGet = new HttpGet("https://localhost:" + cluster.getHttpPort() + AUTH_INFO_ENDPOINT);
 
-			assertThatThrownBy(() -> client.execute(httpGet), instanceOf(SSLHandshakeException.class));
-		}
-	}
+            assertThatThrownBy(() -> client.execute(httpGet), instanceOf(SSLHandshakeException.class));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/UserBruteForceAttacksPreventionTests.java
+++ b/src/integrationTest/java/org/opensearch/security/UserBruteForceAttacksPreventionTests.java
@@ -35,91 +35,99 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class UserBruteForceAttacksPreventionTests {
 
-	private static final User USER_1 = new User("simple-user-1").roles(ALL_ACCESS);
-	private static final User USER_2 = new User("simple-user-2").roles(ALL_ACCESS);
-	private static final User USER_3 = new User("simple-user-3").roles(ALL_ACCESS);
-	private static final User USER_4 = new User("simple-user-4").roles(ALL_ACCESS);
-	private static final User USER_5 = new User("simple-user-5").roles(ALL_ACCESS);
+    private static final User USER_1 = new User("simple-user-1").roles(ALL_ACCESS);
+    private static final User USER_2 = new User("simple-user-2").roles(ALL_ACCESS);
+    private static final User USER_3 = new User("simple-user-3").roles(ALL_ACCESS);
+    private static final User USER_4 = new User("simple-user-4").roles(ALL_ACCESS);
+    private static final User USER_5 = new User("simple-user-5").roles(ALL_ACCESS);
 
-	public static final int ALLOWED_TRIES = 3;
-	public static final int TIME_WINDOW_SECONDS = 3;
-	private static final AuthFailureListeners listener = new AuthFailureListeners()
-		.addRateLimit(new RateLimiting("internal_authentication_backend_limiting").type("username").authenticationBackend("intern")
-			.allowedTries(ALLOWED_TRIES).timeWindowSeconds(TIME_WINDOW_SECONDS).blockExpirySeconds(2).maxBlockedClients(500)
-			.maxTrackedClients(500));
+    public static final int ALLOWED_TRIES = 3;
+    public static final int TIME_WINDOW_SECONDS = 3;
+    private static final AuthFailureListeners listener = new AuthFailureListeners().addRateLimit(
+        new RateLimiting("internal_authentication_backend_limiting").type("username")
+            .authenticationBackend("intern")
+            .allowedTries(ALLOWED_TRIES)
+            .timeWindowSeconds(TIME_WINDOW_SECONDS)
+            .blockExpirySeconds(2)
+            .maxBlockedClients(500)
+            .maxTrackedClients(500)
+    );
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false).authFailureListeners(listener)
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_1, USER_2, USER_3, USER_4, USER_5).build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authFailureListeners(listener)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_1, USER_2, USER_3, USER_4, USER_5)
+        .build();
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("org.opensearch.security.auth.BackendRegistry");
+    @Rule
+    public LogsRule logsRule = new LogsRule("org.opensearch.security.auth.BackendRegistry");
 
-	@Test
-	public void shouldAuthenticateUserWhenBlockadeIsNotActive() {
-		try(TestRestClient client = cluster.getRestClient(USER_1)) {
+    @Test
+    public void shouldAuthenticateUserWhenBlockadeIsNotActive() {
+        try (TestRestClient client = cluster.getRestClient(USER_1)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void shouldBlockUserWhenNumberOfFailureLoginAttemptIsEqualToLimit() {
-		authenticateUserWithIncorrectPassword(USER_2, ALLOWED_TRIES);
-		try(TestRestClient client = cluster.getRestClient(USER_2)) {
-				HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldBlockUserWhenNumberOfFailureLoginAttemptIsEqualToLimit() {
+        authenticateUserWithIncorrectPassword(USER_2, ALLOWED_TRIES);
+        try (TestRestClient client = cluster.getRestClient(USER_2)) {
+            HttpResponse response = client.getAuthInfo();
 
-				response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-		//Rejecting REST request because of blocked user:
-		logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_2.getName());
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+        // Rejecting REST request because of blocked user:
+        logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_2.getName());
+    }
 
-	@Test
-	public void shouldBlockUserWhenNumberOfFailureLoginAttemptIsGreaterThanLimit() {
-		authenticateUserWithIncorrectPassword(USER_3, ALLOWED_TRIES * 2);
-		try(TestRestClient client = cluster.getRestClient(USER_3)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldBlockUserWhenNumberOfFailureLoginAttemptIsGreaterThanLimit() {
+        authenticateUserWithIncorrectPassword(USER_3, ALLOWED_TRIES * 2);
+        try (TestRestClient client = cluster.getRestClient(USER_3)) {
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-		logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_3.getName());
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+        logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_3.getName());
+    }
 
-	@Test
-	public void shouldNotBlockUserWhenNumberOfLoginAttemptIsBelowLimit() {
-		authenticateUserWithIncorrectPassword(USER_4, ALLOWED_TRIES - 1);
-		try(TestRestClient client = cluster.getRestClient(USER_4)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldNotBlockUserWhenNumberOfLoginAttemptIsBelowLimit() {
+        authenticateUserWithIncorrectPassword(USER_4, ALLOWED_TRIES - 1);
+        try (TestRestClient client = cluster.getRestClient(USER_4)) {
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void shouldReleaseLock() throws InterruptedException {
-		authenticateUserWithIncorrectPassword(USER_5, ALLOWED_TRIES);
-		try(TestRestClient client = cluster.getRestClient(USER_5)) {
-			HttpResponse response = client.getAuthInfo();
-			response.assertStatusCode(SC_UNAUTHORIZED);
-			TimeUnit.SECONDS.sleep(TIME_WINDOW_SECONDS);
+    @Test
+    public void shouldReleaseLock() throws InterruptedException {
+        authenticateUserWithIncorrectPassword(USER_5, ALLOWED_TRIES);
+        try (TestRestClient client = cluster.getRestClient(USER_5)) {
+            HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            TimeUnit.SECONDS.sleep(TIME_WINDOW_SECONDS);
 
-			response = client.getAuthInfo();
+            response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_OK);
-		}
-		logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_5.getName());
-	}
+            response.assertStatusCode(SC_OK);
+        }
+        logsRule.assertThatContain("Rejecting REST request because of blocked user: " + USER_5.getName());
+    }
 
-	private static void authenticateUserWithIncorrectPassword(User user, int numberOfAttempts) {
-		try(TestRestClient client = cluster.getRestClient(user.getName(), "incorrect password")) {
-			for(int i = 0; i < numberOfAttempts; ++i) {
-				HttpResponse response = client.getAuthInfo();
-				response.assertStatusCode(SC_UNAUTHORIZED);
-			}
-		}
-	}
+    private static void authenticateUserWithIncorrectPassword(User user, int numberOfAttempts) {
+        try (TestRestClient client = cluster.getRestClient(user.getName(), "incorrect password")) {
+            for (int i = 0; i < numberOfAttempts; ++i) {
+                HttpResponse response = client.getAuthInfo();
+                response.assertStatusCode(SC_UNAUTHORIZED);
+            }
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/AnonymousAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AnonymousAuthenticationTest.java
@@ -34,95 +34,96 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class AnonymousAuthenticationTest {
 
-	private static final String DEFAULT_ANONYMOUS_USER_NAME = "opendistro_security_anonymous";
-	private static final String DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME = "opendistro_security_anonymous_backendrole";
+    private static final String DEFAULT_ANONYMOUS_USER_NAME = "opendistro_security_anonymous";
+    private static final String DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME = "opendistro_security_anonymous_backendrole";
 
-	/**
-	* Custom role assigned to the anonymous user via {@link #ANONYMOUS_USER_CUSTOM_ROLE_MAPPING}
-	*/
-	private static final TestSecurityConfig.Role ANONYMOUS_USER_CUSTOM_ROLE = new TestSecurityConfig.Role("anonymous_user_custom_role");
+    /**
+    * Custom role assigned to the anonymous user via {@link #ANONYMOUS_USER_CUSTOM_ROLE_MAPPING}
+    */
+    private static final TestSecurityConfig.Role ANONYMOUS_USER_CUSTOM_ROLE = new TestSecurityConfig.Role("anonymous_user_custom_role");
 
-	/**
-	* Maps {@link #ANONYMOUS_USER_CUSTOM_ROLE} to {@link #DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME}
-	*/
-	private static final RolesMapping ANONYMOUS_USER_CUSTOM_ROLE_MAPPING = new RolesMapping(ANONYMOUS_USER_CUSTOM_ROLE)
-			.backendRoles(DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME);
+    /**
+    * Maps {@link #ANONYMOUS_USER_CUSTOM_ROLE} to {@link #DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME}
+    */
+    private static final RolesMapping ANONYMOUS_USER_CUSTOM_ROLE_MAPPING = new RolesMapping(ANONYMOUS_USER_CUSTOM_ROLE).backendRoles(
+        DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME
+    );
 
-	/**
-	* User who is stored in the internal user database and can authenticate
-	*/
-	private static final TestSecurityConfig.User EXISTING_USER = new TestSecurityConfig.User("existing_user")
-			.roles(new TestSecurityConfig.Role("existing_user"));
+    /**
+    * User who is stored in the internal user database and can authenticate
+    */
+    private static final TestSecurityConfig.User EXISTING_USER = new TestSecurityConfig.User("existing_user").roles(
+        new TestSecurityConfig.Role("existing_user")
+    );
 
-	/**
-	* User who is not stored in the internal user database and can not authenticate
-	*/
-	private static final TestSecurityConfig.User NOT_EXISTING_USER = new TestSecurityConfig.User("not_existing_user")
-			.roles(new TestSecurityConfig.Role("not_existing_user"));
+    /**
+    * User who is not stored in the internal user database and can not authenticate
+    */
+    private static final TestSecurityConfig.User NOT_EXISTING_USER = new TestSecurityConfig.User("not_existing_user").roles(
+        new TestSecurityConfig.Role("not_existing_user")
+    );
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.SINGLENODE)
-			.anonymousAuth(true)
-			.authc(AUTHC_HTTPBASIC_INTERNAL)
-			.users(EXISTING_USER)
-			.roles(ANONYMOUS_USER_CUSTOM_ROLE)
-			.rolesMapping(ANONYMOUS_USER_CUSTOM_ROLE_MAPPING)
-			.build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(true)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(EXISTING_USER)
+        .roles(ANONYMOUS_USER_CUSTOM_ROLE)
+        .rolesMapping(ANONYMOUS_USER_CUSTOM_ROLE_MAPPING)
+        .build();
 
-	private static final String USER_NAME_POINTER = "/user_name";
-	private static final String BACKEND_ROLES_POINTER = "/backend_roles";
-	private static final String ROLES_POINTER = "/roles";
+    private static final String USER_NAME_POINTER = "/user_name";
+    private static final String BACKEND_ROLES_POINTER = "/backend_roles";
+    private static final String ROLES_POINTER = "/roles";
 
+    @Test
+    public void shouldAuthenticate_positive_anonymousUser() {
+        try (TestRestClient client = cluster.getRestClient()) {
 
-	@Test
-	public void shouldAuthenticate_positive_anonymousUser() {
-		try(TestRestClient client = cluster.getRestClient()){
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(200);
 
-			response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(USER_NAME_POINTER);
+            assertThat(username, equalTo(DEFAULT_ANONYMOUS_USER_NAME));
 
-			String username = response.getTextFromJsonBody(USER_NAME_POINTER);
-			assertThat(username, equalTo(DEFAULT_ANONYMOUS_USER_NAME));
+            List<String> backendRoles = response.getTextArrayFromJsonBody(BACKEND_ROLES_POINTER);
+            assertThat(backendRoles, hasSize(1));
+            assertThat(backendRoles, contains(DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME));
 
-			List<String> backendRoles = response.getTextArrayFromJsonBody(BACKEND_ROLES_POINTER);
-			assertThat(backendRoles, hasSize(1));
-			assertThat(backendRoles, contains(DEFAULT_ANONYMOUS_USER_BACKEND_ROLE_NAME));
+            List<String> roles = response.getTextArrayFromJsonBody(ROLES_POINTER);
+            assertThat(roles, hasSize(1));
+            assertThat(roles, contains(ANONYMOUS_USER_CUSTOM_ROLE.getName()));
+        }
+    }
 
-			List<String> roles = response.getTextArrayFromJsonBody(ROLES_POINTER);
-			assertThat(roles, hasSize(1));
-			assertThat(roles, contains(ANONYMOUS_USER_CUSTOM_ROLE.getName()));
-		}
-	}
+    @Test
+    public void shouldAuthenticate_positive_existingUser() {
+        try (TestRestClient client = cluster.getRestClient(EXISTING_USER)) {
 
-	@Test
-	public void shouldAuthenticate_positive_existingUser() {
-		try(TestRestClient client = cluster.getRestClient(EXISTING_USER)){
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(200);
 
-			response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(USER_NAME_POINTER);
+            assertThat(username, equalTo(EXISTING_USER.getName()));
 
-			String username = response.getTextFromJsonBody(USER_NAME_POINTER);
-			assertThat(username, equalTo(EXISTING_USER.getName()));
+            List<String> backendRoles = response.getTextArrayFromJsonBody(BACKEND_ROLES_POINTER);
+            assertThat(backendRoles, hasSize(0));
 
-			List<String> backendRoles = response.getTextArrayFromJsonBody(BACKEND_ROLES_POINTER);
-			assertThat(backendRoles, hasSize(0));
+            List<String> roles = response.getTextArrayFromJsonBody(ROLES_POINTER);
+            assertThat(roles, hasSize(EXISTING_USER.getRoleNames().size()));
+            assertThat(roles, containsInAnyOrder(EXISTING_USER.getRoleNames().toArray()));
+        }
+    }
 
-			List<String> roles = response.getTextArrayFromJsonBody(ROLES_POINTER);
-			assertThat(roles, hasSize(EXISTING_USER.getRoleNames().size()));
-			assertThat(roles, containsInAnyOrder(EXISTING_USER.getRoleNames().toArray()));
-		}
-	}
+    @Test
+    public void shouldAuthenticate_negative_notExistingUser() {
+        try (TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER)) {
 
-	@Test
-	public void shouldAuthenticate_negative_notExistingUser() {
-		try(TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER)){
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
-
-			response.assertStatusCode(401);
-		}
-	}
+            response.assertStatusCode(401);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/AuthInfo.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AuthInfo.java
@@ -17,14 +17,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 class AuthInfo {
 
-	private final List<String> customAttributeNames;
+    private final List<String> customAttributeNames;
 
-	@ConstructorProperties("custom_attribute_names")
-	public AuthInfo(List<String> customAttributeNames) {
-		this.customAttributeNames = customAttributeNames;
-	}
+    @ConstructorProperties("custom_attribute_names")
+    public AuthInfo(List<String> customAttributeNames) {
+        this.customAttributeNames = customAttributeNames;
+    }
 
-	public List<String> getCustomAttributeNames() {
-		return customAttributeNames;
-	}
+    public List<String> getCustomAttributeNames() {
+        return customAttributeNames;
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
@@ -37,110 +37,110 @@ import static org.hamcrest.Matchers.notNullValue;
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class BasicAuthTests {
-	static final User TEST_USER = new User("test_user").password("s3cret");
+    static final User TEST_USER = new User("test_user").password("s3cret");
 
-	public static final String CUSTOM_ATTRIBUTE_NAME = "superhero";
-	static final User SUPER_USER = new User("super-user").password("super-password")
-		.attr(CUSTOM_ATTRIBUTE_NAME, true);
-	public static final String NOT_EXISTING_USER = "not-existing-user";
-	public static final String INVALID_PASSWORD = "secret-password";
+    public static final String CUSTOM_ATTRIBUTE_NAME = "superhero";
+    static final User SUPER_USER = new User("super-user").password("super-password").attr(CUSTOM_ATTRIBUTE_NAME, true);
+    public static final String NOT_EXISTING_USER = "not-existing-user";
+    public static final String INVALID_PASSWORD = "secret-password";
 
-	public static final AuthcDomain AUTHC_DOMAIN = new AuthcDomain("basic", 0)
-		.httpAuthenticatorWithChallenge("basic").backend("internal");
+    public static final AuthcDomain AUTHC_DOMAIN = new AuthcDomain("basic", 0).httpAuthenticatorWithChallenge("basic").backend("internal");
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(AUTHC_DOMAIN).users(TEST_USER, SUPER_USER).build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_DOMAIN)
+        .users(TEST_USER, SUPER_USER)
+        .build();
 
-	@Test
-	public void shouldRespondWith401WhenUserDoesNotExist() {
-		try (TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER, INVALID_PASSWORD)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldRespondWith401WhenUserDoesNotExist() {
+        try (TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER, INVALID_PASSWORD)) {
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+    }
 
-	@Test
-	public void shouldRespondWith401WhenUserNameIsIncorrect() {
-		try (TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER, TEST_USER.getPassword())) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldRespondWith401WhenUserNameIsIncorrect() {
+        try (TestRestClient client = cluster.getRestClient(NOT_EXISTING_USER, TEST_USER.getPassword())) {
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+    }
 
-	@Test
-	public void shouldRespondWith401WhenPasswordIsIncorrect() {
-		try (TestRestClient client = cluster.getRestClient(TEST_USER.getName(), INVALID_PASSWORD)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldRespondWith401WhenPasswordIsIncorrect() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER.getName(), INVALID_PASSWORD)) {
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+    }
 
-	@Test
-	public void shouldRespondWith200WhenCredentialsAreCorrect() {
-		try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
+    @Test
+    public void shouldRespondWith200WhenCredentialsAreCorrect() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_OK);
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_OK);
+        }
+    }
 
-	@Test
-	public void testBrowserShouldRequestForCredentials() {
-		try (TestRestClient client = cluster.getRestClient()) {
+    @Test
+    public void testBrowserShouldRequestForCredentials() {
+        try (TestRestClient client = cluster.getRestClient()) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_UNAUTHORIZED);
-			assertThatBrowserAskUserForCredentials(response);
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            assertThatBrowserAskUserForCredentials(response);
+        }
+    }
 
-	@Test
-	public void testUserShouldNotHaveAssignedCustomAttributes() {
-		try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
+    @Test
+    public void testUserShouldNotHaveAssignedCustomAttributes() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_OK);
-			AuthInfo authInfo = response.getBodyAs(AuthInfo.class);
-			assertThat(authInfo, is(notNullValue()));
-			assertThat(authInfo.getCustomAttributeNames(), is(notNullValue()));
-			assertThat(authInfo.getCustomAttributeNames(), hasSize(0));
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_OK);
+            AuthInfo authInfo = response.getBodyAs(AuthInfo.class);
+            assertThat(authInfo, is(notNullValue()));
+            assertThat(authInfo.getCustomAttributeNames(), is(notNullValue()));
+            assertThat(authInfo.getCustomAttributeNames(), hasSize(0));
+        }
+    }
 
-	@Test
-	public void testUserShouldHaveAssignedCustomAttributes() {
-		try (TestRestClient client = cluster.getRestClient(SUPER_USER)) {
+    @Test
+    public void testUserShouldHaveAssignedCustomAttributes() {
+        try (TestRestClient client = cluster.getRestClient(SUPER_USER)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			assertThat(response, is(notNullValue()));
-			response.assertStatusCode(SC_OK);
-			AuthInfo authInfo = response.getBodyAs(AuthInfo.class);
-			assertThat(authInfo, is(notNullValue()));
-			List<String> customAttributeNames = authInfo.getCustomAttributeNames();
-			assertThat(customAttributeNames, is(notNullValue()));
-			assertThat(customAttributeNames, hasSize(1));
-			assertThat(customAttributeNames.get(0), Matchers.equalTo("attr.internal." + CUSTOM_ATTRIBUTE_NAME));
-		}
-	}
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_OK);
+            AuthInfo authInfo = response.getBodyAs(AuthInfo.class);
+            assertThat(authInfo, is(notNullValue()));
+            List<String> customAttributeNames = authInfo.getCustomAttributeNames();
+            assertThat(customAttributeNames, is(notNullValue()));
+            assertThat(customAttributeNames, hasSize(1));
+            assertThat(customAttributeNames.get(0), Matchers.equalTo("attr.internal." + CUSTOM_ATTRIBUTE_NAME));
+        }
+    }
 
-	private void assertThatBrowserAskUserForCredentials(HttpResponse response) {
-		String reason = "Browser does not ask user for credentials";
-		assertThat(reason, response.containHeader(HttpHeaders.WWW_AUTHENTICATE), equalTo(true));
-		assertThat(response.getHeader(HttpHeaders.WWW_AUTHENTICATE).getValue(), containsStringIgnoringCase("basic"));
-	}
+    private void assertThatBrowserAskUserForCredentials(HttpResponse response) {
+        String reason = "Browser does not ask user for credentials";
+        assertThat(reason, response.containHeader(HttpHeaders.WWW_AUTHENTICATE), equalTo(true));
+        assertThat(response.getHeader(HttpHeaders.WWW_AUTHENTICATE).getValue(), containsStringIgnoringCase("basic"));
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/BasicAuthWithoutChallengeTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/BasicAuthWithoutChallengeTests.java
@@ -28,24 +28,25 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class BasicAuthWithoutChallengeTests {
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(AUTHC_HTTPBASIC_INTERNAL_WITHOUT_CHALLENGE).build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL_WITHOUT_CHALLENGE)
+        .build();
 
-	@Test
-	public void browserShouldNotRequestUserForCredentials() {
-		try (TestRestClient client = cluster.getRestClient()) {
+    @Test
+    public void browserShouldNotRequestUserForCredentials() {
+        try (TestRestClient client = cluster.getRestClient()) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			assertThatBrowserDoesNotAskUserForCredentials(response);
-		}
-	}
+            response.assertStatusCode(401);
+            assertThatBrowserDoesNotAskUserForCredentials(response);
+        }
+    }
 
-	private void assertThatBrowserDoesNotAskUserForCredentials(HttpResponse response) {
-		String reason = "Browser asked user for credentials which is not expected";
-		assertThat(reason, response.containHeader(HttpHeaders.WWW_AUTHENTICATE), equalTo(false));
-	}
+    private void assertThatBrowserDoesNotAskUserForCredentials(HttpResponse response) {
+        String reason = "Browser asked user for credentials which is not expected";
+        assertThat(reason, response.containHeader(HttpHeaders.WWW_AUTHENTICATE), equalTo(false));
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/CommonProxyAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/CommonProxyAuthenticationTests.java
@@ -31,228 +31,225 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 */
 abstract class CommonProxyAuthenticationTests {
 
-	protected static final String RESOURCE_AUTH_INFO = "/_opendistro/_security/authinfo";
-	protected static final TestSecurityConfig.User USER_ADMIN = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    protected static final String RESOURCE_AUTH_INFO = "/_opendistro/_security/authinfo";
+    protected static final TestSecurityConfig.User USER_ADMIN = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	protected static final String ATTRIBUTE_DEPARTMENT = "department";
-	protected static final String ATTRIBUTE_SKILLS = "skills";
+    protected static final String ATTRIBUTE_DEPARTMENT = "department";
+    protected static final String ATTRIBUTE_SKILLS = "skills";
 
-	protected static final String USER_ATTRIBUTE_DEPARTMENT_NAME = "attr.proxy." + ATTRIBUTE_DEPARTMENT;
-	protected static final String USER_ATTRIBUTE_SKILLS_NAME = "attr.proxy." + ATTRIBUTE_SKILLS;
-	protected static final String USER_ATTRIBUTE_USERNAME_NAME = "attr.proxy.username";
+    protected static final String USER_ATTRIBUTE_DEPARTMENT_NAME = "attr.proxy." + ATTRIBUTE_DEPARTMENT;
+    protected static final String USER_ATTRIBUTE_SKILLS_NAME = "attr.proxy." + ATTRIBUTE_SKILLS;
+    protected static final String USER_ATTRIBUTE_USERNAME_NAME = "attr.proxy.username";
 
-	protected static final String HEADER_PREFIX_CUSTOM_ATTRIBUTES = "x-custom-attr";
-	protected static final String HEADER_PROXY_USER = "x-proxy-user";
-	protected static final String HEADER_PROXY_ROLES = "x-proxy-roles";
-	protected static final String HEADER_FORWARDED_FOR = "X-Forwarded-For";
-	protected static final String HEADER_DEPARTMENT = HEADER_PREFIX_CUSTOM_ATTRIBUTES + ATTRIBUTE_DEPARTMENT;
-	protected static final String HEADER_SKILLS = HEADER_PREFIX_CUSTOM_ATTRIBUTES + ATTRIBUTE_SKILLS;
+    protected static final String HEADER_PREFIX_CUSTOM_ATTRIBUTES = "x-custom-attr";
+    protected static final String HEADER_PROXY_USER = "x-proxy-user";
+    protected static final String HEADER_PROXY_ROLES = "x-proxy-roles";
+    protected static final String HEADER_FORWARDED_FOR = "X-Forwarded-For";
+    protected static final String HEADER_DEPARTMENT = HEADER_PREFIX_CUSTOM_ATTRIBUTES + ATTRIBUTE_DEPARTMENT;
+    protected static final String HEADER_SKILLS = HEADER_PREFIX_CUSTOM_ATTRIBUTES + ATTRIBUTE_SKILLS;
 
-	protected static final String IP_PROXY = "127.0.0.10";
-	protected static final String IP_NON_PROXY = "127.0.0.5";
-	protected static final String IP_CLIENT = "127.0.0.1";
+    protected static final String IP_PROXY = "127.0.0.10";
+    protected static final String IP_NON_PROXY = "127.0.0.5";
+    protected static final String IP_CLIENT = "127.0.0.1";
 
-	protected static final String USER_KIRK = "kirk";
-	protected static final String USER_SPOCK = "spock";
+    protected static final String USER_KIRK = "kirk";
+    protected static final String USER_SPOCK = "spock";
 
-	protected static final String BACKEND_ROLE_FIRST_MATE = "firstMate";
-	protected static final String BACKEND_ROLE_CAPTAIN = "captain";
-	protected static final String DEPARTMENT_BRIDGE = "bridge";
+    protected static final String BACKEND_ROLE_FIRST_MATE = "firstMate";
+    protected static final String BACKEND_ROLE_CAPTAIN = "captain";
+    protected static final String DEPARTMENT_BRIDGE = "bridge";
 
-	protected static final String PERSONAL_INDEX_NAME_PATTERN = "personal-${" + USER_ATTRIBUTE_DEPARTMENT_NAME + "}-${" + USER_ATTRIBUTE_USERNAME_NAME + "}";
-	protected static final String PERSONAL_INDEX_NAME_SPOCK = "personal-" + DEPARTMENT_BRIDGE + "-" + USER_SPOCK;
-	protected static final String PERSONAL_INDEX_NAME_KIRK = "personal-" + DEPARTMENT_BRIDGE + "-" + USER_KIRK;
+    protected static final String PERSONAL_INDEX_NAME_PATTERN = "personal-${"
+        + USER_ATTRIBUTE_DEPARTMENT_NAME
+        + "}-${"
+        + USER_ATTRIBUTE_USERNAME_NAME
+        + "}";
+    protected static final String PERSONAL_INDEX_NAME_SPOCK = "personal-" + DEPARTMENT_BRIDGE + "-" + USER_SPOCK;
+    protected static final String PERSONAL_INDEX_NAME_KIRK = "personal-" + DEPARTMENT_BRIDGE + "-" + USER_KIRK;
 
-	protected static final String POINTER_USERNAME = "/user_name";
-	protected static final String POINTER_BACKEND_ROLES = "/backend_roles";
-	protected static final String POINTER_ROLES = "/roles";
-	protected static final String POINTER_CUSTOM_ATTRIBUTES = "/custom_attribute_names";
-	protected static final String POINTER_TOTAL_HITS = "/hits/total/value";
-	protected static final String POINTER_FIRST_DOCUMENT_ID = "/hits/hits/0/_id";
-	protected static final String POINTER_FIRST_DOCUMENT_INDEX = "/hits/hits/0/_index";
-	protected static final String POINTER_FIRST_DOCUMENT_SOURCE_TITLE = "/hits/hits/0/_source/title";
+    protected static final String POINTER_USERNAME = "/user_name";
+    protected static final String POINTER_BACKEND_ROLES = "/backend_roles";
+    protected static final String POINTER_ROLES = "/roles";
+    protected static final String POINTER_CUSTOM_ATTRIBUTES = "/custom_attribute_names";
+    protected static final String POINTER_TOTAL_HITS = "/hits/total/value";
+    protected static final String POINTER_FIRST_DOCUMENT_ID = "/hits/hits/0/_id";
+    protected static final String POINTER_FIRST_DOCUMENT_INDEX = "/hits/hits/0/_index";
+    protected static final String POINTER_FIRST_DOCUMENT_SOURCE_TITLE = "/hits/hits/0/_source/title";
 
-	protected static final TestSecurityConfig.Role ROLE_ALL_INDEX_SEARCH = new TestSecurityConfig.Role("all-index-search").indexPermissions("indices:data/read/search")
-		.on("*");
+    protected static final TestSecurityConfig.Role ROLE_ALL_INDEX_SEARCH = new TestSecurityConfig.Role("all-index-search").indexPermissions(
+        "indices:data/read/search"
+    ).on("*");
 
-	protected static final TestSecurityConfig.Role ROLE_PERSONAL_INDEX_SEARCH = new TestSecurityConfig.Role("personal-index-search").indexPermissions("indices:data/read/search")
-		.on(PERSONAL_INDEX_NAME_PATTERN);
+    protected static final TestSecurityConfig.Role ROLE_PERSONAL_INDEX_SEARCH = new TestSecurityConfig.Role("personal-index-search")
+        .indexPermissions("indices:data/read/search")
+        .on(PERSONAL_INDEX_NAME_PATTERN);
 
-	protected static final RolesMapping ROLES_MAPPING_CAPTAIN = new RolesMapping(ROLE_PERSONAL_INDEX_SEARCH).backendRoles(BACKEND_ROLE_CAPTAIN);
+    protected static final RolesMapping ROLES_MAPPING_CAPTAIN = new RolesMapping(ROLE_PERSONAL_INDEX_SEARCH).backendRoles(
+        BACKEND_ROLE_CAPTAIN
+    );
 
-	protected static final RolesMapping ROLES_MAPPING_FIRST_MATE = new RolesMapping(ROLE_ALL_INDEX_SEARCH)
-		.backendRoles(BACKEND_ROLE_FIRST_MATE);
+    protected static final RolesMapping ROLES_MAPPING_FIRST_MATE = new RolesMapping(ROLE_ALL_INDEX_SEARCH).backendRoles(
+        BACKEND_ROLE_FIRST_MATE
+    );
 
-	protected abstract LocalCluster getCluster();
+    protected abstract LocalCluster getCluster();
 
-	protected void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
-		try(TestRestClient client = getCluster().getRestClient(USER_ADMIN)) {
-			TestRestClient.HttpResponse response = client.get(RESOURCE_AUTH_INFO);
+    protected void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
+        try (TestRestClient client = getCluster().getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse response = client.get(RESOURCE_AUTH_INFO);
 
-			response.assertStatusCode(200);
-		}
-	}
+            response.assertStatusCode(200);
+        }
+    }
 
-	protected void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_KIRK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_KIRK).header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_KIRK));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_KIRK));
+        }
+    }
 
-	protected void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_FIRST_MATE);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_SPOCK).header(HEADER_PROXY_ROLES, BACKEND_ROLE_FIRST_MATE);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_SPOCK));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SPOCK));
+        }
+    }
 
-	protected void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_PROXY_USER, USER_KIRK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_PROXY_USER, USER_KIRK).header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-		}
-	}
+            response.assertStatusCode(401);
+        }
+    }
 
-	protected void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-		}
-	}
+            response.assertStatusCode(401);
+        }
+    }
 
-	protected void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_KIRK);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_KIRK);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_KIRK));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_KIRK));
+        }
+    }
 
-	protected void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_NON_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_KIRK);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_NON_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_KIRK);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-		}
-	}
+            response.assertStatusCode(401);
+        }
+    }
 
-	protected void shouldRetrieveEmptyListOfRoles() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldRetrieveEmptyListOfRoles() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_SPOCK);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(0));
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
-			assertThat(roles, hasSize(0));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(0));
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
+            assertThat(roles, hasSize(0));
+        }
+    }
 
-	protected void shouldRetrieveSingleRoleFirstMate() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_FIRST_MATE);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldRetrieveSingleRoleFirstMate() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_SPOCK).header(HEADER_PROXY_ROLES, BACKEND_ROLE_FIRST_MATE);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(1));
-			assertThat(backendRoles, contains(BACKEND_ROLE_FIRST_MATE));
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
-			assertThat(roles, hasSize(1));
-			assertThat(roles, contains(ROLE_ALL_INDEX_SEARCH.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(1));
+            assertThat(backendRoles, contains(BACKEND_ROLE_FIRST_MATE));
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
+            assertThat(roles, hasSize(1));
+            assertThat(roles, contains(ROLE_ALL_INDEX_SEARCH.getName()));
+        }
+    }
 
-	protected void shouldRetrieveSingleRoleCaptain() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldRetrieveSingleRoleCaptain() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        ).header(HEADER_FORWARDED_FOR, IP_CLIENT).header(HEADER_PROXY_USER, USER_SPOCK).header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(1));
-			assertThat(backendRoles, contains(BACKEND_ROLE_CAPTAIN));
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
-			assertThat(roles, hasSize(1));
-			assertThat(roles, contains(ROLE_PERSONAL_INDEX_SEARCH.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(1));
+            assertThat(backendRoles, contains(BACKEND_ROLE_CAPTAIN));
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
+            assertThat(roles, hasSize(1));
+            assertThat(roles, contains(ROLE_PERSONAL_INDEX_SEARCH.getName()));
+        }
+    }
 
-	protected void shouldRetrieveMultipleRoles() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN + "," + BACKEND_ROLE_FIRST_MATE);
-		try(TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
+    protected void shouldRetrieveMultipleRoles() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN + "," + BACKEND_ROLE_FIRST_MATE);
+        try (TestRestClient client = getCluster().createGenericClientRestClient(testRestClientConfiguration)) {
 
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(2));
-			assertThat(backendRoles, containsInAnyOrder(BACKEND_ROLE_CAPTAIN, BACKEND_ROLE_FIRST_MATE));
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
-			assertThat(roles, hasSize(2));
-			assertThat(roles, containsInAnyOrder(ROLE_PERSONAL_INDEX_SEARCH.getName(), ROLE_ALL_INDEX_SEARCH.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(2));
+            assertThat(backendRoles, containsInAnyOrder(BACKEND_ROLE_CAPTAIN, BACKEND_ROLE_FIRST_MATE));
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
+            assertThat(roles, hasSize(2));
+            assertThat(roles, containsInAnyOrder(ROLE_PERSONAL_INDEX_SEARCH.getName(), ROLE_ALL_INDEX_SEARCH.getName()));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/DirectoryInformationTrees.java
+++ b/src/integrationTest/java/org/opensearch/security/http/DirectoryInformationTrees.java
@@ -14,111 +14,110 @@ import org.opensearch.test.framework.ldap.LdifData;
 
 class DirectoryInformationTrees {
 
-	public static final String DN_PEOPLE_TEST_ORG = "ou=people,o=test.org";
-	public static final String DN_OPEN_SEARCH_PEOPLE_TEST_ORG = "cn=Open Search,ou=people,o=test.org";
-	public static final String DN_CHRISTPHER_PEOPLE_TEST_ORG = "cn=Christpher,ou=people,o=test.org";
-	public static final String DN_KIRK_PEOPLE_TEST_ORG = "cn=Kirk,ou=people,o=test.org";
-	public static final String DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG = "cn=Captain Spock,ou=people,o=test.org";
-	public static final String DN_LEONARD_PEOPLE_TEST_ORG = "cn=Leonard,ou=people,o=test.org";
-	public static final String DN_JEAN_PEOPLE_TEST_ORG = "cn=Jean,ou=people,o=test.org";
-	public static final String DN_GROUPS_TEST_ORG = "ou=groups,o=test.org";
-	public static final String DN_BRIDGE_GROUPS_TEST_ORG = "cn=bridge,ou=groups,o=test.org";
+    public static final String DN_PEOPLE_TEST_ORG = "ou=people,o=test.org";
+    public static final String DN_OPEN_SEARCH_PEOPLE_TEST_ORG = "cn=Open Search,ou=people,o=test.org";
+    public static final String DN_CHRISTPHER_PEOPLE_TEST_ORG = "cn=Christpher,ou=people,o=test.org";
+    public static final String DN_KIRK_PEOPLE_TEST_ORG = "cn=Kirk,ou=people,o=test.org";
+    public static final String DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG = "cn=Captain Spock,ou=people,o=test.org";
+    public static final String DN_LEONARD_PEOPLE_TEST_ORG = "cn=Leonard,ou=people,o=test.org";
+    public static final String DN_JEAN_PEOPLE_TEST_ORG = "cn=Jean,ou=people,o=test.org";
+    public static final String DN_GROUPS_TEST_ORG = "ou=groups,o=test.org";
+    public static final String DN_BRIDGE_GROUPS_TEST_ORG = "cn=bridge,ou=groups,o=test.org";
 
-	public static final String USER_KIRK = "kirk";
-	public static final String PASSWORD_KIRK = "kirk-secret";
-	public static final String USER_SPOCK = "spock";
-	public static final String PASSWORD_SPOCK = "spocksecret";
-	public static final String USER_OPENS = "opens";
-	public static final String PASSWORD_OPEN_SEARCH = "open_search-secret";
-	public static final String USER_JEAN = "jean";
-	public static final String PASSWORD_JEAN = "jeansecret";
-	public static final String USER_LEONARD = "leonard";
-	public static final String PASSWORD_LEONARD = "Leonard-secret";
-	public static final String PASSWORD_CHRISTPHER = "christpher_secret";
+    public static final String USER_KIRK = "kirk";
+    public static final String PASSWORD_KIRK = "kirk-secret";
+    public static final String USER_SPOCK = "spock";
+    public static final String PASSWORD_SPOCK = "spocksecret";
+    public static final String USER_OPENS = "opens";
+    public static final String PASSWORD_OPEN_SEARCH = "open_search-secret";
+    public static final String USER_JEAN = "jean";
+    public static final String PASSWORD_JEAN = "jeansecret";
+    public static final String USER_LEONARD = "leonard";
+    public static final String PASSWORD_LEONARD = "Leonard-secret";
+    public static final String PASSWORD_CHRISTPHER = "christpher_secret";
 
-	public static final String CN_GROUP_ADMIN = "admin";
-	public static final String CN_GROUP_CREW = "crew";
-	public static final String CN_GROUP_BRIDGE = "bridge";
+    public static final String CN_GROUP_ADMIN = "admin";
+    public static final String CN_GROUP_CREW = "crew";
+    public static final String CN_GROUP_BRIDGE = "bridge";
 
-	public static final String USER_SEARCH = "(uid={0})";
-	public static final String USERNAME_ATTRIBUTE = "uid";
+    public static final String USER_SEARCH = "(uid={0})";
+    public static final String USERNAME_ATTRIBUTE = "uid";
 
-	static final LdifData LDIF_DATA = new LdifBuilder()
-		.root("o=test.org")
-			.dc("TEST")
-			.classes("top", "domain")
-		.newRecord(DN_PEOPLE_TEST_ORG)
-			.ou("people")
-			.classes("organizationalUnit", "top")
-		.newRecord(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Open Search")
-			.sn("Search")
-			.uid(USER_OPENS)
-			.userPassword(PASSWORD_OPEN_SEARCH)
-			.mail("open.search@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Captain Spock")
-			.sn(USER_SPOCK)
-			.uid(USER_SPOCK)
-			.userPassword(PASSWORD_SPOCK)
-			.mail("spock@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_KIRK_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Kirk")
-			.sn("Kirk")
-			.uid(USER_KIRK)
-			.userPassword(PASSWORD_KIRK)
-			.mail("spock@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_CHRISTPHER_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Christpher")
-			.sn("Christpher")
-			.uid("christpher")
-			.userPassword(PASSWORD_CHRISTPHER)
-			.mail("christpher@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_LEONARD_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Leonard")
-			.sn("Leonard")
-			.uid(USER_LEONARD)
-			.userPassword(PASSWORD_LEONARD)
-			.mail("leonard@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_JEAN_PEOPLE_TEST_ORG)
-			.classes("inetOrgPerson")
-			.cn("Jean")
-			.sn("Jean")
-			.uid(USER_JEAN)
-			.userPassword(PASSWORD_JEAN)
-			.mail("jean@example.com")
-			.ou("Human Resources")
-		.newRecord(DN_GROUPS_TEST_ORG)
-			.ou("groups")
-			.cn("groupsRoot")
-			.classes("groupofuniquenames", "top")
-		.newRecord("cn=admin,ou=groups,o=test.org")
-			.ou("groups")
-			.cn(CN_GROUP_ADMIN)
-			.uniqueMember(DN_KIRK_PEOPLE_TEST_ORG)
-			.classes("groupofuniquenames", "top")
-		.newRecord("cn=crew,ou=groups,o=test.org")
-			.ou("groups")
-			.cn(CN_GROUP_CREW)
-			.uniqueMember(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
-			.uniqueMember(DN_CHRISTPHER_PEOPLE_TEST_ORG)
-			.uniqueMember(DN_BRIDGE_GROUPS_TEST_ORG)
-			.classes("groupofuniquenames", "top")
-		.newRecord(DN_BRIDGE_GROUPS_TEST_ORG)
-			.ou("groups")
-			.cn(CN_GROUP_BRIDGE)
-			.uniqueMember(DN_JEAN_PEOPLE_TEST_ORG)
-			.classes("groupofuniquenames", "top")
-		.buildRecord()
-		.buildLdif();
+    static final LdifData LDIF_DATA = new LdifBuilder().root("o=test.org")
+        .dc("TEST")
+        .classes("top", "domain")
+        .newRecord(DN_PEOPLE_TEST_ORG)
+        .ou("people")
+        .classes("organizationalUnit", "top")
+        .newRecord(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Open Search")
+        .sn("Search")
+        .uid(USER_OPENS)
+        .userPassword(PASSWORD_OPEN_SEARCH)
+        .mail("open.search@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Captain Spock")
+        .sn(USER_SPOCK)
+        .uid(USER_SPOCK)
+        .userPassword(PASSWORD_SPOCK)
+        .mail("spock@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_KIRK_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Kirk")
+        .sn("Kirk")
+        .uid(USER_KIRK)
+        .userPassword(PASSWORD_KIRK)
+        .mail("spock@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_CHRISTPHER_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Christpher")
+        .sn("Christpher")
+        .uid("christpher")
+        .userPassword(PASSWORD_CHRISTPHER)
+        .mail("christpher@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_LEONARD_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Leonard")
+        .sn("Leonard")
+        .uid(USER_LEONARD)
+        .userPassword(PASSWORD_LEONARD)
+        .mail("leonard@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_JEAN_PEOPLE_TEST_ORG)
+        .classes("inetOrgPerson")
+        .cn("Jean")
+        .sn("Jean")
+        .uid(USER_JEAN)
+        .userPassword(PASSWORD_JEAN)
+        .mail("jean@example.com")
+        .ou("Human Resources")
+        .newRecord(DN_GROUPS_TEST_ORG)
+        .ou("groups")
+        .cn("groupsRoot")
+        .classes("groupofuniquenames", "top")
+        .newRecord("cn=admin,ou=groups,o=test.org")
+        .ou("groups")
+        .cn(CN_GROUP_ADMIN)
+        .uniqueMember(DN_KIRK_PEOPLE_TEST_ORG)
+        .classes("groupofuniquenames", "top")
+        .newRecord("cn=crew,ou=groups,o=test.org")
+        .ou("groups")
+        .cn(CN_GROUP_CREW)
+        .uniqueMember(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
+        .uniqueMember(DN_CHRISTPHER_PEOPLE_TEST_ORG)
+        .uniqueMember(DN_BRIDGE_GROUPS_TEST_ORG)
+        .classes("groupofuniquenames", "top")
+        .newRecord(DN_BRIDGE_GROUPS_TEST_ORG)
+        .ou("groups")
+        .cn(CN_GROUP_BRIDGE)
+        .uniqueMember(DN_JEAN_PEOPLE_TEST_ORG)
+        .classes("groupofuniquenames", "top")
+        .buildRecord()
+        .buildLdif();
 }

--- a/src/integrationTest/java/org/opensearch/security/http/DisabledBasicAuthTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/DisabledBasicAuthTests.java
@@ -28,20 +28,21 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.JWT_A
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DisabledBasicAuthTests {
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(DISABLED_AUTHC_HTTPBASIC_INTERNAL).users(TEST_USER)
-		.authc(JWT_AUTH_DOMAIN)
-		.build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(DISABLED_AUTHC_HTTPBASIC_INTERNAL)
+        .users(TEST_USER)
+        .authc(JWT_AUTH_DOMAIN)
+        .build();
 
-	@Test
-	public void shouldRespondWith401WhenCredentialsAreCorrectButBasicAuthIsDisabled() {
-		try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
+    @Test
+    public void shouldRespondWith401WhenCredentialsAreCorrectButBasicAuthIsDisabled() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(SC_UNAUTHORIZED);
-		}
-	}
+            response.assertStatusCode(SC_UNAUTHORIZED);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/ExtendedProxyAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/ExtendedProxyAuthenticationTest.java
@@ -48,202 +48,213 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ExtendedProxyAuthenticationTest extends CommonProxyAuthenticationTests {
 
+    public static final String ID_ONE_1 = "one#1";
+    public static final String ID_TWO_2 = "two#2";
+    public static final Map<String, Object> PROXY_AUTHENTICATOR_CONFIG = Map.of(
+        "user_header",
+        HEADER_PROXY_USER,
+        "roles_header",
+        HEADER_PROXY_ROLES,
+        "attr_header_prefix",
+        HEADER_PREFIX_CUSTOM_ATTRIBUTES
+    );
 
-	public static final String ID_ONE_1 = "one#1";
-	public static final String ID_TWO_2 = "two#2";
-	public static final Map<String, Object> PROXY_AUTHENTICATOR_CONFIG = Map.of(
-		"user_header", HEADER_PROXY_USER,
-		"roles_header", HEADER_PROXY_ROLES,
-		"attr_header_prefix", HEADER_PREFIX_CUSTOM_ATTRIBUTES
-	);
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .xff(new XffConfig(true).internalProxiesRegexp("127\\.0\\.0\\.10"))
+        .authc(
+            new AuthcDomain("proxy_auth_domain", -5, true).httpAuthenticator(
+                new HttpAuthenticator("extended-proxy").challenge(false).config(PROXY_AUTHENTICATOR_CONFIG)
+            ).backend(new AuthenticationBackend("noop"))
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_ADMIN)
+        .roles(ROLE_ALL_INDEX_SEARCH, ROLE_PERSONAL_INDEX_SEARCH)
+        .rolesMapping(ROLES_MAPPING_CAPTAIN, ROLES_MAPPING_FIRST_MATE)
+        .build();
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.xff(new XffConfig(true).internalProxiesRegexp("127\\.0\\.0\\.10"))
-		.authc(new AuthcDomain("proxy_auth_domain", -5, true)
-			.httpAuthenticator(new HttpAuthenticator("extended-proxy").challenge(false).config(PROXY_AUTHENTICATOR_CONFIG))
-			.backend(new AuthenticationBackend("noop")))
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_ADMIN).roles(ROLE_ALL_INDEX_SEARCH, ROLE_PERSONAL_INDEX_SEARCH)
-		.rolesMapping(ROLES_MAPPING_CAPTAIN, ROLES_MAPPING_FIRST_MATE).build();
+    @Override
+    protected LocalCluster getCluster() {
+        return cluster;
+    }
 
-	@Override
-	protected LocalCluster getCluster() {
-		return cluster;
-	}
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(PERSONAL_INDEX_NAME_SPOCK).setId(ID_ONE_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+            client.prepareIndex(PERSONAL_INDEX_NAME_KIRK).setId(ID_TWO_2).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
+        }
+    }
 
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()){
-			client.prepareIndex(PERSONAL_INDEX_NAME_SPOCK).setId(ID_ONE_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
-			client.prepareIndex(PERSONAL_INDEX_NAME_KIRK).setId(ID_TWO_2).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
-		}
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
+        super.shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
-		super.shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
+        super.shouldAuthenticateWithProxy_positiveUserKirk();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
-		super.shouldAuthenticateWithProxy_positiveUserKirk();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
+        super.shouldAuthenticateWithProxy_positiveUserSpock();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
-		super.shouldAuthenticateWithProxy_positiveUserSpock();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxyWhenRolesHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxyWhenRolesHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveEmptyListOfRoles() throws IOException {
+        super.shouldRetrieveEmptyListOfRoles();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveEmptyListOfRoles() throws IOException {
-		super.shouldRetrieveEmptyListOfRoles();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveSingleRoleFirstMate() throws IOException {
+        super.shouldRetrieveSingleRoleFirstMate();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveSingleRoleFirstMate() throws IOException {
-		super.shouldRetrieveSingleRoleFirstMate();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveSingleRoleCaptain() throws IOException {
+        super.shouldRetrieveSingleRoleCaptain();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveSingleRoleCaptain() throws IOException {
-		super.shouldRetrieveSingleRoleCaptain();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveMultipleRoles() throws IOException {
+        super.shouldRetrieveMultipleRoles();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveMultipleRoles() throws IOException {
-		super.shouldRetrieveMultipleRoles();
-	}
+    // tests specific for extended proxy authentication
 
-	// tests specific for extended proxy authentication
+    @Test
+    public void shouldRetrieveCustomAttributeNameDepartment() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
+            .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
+        try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-	@Test
-	public void shouldRetrieveCustomAttributeNameDepartment() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
-			.header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
-		try(TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
+            HttpResponse response = client.getAuthInfo();
 
-			HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(200);
+            List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
+            assertThat(customAttributes, hasSize(2));
+            assertThat(customAttributes, containsInAnyOrder(USER_ATTRIBUTE_USERNAME_NAME, USER_ATTRIBUTE_DEPARTMENT_NAME));
+        }
+    }
 
-			response.assertStatusCode(200);
-			List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
-			assertThat(customAttributes, hasSize(2));
-			assertThat(customAttributes, containsInAnyOrder(USER_ATTRIBUTE_USERNAME_NAME, USER_ATTRIBUTE_DEPARTMENT_NAME));
-		}
-	}
+    @Test
+    public void shouldRetrieveCustomAttributeNameSkills() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
+            .header(HEADER_SKILLS, "bilocation");
+        try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-	@Test
-	public void shouldRetrieveCustomAttributeNameSkills() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
-			.header(HEADER_SKILLS, "bilocation");
-		try(TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
+            HttpResponse response = client.getAuthInfo();
 
-			HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(200);
+            List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
+            assertThat(customAttributes, hasSize(2));
+            assertThat(customAttributes, containsInAnyOrder(USER_ATTRIBUTE_USERNAME_NAME, USER_ATTRIBUTE_SKILLS_NAME));
+        }
+    }
 
-			response.assertStatusCode(200);
-			List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
-			assertThat(customAttributes, hasSize(2));
-			assertThat(customAttributes, containsInAnyOrder(USER_ATTRIBUTE_USERNAME_NAME, USER_ATTRIBUTE_SKILLS_NAME));
-		}
-	}
+    @Test
+    public void shouldRetrieveMultipleCustomAttributes() throws IOException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
+            .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE)
+            .header(HEADER_SKILLS, "bilocation");
+        try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-	@Test
-	public void shouldRetrieveMultipleCustomAttributes() throws IOException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
-			.header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE)
-			.header(HEADER_SKILLS, "bilocation");
-		try(TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
+            HttpResponse response = client.getAuthInfo();
 
-			HttpResponse response = client.getAuthInfo();
+            response.assertStatusCode(200);
+            List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
+            assertThat(customAttributes, hasSize(3));
+            assertThat(
+                customAttributes,
+                containsInAnyOrder(USER_ATTRIBUTE_DEPARTMENT_NAME, USER_ATTRIBUTE_USERNAME_NAME, USER_ATTRIBUTE_SKILLS_NAME)
+            );
+        }
+    }
 
-			response.assertStatusCode(200);
-			List<String> customAttributes = response.getTextArrayFromJsonBody(POINTER_CUSTOM_ATTRIBUTES);
-			assertThat(customAttributes, hasSize(3));
-			assertThat(customAttributes, containsInAnyOrder(
-				USER_ATTRIBUTE_DEPARTMENT_NAME,
-				USER_ATTRIBUTE_USERNAME_NAME,
-				USER_ATTRIBUTE_SKILLS_NAME)
-			);
-		}
-	}
+    @Test
+    public void shouldRetrieveUserRolesAndAttributesSoThatAccessToPersonalIndexIsPossible_positive() throws UnknownHostException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
+            .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
+        try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-	@Test
-	public void shouldRetrieveUserRolesAndAttributesSoThatAccessToPersonalIndexIsPossible_positive() throws UnknownHostException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
-			.header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
-		try(TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
+            HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_SPOCK + "/_search");
 
-			HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_SPOCK + "/_search");
+            response.assertStatusCode(200);
+            assertThat(response.getLongFromJsonBody(POINTER_TOTAL_HITS), equalTo(1L));
+            assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_ID), equalTo(ID_ONE_1));
+            assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_INDEX), equalTo(PERSONAL_INDEX_NAME_SPOCK));
+            assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_SOURCE_TITLE), equalTo(TITLE_MAGNUM_OPUS));
+        }
+    }
 
-			response.assertStatusCode(200);
-			assertThat(response.getLongFromJsonBody(POINTER_TOTAL_HITS), equalTo(1L));
-			assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_ID), equalTo(ID_ONE_1));
-			assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_INDEX), equalTo(PERSONAL_INDEX_NAME_SPOCK));
-			assertThat(response.getTextFromJsonBody(POINTER_FIRST_DOCUMENT_SOURCE_TITLE), equalTo(TITLE_MAGNUM_OPUS));
-		}
-	}
+    @Test
+    public void shouldRetrieveUserRolesAndAttributesSoThatAccessToPersonalIndexIsPossible_negative() throws UnknownHostException {
+        TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration().sourceInetAddress(
+            InetAddress.getByName(IP_PROXY)
+        )
+            .header(HEADER_FORWARDED_FOR, IP_CLIENT)
+            .header(HEADER_PROXY_USER, USER_SPOCK)
+            .header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
+            .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
+        try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-	@Test
-	public void shouldRetrieveUserRolesAndAttributesSoThatAccessToPersonalIndexIsPossible_negative() throws UnknownHostException {
-		TestRestClientConfiguration testRestClientConfiguration = new TestRestClientConfiguration()
-			.sourceInetAddress(InetAddress.getByName(IP_PROXY))
-			.header(HEADER_FORWARDED_FOR, IP_CLIENT)
-			.header(HEADER_PROXY_USER, USER_SPOCK)
-			.header(HEADER_PROXY_ROLES, BACKEND_ROLE_CAPTAIN)
-			.header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
-		try(TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
+            HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_KIRK + "/_search");
 
-			HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_KIRK + "/_search");
-
-			response.assertStatusCode(403);
-		}
-	}
+            response.assertStatusCode(403);
+        }
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
@@ -19,7 +19,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.message.BasicHeader ;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -67,197 +67,204 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class JwtAuthenticationTests {
 
-	public static final String CLAIM_USERNAME = "preferred-username";
-	public static final String CLAIM_ROLES = "backend-user-roles";
+    public static final String CLAIM_USERNAME = "preferred-username";
+    public static final String CLAIM_ROLES = "backend-user-roles";
 
-	public static final String USER_SUPERHERO = "superhero";
-	public static final String USERNAME_ROOT = "root";
-	public static final String ROLE_ADMIN = "role_admin";
-	public static final String ROLE_DEVELOPER = "role_developer";
-	public static final String ROLE_QA = "role_qa";
-	public static final String ROLE_CTO = "role_cto";
-	public static final String ROLE_CEO = "role_ceo";
-	public static final String ROLE_VP = "role_vp";
-	public static final String POINTER_BACKEND_ROLES = "/backend_roles";
-	public static final String POINTER_USERNAME = "/user_name";
+    public static final String USER_SUPERHERO = "superhero";
+    public static final String USERNAME_ROOT = "root";
+    public static final String ROLE_ADMIN = "role_admin";
+    public static final String ROLE_DEVELOPER = "role_developer";
+    public static final String ROLE_QA = "role_qa";
+    public static final String ROLE_CTO = "role_cto";
+    public static final String ROLE_CEO = "role_ceo";
+    public static final String ROLE_VP = "role_vp";
+    public static final String POINTER_BACKEND_ROLES = "/backend_roles";
+    public static final String POINTER_USERNAME = "/user_name";
 
-	public static final String QA_DEPARTMENT = "qa-department";
+    public static final String QA_DEPARTMENT = "qa-department";
 
-	public static final String CLAIM_DEPARTMENT = "department";
+    public static final String CLAIM_DEPARTMENT = "department";
 
-	public static final String DEPARTMENT_SONG_INDEX_PATTERN = String.format("song_lyrics_${attr.jwt.%s}", CLAIM_DEPARTMENT);
+    public static final String DEPARTMENT_SONG_INDEX_PATTERN = String.format("song_lyrics_${attr.jwt.%s}", CLAIM_DEPARTMENT);
 
-	public static final String QA_SONG_INDEX_NAME = String.format("song_lyrics_%s", QA_DEPARTMENT);
+    public static final String QA_SONG_INDEX_NAME = String.format("song_lyrics_%s", QA_DEPARTMENT);
 
-	private static final KeyPair KEY_PAIR = Keys.keyPairFor(SignatureAlgorithm.RS256);
-	private static final String PUBLIC_KEY = new String(Base64.getEncoder().encode(KEY_PAIR.getPublic().getEncoded()), US_ASCII);
+    private static final KeyPair KEY_PAIR = Keys.keyPairFor(SignatureAlgorithm.RS256);
+    private static final String PUBLIC_KEY = new String(Base64.getEncoder().encode(KEY_PAIR.getPublic().getEncoded()), US_ASCII);
 
-	static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	private static final String JWT_AUTH_HEADER = "jwt-auth";
+    private static final String JWT_AUTH_HEADER = "jwt-auth";
 
-	private static final JwtAuthorizationHeaderFactory tokenFactory = new JwtAuthorizationHeaderFactory(
-		KEY_PAIR.getPrivate(),
-		CLAIM_USERNAME,
-		CLAIM_ROLES,
-		JWT_AUTH_HEADER);
+    private static final JwtAuthorizationHeaderFactory tokenFactory = new JwtAuthorizationHeaderFactory(
+        KEY_PAIR.getPrivate(),
+        CLAIM_USERNAME,
+        CLAIM_ROLES,
+        JWT_AUTH_HEADER
+    );
 
-	public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN = new TestSecurityConfig
-		.AuthcDomain("jwt", BASIC_AUTH_DOMAIN_ORDER - 1)
-		.jwtHttpAuthenticator(new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(PUBLIC_KEY).subjectKey(CLAIM_USERNAME)
-			.rolesKey(CLAIM_ROLES))
-		.backend("noop");
-	public static final String SONG_ID_1 = "song-id-01";
+    public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN = new TestSecurityConfig.AuthcDomain(
+        "jwt",
+        BASIC_AUTH_DOMAIN_ORDER - 1
+    ).jwtHttpAuthenticator(
+        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(PUBLIC_KEY).subjectKey(CLAIM_USERNAME).rolesKey(CLAIM_ROLES)
+    ).backend("noop");
+    public static final String SONG_ID_1 = "song-id-01";
 
-	public static final Role DEPARTMENT_SONG_LISTENER_ROLE = new Role("department-song-listener-role")
-		.indexPermissions("indices:data/read/search").on(DEPARTMENT_SONG_INDEX_PATTERN);
+    public static final Role DEPARTMENT_SONG_LISTENER_ROLE = new Role("department-song-listener-role").indexPermissions(
+        "indices:data/read/search"
+    ).on(DEPARTMENT_SONG_INDEX_PATTERN);
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.nodeSettings(Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName()  +"__" + ALL_ACCESS.getName())))
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(ADMIN_USER).roles(DEPARTMENT_SONG_LISTENER_ROLE)
-		.authc(JWT_AUTH_DOMAIN)
-		.build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .nodeSettings(
+            Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()))
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .roles(DEPARTMENT_SONG_LISTENER_ROLE)
+        .authc(JWT_AUTH_DOMAIN)
+        .build();
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.http.jwt.HTTPJwtAuthenticator");
+    @Rule
+    public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.http.jwt.HTTPJwtAuthenticator");
 
-	@BeforeClass
-	public static void createTestData() {
-		try (Client client = cluster.getInternalNodeClient()) {
-			client.prepareIndex(QA_SONG_INDEX_NAME).setId(SONG_ID_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
-		}
-		try(TestRestClient client = cluster.getRestClient(ADMIN_USER)){
-			client.createRoleMapping(ROLE_VP, DEPARTMENT_SONG_LISTENER_ROLE.getName());
-		}
-	}
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(QA_SONG_INDEX_NAME).setId(SONG_ID_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+        }
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            client.createRoleMapping(ROLE_VP, DEPARTMENT_SONG_LISTENER_ROLE.getName());
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_positive() {
-		try(TestRestClient client = cluster.getRestClient(tokenFactory.generateValidToken(USER_SUPERHERO))){
+    @Test
+    public void shouldAuthenticateWithJwtToken_positive() {
+        try (TestRestClient client = cluster.getRestClient(tokenFactory.generateValidToken(USER_SUPERHERO))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_SUPERHERO));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SUPERHERO));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_positiveWithAnotherUsername() {
-		try(TestRestClient client = cluster.getRestClient(tokenFactory.generateValidToken(USERNAME_ROOT))){
+    @Test
+    public void shouldAuthenticateWithJwtToken_positiveWithAnotherUsername() {
+        try (TestRestClient client = cluster.getRestClient(tokenFactory.generateValidToken(USERNAME_ROOT))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USERNAME_ROOT));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USERNAME_ROOT));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_failureLackingUserName() {
-		try(TestRestClient client = cluster.getRestClient(tokenFactory.generateTokenWithoutPreferredUsername(USER_SUPERHERO))){
+    @Test
+    public void shouldAuthenticateWithJwtToken_failureLackingUserName() {
+        try (TestRestClient client = cluster.getRestClient(tokenFactory.generateTokenWithoutPreferredUsername(USER_SUPERHERO))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatContainExactly("No subject found in JWT token");
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatContainExactly("No subject found in JWT token");
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_failureExpiredToken() {
-		try(TestRestClient client = cluster.getRestClient(tokenFactory.generateExpiredToken(USER_SUPERHERO))){
+    @Test
+    public void shouldAuthenticateWithJwtToken_failureExpiredToken() {
+        try (TestRestClient client = cluster.getRestClient(tokenFactory.generateExpiredToken(USER_SUPERHERO))) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatContainExactly("Invalid or expired JWT token.");
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatContainExactly("Invalid or expired JWT token.");
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_failureIncorrectFormatOfToken() {
-		Header header = new BasicHeader(AUTHORIZATION, "not.a.token");
-		try(TestRestClient client = cluster.getRestClient(header)){
+    @Test
+    public void shouldAuthenticateWithJwtToken_failureIncorrectFormatOfToken() {
+        Header header = new BasicHeader(AUTHORIZATION, "not.a.token");
+        try (TestRestClient client = cluster.getRestClient(header)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatContainExactly(String.format("No JWT token found in '%s' header header", JWT_AUTH_HEADER));
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatContainExactly(String.format("No JWT token found in '%s' header header", JWT_AUTH_HEADER));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateWithJwtToken_failureIncorrectSignature() {
-		KeyPair incorrectKeyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
-		Header header = tokenFactory.generateTokenSignedWithKey(incorrectKeyPair.getPrivate(), USER_SUPERHERO);
-		try(TestRestClient client = cluster.getRestClient(header)){
+    @Test
+    public void shouldAuthenticateWithJwtToken_failureIncorrectSignature() {
+        KeyPair incorrectKeyPair = Keys.keyPairFor(SignatureAlgorithm.RS256);
+        Header header = tokenFactory.generateTokenSignedWithKey(incorrectKeyPair.getPrivate(), USER_SUPERHERO);
+        try (TestRestClient client = cluster.getRestClient(header)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatContainExactly("Invalid or expired JWT token.");
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatContainExactly("Invalid or expired JWT token.");
+        }
+    }
 
-	@Test
-	public void shouldReadRolesFromToken_positiveFirstRoleSet() {
-		Header header = tokenFactory.generateValidToken(USER_SUPERHERO, ROLE_ADMIN, ROLE_DEVELOPER, ROLE_QA);
-		try(TestRestClient client = cluster.getRestClient(header)){
+    @Test
+    public void shouldReadRolesFromToken_positiveFirstRoleSet() {
+        Header header = tokenFactory.generateValidToken(USER_SUPERHERO, ROLE_ADMIN, ROLE_DEVELOPER, ROLE_QA);
+        try (TestRestClient client = cluster.getRestClient(header)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(roles, hasSize(3));
-			assertThat(roles, containsInAnyOrder(ROLE_ADMIN, ROLE_DEVELOPER, ROLE_QA));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(3));
+            assertThat(roles, containsInAnyOrder(ROLE_ADMIN, ROLE_DEVELOPER, ROLE_QA));
+        }
+    }
 
-	@Test
-	public void shouldReadRolesFromToken_positiveSecondRoleSet() {
-		Header header = tokenFactory.generateValidToken(USER_SUPERHERO, ROLE_CTO, ROLE_CEO, ROLE_VP);
-		try(TestRestClient client = cluster.getRestClient(header)){
+    @Test
+    public void shouldReadRolesFromToken_positiveSecondRoleSet() {
+        Header header = tokenFactory.generateValidToken(USER_SUPERHERO, ROLE_CTO, ROLE_CEO, ROLE_VP);
+        try (TestRestClient client = cluster.getRestClient(header)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(roles, hasSize(3));
-			assertThat(roles, containsInAnyOrder(ROLE_CTO, ROLE_CEO, ROLE_VP));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(3));
+            assertThat(roles, containsInAnyOrder(ROLE_CTO, ROLE_CEO, ROLE_VP));
+        }
+    }
 
-	@Test
-	public void shouldExposeTokenClaimsAsUserAttributes_positive() throws IOException {
-		String[] roles = { ROLE_VP };
-		Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, QA_DEPARTMENT);
-		Header header = tokenFactory.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
-		try(RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))){
-			SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldExposeTokenClaimsAsUserAttributes_positive() throws IOException {
+        String[] roles = { ROLE_VP };
+        Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, QA_DEPARTMENT);
+        Header header = tokenFactory.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))) {
+            SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
 
-			SearchResponse response = client.search(searchRequest, DEFAULT);
+            SearchResponse response = client.search(searchRequest, DEFAULT);
 
-			assertThat(response, isSuccessfulSearchResponse());
-			assertThat(response, numberOfTotalHitsIsEqualTo(1));
-			assertThat(response, searchHitsContainDocumentWithId(0, QA_SONG_INDEX_NAME, SONG_ID_1));
-			assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-		}
-	}
+            assertThat(response, isSuccessfulSearchResponse());
+            assertThat(response, numberOfTotalHitsIsEqualTo(1));
+            assertThat(response, searchHitsContainDocumentWithId(0, QA_SONG_INDEX_NAME, SONG_ID_1));
+            assertThat(response, searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+        }
+    }
 
-	@Test
-	public void shouldExposeTokenClaimsAsUserAttributes_negative() throws IOException {
-		String[] roles = { ROLE_VP };
-		Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, "department-without-access-to-qa-song-index");
-		Header header = tokenFactory.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
-		try(RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))){
-			SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
+    @Test
+    public void shouldExposeTokenClaimsAsUserAttributes_negative() throws IOException {
+        String[] roles = { ROLE_VP };
+        Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, "department-without-access-to-qa-song-index");
+        Header header = tokenFactory.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))) {
+            SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
 
-			assertThatThrownBy(() -> client.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> client.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -26,116 +26,116 @@ import static io.jsonwebtoken.SignatureAlgorithm.RS256;
 import static java.util.Objects.requireNonNull;
 
 class JwtAuthorizationHeaderFactory {
-	public static final String AUDIENCE = "OpenSearch";
-	public static final String ISSUER = "test-code";
-	private final PrivateKey privateKey;
+    public static final String AUDIENCE = "OpenSearch";
+    public static final String ISSUER = "test-code";
+    private final PrivateKey privateKey;
 
-	private final String usernameClaimName;
+    private final String usernameClaimName;
 
-	private final String rolesClaimName;
+    private final String rolesClaimName;
 
-	private final String headerName;
+    private final String headerName;
 
-	public JwtAuthorizationHeaderFactory(PrivateKey privateKey, String usernameClaimName, String rolesClaimName, String headerName) {
-		this.privateKey = requireNonNull(privateKey, "Private key is required");
-		this.usernameClaimName = requireNonNull(usernameClaimName, "Username claim name is required");
-		this.rolesClaimName = requireNonNull(rolesClaimName, "Roles claim name is required.");
-		this.headerName = requireNonNull(headerName, "Header name is required");
-	}
+    public JwtAuthorizationHeaderFactory(PrivateKey privateKey, String usernameClaimName, String rolesClaimName, String headerName) {
+        this.privateKey = requireNonNull(privateKey, "Private key is required");
+        this.usernameClaimName = requireNonNull(usernameClaimName, "Username claim name is required");
+        this.rolesClaimName = requireNonNull(rolesClaimName, "Roles claim name is required.");
+        this.headerName = requireNonNull(headerName, "Header name is required");
+    }
 
-	Header generateValidToken(String username, String...roles) {
-		requireNonNull(username, "Username is required");
-		Date now = new Date();
-		String token = Jwts.builder()
-			.setClaims(customClaimsMap(username, roles))
-			.setIssuer(ISSUER)
-			.setSubject(subject(username))
-			.setAudience(AUDIENCE)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + 3600 * 1000))
-			.signWith(privateKey, RS256)
-			.compact();
-		return toHeader(token);
-	}
+    Header generateValidToken(String username, String... roles) {
+        requireNonNull(username, "Username is required");
+        Date now = new Date();
+        String token = Jwts.builder()
+            .setClaims(customClaimsMap(username, roles))
+            .setIssuer(ISSUER)
+            .setSubject(subject(username))
+            .setAudience(AUDIENCE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(privateKey, RS256)
+            .compact();
+        return toHeader(token);
+    }
 
-	private Map<String, Object> customClaimsMap(String username, String[] roles) {
-		ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder();
-		if(StringUtils.isNoneEmpty(username)) {
-			builder.put(usernameClaimName, username);
-		}
-		if((roles != null) && (roles.length > 0)) {
-			builder.put(rolesClaimName, Arrays.stream(roles).collect(Collectors.joining(",")));
-		}
-		return builder.build();
-	}
+    private Map<String, Object> customClaimsMap(String username, String[] roles) {
+        ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder();
+        if (StringUtils.isNoneEmpty(username)) {
+            builder.put(usernameClaimName, username);
+        }
+        if ((roles != null) && (roles.length > 0)) {
+            builder.put(rolesClaimName, Arrays.stream(roles).collect(Collectors.joining(",")));
+        }
+        return builder.build();
+    }
 
-	Header generateValidTokenWithCustomClaims(String username, String[] roles, Map<String, Object> additionalClaims) {
-		requireNonNull(username, "Username is required");
-		requireNonNull(additionalClaims, "Custom claims are required");
-		Map<String, Object> claims = new HashMap<>(customClaimsMap(username, roles));
-		claims.putAll(additionalClaims);
-		Date now = new Date();
-		String token = Jwts.builder()
-			.setClaims(claims)
-			.setIssuer(ISSUER)
-			.setSubject(subject(username))
-			.setAudience(AUDIENCE)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + 3600 * 1000))
-			.signWith(privateKey, RS256)
-			.compact();
-		return toHeader(token);
-	}
+    Header generateValidTokenWithCustomClaims(String username, String[] roles, Map<String, Object> additionalClaims) {
+        requireNonNull(username, "Username is required");
+        requireNonNull(additionalClaims, "Custom claims are required");
+        Map<String, Object> claims = new HashMap<>(customClaimsMap(username, roles));
+        claims.putAll(additionalClaims);
+        Date now = new Date();
+        String token = Jwts.builder()
+            .setClaims(claims)
+            .setIssuer(ISSUER)
+            .setSubject(subject(username))
+            .setAudience(AUDIENCE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(privateKey, RS256)
+            .compact();
+        return toHeader(token);
+    }
 
-	private BasicHeader toHeader(String token) {
-		return new BasicHeader(headerName, token);
-	}
+    private BasicHeader toHeader(String token) {
+        return new BasicHeader(headerName, token);
+    }
 
-	Header generateTokenWithoutPreferredUsername(String username) {
-		requireNonNull(username, "Username is required");
-		Date now = new Date();
-		String token = Jwts.builder()
-			.setIssuer(ISSUER)
-			.setSubject(username)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + 3600 * 1000))
-			.signWith(privateKey, RS256)
-			.compact();
-		return toHeader(token);
-	}
+    Header generateTokenWithoutPreferredUsername(String username) {
+        requireNonNull(username, "Username is required");
+        Date now = new Date();
+        String token = Jwts.builder()
+            .setIssuer(ISSUER)
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(privateKey, RS256)
+            .compact();
+        return toHeader(token);
+    }
 
-	public Header generateExpiredToken(String username) {
-		requireNonNull(username, "Username is required");
-		Date now = new Date(1000);
-		String token = Jwts.builder()
-			.setClaims(Map.of(usernameClaimName, username))
-			.setIssuer(ISSUER)
-			.setSubject(subject(username))
-			.setAudience(AUDIENCE)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + 3600 * 1000))
-			.signWith(privateKey, RS256)
-			.compact();
-		return toHeader(token);
-	}
+    public Header generateExpiredToken(String username) {
+        requireNonNull(username, "Username is required");
+        Date now = new Date(1000);
+        String token = Jwts.builder()
+            .setClaims(Map.of(usernameClaimName, username))
+            .setIssuer(ISSUER)
+            .setSubject(subject(username))
+            .setAudience(AUDIENCE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(privateKey, RS256)
+            .compact();
+        return toHeader(token);
+    }
 
-	public Header generateTokenSignedWithKey(PrivateKey key, String username) {
-		requireNonNull(key, "Private key is required");
-		requireNonNull(username, "Username is required");
-		Date now = new Date();
-		String token = Jwts.builder()
-			.setClaims(Map.of(usernameClaimName, username))
-			.setIssuer(ISSUER)
-			.setSubject(subject(username))
-			.setAudience(AUDIENCE)
-			.setIssuedAt(now)
-			.setExpiration(new Date(now.getTime() + 3600 * 1000))
-			.signWith(key, RS256)
-			.compact();
-		return toHeader(token);
-	}
+    public Header generateTokenSignedWithKey(PrivateKey key, String username) {
+        requireNonNull(key, "Private key is required");
+        requireNonNull(username, "Username is required");
+        Date now = new Date();
+        String token = Jwts.builder()
+            .setClaims(Map.of(usernameClaimName, username))
+            .setIssuer(ISSUER)
+            .setSubject(subject(username))
+            .setAudience(AUDIENCE)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(key, RS256)
+            .compact();
+        return toHeader(token);
+    }
 
-	private static String subject(String username) {
-		return "subject-" + username;
-	}
+    private static String subject(String username) {
+        return "subject-" + username;
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
@@ -52,61 +52,69 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class LdapAuthenticationTest {
 
-	private static final Logger log = LogManager.getLogger(LdapAuthenticationTest.class);
+    private static final Logger log = LogManager.getLogger(LdapAuthenticationTest.class);
 
-	private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+    private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
 
-	public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(TEST_CERTIFICATES.getRootCertificateData(),
-		TEST_CERTIFICATES.getLdapCertificateData(), LDIF_DATA);
+    public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(
+        TEST_CERTIFICATES.getRootCertificateData(),
+        TEST_CERTIFICATES.getLdapCertificateData(),
+        LDIF_DATA
+    );
 
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.testCertificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true)
-			.httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
-			.backend(new AuthenticationBackend("ldap")
-				.config(() -> LdapAuthenticationConfigBuilder.config()
-					// this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used to postpone
-					// execution of the code in this block.
-					.enableSsl(false)
-					.enableStartTls(false)
-					.hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))
-					.bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-					.password(PASSWORD_OPEN_SEARCH)
-					.userBase(DN_PEOPLE_TEST_ORG)
-					.userSearch(USER_SEARCH)
-					.usernameAttribute(USERNAME_ATTRIBUTE)
-					.build())))
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER)
-		.build();
+    public static LocalCluster cluster = new LocalCluster.Builder().testCertificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(
+            new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true).httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
+                .backend(
+                    new AuthenticationBackend("ldap").config(
+                        () -> LdapAuthenticationConfigBuilder.config()
+                            // this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used to
+                            // postpone
+                            // execution of the code in this block.
+                            .enableSsl(false)
+                            .enableStartTls(false)
+                            .hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .build()
+                    )
+                )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .build();
 
-	@ClassRule
-	public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
+    @ClassRule
+    public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
+    @Rule
+    public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_positive() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldAuthenticateUserWithLdap_positive() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-		}
-	}
+            response.assertStatusCode(200);
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
-				.concat("' because the provided password was incorrect.");
-			logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
-		}
-	}
+            response.assertStatusCode(401);
+            String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
+                .concat("' because the provided password was incorrect.");
+            logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/LdapStartTlsAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapStartTlsAuthenticationTest.java
@@ -51,59 +51,68 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class LdapStartTlsAuthenticationTest {
 
-	private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+    private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
 
-	public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(TEST_CERTIFICATES.getRootCertificateData(),
-		TEST_CERTIFICATES.getLdapCertificateData(), LDIF_DATA);
+    public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(
+        TEST_CERTIFICATES.getRootCertificateData(),
+        TEST_CERTIFICATES.getLdapCertificateData(),
+        LDIF_DATA
+    );
 
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.testCertificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(new AuthcDomain("ldap-config-id", BASIC_AUTH_DOMAIN_ORDER + 1, true)
-			.httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
-			.backend(new AuthenticationBackend("ldap")
-				.config(() -> LdapAuthenticationConfigBuilder.config()
-					// this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
-					.hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))
-					.enableSsl(false)
-					.enableStartTls(true)
-					.bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-					.password(PASSWORD_OPEN_SEARCH)
-					.userBase(DN_PEOPLE_TEST_ORG)
-					.userSearch(USER_SEARCH)
-					.usernameAttribute(USERNAME_ATTRIBUTE)
-					.penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
-					.build())))
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER)
-		.build();
+    public static LocalCluster cluster = new LocalCluster.Builder().testCertificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(
+            new AuthcDomain("ldap-config-id", BASIC_AUTH_DOMAIN_ORDER + 1, true).httpAuthenticator(
+                new HttpAuthenticator("basic").challenge(false)
+            )
+                .backend(
+                    new AuthenticationBackend("ldap").config(
+                        () -> LdapAuthenticationConfigBuilder.config()
+                            // this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
+                            .hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))
+                            .enableSsl(false)
+                            .enableStartTls(true)
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
+                            .build()
+                    )
+                )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .build();
 
-	@ClassRule
-	public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
+    @ClassRule
+    public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
+    @Rule
+    public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_positive() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldAuthenticateUserWithLdap_positive() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-		}
-	}
+            response.assertStatusCode(200);
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
-				.concat("' because the provided password was incorrect.");
-			logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
-		}
-	}
+            response.assertStatusCode(401);
+            String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
+                .concat("' because the provided password was incorrect.");
+            logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
@@ -90,310 +90,325 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class LdapTlsAuthenticationTest {
 
-	private static final String SONG_INDEX_NAME = "song_lyrics";
+    private static final String SONG_INDEX_NAME = "song_lyrics";
 
-	private static final String HEADER_NAME_IMPERSONATE = "opendistro_security_impersonate_as";
+    private static final String HEADER_NAME_IMPERSONATE = "opendistro_security_impersonate_as";
 
-	private static final String PERSONAL_INDEX_NAME_SPOCK = "personal-" + USER_SPOCK;
-	private static final String PERSONAL_INDEX_NAME_KIRK = "personal-" + USER_KIRK;
+    private static final String PERSONAL_INDEX_NAME_SPOCK = "personal-" + USER_SPOCK;
+    private static final String PERSONAL_INDEX_NAME_KIRK = "personal-" + USER_KIRK;
 
-	private static final String POINTER_BACKEND_ROLES = "/backend_roles";
-	private static final String POINTER_ROLES = "/roles";
-	private static final String POINTER_USERNAME = "/user_name";
-	private static final String POINTER_ERROR_REASON = "/error/reason";
+    private static final String POINTER_BACKEND_ROLES = "/backend_roles";
+    private static final String POINTER_ROLES = "/roles";
+    private static final String POINTER_USERNAME = "/user_name";
+    private static final String POINTER_ERROR_REASON = "/error/reason";
 
-	private static final String SONG_ID_1 = "l0001";
-	private static final String SONG_ID_2 = "l0002";
-	private static final String SONG_ID_3 = "l0003";
+    private static final String SONG_ID_1 = "l0001";
+    private static final String SONG_ID_2 = "l0002";
+    private static final String SONG_ID_3 = "l0003";
 
-	private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
 
-	private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+    private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
 
-	private static final Role ROLE_INDEX_ADMINISTRATOR = new Role("index_administrator").indexPermissions("*").on("*");
-	private static final Role ROLE_PERSONAL_INDEX_ACCESS = new Role("personal_index_access").indexPermissions("*").on("personal-${attr.ldap.uid}");
+    private static final Role ROLE_INDEX_ADMINISTRATOR = new Role("index_administrator").indexPermissions("*").on("*");
+    private static final Role ROLE_PERSONAL_INDEX_ACCESS = new Role("personal_index_access").indexPermissions("*")
+        .on("personal-${attr.ldap.uid}");
 
-	private static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(TEST_CERTIFICATES.getRootCertificateData(),
-		TEST_CERTIFICATES.getLdapCertificateData(), LDIF_DATA);
+    private static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(
+        TEST_CERTIFICATES.getRootCertificateData(),
+        TEST_CERTIFICATES.getLdapCertificateData(),
+        LDIF_DATA
+    );
 
-	private static final Map<String, Object> USER_IMPERSONATION_CONFIGURATION = Map.of(
-		"plugins.security.authcz.rest_impersonation_user." + USER_KIRK, List.of(USER_SPOCK)
-	);
+    private static final Map<String, Object> USER_IMPERSONATION_CONFIGURATION = Map.of(
+        "plugins.security.authcz.rest_impersonation_user." + USER_KIRK,
+        List.of(USER_SPOCK)
+    );
 
-	private static final LocalCluster cluster = new LocalCluster.Builder()
-		.testCertificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.nodeSettings(USER_IMPERSONATION_CONFIGURATION)
-		.authc(new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true)
-			.httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
-			.backend(new AuthenticationBackend("ldap")
-				.config(() -> LdapAuthenticationConfigBuilder.config()
-					// this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
-					.hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
-					.enableSsl(true)
-					.bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-					.password(PASSWORD_OPEN_SEARCH)
-					.userBase(DN_PEOPLE_TEST_ORG)
-					.userSearch(USER_SEARCH)
-					.usernameAttribute(USERNAME_ATTRIBUTE)
-					.penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
-					.build())))
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER)
-		.roles(ROLE_INDEX_ADMINISTRATOR, ROLE_PERSONAL_INDEX_ACCESS)
-		.rolesMapping(
-			new RolesMapping(ROLE_INDEX_ADMINISTRATOR).backendRoles(CN_GROUP_ADMIN),
-			new RolesMapping(ROLE_PERSONAL_INDEX_ACCESS).backendRoles(CN_GROUP_CREW)
-		)
-		.authz(new AuthzDomain("ldap_roles").httpEnabled(true).transportEnabled(true)
-			.authorizationBackend(new AuthorizationBackend("ldap")
-				.config(() -> new LdapAuthorizationConfigBuilder()
-					.hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
-					.enableSsl(true)
-					.bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-					.password(PASSWORD_OPEN_SEARCH)
-					.userBase(DN_PEOPLE_TEST_ORG)
-					.userSearch(USER_SEARCH)
-					.usernameAttribute(USERNAME_ATTRIBUTE)
-					.penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
-					.roleBase(DN_GROUPS_TEST_ORG)
-					.roleSearch("(uniqueMember={0})")
-					.userRoleAttribute(null)
-					.userRoleName("disabled")
-					.roleName("cn")
-					.resolveNestedRoles(true)
-					.build())))
-		.build();
+    private static final LocalCluster cluster = new LocalCluster.Builder().testCertificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .nodeSettings(USER_IMPERSONATION_CONFIGURATION)
+        .authc(
+            new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true).httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
+                .backend(
+                    new AuthenticationBackend("ldap").config(
+                        () -> LdapAuthenticationConfigBuilder.config()
+                            // this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
+                            .hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
+                            .enableSsl(true)
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
+                            .build()
+                    )
+                )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .roles(ROLE_INDEX_ADMINISTRATOR, ROLE_PERSONAL_INDEX_ACCESS)
+        .rolesMapping(
+            new RolesMapping(ROLE_INDEX_ADMINISTRATOR).backendRoles(CN_GROUP_ADMIN),
+            new RolesMapping(ROLE_PERSONAL_INDEX_ACCESS).backendRoles(CN_GROUP_CREW)
+        )
+        .authz(
+            new AuthzDomain("ldap_roles").httpEnabled(true)
+                .transportEnabled(true)
+                .authorizationBackend(
+                    new AuthorizationBackend("ldap").config(
+                        () -> new LdapAuthorizationConfigBuilder().hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
+                            .enableSsl(true)
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
+                            .roleBase(DN_GROUPS_TEST_ORG)
+                            .roleSearch("(uniqueMember={0})")
+                            .userRoleAttribute(null)
+                            .userRoleName("disabled")
+                            .roleName("cn")
+                            .resolveNestedRoles(true)
+                            .build()
+                    )
+                )
+        )
+        .build();
 
-	@ClassRule
-	public static final RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
+    @ClassRule
+    public static final RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
+    @Rule
+    public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
 
-	@BeforeClass
-	public static void createTestData() {
-		try(Client client = cluster.getInternalNodeClient()){
-			client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
-			client.prepareIndex(PERSONAL_INDEX_NAME_SPOCK).setId(SONG_ID_2).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
-			client.prepareIndex(PERSONAL_INDEX_NAME_KIRK).setId(SONG_ID_3).setRefreshPolicy(IMMEDIATE).setSource(SONGS[2].asMap()).get();
-		}
-	}
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.prepareIndex(SONG_INDEX_NAME).setId(SONG_ID_1).setRefreshPolicy(IMMEDIATE).setSource(SONGS[0].asMap()).get();
+            client.prepareIndex(PERSONAL_INDEX_NAME_SPOCK).setId(SONG_ID_2).setRefreshPolicy(IMMEDIATE).setSource(SONGS[1].asMap()).get();
+            client.prepareIndex(PERSONAL_INDEX_NAME_KIRK).setId(SONG_ID_3).setRefreshPolicy(IMMEDIATE).setSource(SONGS[2].asMap()).get();
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_positiveSpockUser() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
+    @Test
+    public void shouldAuthenticateUserWithLdap_positiveSpockUser() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_SPOCK));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SPOCK));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_positiveKirkUser() {
-		try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
+    @Test
+    public void shouldAuthenticateUserWithLdap_positiveKirkUser() {
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			String username = response.getTextFromJsonBody(POINTER_USERNAME);
-			assertThat(username, equalTo(USER_KIRK));
-		}
-	}
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_KIRK));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
+    @Test
+    public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectPassword() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, "incorrect password")) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
-				.concat("' because the provided password was incorrect.");
-			logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
-		}
-	}
+            response.assertStatusCode(401);
+            String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
+                .concat("' because the provided password was incorrect.");
+            logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectUsername() {
-		final String username = "invalid-user-name";
-		try (TestRestClient client = cluster.getRestClient(username, PASSWORD_SPOCK)) {
+    @Test
+    public void shouldAuthenticateUserWithLdap_negativeWhenIncorrectUsername() {
+        final String username = "invalid-user-name";
+        try (TestRestClient client = cluster.getRestClient(username, PASSWORD_SPOCK)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatStackTraceContain(String.format("No user %s found", username));
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatStackTraceContain(String.format("No user %s found", username));
+        }
+    }
 
-	@Test
-	public void shouldAuthenticateUserWithLdap_negativeWhenUserDoesNotExist() {
-		final String username = "doesNotExist";
-		try (TestRestClient client = cluster.getRestClient(username, "password")) {
+    @Test
+    public void shouldAuthenticateUserWithLdap_negativeWhenUserDoesNotExist() {
+        final String username = "doesNotExist";
+        try (TestRestClient client = cluster.getRestClient(username, "password")) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-			logsRule.assertThatStackTraceContain(String.format("No user %s found", username));
-		}
-	}
+            response.assertStatusCode(401);
+            logsRule.assertThatStackTraceContain(String.format("No user %s found", username));
+        }
+    }
 
-	@Test
-	public void shouldResolveUserRolesAgainstLdapBackend_positiveSpockUser() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
+    @Test
+    public void shouldResolveUserRolesAgainstLdapBackend_positiveSpockUser() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, contains(CN_GROUP_CREW));
-			assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_PERSONAL_INDEX_ACCESS.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, contains(CN_GROUP_CREW));
+            assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_PERSONAL_INDEX_ACCESS.getName()));
+        }
+    }
 
-	@Test
-	public void shouldResolveUserRolesAgainstLdapBackend_positiveKirkUser() {
-		try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
+    @Test
+    public void shouldResolveUserRolesAgainstLdapBackend_positiveKirkUser() {
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
 
-			HttpResponse response = client.getAuthInfo();
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			assertThat(response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES), contains(CN_GROUP_ADMIN));
-			assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_INDEX_ADMINISTRATOR.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            assertThat(response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES), contains(CN_GROUP_ADMIN));
+            assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_INDEX_ADMINISTRATOR.getName()));
+        }
+    }
 
-	@Test
-	public void shouldPerformAuthorizationAgainstLdapToAccessIndex_positive() throws IOException {
-		try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK)) {
-			SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
+    @Test
+    public void shouldPerformAuthorizationAgainstLdapToAccessIndex_positive() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK)) {
+            SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
 
-			SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse searchResponse = client.search(request, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1));
+        }
+    }
 
-	@Test
-	public void shouldPerformAuthorizationAgainstLdapToAccessIndex_negative() throws IOException {
-		try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_LEONARD, PASSWORD_LEONARD)) {
-			SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
+    @Test
+    public void shouldPerformAuthorizationAgainstLdapToAccessIndex_negative() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_LEONARD, PASSWORD_LEONARD)) {
+            SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
 
-			assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldResolveUserAttributesLoadedFromLdap_positive() throws IOException {
-		try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
-			SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
+    @Test
+    public void shouldResolveUserAttributesLoadedFromLdap_positive() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
+            SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
 
-			SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse searchResponse = client.search(request, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, PERSONAL_INDEX_NAME_SPOCK, SONG_ID_2));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, PERSONAL_INDEX_NAME_SPOCK, SONG_ID_2));
+        }
+    }
 
-	@Test
-	public void shouldResolveUserAttributesLoadedFromLdap_negative() throws IOException {
-		try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
-			SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
+    @Test
+    public void shouldResolveUserAttributesLoadedFromLdap_negative() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
+            SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
 
-			assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 
-	@Test
-	public void shouldResolveNestedGroups_positive() {
-		try (TestRestClient client = cluster.getRestClient(USER_JEAN, PASSWORD_JEAN)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldResolveNestedGroups_positive() {
+        try (TestRestClient client = cluster.getRestClient(USER_JEAN, PASSWORD_JEAN)) {
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(2));
-			//CN_GROUP_CREW is retrieved recursively: cn=Jean,ou=people,o=test.org -> cn=bridge,ou=groups,o=test.org -> cn=crew,ou=groups,o=test.org
-			assertThat(backendRoles,  containsInAnyOrder(CN_GROUP_CREW, CN_GROUP_BRIDGE));
-			assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_PERSONAL_INDEX_ACCESS.getName()));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(2));
+            // CN_GROUP_CREW is retrieved recursively: cn=Jean,ou=people,o=test.org -> cn=bridge,ou=groups,o=test.org ->
+            // cn=crew,ou=groups,o=test.org
+            assertThat(backendRoles, containsInAnyOrder(CN_GROUP_CREW, CN_GROUP_BRIDGE));
+            assertThat(response.getTextArrayFromJsonBody(POINTER_ROLES), contains(ROLE_PERSONAL_INDEX_ACCESS.getName()));
+        }
+    }
 
-	@Test
-	public void shouldResolveNestedGroups_negative() {
-		try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
-			HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldResolveNestedGroups_negative() {
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
+            HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(200);
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles,  not(containsInAnyOrder(CN_GROUP_CREW)));
-		}
-	}
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, not(containsInAnyOrder(CN_GROUP_CREW)));
+        }
+    }
 
-	@Test
-	public void shouldImpersonateUser_positive() {
-		try(TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)){
+    @Test
+    public void shouldImpersonateUser_positive() {
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
 
-			HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK));
+            HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK));
 
-			response.assertStatusCode(200);
-			assertThat(response.getTextFromJsonBody(POINTER_USERNAME), equalTo(USER_SPOCK));
-			List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
-			assertThat(backendRoles, hasSize(1));
-			assertThat(backendRoles, contains(CN_GROUP_CREW));
-		}
-	}
+            response.assertStatusCode(200);
+            assertThat(response.getTextFromJsonBody(POINTER_USERNAME), equalTo(USER_SPOCK));
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(1));
+            assertThat(backendRoles, contains(CN_GROUP_CREW));
+        }
+    }
 
-	@Test
-	public void shouldImpersonateUser_negativeJean() {
-		try(TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)){
+    @Test
+    public void shouldImpersonateUser_negativeJean() {
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
 
-			HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_JEAN));
+            HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_JEAN));
 
-			response.assertStatusCode(403);
-			String expectedMessage = String.format("'%s' is not allowed to impersonate as '%s'", USER_KIRK, USER_JEAN);
-			assertThat(response.getTextFromJsonBody(POINTER_ERROR_REASON), equalTo(expectedMessage));
-		}
-	}
+            response.assertStatusCode(403);
+            String expectedMessage = String.format("'%s' is not allowed to impersonate as '%s'", USER_KIRK, USER_JEAN);
+            assertThat(response.getTextFromJsonBody(POINTER_ERROR_REASON), equalTo(expectedMessage));
+        }
+    }
 
-	@Test
-	public void shouldImpersonateUser_negativeKirk() {
-		try(TestRestClient client = cluster.getRestClient(USER_JEAN, PASSWORD_JEAN)){
+    @Test
+    public void shouldImpersonateUser_negativeKirk() {
+        try (TestRestClient client = cluster.getRestClient(USER_JEAN, PASSWORD_JEAN)) {
 
-			HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_KIRK));
+            HttpResponse response = client.getAuthInfo(new BasicHeader(HEADER_NAME_IMPERSONATE, USER_KIRK));
 
-			response.assertStatusCode(403);
-			String expectedMessage = String.format("'%s' is not allowed to impersonate as '%s'", USER_JEAN, USER_KIRK);
-			assertThat(response.getTextFromJsonBody(POINTER_ERROR_REASON), equalTo(expectedMessage));
-		}
-	}
+            response.assertStatusCode(403);
+            String expectedMessage = String.format("'%s' is not allowed to impersonate as '%s'", USER_JEAN, USER_KIRK);
+            assertThat(response.getTextFromJsonBody(POINTER_ERROR_REASON), equalTo(expectedMessage));
+        }
+    }
 
-	@Test
-	public void shouldAccessImpersonatedUserPersonalIndex_positive() throws IOException {
-		BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
-		try(RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)){
-			SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
+    @Test
+    public void shouldAccessImpersonatedUserPersonalIndex_positive() throws IOException {
+        BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
+            SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
 
-			SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse searchResponse = client.search(request, DEFAULT);
 
-			assertThat(searchResponse, isSuccessfulSearchResponse());
-			assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
-			assertThat(searchResponse, searchHitsContainDocumentWithId(0, PERSONAL_INDEX_NAME_SPOCK, SONG_ID_2));
-		}
-	}
+            assertThat(searchResponse, isSuccessfulSearchResponse());
+            assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
+            assertThat(searchResponse, searchHitsContainDocumentWithId(0, PERSONAL_INDEX_NAME_SPOCK, SONG_ID_2));
+        }
+    }
 
-	@Test
-	public void shouldAccessImpersonatedUserPersonalIndex_negative() throws IOException {
-		BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
-		try(RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)){
-			SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
+    @Test
+    public void shouldAccessImpersonatedUserPersonalIndex_negative() throws IOException {
+        BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
+            SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
 
-			assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
-		}
-	}
+            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/ProxyAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/ProxyAuthenticationTest.java
@@ -33,89 +33,96 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class ProxyAuthenticationTest extends CommonProxyAuthenticationTests {
 
-	private static final Map<String, Object> PROXY_AUTHENTICATOR_CONFIG = Map.of(
-		"user_header", HEADER_PROXY_USER,
-		"roles_header", HEADER_PROXY_ROLES
-	);
+    private static final Map<String, Object> PROXY_AUTHENTICATOR_CONFIG = Map.of(
+        "user_header",
+        HEADER_PROXY_USER,
+        "roles_header",
+        HEADER_PROXY_ROLES
+    );
 
-	@ClassRule
-	public static final LocalCluster cluster = new LocalCluster.Builder()
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.xff(new XffConfig(true).internalProxiesRegexp("127\\.0\\.0\\.10"))
-		.authc(new AuthcDomain("proxy_auth_domain", -5, true)
-			.httpAuthenticator(new HttpAuthenticator("proxy").challenge(false).config(PROXY_AUTHENTICATOR_CONFIG))
-			.backend(new AuthenticationBackend("noop")))
-		.authc(AUTHC_HTTPBASIC_INTERNAL).users(USER_ADMIN).roles(ROLE_ALL_INDEX_SEARCH, ROLE_PERSONAL_INDEX_SEARCH)
-		.rolesMapping(ROLES_MAPPING_CAPTAIN, ROLES_MAPPING_FIRST_MATE).build();
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .xff(new XffConfig(true).internalProxiesRegexp("127\\.0\\.0\\.10"))
+        .authc(
+            new AuthcDomain("proxy_auth_domain", -5, true).httpAuthenticator(
+                new HttpAuthenticator("proxy").challenge(false).config(PROXY_AUTHENTICATOR_CONFIG)
+            ).backend(new AuthenticationBackend("noop"))
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_ADMIN)
+        .roles(ROLE_ALL_INDEX_SEARCH, ROLE_PERSONAL_INDEX_SEARCH)
+        .rolesMapping(ROLES_MAPPING_CAPTAIN, ROLES_MAPPING_FIRST_MATE)
+        .build();
 
-	@Override
-	protected LocalCluster getCluster() {
-		return cluster;
-	}
+    @Override
+    protected LocalCluster getCluster() {
+        return cluster;
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
-		super.shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured() {
+        super.shouldAuthenticateWithBasicAuthWhenProxyAuthenticationIsConfigured();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
-		super.shouldAuthenticateWithProxy_positiveUserKirk();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_positiveUserKirk() throws IOException {
+        super.shouldAuthenticateWithProxy_positiveUserKirk();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
-		super.shouldAuthenticateWithProxy_positiveUserSpock();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_positiveUserSpock() throws IOException {
+        super.shouldAuthenticateWithProxy_positiveUserSpock();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenXffHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenUserNameHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
-		super.shouldAuthenticateWithProxyWhenRolesHeaderIsMissing();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxyWhenRolesHeaderIsMissing() throws IOException {
+        super.shouldAuthenticateWithProxyWhenRolesHeaderIsMissing();
+    }
 
-	@Test
-	@Override
-	public void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
-		super.shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy();
-	}
+    @Test
+    @Override
+    public void shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy() throws IOException {
+        super.shouldAuthenticateWithProxy_negativeWhenRequestWasNotSendByProxy();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveEmptyListOfRoles() throws IOException {
-		super.shouldRetrieveEmptyListOfRoles();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveEmptyListOfRoles() throws IOException {
+        super.shouldRetrieveEmptyListOfRoles();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveSingleRoleFirstMate() throws IOException {
-		super.shouldRetrieveSingleRoleFirstMate();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveSingleRoleFirstMate() throws IOException {
+        super.shouldRetrieveSingleRoleFirstMate();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveSingleRoleCaptain() throws IOException {
-		super.shouldRetrieveSingleRoleCaptain();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveSingleRoleCaptain() throws IOException {
+        super.shouldRetrieveSingleRoleCaptain();
+    }
 
-	@Test
-	@Override
-	public void shouldRetrieveMultipleRoles() throws IOException {
-		super.shouldRetrieveMultipleRoles();
-	}
+    @Test
+    @Override
+    public void shouldRetrieveMultipleRoles() throws IOException {
+        super.shouldRetrieveMultipleRoles();
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/UntrustedLdapServerCertificateTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/UntrustedLdapServerCertificateTest.java
@@ -50,48 +50,55 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class UntrustedLdapServerCertificateTest {
 
-	private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
-	private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
+    private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
 
-	public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(TEST_CERTIFICATES.getRootCertificateData(),
-		TEST_CERTIFICATES.createSelfSignedCertificate("CN=untrusted"), LDIF_DATA);
+    public static final EmbeddedLDAPServer embeddedLDAPServer = new EmbeddedLDAPServer(
+        TEST_CERTIFICATES.getRootCertificateData(),
+        TEST_CERTIFICATES.createSelfSignedCertificate("CN=untrusted"),
+        LDIF_DATA
+    );
 
-	public static LocalCluster cluster = new LocalCluster.Builder()
-		.testCertificates(TEST_CERTIFICATES)
-		.clusterManager(ClusterManager.SINGLENODE).anonymousAuth(false)
-		.authc(new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true)
-			.httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
-			.backend(new AuthenticationBackend("ldap")
-				.config(() -> LdapAuthenticationConfigBuilder.config()
-					// this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
-					.hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
-					.enableSsl(true)
-					.bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
-					.password(PASSWORD_OPEN_SEARCH)
-					.userBase(DN_PEOPLE_TEST_ORG)
-					.userSearch(USER_SEARCH)
-					.usernameAttribute(USERNAME_ATTRIBUTE)
-					.penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
-					.build())))
-		.authc(AUTHC_HTTPBASIC_INTERNAL)
-		.users(ADMIN_USER)
-		.build();
+    public static LocalCluster cluster = new LocalCluster.Builder().testCertificates(TEST_CERTIFICATES)
+        .clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(
+            new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true).httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
+                .backend(
+                    new AuthenticationBackend("ldap").config(
+                        () -> LdapAuthenticationConfigBuilder.config()
+                            // this port is available when embeddedLDAPServer is already started, therefore Supplier interface is used
+                            .hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))
+                            .enableSsl(true)
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .penTrustedCasFilePath(TEST_CERTIFICATES.getRootCertificate().getAbsolutePath())
+                            .build()
+                    )
+                )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .build();
 
-	@ClassRule
-	public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
+    @ClassRule
+    public static RuleChain ruleChain = RuleChain.outerRule(embeddedLDAPServer).around(cluster);
 
-	@Rule
-	public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
+    @Rule
+    public LogsRule logsRule = new LogsRule("com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend");
 
-	@Test
-	public void shouldNotAuthenticateUserWithLdap() {
-		try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
-			TestRestClient.HttpResponse response = client.getAuthInfo();
+    @Test
+    public void shouldNotAuthenticateUserWithLdap() {
+        try (TestRestClient client = cluster.getRestClient(USER_SPOCK, PASSWORD_SPOCK)) {
+            TestRestClient.HttpResponse response = client.getAuthInfo();
 
-			response.assertStatusCode(401);
-		}
-		logsRule.assertThatStackTraceContain("javax.net.ssl.SSLHandshakeException");
-	}
+            response.assertStatusCode(401);
+        }
+        logsRule.assertThatStackTraceContain("javax.net.ssl.SSLHandshakeException");
+    }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
@@ -36,36 +36,36 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class PrivilegesEvaluatorTest {
 
-	protected final static TestSecurityConfig.User NEGATIVE_LOOKAHEAD = new TestSecurityConfig.User(
-			"negative_lookahead_user")
-			.roles(new Role("negative_lookahead_role").indexPermissions("read").on("/^(?!t.*).*/")
-					.clusterPermissions("cluster_composite_ops"));
+    protected final static TestSecurityConfig.User NEGATIVE_LOOKAHEAD = new TestSecurityConfig.User("negative_lookahead_user").roles(
+        new Role("negative_lookahead_role").indexPermissions("read").on("/^(?!t.*).*/").clusterPermissions("cluster_composite_ops")
+    );
 
-	protected final static TestSecurityConfig.User NEGATED_REGEX = new TestSecurityConfig.User("negated_regex_user")
-			.roles(new Role("negated_regex_role").indexPermissions("read").on("/^[a-z].*/")
-					.clusterPermissions("cluster_composite_ops"));
+    protected final static TestSecurityConfig.User NEGATED_REGEX = new TestSecurityConfig.User("negated_regex_user").roles(
+        new Role("negated_regex_role").indexPermissions("read").on("/^[a-z].*/").clusterPermissions("cluster_composite_ops")
+    );
 
-	@ClassRule
-	public static LocalCluster cluster = new LocalCluster.Builder()
-			.clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS).authc(AUTHC_HTTPBASIC_INTERNAL)
-			.users(NEGATIVE_LOOKAHEAD, NEGATED_REGEX).build();
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(NEGATIVE_LOOKAHEAD, NEGATED_REGEX)
+        .build();
 
-	@Test
-	public void testNegativeLookaheadPattern() throws Exception {
+    @Test
+    public void testNegativeLookaheadPattern() throws Exception {
 
-		try (TestRestClient client = cluster.getRestClient(NEGATIVE_LOOKAHEAD)) {
-			assertThat(client.get("*/_search").getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-			assertThat(client.get("r*/_search").getStatusCode(), equalTo(HttpStatus.SC_OK));
-		}
-	}
+        try (TestRestClient client = cluster.getRestClient(NEGATIVE_LOOKAHEAD)) {
+            assertThat(client.get("*/_search").getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            assertThat(client.get("r*/_search").getStatusCode(), equalTo(HttpStatus.SC_OK));
+        }
+    }
 
-	@Test
-	public void testRegexPattern() throws Exception {
+    @Test
+    public void testRegexPattern() throws Exception {
 
-		try (TestRestClient client = cluster.getRestClient(NEGATED_REGEX)) {
-			assertThat(client.get("*/_search").getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-			assertThat(client.get("r*/_search").getStatusCode(), equalTo(HttpStatus.SC_OK));
-		}
+        try (TestRestClient client = cluster.getRestClient(NEGATED_REGEX)) {
+            assertThat(client.get("*/_search").getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            assertThat(client.get("r*/_search").getStatusCode(), equalTo(HttpStatus.SC_OK));
+        }
 
-	}
+    }
 }


### PR DESCRIPTION
### Description
This PR follows-up #2840

It updates the formatting for all java files under the `**/integrationTest/` path

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
