### PR TITLE
Update snappy to 1.1.10.1 and guava to 32.0.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,7 +341,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
-    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
@@ -406,7 +406,7 @@ dependencies {
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
-    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.4'
+    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.1'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
-        kafka_version  = '3.4.0'
+        kafka_version  = '3.5.0'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"

--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,7 @@ dependencies {
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
+    runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
     implementation 'org.apache.commons:commons-lang3:3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -290,6 +290,7 @@ configurations {
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
             force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
             force "com.github.luben:zstd-jni:${versions.zstd}"
+            force "org.xerial.snappy:snappy-java:1.1.10.1"
         }
     }
 


### PR DESCRIPTION
### Description

Upgrades snappt to 1.1.10.1 and guava to 32.0.1-jre

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

- https://github.com/opensearch-project/security/issues/2885
- https://github.com/opensearch-project/security/issues/2882
- https://github.com/opensearch-project/security/issues/2884
- https://github.com/opensearch-project/security/issues/2883

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
