### PR TITLE
Use boucycastle PEM reader instead of reg expression

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -96,6 +96,8 @@ public class HTTPSamlAuthenticatorTest {
         + "T9IKkp7810LOKhrCDQ==\n"
         + "-----END ENCRYPTED PRIVATE KEY-----";
 
+    private final static String PRIVATE_KEY_PATTERN = "-----BEGIN PRIVATE KEY-----\n%s\n-----END PRIVATE KEY-----";
+
     private static X509Certificate spSigningCertificate;
     private static PrivateKey spSigningPrivateKey;
 
@@ -172,7 +174,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("exchange_key", "abc")
             .put("roles_key", "roles")
@@ -220,7 +222,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("exchange_key", "abc")
             .put("roles_key", "roles")
@@ -271,7 +273,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("exchange_key", "abc")
             .put("roles_key", "roles")
@@ -322,7 +324,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("exchange_key", "abc")
             .put("roles_key", "roles")
@@ -373,7 +375,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("exchange_key", "abc")
             .put("roles_key", "roles")
@@ -782,7 +784,7 @@ public class HTTPSamlAuthenticatorTest {
             .put("roles_key", "roles")
             .put(
                 "sp.signature_private_key",
-                "-BEGIN PRIVATE KEY-\n" + Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()) + "-END PRIVATE KEY-"
+                String.format(PRIVATE_KEY_PATTERN, Base64.getEncoder().encodeToString(spSigningPrivateKey.getEncoded()))
             )
             .put("path.home", ".")
             .build();


### PR DESCRIPTION
### Description
Use BouncyCastle PEMReader instead of
regular expression to read and parse private key pem files.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
