### PR TITLE
[Backport 2.x] Bump org.glassfish.jaxb:jaxb-runtime and org.glassfish.jaxb:txw2 to 2.3.8 (#2977)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
 
         common_utils_version = System.getProperty("common_utils.version", '2.9.0.0-SNAPSHOT')
         kafka_version  = '3.5.0'
+        jaxb_version = '2.3.8'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -346,7 +347,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'
     runtimeOnly 'com.google.guava:failureaccess:1.0.1'
     runtimeOnly 'org.apache.commons:commons-text:1.10.0'
-    runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.4'
+    runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:1.3'
     runtimeOnly 'com.google.code.findbugs:jsr305:3.0.2'
     runtimeOnly 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
@@ -356,7 +357,7 @@ dependencies {
     runtimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl:2.17.1'
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.1'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
-    runtimeOnly 'org.glassfish.jaxb:txw2:2.3.4'
+    runtimeOnly "org.glassfish.jaxb:txw2:${jaxb_version}"
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.4.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
     runtimeOnly 'org.apache.santuario:xmlsec:2.2.3'


### PR DESCRIPTION
Backport #2977 to 2.x