### PR TITLE
[Backport 2.x] Bump guava to 32.1.1-jre (#2976)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", '2.9.0.0-SNAPSHOT')
         kafka_version  = '3.5.0'
         jaxb_version = '2.3.8'
+        guava_version = '32.1.1-jre'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -422,14 +423,14 @@ configurations.all {
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "com.github.luben:zstd-jni:${versions.zstd}"
         force "org.xerial.snappy:snappy-java:1.1.10.1"
-        force 'com.google.guava:guava:32.0.1-jre'
+        force "com.google.guava:guava:${guava_version}"
     }
 }
 
 dependencies {
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation 'com.google.guava:guava:32.0.1-jre'
+    implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
@@ -490,7 +491,6 @@ dependencies {
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:1.3'
     runtimeOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
     runtimeOnly 'org.lz4:lz4-java:1.8.0'
     runtimeOnly 'io.dropwizard.metrics:metrics-core:3.1.2'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.30'


### PR DESCRIPTION
(cherry picked from commit 9599155caad2d3c72a1b999ea4b7cab999e6ef93)

Backport #2976 to 2.x