### PR TITLE
add workflow cluster permissions to alerting roles

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -28,6 +28,8 @@ alerting_read_access:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opendistro/alerting/alerts/get'
+    - 'cluster:admin/opensearch/alerting/workflow/get'
+    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
     - 'cluster:admin/opendistro/alerting/destination/get'
     - 'cluster:admin/opendistro/alerting/monitor/get'
     - 'cluster:admin/opendistro/alerting/monitor/search'
@@ -38,6 +40,8 @@ alerting_ack_alerts:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opendistro/alerting/alerts/*'
+    - 'cluster:admin/opendistro/alerting/workflow_alerts/*'
+    - 'cluster:admin/opendistro/alerting/chained_alerts/*'
 
 # Allows users to use all alerting functionality
 alerting_full_access:

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -28,20 +28,20 @@ alerting_read_access:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opendistro/alerting/alerts/get'
-    - 'cluster:admin/opensearch/alerting/workflow/get'
-    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
     - 'cluster:admin/opendistro/alerting/destination/get'
     - 'cluster:admin/opendistro/alerting/monitor/get'
     - 'cluster:admin/opendistro/alerting/monitor/search'
     - 'cluster:admin/opensearch/alerting/findings/get'
+    - 'cluster:admin/opensearch/alerting/workflow/get'
+    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opendistro/alerting/alerts/*'
-    - 'cluster:admin/opendistro/alerting/workflow_alerts/*'
     - 'cluster:admin/opendistro/alerting/chained_alerts/*'
+    - 'cluster:admin/opendistro/alerting/workflow_alerts/*'
 
 # Allows users to use all alerting functionality
 alerting_full_access:


### PR DESCRIPTION
### Description
Adds cluster permissions for alerting workflows to alerting roles

**`alerting_read_access`** role is mapped additionally to 
**`'cluster:admin/opensearch/alerting/workflow/get'`** and **`cluster:admin/opensearch/alerting/workflow_alerts/get'`**

**`alerting_ack_alerts`** is mapped to **'cluster:admin/opendistro/alerting/workflow_alerts/*`**  and **'cluster:admin/opendistro/alerting/chained_alerts/*'**

These roles are merged in https://github.com/opensearch-project/common-utils/blob/main/src/main/kotlin/org/opensearch/commons/alerting/action/AlertingActions.kt#L9-L20

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
