### PR TITLE
[Feature/Extension] Restrict OBO token's usage for certain endpoints

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -35,7 +35,6 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
-import static org.junit.Assert;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -60,7 +60,11 @@ public class OnBehalfOfJwtAuthenticationTest {
     public static final String OBO_TOKEN_REASON = "{\"reason\":\"Test generation\"}";
     public static final String OBO_ENDPOINT_PREFIX = "_plugins/_security/api/user/onbehalfof";
     public static final String OBO_REASON = "{\"reason\":\"Testing\", \"service\":\"self-issued\"}";
-    public static final String CURRENT_AND_NEW_PASSWORDS = "{ \"current_password\": \"" + DEFAULT_PASSWORD + "\", \"password\": \"" + NEW_PASSWORD + "\" }";
+    public static final String CURRENT_AND_NEW_PASSWORDS = "{ \"current_password\": \""
+        + DEFAULT_PASSWORD
+        + "\", \"password\": \""
+        + NEW_PASSWORD
+        + "\" }";
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -59,7 +59,7 @@ public class OnBehalfOfJwtAuthenticationTest {
     public static final String NEW_PASSWORD = "testPassword123!!";
     public static final String OBO_TOKEN_REASON = "{\"reason\":\"Test generation\"}";
     public static final String OBO_ENDPOINT_PREFIX = "_plugins/_security/api/user/onbehalfof";
-    public static final String OBO_REASON = "{\"reason\":\"Testing\", \"service\":\"extension123\"}";
+    public static final String OBO_REASON = "{\"reason\":\"Testing\", \"service\":\"self-issued\"}";
     public static final String CURRENT_AND_NEW_PASSWORDS = "{ \"current_password\": \"" + DEFAULT_PASSWORD + "\", \"password\": \"" + NEW_PASSWORD + "\" }";
 
     @ClassRule

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -58,6 +58,7 @@ public class OnBehalfOfJwtAuthenticationTest {
     public static final String DEFAULT_PASSWORD = "secret";
     public static final String OBO_TOKEN_REASON = "{\"reason\":\"Test generation\"}";
     public static final String OBO_ENDPOINT_PREFIX = "_plugins/_security/api/user/onbehalfof";
+    public static final String OBO_REASON = "{\"reason\":\"Testing\", \"service\":\"extension123\"}";
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
@@ -96,8 +97,8 @@ public class OnBehalfOfJwtAuthenticationTest {
         Header adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
 
         try (TestRestClient client = cluster.getRestClient(adminOboAuthHeader)) {
-            TestRestClient.HttpResponse response = client.getOBOToken(adminOboAuthHeader);
-            response.assertStatusCode(403);
+            TestRestClient.HttpResponse response = client.getOBOTokenFromOboEndpoint(OBO_REASON, adminOboAuthHeader);
+            response.assertStatusCode(401);
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 
@@ -76,60 +78,51 @@ public class OnBehalfOfJwtAuthenticationTest {
 
     @Test
     public void shouldAuthenticateWithOBOTokenEndPoint() {
-        Header adminOboAuthHeader;
-
-        try (TestRestClient client = cluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
-
-            client.assertCorrectCredentials(ADMIN_USER_NAME);
-
-            TestRestClient.HttpResponse response = client.postJson(OBO_ENDPOINT_PREFIX, OBO_TOKEN_REASON);
-            response.assertStatusCode(200);
-
-            Map<String, Object> oboEndPointResponse = response.getBodyAs(Map.class);
-            assertThat(oboEndPointResponse, allOf(aMapWithSize(3), hasKey("user"), hasKey("onBehalfOfToken"), hasKey("duration")));
-
-            String encodedOboTokenStr = oboEndPointResponse.get("onBehalfOfToken").toString();
-
-            adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + encodedOboTokenStr);
-        }
-
-        try (TestRestClient client = cluster.getRestClient(adminOboAuthHeader)) {
-
-            TestRestClient.HttpResponse response = client.getAuthInfo();
-            response.assertStatusCode(200);
-
-            String username = response.getTextFromJsonBody(POINTER_USERNAME);
-            assertThat(username, equalTo(ADMIN_USER_NAME));
-        }
+        String oboToken = generateOboToken(ADMIN_USER_NAME, DEFAULT_PASSWORD);
+        Header adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
+        authenticateWithOboToken(adminOboAuthHeader, ADMIN_USER_NAME, 200);
     }
 
     @Test
     public void shouldNotAuthenticateWithATemperedOBOToken() {
-        Header adminOboAuthHeader;
+        String oboToken = generateOboToken(ADMIN_USER_NAME, DEFAULT_PASSWORD);
+        oboToken = oboToken.substring(0, oboToken.length() - 1); // tampering the token
+        Header adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
+        authenticateWithOboToken(adminOboAuthHeader, ADMIN_USER_NAME, 401);
+    }
 
-        try (TestRestClient client = cluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
-
-            client.assertCorrectCredentials(ADMIN_USER_NAME);
-
-            TestRestClient.HttpResponse response = client.postJson(OBO_ENDPOINT_PREFIX, OBO_TOKEN_REASON);
-            response.assertStatusCode(200);
-
-            Map<String, Object> oboEndPointResponse = response.getBodyAs(Map.class);
-            assertThat(oboEndPointResponse, allOf(aMapWithSize(3), hasKey("user"), hasKey("onBehalfOfToken"), hasKey("duration")));
-
-            String encodedOboTokenStr = oboEndPointResponse.get("onBehalfOfToken").toString();
-            StringBuilder stringBuilder = new StringBuilder(encodedOboTokenStr);
-            stringBuilder.deleteCharAt(encodedOboTokenStr.length() - 1);
-            String temperedOboTokenStr = stringBuilder.toString();
-
-            adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + temperedOboTokenStr);
-        }
+    @Test
+    public void shouldNotAuthenticateForUsingOBOTokenToAccessOBOEndpoint() {
+        String oboToken = generateOboToken(ADMIN_USER_NAME, DEFAULT_PASSWORD);
+        Header adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
 
         try (TestRestClient client = cluster.getRestClient(adminOboAuthHeader)) {
+            TestRestClient.HttpResponse response = client.getOBOToken(adminOboAuthHeader);
+            response.assertStatusCode(403);
+        }
+    }
 
+    private String generateOboToken(String username, String password) {
+        try (TestRestClient client = cluster.getRestClient(username, password)) {
+            client.assertCorrectCredentials(username);
+            TestRestClient.HttpResponse response = client.postJson(OBO_ENDPOINT_PREFIX, OBO_TOKEN_REASON);
+            response.assertStatusCode(200);
+            Map<String, Object> oboEndPointResponse = response.getBodyAs(Map.class);
+            assertThat(oboEndPointResponse, allOf(aMapWithSize(3), hasKey("user"), hasKey("onBehalfOfToken"), hasKey("duration")));
+            return oboEndPointResponse.get("onBehalfOfToken").toString();
+        }
+    }
+
+    private void authenticateWithOboToken(Header authHeader, String expectedUsername, int expectedStatusCode) {
+        try (TestRestClient client = cluster.getRestClient(authHeader)) {
             TestRestClient.HttpResponse response = client.getAuthInfo();
-            response.assertStatusCode(401);
-            response.getBody().contains("Unauthorized");
+            response.assertStatusCode(expectedStatusCode);
+            if (expectedStatusCode == 200) {
+                String username = response.getTextFromJsonBody(POINTER_USERNAME);
+                assertThat(username, equalTo(expectedUsername));
+            } else {
+                Assert.assertTrue(response.getBody().contains("Unauthorized"));
+            }
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -62,7 +62,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.routing.HttpRoutePlanner;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -135,6 +135,10 @@ public class TestRestClient implements AutoCloseable {
         return executeRequest(new HttpGet(getHttpServerUri() + "/_opendistro/_security/authinfo?pretty"), headers);
     }
 
+    public HttpResponse getOBOToken(Header... headers) {
+        return executeRequest(new HttpPost(getHttpServerUri() + "/_plugin/_security/api/user/onbehalfof?pretty"), headers);
+    }
+
     public void assertCorrectCredentials(String expectedUserName) {
         HttpResponse response = getAuthInfo();
         assertThat(response, notNullValue());

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -135,8 +135,14 @@ public class TestRestClient implements AutoCloseable {
         return executeRequest(new HttpGet(getHttpServerUri() + "/_opendistro/_security/authinfo?pretty"), headers);
     }
 
-    public HttpResponse getOBOToken(Header... headers) {
-        return executeRequest(new HttpPost(getHttpServerUri() + "/_plugin/_security/api/user/onbehalfof?pretty"), headers);
+    public HttpResponse getOBOTokenFromOboEndpoint(String jsonData, Header... headers) {
+        try {
+            HttpPost httpPost = new HttpPost(new URIBuilder(getHttpServerUri() + "/_plugins/_security/api/user/onbehalfof?pretty").build());
+            httpPost.setEntity(toStringEntity(jsonData));
+            return executeRequest(httpPost, mergeHeaders(CONTENT_TYPE_JSON, headers));
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException("Incorrect URI syntax", ex);
+        }
     }
 
     public void assertCorrectCredentials(String expectedUserName) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -62,6 +62,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.routing.HttpRoutePlanner;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
@@ -140,6 +141,16 @@ public class TestRestClient implements AutoCloseable {
             HttpPost httpPost = new HttpPost(new URIBuilder(getHttpServerUri() + "/_plugins/_security/api/user/onbehalfof?pretty").build());
             httpPost.setEntity(toStringEntity(jsonData));
             return executeRequest(httpPost, mergeHeaders(CONTENT_TYPE_JSON, headers));
+        } catch (URISyntaxException ex) {
+            throw new RuntimeException("Incorrect URI syntax", ex);
+        }
+    }
+
+    public HttpResponse changeInternalUserPassword(String jsonData, Header...headers) {
+        try {
+            HttpPut httpPut = new HttpPut(new URIBuilder(getHttpServerUri() + "/_plugins/_security/api/account?pretty").build());
+            httpPut.setEntity(toStringEntity(jsonData));
+            return executeRequest(httpPut, mergeHeaders(CONTENT_TYPE_JSON, headers));
         } catch (URISyntaxException ex) {
             throw new RuntimeException("Incorrect URI syntax", ex);
         }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -145,7 +145,7 @@ public class TestRestClient implements AutoCloseable {
         }
     }
 
-    public HttpResponse changeInternalUserPassword(String jsonData, Header...headers) {
+    public HttpResponse changeInternalUserPassword(String jsonData, Header... headers) {
         try {
             HttpPut httpPut = new HttpPut(new URIBuilder(getHttpServerUri() + "/_plugins/_security/api/account?pretty").build());
             httpPut.setEntity(toStringEntity(jsonData));

--- a/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
+++ b/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
@@ -24,7 +24,7 @@ import org.greenrobot.eventbus.Subscribe;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.transport.TransportAddress;
+import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -105,12 +105,15 @@ public class JwtVendor {
         List<String> roles,
         List<String> backendRoles
     ) throws Exception {
+        String tokenIdentifier = "OBO";
         long timeMillis = timeProvider.getAsLong();
         Instant now = Instant.ofEpochMilli(timeProvider.getAsLong());
 
         jwtProducer.setSignatureProvider(JwsUtils.getSignatureProvider(signingKey));
         JwtClaims jwtClaims = new JwtClaims();
         JwtToken jwt = new JwtToken(jwtClaims);
+
+        jwtClaims.setProperty("token_identifier", tokenIdentifier);
 
         jwtClaims.setIssuer(issuer);
 

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -105,7 +105,7 @@ public class JwtVendor {
         List<String> roles,
         List<String> backendRoles
     ) throws Exception {
-        String tokenIdentifier = "OBO";
+        String tokenIdentifier = "obo";
         long timeMillis = timeProvider.getAsLong();
         Instant now = Instant.ofEpochMilli(timeProvider.getAsLong());
 
@@ -113,7 +113,7 @@ public class JwtVendor {
         JwtClaims jwtClaims = new JwtClaims();
         JwtToken jwt = new JwtToken(jwtClaims);
 
-        jwtClaims.setProperty("token_identifier", tokenIdentifier);
+        jwtClaims.setProperty("typ", tokenIdentifier);
 
         jwtClaims.setIssuer(issuer);
 

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -89,6 +89,8 @@ public class SecurityRestFilter {
     private static final String HEALTH_SUFFIX = "health";
     private static final String WHO_AM_I_SUFFIX = "whoami";
 
+    private static final String ON_BEHALF_OF_SUFFIX = "onbehalfof";
+
     private static final String REGEX_PATH_PREFIX = "/(" + LEGACY_OPENDISTRO_PREFIX + "|" + PLUGINS_PREFIX + ")/" + "(.*)";
     private static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
 
@@ -260,8 +262,7 @@ public class SecurityRestFilter {
         }
 
         if (HTTPHelper.containsOBOToken(request)) {
-            String OBO_ENDPOINT_PREFIX = "_plugins/_security/api/user/onbehalfof";
-            if (request.method() == Method.POST && OBO_ENDPOINT_PREFIX.equals(suffix)) {
+            if (request.method() == Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)) {
                 final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
                 log.error(exception.toString());
                 auditLog.logBadHeaders(request);

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -89,8 +89,6 @@ public class SecurityRestFilter {
     private static final String HEALTH_SUFFIX = "health";
     private static final String WHO_AM_I_SUFFIX = "whoami";
 
-    private static final String ON_BEHALF_OF_SUFFIX = "onbehalfof";
-
     private static final String REGEX_PATH_PREFIX = "/(" + LEGACY_OPENDISTRO_PREFIX + "|" + PLUGINS_PREFIX + ")/" + "(.*)";
     private static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
 
@@ -260,17 +258,6 @@ public class SecurityRestFilter {
                 );
             }
         }
-
-        if (HTTPHelper.containsOBOToken(request)) {
-            if (request.method() == Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)) {
-                final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
-                log.error(exception.toString());
-                auditLog.logBadHeaders(request);
-                channel.sendResponse(new BytesRestResponse(channel, RestStatus.FORBIDDEN, exception));
-                return true;
-            }
-        }
-
         return false;
     }
 

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -259,6 +259,17 @@ public class SecurityRestFilter {
             }
         }
 
+        if (HTTPHelper.containsOBOToken(request)) {
+            String OBO_ENDPOINT_PREFIX = "_plugins/_security/api/user/onbehalfof";
+            if (request.method() == Method.POST && OBO_ENDPOINT_PREFIX.equals(suffix)) {
+                final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
+                log.error(exception.toString());
+                auditLog.logBadHeaders(request);
+                channel.sendResponse(new BytesRestResponse(channel, RestStatus.FORBIDDEN, exception));
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -50,6 +50,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
     private static final String REGEX_PATH_PREFIX = "/(" + LEGACY_OPENDISTRO_PREFIX + "|" + PLUGINS_PREFIX + ")/" + "(.*)";
     private static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
     private static final String ON_BEHALF_OF_SUFFIX = "api/user/onbehalfof";
+    private static final String ACCOUNT_SUFFIX = "api/account";
 
     protected final Logger log = LogManager.getLogger(this.getClass());
 
@@ -181,7 +182,8 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
         try {
             Matcher matcher = PATTERN_PATH_PREFIX.matcher(request.path());
             final String suffix = matcher.matches() ? matcher.group(2) : null;
-            if (request.method() == RestRequest.Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)) {
+            if (request.method() == RestRequest.Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)
+                || request.method() == RestRequest.Method.PUT && ACCOUNT_SUFFIX.equals(suffix)) {
                 final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
                 log.error(exception.toString());
                 return null;

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -184,7 +184,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
             }
 
             final String tokenType = claims.get(TOKEN_TYPE_CLAIM).toString();
-            if (tokenType != TOKEN_TYPE) {
+            if (!tokenType.equals(TOKEN_TYPE)) {
                 log.error("This toke is not verifying as an on-behalf-of token");
                 return null;
             }

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -49,7 +49,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
 
     private static final String REGEX_PATH_PREFIX = "/(" + LEGACY_OPENDISTRO_PREFIX + "|" + PLUGINS_PREFIX + ")/" + "(.*)";
     private static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
-    private static final String ON_BEHALF_OF_SUFFIX = "onbehalfof";
+    private static final String ON_BEHALF_OF_SUFFIX = "api/user/onbehalfof";
 
     protected final Logger log = LogManager.getLogger(this.getClass());
 
@@ -179,6 +179,14 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
         }
 
         try {
+            Matcher matcher = PATTERN_PATH_PREFIX.matcher(request.path());
+            final String suffix = matcher.matches() ? matcher.group(2) : null;
+            if (request.method() == RestRequest.Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)) {
+                final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
+                log.error(exception.toString());
+                return null;
+            }
+
             final Claims claims = jwtParser.parseClaimsJws(jwtToken).getBody();
 
             final String subject = claims.getSubject();
@@ -203,14 +211,6 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
             String[] backendRoles = extractBackendRolesFromClaims(claims);
 
             final AuthCredentials ac = new AuthCredentials(subject, roles, backendRoles).markComplete();
-
-            Matcher matcher = PATTERN_PATH_PREFIX.matcher(request.path());
-            final String suffix = matcher.matches() ? matcher.group(2) : null;
-            if (request.method() == RestRequest.Method.POST && ON_BEHALF_OF_SUFFIX.equals(suffix)) {
-                final OpenSearchException exception = ExceptionUtils.invalidUsageOfOBOTokenException();
-                log.error(exception.toString());
-                return null;
-            }
 
             for (Entry<String, Object> claim : claims.entrySet()) {
                 ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -45,7 +45,8 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
 
     private static final Pattern BEARER = Pattern.compile("^\\s*Bearer\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER_PREFIX = "bearer ";
-    private static final String SUBJECT_CLAIM = "sub";
+    private static final String TOKEN_TYPE_CLAIM = "typ";
+    private static final String TOKEN_TYPE = "obo";
 
     private final JwtParser jwtParser;
     private final String encryptionKey;
@@ -179,6 +180,12 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
             final String audience = claims.getAudience();
             if (Objects.isNull(audience)) {
                 log.error("Valid jwt on behalf of token with no audience");
+                return null;
+            }
+
+            final String tokenType = claims.get(TOKEN_TYPE_CLAIM).toString();
+            if (tokenType != TOKEN_TYPE) {
+                log.error("This toke is not verifying as an on-behalf-of token");
                 return null;
             }
 

--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -65,7 +65,7 @@ public class ExceptionUtils {
     }
 
     public static OpenSearchException invalidUsageOfOBOTokenException() {
-        return new OpenSearchException("On-Behalf-Token is not allowed to access this endopoint.");
+        return new OpenSearchException("On-Behalf-Of Token is not allowed to be used for accessing this endopoint.");
     }
 
     public static OpenSearchException createTransportClientNoLongerSupportedException() {

--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -64,6 +64,10 @@ public class ExceptionUtils {
         );
     }
 
+    public static OpenSearchException invalidUsageOfOBOTokenException() {
+        return new OpenSearchException("On-Behalf-Token is not allowed to access this endopoint.");
+    }
+
     public static OpenSearchException createTransportClientNoLongerSupportedException() {
         return new OpenSearchException("Transport client authentication no longer supported.");
     }

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -104,7 +104,7 @@ public class HTTPHelper {
         return false;
     }
 
-    public static boolean containsOBOToken(final RestRequest request){
+    public static boolean containsOBOToken(final RestRequest request) {
         final Map<String, List<String>> headers;
 
         if (request != null && (headers = request.getHeaders()) != null) {

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -31,6 +31,9 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.rest.RestRequest;
@@ -100,4 +103,40 @@ public class HTTPHelper {
 
         return false;
     }
+
+    public static boolean containsOBOToken(final RestRequest request){
+        final Map<String, List<String>> headers;
+
+        if (request != null && (headers = request.getHeaders()) != null) {
+            List<String> authHeaders = headers.get("Authorization");
+            if (authHeaders != null && !authHeaders.isEmpty()) {
+                // Iterate through the list of 'Authorization' headers, checking each for the 'Bearer' prefix.
+                for (String authHeader : authHeaders) {
+                    if (authHeader != null && authHeader.startsWith("Bearer ")) {
+                        // Header found, extract the token to verify it's an OBO token.
+                        String token = authHeader.substring("Bearer ".length());
+                        if (isOBOToken(token)) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static boolean isOBOToken(String token) {
+        String tokenIdentifierClaimKey = "token_identifier";
+        String tokenIdentifier = "OBO";
+
+        Jws<Claims> claimsJws = Jwts.parserBuilder().build().parseClaimsJws(token);
+        Claims claims = claimsJws.getBody();
+
+        if (claims.containsKey(tokenIdentifierClaimKey) && tokenIdentifier.equals(claims.get(tokenIdentifierClaimKey))) {
+            return true;
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -127,8 +127,8 @@ public class HTTPHelper {
     }
 
     private static boolean isOBOToken(String token) {
-        String tokenIdentifierClaimKey = "token_identifier";
-        String tokenIdentifier = "OBO";
+        String tokenIdentifierClaimKey = "typ";
+        String tokenIdentifier = "obo";
 
         Jws<Claims> claimsJws = Jwts.parserBuilder().build().parseClaimsJws(token);
         Claims claims = claimsJws.getBody();

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -31,9 +31,6 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.rest.RestRequest;
@@ -103,40 +100,4 @@ public class HTTPHelper {
 
         return false;
     }
-
-    public static boolean containsOBOToken(final RestRequest request) {
-        final Map<String, List<String>> headers;
-
-        if (request != null && (headers = request.getHeaders()) != null) {
-            List<String> authHeaders = headers.get("Authorization");
-            if (authHeaders != null && !authHeaders.isEmpty()) {
-                // Iterate through the list of 'Authorization' headers, checking each for the 'Bearer' prefix.
-                for (String authHeader : authHeaders) {
-                    if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                        // Header found, extract the token to verify it's an OBO token.
-                        String token = authHeader.substring("Bearer ".length());
-                        if (isOBOToken(token)) {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private static boolean isOBOToken(String token) {
-        String tokenIdentifierClaimKey = "typ";
-        String tokenIdentifier = "obo";
-
-        Jws<Claims> claimsJws = Jwts.parserBuilder().build().parseClaimsJws(token);
-        Claims claims = claimsJws.getBody();
-
-        if (claims.containsKey(tokenIdentifierClaimKey) && tokenIdentifier.equals(claims.get(tokenIdentifierClaimKey))) {
-            return true;
-        }
-        return false;
-    }
-
 }

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -62,6 +62,7 @@ public class JwtVendorTest {
         JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
         JwtToken jwt = jwtConsumer.getJwtToken();
 
+        Assert.assertEquals("obo", jwt.getClaim("typ"));
         Assert.assertEquals("cluster_0", jwt.getClaim("iss"));
         Assert.assertEquals("admin", jwt.getClaim("sub"));
         Assert.assertEquals("audience_0", jwt.getClaim("aud"));

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -83,7 +83,7 @@ public class OnBehalfOfAuthenticatorTest {
             final AuthCredentials credentials = extractCredentialsFromJwtHeader(
                 BaseEncoding.base64().encode(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 }),
                 claimsEncryptionKey,
-                Jwts.builder().setSubject("Leonard McCoy"),
+                Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy"),
                 false
             );
             Assert.fail("Expected a WeakKeyException");
@@ -119,6 +119,7 @@ public class OnBehalfOfAuthenticatorTest {
     @Test
     public void testDisabled() throws Exception {
         String jwsToken = Jwts.builder()
+            .claim("typ", "obo")
             .setSubject("Leonard McCoy")
             .setAudience("ext_0")
             .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(signingKeyB64Encoded)), SignatureAlgorithm.HS512)
@@ -135,6 +136,7 @@ public class OnBehalfOfAuthenticatorTest {
     @Test
     public void testNonSpecifyOBOSetting() throws Exception {
         String jwsToken = Jwts.builder()
+            .claim("typ", "obo")
             .setSubject("Leonard McCoy")
             .setAudience("ext_0")
             .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(signingKeyB64Encoded)), SignatureAlgorithm.HS512)

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -16,7 +16,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.crypto.SecretKey;
@@ -169,7 +168,7 @@ public class OnBehalfOfAuthenticatorTest {
         Assert.assertEquals("Leonard McCoy", credentials.getUsername());
         Assert.assertEquals(0, credentials.getSecurityRoles().size());
         Assert.assertEquals(0, credentials.getBackendRoles().size());
-        Assert.assertEquals(2, credentials.getAttributes().size());
+        Assert.assertEquals(3, credentials.getAttributes().size());
     }
 
     @Test
@@ -227,10 +226,10 @@ public class OnBehalfOfAuthenticatorTest {
     public void testNoTokenType() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-                signingKeyB64Encoded,
-                claimsEncryptionKey,
-                Jwts.builder().setSubject("Leonard McCoy").claim("dr", "role1,role2").setAudience("svc1"),
-                true
+            signingKeyB64Encoded,
+            claimsEncryptionKey,
+            Jwts.builder().setSubject("Leonard McCoy").claim("dr", "role1,role2").setAudience("svc1"),
+            true
         );
 
         Assert.assertNull(credentials);

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -52,7 +52,7 @@ public class OnBehalfOfAuthenticatorTest {
             final AuthCredentials credentials = extractCredentialsFromJwtHeader(
                 null,
                 claimsEncryptionKey,
-                Jwts.builder().setSubject("Leonard McCoy"),
+                Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy"),
                 false
             );
             Assert.fail("Expected a RuntimeException");
@@ -68,7 +68,7 @@ public class OnBehalfOfAuthenticatorTest {
             final AuthCredentials credentials = extractCredentialsFromJwtHeader(
                 null,
                 claimsEncryptionKey,
-                Jwts.builder().setSubject("Leonard McCoy"),
+                Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy"),
                 false
             );
             Assert.fail("Expected a RuntimeException");
@@ -153,6 +153,7 @@ public class OnBehalfOfAuthenticatorTest {
     public void testBearer() throws Exception {
 
         String jwsToken = Jwts.builder()
+            .claim("typ", "obo")
             .setSubject("Leonard McCoy")
             .setAudience("ext_0")
             .signWith(Keys.hmacShaKeyFor(Base64.getDecoder().decode(signingKeyB64Encoded)), SignatureAlgorithm.HS512)
@@ -175,6 +176,7 @@ public class OnBehalfOfAuthenticatorTest {
     public void testBearerWrongPosition() throws Exception {
 
         String jwsToken = Jwts.builder()
+            .claim("typ", "obo")
             .setSubject("Leonard McCoy")
             .setAudience("ext_0")
             .signWith(secretKey, SignatureAlgorithm.HS512)
@@ -192,6 +194,7 @@ public class OnBehalfOfAuthenticatorTest {
     @Test
     public void testBasicAuthHeader() throws Exception {
         String jwsToken = Jwts.builder()
+            .claim("typ", "obo")
             .setSubject("Leonard McCoy")
             .setAudience("ext_0")
             .signWith(secretKey, SignatureAlgorithm.HS512)
@@ -207,11 +210,10 @@ public class OnBehalfOfAuthenticatorTest {
     @Test
     public void testRoles() throws Exception {
 
-        List<String> roles = List.of("IT", "HR");
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Leonard McCoy").claim("dr", "role1,role2").setAudience("svc1"),
+            Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy").claim("dr", "role1,role2").setAudience("svc1"),
             true
         );
 
@@ -222,12 +224,25 @@ public class OnBehalfOfAuthenticatorTest {
     }
 
     @Test
+    public void testNoTokenType() throws Exception {
+
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+                signingKeyB64Encoded,
+                claimsEncryptionKey,
+                Jwts.builder().setSubject("Leonard McCoy").claim("dr", "role1,role2").setAudience("svc1"),
+                true
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
     public void testNullClaim() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Leonard McCoy").claim("dr", null).setAudience("svc1"),
+            Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy").claim("dr", null).setAudience("svc1"),
             false
         );
 
@@ -242,7 +257,7 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Leonard McCoy").claim("dr", 123L).setAudience("svc1"),
+            Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy").claim("dr", 123L).setAudience("svc1"),
             true
         );
 
@@ -258,7 +273,7 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Leonard McCoy").setAudience("svc1"),
+            Jwts.builder().claim("typ", "obo").setSubject("Leonard McCoy").setAudience("svc1"),
             false
         );
 
@@ -274,7 +289,7 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().claim("roles", "role1,role2").claim("asub", "Dr. Who").setAudience("svc1"),
+            Jwts.builder().claim("typ", "obo").claim("roles", "role1,role2").claim("asub", "Dr. Who").setAudience("svc1"),
             false
         );
 
@@ -287,7 +302,7 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Expired").setExpiration(new Date(100)),
+            Jwts.builder().claim("typ", "obo").setSubject("Expired").setExpiration(new Date(100)),
             false
         );
 
@@ -300,7 +315,7 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             signingKeyB64Encoded,
             claimsEncryptionKey,
-            Jwts.builder().setSubject("Expired").setNotBefore(new Date(System.currentTimeMillis() + (1000 * 36000))),
+            Jwts.builder().claim("typ", "obo").setSubject("Expired").setNotBefore(new Date(System.currentTimeMillis() + (1000 * 36000))),
             false
         );
 
@@ -311,7 +326,7 @@ public class OnBehalfOfAuthenticatorTest {
     public void testRolesArray() throws Exception {
 
         JwtBuilder builder = Jwts.builder()
-            .setPayload("{" + "\"sub\": \"Cluster_0\"," + "\"aud\": \"ext_0\"," + "\"dr\": \"a,b,3rd\"" + "}");
+            .setPayload("{" + "\"typ\": \"obo\"," + "\"sub\": \"Cluster_0\"," + "\"aud\": \"ext_0\"," + "\"dr\": \"a,b,3rd\"" + "}");
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(signingKeyB64Encoded, claimsEncryptionKey, builder, true);
 


### PR DESCRIPTION
### Description
Edge Cases Of OBO Token Usage: 
- [x] User should not use OBO Token to issue another OBO Token
- [x] User should not use OBO Token to modify users' authinfo, such as resetting password

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
New feature


### Issues Resolved
* Resolve https://github.com/opensearch-project/security/issues/2891

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
