### PR TITLE
Bumping spring-core and spring-expression from 5.3.26 to 5.3.28 to patch CVE vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ configurations.all {
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
-        force "org.springframework:spring-core:5.3.27"
+        force "org.springframework:spring-core:5.3.28"
         force "org.springframework:spring-expression:5.3.27"
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ configurations.all {
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.28"
-        force "org.springframework:spring-expression:5.3.27"
+        force "org.springframework:spring-expression:5.3.28"
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ configurations.all {
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
-        force "org.springframework:spring-core:5.3.26"
+        force "org.springframework:spring-core:5.3.27"
         force "org.springframework:spring-expression:5.3.27"
         force "com.google.guava:guava:30.0-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"


### PR DESCRIPTION
### Description
This mirrors the changes in main (#2717) and 2.x (#2763). The backport workflow was not used because there have been major changes to the build file between 1.x and 2.x

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
