### PR TITLE
[Backport 2.8] Resolve CVE-2023-2976 by forcing use of Guava 32.0.1 (#2937)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,8 @@ configurations.all {
         force "io.netty:netty-transport:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+        force "com.github.luben:zstd-jni:${versions.zstd}"
+        force "org.xerial.snappy:snappy-java:1.1.10.1"
         force 'com.google.guava:guava:32.0.1-jre'
     }
 }
@@ -293,10 +295,10 @@ dependencies {
     implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
-    implementation 'commons-cli:commons-cli:1.3.1'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.67'
+    implementation 'commons-cli:commons-cli:1.5.0'
+    implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'
@@ -367,9 +369,10 @@ dependencies {
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
-    runtimeOnly 'com.github.luben:zstd-jni:1.5.2-1'
+    runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
+    runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
+    runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
     implementation 'org.apache.commons:commons-lang3:3.4'

--- a/build.gradle
+++ b/build.gradle
@@ -285,7 +285,7 @@ configurations.all {
         force "io.netty:netty-transport:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
-        force "com.github.luben:zstd-jni:${versions.zstd}"
+        force "com.github.luben:zstd-jni:1.5.5-3"
         force "org.xerial.snappy:snappy-java:1.1.10.1"
         force 'com.google.guava:guava:32.0.1-jre'
     }
@@ -369,7 +369,7 @@ dependencies {
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'
-    runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
+    runtimeOnly "com.github.luben:zstd-jni:1.5.5-3"
     runtimeOnly 'org.checkerframework:checker-qual:3.5.0'
     runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,7 @@ configurations.all {
         force "io.netty:netty-transport:${versions.netty}"
         force "io.netty:netty-transport-native-unix-common:${versions.netty}"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+        force 'com.google.guava:guava:32.0.1-jre'
     }
 }
 
@@ -418,6 +419,14 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
+
+    //Checkstyle
+    checkstyle 'com.puppycrawl.tools:checkstyle:10.12.1'
+
+    //spotless
+    implementation('com.google.googlejavaformat:google-java-format:1.17.0') {
+        exclude group: 'com.google.guava'
+    }
 }
 
 jar {


### PR DESCRIPTION
Backports #2937 

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
