### PR TITLE
Bump BouncyCastle from jdk15on to jdk15to18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -479,7 +479,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
-    implementation "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
+    implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'
     implementation('org.apache.cxf:cxf-rt-rs-security-jose:3.5.5') {
@@ -549,7 +549,7 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
+    runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
@@ -613,8 +613,8 @@ dependencies {
     integrationTestImplementation 'org.apache.logging.log4j:log4j-core:2.17.1'
     integrationTestImplementation 'org.apache.logging.log4j:log4j-jul:2.17.1'
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
-    integrationTestImplementation "org.bouncycastle:bcutil-jdk15on:${versions.bouncycastle}"
+    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
+    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:${versions.bouncycastle}"
     integrationTestImplementation('org.awaitility:awaitility:4.2.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }

--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -55,10 +55,13 @@ grant {
   permission java.net.NetPermission "getNetworkInformation";
   permission java.net.NetPermission "getProxySelector";
   permission java.net.SocketPermission "*", "connect,accept,resolve";
-  
+
+  // BouncyCastle permissions
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
-  
+  permission java.security.SecurityPermission "removeProviderProperty.BC";
+  permission java.util.PropertyPermission "jdk.tls.rejectClientInitiatedRenegotiation", "write";
+
   permission java.lang.RuntimePermission "accessUserInformation";
   
   permission java.security.SecurityPermission "org.apache.xml.security.register";

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -17,9 +17,49 @@
 
 package org.opensearch.security.ssl;
 
-import java.io.ByteArrayInputStream;
+import com.google.common.collect.ImmutableList;
+import io.netty.handler.codec.http2.Http2SecurityUtil;
+import io.netty.handler.ssl.ApplicationProtocolConfig;
+import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
+import io.netty.handler.ssl.ApplicationProtocolNames;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.SupportedCipherSuiteFilter;
+import io.netty.util.internal.PlatformDependent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Object;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1String;
+import org.bouncycastle.asn1.ASN1TaggedObject;
+import org.opensearch.OpenSearchException;
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.SpecialPermission;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.env.Environment;
+import org.opensearch.security.ssl.util.CertFileProps;
+import org.opensearch.security.ssl.util.CertFromFile;
+import org.opensearch.security.ssl.util.CertFromKeystore;
+import org.opensearch.security.ssl.util.CertFromTruststore;
+import org.opensearch.security.ssl.util.ExceptionUtils;
+import org.opensearch.security.ssl.util.KeystoreProps;
+import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.transport.NettyAllocator;
+
+import javax.crypto.Cipher;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -45,48 +85,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import javax.crypto.Cipher;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLParameters;
-
-import io.netty.handler.codec.http2.Http2SecurityUtil;
-import io.netty.handler.ssl.ApplicationProtocolConfig;
-import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
-import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
-import io.netty.handler.ssl.ApplicationProtocolNames;
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.OpenSsl;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
-import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.ssl.SupportedCipherSuiteFilter;
-import io.netty.util.internal.PlatformDependent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.bouncycastle.asn1.ASN1InputStream;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.ASN1String;
-import org.bouncycastle.asn1.ASN1TaggedObject;
-
-import org.opensearch.OpenSearchException;
-import org.opensearch.OpenSearchSecurityException;
-import org.opensearch.SpecialPermission;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.env.Environment;
-import org.opensearch.security.ssl.util.CertFileProps;
-import org.opensearch.security.ssl.util.CertFromFile;
-import org.opensearch.security.ssl.util.CertFromKeystore;
-import org.opensearch.security.ssl.util.CertFromTruststore;
-import org.opensearch.security.ssl.util.ExceptionUtils;
-import org.opensearch.security.ssl.util.KeystoreProps;
-import org.opensearch.security.ssl.util.SSLConfigConstants;
-import org.opensearch.transport.NettyAllocator;
 
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
@@ -1171,34 +1169,27 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
     }
 
     private List<String> getOtherName(List<?> altName) {
-        ASN1Primitive oct = null;
-        try {
-            byte[] altNameBytes = (byte[]) altName.get(1);
-            oct = (new ASN1InputStream(new ByteArrayInputStream(altNameBytes)).readObject());
-        } catch (IOException e) {
-            throw new RuntimeException("Could not read ASN1InputStream", e);
+        if (altName.size() < 2) {
+            log.warn("Couldn't parse subject alternative names");
+            return null;
         }
-        if (oct instanceof ASN1TaggedObject) {
-            oct = ((ASN1TaggedObject) oct).getObject();
+        try (final ASN1InputStream in = new ASN1InputStream((byte[]) altName.get(1))) {
+            final ASN1Primitive asn1Primitive = in.readObject();
+            final ASN1Sequence sequence = ASN1Sequence.getInstance(asn1Primitive);
+            final ASN1ObjectIdentifier asn1ObjectIdentifier = ASN1ObjectIdentifier.getInstance(sequence.getObjectAt(0));
+            final ASN1TaggedObject asn1TaggedObject = ASN1TaggedObject.getInstance(sequence.getObjectAt(1));
+            ASN1Object maybeTaggedAsn1Primitive = asn1TaggedObject.getBaseObject();
+            if (maybeTaggedAsn1Primitive instanceof ASN1TaggedObject) {
+                maybeTaggedAsn1Primitive = ASN1TaggedObject.getInstance(maybeTaggedAsn1Primitive).getBaseObject();
+            }
+            if (maybeTaggedAsn1Primitive instanceof ASN1String) {
+                return ImmutableList.of(asn1ObjectIdentifier.getId(), maybeTaggedAsn1Primitive.toString());
+            } else {
+                log.warn("Couldn't parse subject alternative names");
+                return null;
+            }
+        } catch (final Exception ioe) { // catch all exception here since BC throws diff exceptions
+            throw new RuntimeException("Couldn't parse subject alternative names", ioe);
         }
-        ASN1Sequence seq = ASN1Sequence.getInstance(oct);
-
-        // Get object identifier from first in sequence
-        ASN1ObjectIdentifier asnOID = (ASN1ObjectIdentifier) seq.getObjectAt(0);
-        String oid = asnOID.getId();
-
-        // Get value of object from second element
-        final ASN1TaggedObject obj = (ASN1TaggedObject) seq.getObjectAt(1);
-        // Could be tagged twice due to bug in java cert.getSubjectAltName
-        ASN1Primitive prim = obj.getObject();
-        if (prim instanceof ASN1TaggedObject) {
-            prim = ASN1TaggedObject.getInstance(((ASN1TaggedObject) prim)).getObject();
-        }
-
-        if (prim instanceof ASN1String) {
-            return Collections.unmodifiableList(Arrays.asList(oid, ((ASN1String) prim).getString()));
-        }
-
-        return null;
     }
 }


### PR DESCRIPTION
### Description
Bump BouncyCastle to jdk15to18on since jsk15on is not supported anymore. I'm waiting for https://github.com/opensearch-project/OpenSearch/pull/8247 in OpenSearch to move forward with it.

### Issues Resolved

https://github.com/opensearch-project/security/issues/2888

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
