### PR TITLE
Set ConfigurationLoader mget request preference to _primary for strong consistency

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -222,6 +222,7 @@ public class ConfigurationLoaderSecurity7 {
 
         mget.refresh(true);
         mget.realtime(true);
+        mget.preference("_primary");
 
         client.multiGet(mget, new ActionListener<MultiGetResponse>() {
             @Override


### PR DESCRIPTION
### Description

Update `ConfigurationLoader7` to set the preference of the mget request to `_primary` to instruct it to execute the request on the primary shard for maximum consistency. 

See issue discussed here: https://github.com/opensearch-project/security/issues/2898

In Segment replication, replication may be a bit slower so this change guarantees that the request to reload the security config is performed on the primary. See https://github.com/opensearch-project/OpenSearch/issues/8182#issuecomment-1602879714

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

https://github.com/opensearch-project/security/issues/2898

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
