### PR TITLE
Remove commons-collections 3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -533,7 +533,7 @@ dependencies {
     implementation "org.opensaml:opensaml-storage-api:${open_saml_version}"
 
     implementation "com.nulab-inc:zxcvbn:1.7.0"
-    implementation 'commons-collections:commons-collections:3.2.2'
+
     implementation 'com.jayway.jsonpath:json-path:2.4.0'
     implementation 'net.minidev:json-smart:2.4.10'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'

--- a/src/integrationTest/java/org/opensearch/test/framework/log/LogCapturingAppender.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/log/LogCapturingAppender.java
@@ -9,18 +9,8 @@
 */
 package org.opensearch.test.framework.log;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.apache.commons.collections.Buffer;
-import org.apache.commons.collections.BufferUtils;
-import org.apache.commons.collections.buffer.CircularFifoBuffer;
+import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Queues;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.Core;
 import org.apache.logging.log4j.core.Filter;
@@ -31,6 +21,15 @@ import org.apache.logging.log4j.core.config.Property;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
 import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import static org.opensearch.test.framework.log.LogCapturingAppender.PLUGIN_NAME;
 
@@ -56,12 +55,12 @@ public class LogCapturingAppender extends AbstractAppender {
     /**
     * Buffer for captured log messages
     */
-    private static final Buffer messages = BufferUtils.synchronizedBuffer(new CircularFifoBuffer(MAX_SIZE));
+    private static final Queue<LogMessage> messages = Queues.synchronizedQueue(EvictingQueue.create(MAX_SIZE));
 
     /**
     * Log messages are stored in buffer {@link #messages} only for classes which are added to the {@link #activeLoggers} set.
     */
-    private static final Set<String> activeLoggers = Collections.synchronizedSet(new HashSet<>());
+    private static final Set<String> activeLoggers = ConcurrentHashMap.newKeySet();
 
     protected LogCapturingAppender(
         String name,

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -35,12 +35,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.greenrobot.eventbus.Subscribe;
@@ -112,7 +112,7 @@ public class IndexResolverReplacer {
         this.clusterInfoHolder = clusterInfoHolder;
     }
 
-    private static final boolean isAllWithNoRemote(final String... requestedPatterns) {
+    private static boolean isAllWithNoRemote(final String... requestedPatterns) {
 
         final List<String> patterns = requestedPatterns == null ? null : Arrays.asList(requestedPatterns);
 
@@ -131,11 +131,11 @@ public class IndexResolverReplacer {
         return false;
     }
 
-    private static final boolean isLocalAll(String... requestedPatterns) {
+    private static boolean isLocalAll(String... requestedPatterns) {
         return isLocalAll(requestedPatterns == null ? null : Arrays.asList(requestedPatterns));
     }
 
-    private static final boolean isLocalAll(Collection<String> patterns) {
+    private static boolean isLocalAll(Collection<String> patterns) {
         if (IndexNameExpressionResolver.isAllIndices(patterns)) {
             return true;
         }
@@ -158,8 +158,48 @@ public class IndexResolverReplacer {
         private final ImmutableSet.Builder<String> remoteIndices;
         // set of previously resolved index requests to avoid resolving
         // the same index more than once while processing bulk requests
-        private final Set<MultiKey> alreadyResolved;
+        private final Set<AlreadyResolvedKey> alreadyResolved;
         private final String name;
+
+        private final class AlreadyResolvedKey {
+
+            private final IndicesOptions indicesOptions;
+
+            private final boolean enableCrossClusterResolution;
+
+            private final String[] original;
+
+            private AlreadyResolvedKey(final IndicesOptions indicesOptions, final boolean enableCrossClusterResolution) {
+                this(indicesOptions, enableCrossClusterResolution, null);
+            }
+
+            private AlreadyResolvedKey(
+                final IndicesOptions indicesOptions,
+                final boolean enableCrossClusterResolution,
+                final String[] original
+            ) {
+                this.indicesOptions = indicesOptions;
+                this.enableCrossClusterResolution = enableCrossClusterResolution;
+                this.original = original;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                AlreadyResolvedKey that = (AlreadyResolvedKey) o;
+                return enableCrossClusterResolution == that.enableCrossClusterResolution
+                    && Objects.equals(indicesOptions, that.indicesOptions)
+                    && Arrays.equals(original, that.original);
+            }
+
+            @Override
+            public int hashCode() {
+                int result = Objects.hash(indicesOptions, enableCrossClusterResolution);
+                result = 31 * result + Arrays.hashCode(original);
+                return result;
+            }
+        }
 
         ResolvedIndicesProvider(Object request) {
             aliases = ImmutableSet.builder();
@@ -336,9 +376,13 @@ public class IndexResolverReplacer {
                 || localRequest instanceof SearchRequest
                 || localRequest instanceof ResolveIndexAction.Request;
             // skip the whole thing if we have seen this exact resolveIndexPatterns request
-            if (alreadyResolved.add(
-                new MultiKey(indicesOptions, enableCrossClusterResolution, (original != null) ? new MultiKey(original, false) : null)
-            )) {
+            final AlreadyResolvedKey alreadyResolvedKey;
+            if (original != null) {
+                alreadyResolvedKey = new AlreadyResolvedKey(indicesOptions, enableCrossClusterResolution, original);
+            } else {
+                alreadyResolvedKey = new AlreadyResolvedKey(indicesOptions, enableCrossClusterResolution);
+            }
+            if (alreadyResolved.add(alreadyResolvedKey)) {
                 resolveIndexPatterns(localRequest.getClass().getSimpleName(), indicesOptions, enableCrossClusterResolution, original);
             }
             return IndicesProvider.NOOP;


### PR DESCRIPTION
### Description
Removed commons-collections 3.2.2
Reasons:
- it is not supported anymore 
- there were only 2 places where it used:   
  -  Class `LogCapturingAppender` - replaced `CircularFifoBuffer` with guava `EvictingQueue` 
  - `ResolvedIndicesProvider` - replace `MultyKey` with the custom one 

### Issues Resolved

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
