### PR TITLE
[2.x] Use version of httpclient 4 from core's buildSrc/version.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -292,7 +292,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
-    implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
+    implementation "org.apache.httpcomponents:httpclient-cache:${versions.httpclient}"
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'
     implementation('org.apache.cxf:cxf-rt-rs-security-jose:3.5.5') {
         exclude(group: 'jakarta.activation', module: 'jakarta.activation-api')
@@ -340,8 +340,7 @@ dependencies {
     implementation 'commons-lang:commons-lang:2.4'
     implementation 'commons-collections:commons-collections:3.2.2'
     implementation 'com.jayway.jsonpath:json-path:2.4.0'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation 'net.minidev:json-smart:2.4.10'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'
@@ -381,7 +380,7 @@ dependencies {
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
     testImplementation 'com.unboundid:unboundid-ldapsdk:4.0.9'
     testImplementation 'javax.servlet:servlet-api:2.5'
-    testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
+    testImplementation "org.apache.httpcomponents:fluent-hc:${versions.httpclient}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}"
     testImplementation "org.apache.kafka:kafka-group-coordinator:${kafka_version}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"


### PR DESCRIPTION
### Description

This PR solves for the issue in backwards compatibility tests seen in PRs like: https://github.com/opensearch-project/security/pull/2949

```
> Task :compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all dependencies for configuration ':compileClasspath'.
   > Conflict(s) found for the following module(s):
       - org.apache.httpcomponents:httpclient between versions 4.5.14 and 4.5.13
     Run with:
         --scan or
         :dependencyInsight --configuration compileClasspath --dependency org.apache.httpcomponents:httpclient
     to get more insight on how to solve the conflict.
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
