### PR TITLE
Add password message to /dashboardsinfo endpoint

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
@@ -44,7 +44,7 @@ public class DashboardsInfoTest {
         .build();
 
     @Test
-    public void testNegativeLookaheadPattern() throws Exception {
+    public void testDashboardsInfoValidationMessage() throws Exception {
 
         try (TestRestClient client = cluster.getRestClient(DASHBOARDS_USER)) {
             TestRestClient.HttpResponse response = client.get("_plugins/_security/dashboardsinfo");

--- a/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
@@ -1,0 +1,56 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+* Modifications Copyright OpenSearch Contributors. See
+* GitHub history for details.
+*/
+
+package org.opensearch.security.api;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.rest.DashboardsInfoAction.DEFAULT_PASSWORD_MESSAGE;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class DashboardsInfoTest {
+
+    protected final static TestSecurityConfig.User DASHBOARDS_USER = new TestSecurityConfig.User("dashboards_user").roles(
+        new Role("dashboards_role").indexPermissions("read").on("*").clusterPermissions("cluster_composite_ops")
+    );
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(DASHBOARDS_USER)
+        .build();
+
+    @Test
+    public void testNegativeLookaheadPattern() throws Exception {
+
+        try (TestRestClient client = cluster.getRestClient(DASHBOARDS_USER)) {
+            TestRestClient.HttpResponse response = client.get("_plugins/_security/dashboardsinfo");
+            assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            assertThat(response.getBody(), containsString("password_validation_error_message"));
+            assertThat(response.getBody(), containsString(DEFAULT_PASSWORD_MESSAGE));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoWithSettingsTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoWithSettingsTest.java
@@ -56,7 +56,7 @@ public class DashboardsInfoWithSettingsTest {
         .build();
 
     @Test
-    public void testNegativeLookaheadPattern() throws Exception {
+    public void testDashboardsInfoValidationMessageWithCustomMessage() throws Exception {
 
         try (TestRestClient client = cluster.getRestClient(DASHBOARDS_USER)) {
             TestRestClient.HttpResponse response = client.get("_plugins/_security/dashboardsinfo");

--- a/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoWithSettingsTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoWithSettingsTest.java
@@ -1,0 +1,68 @@
+/*
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+* Modifications Copyright OpenSearch Contributors. See
+* GitHub history for details.
+*/
+
+package org.opensearch.security.api;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.hc.core5.http.HttpStatus;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class DashboardsInfoWithSettingsTest {
+
+    protected final static TestSecurityConfig.User DASHBOARDS_USER = new TestSecurityConfig.User("dashboards_user").roles(
+        new Role("dashboards_role").indexPermissions("read").on("*").clusterPermissions("cluster_composite_ops")
+    );
+
+    private static final String CUSTOM_PASSWORD_MESSAGE =
+        "Password must be minimum 5 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.";
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(DASHBOARDS_USER)
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX,
+                "(?=.*[A-Z])(?=.*[^a-zA-Z\\d])(?=.*[0-9])(?=.*[a-z]).{5,}",
+                ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,
+                CUSTOM_PASSWORD_MESSAGE
+            )
+        )
+        .build();
+
+    @Test
+    public void testNegativeLookaheadPattern() throws Exception {
+
+        try (TestRestClient client = cluster.getRestClient(DASHBOARDS_USER)) {
+            TestRestClient.HttpResponse response = client.get("_plugins/_security/dashboardsinfo");
+            assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            assertThat(response.getBody(), containsString("password_validation_error_message"));
+            assertThat(response.getBody(), containsString(CUSTOM_PASSWORD_MESSAGE));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -65,6 +65,9 @@ public class DashboardsInfoAction extends BaseRestHandler {
     private final PrivilegesEvaluator evaluator;
     private final ThreadContext threadContext;
 
+    public static final String DEFAULT_PASSWORD_MESSAGE = "Password should be at least 8 characters long and contain at least one "
+        + "uppercase letter, one lowercase letter, one digit, and one special character.";
+
     public DashboardsInfoAction(
         final Settings settings,
         final RestController controller,
@@ -103,6 +106,10 @@ public class DashboardsInfoAction extends BaseRestHandler {
                     builder.field("multitenancy_enabled", evaluator.multitenancyEnabled());
                     builder.field("private_tenant_enabled", evaluator.privateTenantEnabled());
                     builder.field("default_tenant", evaluator.dashboardsDefaultTenant());
+                    builder.field(
+                        "password_validation_error_message",
+                        client.settings().get(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE, DEFAULT_PASSWORD_MESSAGE)
+                    );
                     builder.endObject();
 
                     response = new BytesRestResponse(RestStatus.OK, builder);


### PR DESCRIPTION
### Description

Companion Security Dashboards Plugin PR: https://github.com/opensearch-project/security-dashboards-plugin/pull/1503

This modifies the /dashboardsinfo endpoint to include the `plugins.security.restapi.password_validation_error_message` setting or the default message of "Password should be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character.". The purpose of adding this to the endpoint is to utilize this message when rendering both the password edit component and password reset component to include the proper message.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug Fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1501

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
