### PR TITLE
[Backport 2.x] Update snappy to 1.1.10.1 and guava to 32.0.1-jre (#2886)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.1.0.0')
-        kafka_version  = '3.4.0'
+        kafka_version  = '3.5.0'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -269,30 +269,33 @@ bundlePlugin {
     }
 }
 
-configurations.all {
-    resolutionStrategy {
-        force 'commons-codec:commons-codec:1.14'
-        force 'org.slf4j:slf4j-api:1.7.30'
-        force 'org.scala-lang:scala-library:2.13.9'
-        force 'commons-io:commons-io:2.11.0'
-        force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
-        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-        force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
-        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-        force "io.netty:netty-buffer:${versions.netty}"
-        force "io.netty:netty-common:${versions.netty}"
-        force "io.netty:netty-handler:${versions.netty}"
-        force "io.netty:netty-transport:${versions.netty}"
-        force "io.netty:netty-transport-native-unix-common:${versions.netty}"
-        force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
-        force "com.github.luben:zstd-jni:${versions.zstd}"
+configurations {
+    all {
+        resolutionStrategy {
+            force 'commons-codec:commons-codec:1.14'
+            force 'org.slf4j:slf4j-api:1.7.30'
+            force 'org.scala-lang:scala-library:2.13.9'
+            force 'commons-io:commons-io:2.11.0'
+            force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
+            force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+            force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
+            force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+            force "io.netty:netty-buffer:${versions.netty}"
+            force "io.netty:netty-common:${versions.netty}"
+            force "io.netty:netty-handler:${versions.netty}"
+            force "io.netty:netty-transport:${versions.netty}"
+            force "io.netty:netty-transport-native-unix-common:${versions.netty}"
+            force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+            force "com.github.luben:zstd-jni:${versions.zstd}"
+            force "org.xerial.snappy:snappy-java:1.1.10.1"
+        }
     }
 }
 
 dependencies {
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
@@ -360,7 +363,7 @@ dependencies {
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
-    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.8.4'
+    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.1'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
@@ -369,6 +372,7 @@ dependencies {
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
+    runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
     implementation 'org.apache.commons:commons-lang3:3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -269,26 +269,24 @@ bundlePlugin {
     }
 }
 
-configurations {
-    all {
-        resolutionStrategy {
-            force 'commons-codec:commons-codec:1.14'
-            force 'org.slf4j:slf4j-api:1.7.30'
-            force 'org.scala-lang:scala-library:2.13.9'
-            force 'commons-io:commons-io:2.11.0'
-            force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
-            force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
-            force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
-            force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
-            force "io.netty:netty-buffer:${versions.netty}"
-            force "io.netty:netty-common:${versions.netty}"
-            force "io.netty:netty-handler:${versions.netty}"
-            force "io.netty:netty-transport:${versions.netty}"
-            force "io.netty:netty-transport-native-unix-common:${versions.netty}"
-            force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
-            force "com.github.luben:zstd-jni:${versions.zstd}"
-            force "org.xerial.snappy:snappy-java:1.1.10.1"
-        }
+configurations.all {
+    resolutionStrategy {
+        force 'commons-codec:commons-codec:1.14'
+        force 'org.slf4j:slf4j-api:1.7.30'
+        force 'org.scala-lang:scala-library:2.13.9'
+        force 'commons-io:commons-io:2.11.0'
+        force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
+        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+        force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
+        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+        force "io.netty:netty-buffer:${versions.netty}"
+        force "io.netty:netty-common:${versions.netty}"
+        force "io.netty:netty-handler:${versions.netty}"
+        force "io.netty:netty-transport:${versions.netty}"
+        force "io.netty:netty-transport-native-unix-common:${versions.netty}"
+        force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+        force "com.github.luben:zstd-jni:${versions.zstd}"
+        force "org.xerial.snappy:snappy-java:1.1.10.1"
     }
 }
 


### PR DESCRIPTION
Backport #2886 to 2.x