### PR TITLE
[Enchancement] Removed dependency between "test" and "jacocoTestReport"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,6 @@ jobs:
       with:
         arguments: |
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
-          -x test
 
     - name: Coverage
       uses: codecov/codecov-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -390,8 +390,6 @@ tasks.withType(JavaCompile) {
 }
 
 tasks.test.finalizedBy(jacocoTestReport)  // report is always generated after tests run
-tasks.jacocoTestReport.dependsOn(test) // tests are required to run before generating the report
-
 
 allprojects {
     tasks.withType(Javadoc).all { enabled = false }


### PR DESCRIPTION
### Description
As a part of discussions in #2861 there's been determined that CI workflow in Github Actions is excluding a lot of unnecessary task. @nibix created #2913 to address this problem. Most of the unneeded tasks has been already removed in #2861. This PR removes last existing part. @peternied's confirmed removal of dependency in his [comment](https://github.com/opensearch-project/security/issues/2913#issuecomment-1611985104).

This change removes the dependency between "_jacocoTestReport_" and "_test_" tasks. Specifically the dependency that forces to start "_test_" task always when "_jacocoTestReport_" is called. This allows us to always generate coverage report in the end of every task run in "CI" workflow without having to exclude "_test_" task in every single one of them. Unfortunately this will break functionality to create code coverage by starting only "_jacocoTestReport_" task. It looks like this was not used widely and was certainly not used in any of Github Actions Workflows. This will not break creating coverage reports in the end of "_test_" task.

### Issues Resolved
#2913 

### Testing
Manual tests been done to verify that output is in line with expectations. No tests are being added nor are needed.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
