### PR TITLE
fix cluster perm classification for msearch template

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -668,7 +668,7 @@ public class PrivilegesEvaluator {
             || action0.startsWith(SearchScrollAction.NAME)
             || (action0.equals(BulkAction.NAME))
             || (action0.equals(MultiGetAction.NAME))
-            || (action0.equals(MultiSearchAction.NAME))
+            || (action0.startsWith(MultiSearchAction.NAME))
             || (action0.equals(MultiTermVectorsAction.NAME))
             || (action0.equals(ReindexAction.NAME))
 

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
@@ -58,4 +58,10 @@ public class PrivilegesEvaluatorTest extends SingleClusterTest {
         response = rh.executeGetRequest("r*/_search", NegatedRegexUserHeader);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
+
+    @Test
+    public void testClusterPerm() {
+        String clusterPerm = "indices:data/read/msearch/template";
+        Assert.assertEquals(true, PrivilegesEvaluator.isClusterPerm(clusterPerm));
+    }
 }

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
@@ -59,9 +59,4 @@ public class PrivilegesEvaluatorTest extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
 
-    @Test
-    public void testClusterPerm() {
-        String clusterPerm = "indices:data/read/msearch/template";
-        Assert.assertEquals(true, PrivilegesEvaluator.isClusterPerm(clusterPerm));
-    }
 }

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
@@ -58,5 +58,4 @@ public class PrivilegesEvaluatorTest extends SingleClusterTest {
         response = rh.executeGetRequest("r*/_search", NegatedRegexUserHeader);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
     }
-
 }

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -1,3 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+ 
 package org.opensearch.security.privileges;
 
 import org.junit.Test;

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -1,0 +1,28 @@
+package org.opensearch.security.privileges;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.opensearch.security.privileges.PrivilegesEvaluator.isClusterPerm;
+
+public class PrivilegesEvaluatorUnitTest {
+
+    @Test
+    public void testClusterPerm() {
+        String multiSearchTemplate = "indices:data/read/msearch/template";
+        String monitorHealth = "cluster:monitor/health";
+        String writeIndex = "indices:data/write/reindex";
+        String adminClose = "indices:admin/close";
+        String monitorUpgrade = "indices:monitor/upgrade";
+
+        // Cluster Permissions
+        assertTrue(isClusterPerm(multiSearchTemplate));
+        assertTrue(isClusterPerm(writeIndex));
+        assertTrue(isClusterPerm(monitorHealth));
+
+        // Index Permissions
+        assertFalse(isClusterPerm(adminClose));
+        assertFalse(isClusterPerm(monitorUpgrade));
+    }
+}

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -5,7 +5,7 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
- 
+
 package org.opensearch.security.privileges;
 
 import org.junit.Test;


### PR DESCRIPTION
### Description
Changes classification of 'indices:data/read/msearch/template' to be a cluster permission instead of an index permission. It seems that this should have the same classification as  'indices:data/read/msearch', since it is a msearch but just with a template.


https://github.com/opensearch-project/OpenSearch/blob/63dc6aa795f8ec78597c7f93e732b979b6963d8f/modules/lang-mustache/src/main/java/org/opensearch/script/mustache/MultiSearchTemplateAction.java#L40



### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
