### PR TITLE
Use SNAPSHOT in bwc tests to run tests with latest commits

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -35,7 +35,7 @@ runs:
     - name: Build
       uses: gradle/gradle-build-action@v2
       with:
-        arguments: assemble -Dbuild.snapshot=false
+        arguments: assemble
         build-root-directory: ${{ inputs.plugin-branch }}
 
     - id: get-opensearch-version

--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -46,5 +46,5 @@ runs:
     - name: Copy current distro into the expected folder
       run: |
         mkdir -p ./bwc-test/src/test/resources/${{ steps.get-opensearch-version.outputs.version }}
-        cp ${{ inputs.plugin-branch }}/build/distributions/opensearch-security-${{ steps.get-opensearch-version.outputs.version }}.zip ./bwc-test/src/test/resources/${{ steps.get-opensearch-version.outputs.version }}
+        cp ${{ inputs.plugin-branch }}/build/distributions/opensearch-security-${{ steps.get-opensearch-version.outputs.version }}-SNAPSHOT.zip ./bwc-test/src/test/resources/${{ steps.get-opensearch-version.outputs.version }}
       shell: bash

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -84,8 +84,8 @@ String baseName = "securityBwcCluster"
 String bwcFilePath = "src/test/resources/"
 String projectVersion = nextVersion
 
-String previousOpenSearch  = extractVersion(previousVersion);
-String nextOpenSearch  = extractVersion(nextVersion);
+String previousOpenSearch  = extractVersion(previousVersion) + "-SNAPSHOT";
+String nextOpenSearch  = extractVersion(nextVersion) + "-SNAPSHOT";
 
 println previousOpenSearch + nextOpenSearch;
 


### PR DESCRIPTION
### Description

The BWC Tests are not currently referring to a SNAPSHOT version when running testclusters which causes the distribution downloader to look for release or release-candidate versions of the minimum distribution as @saratvemulapalli describes [here](https://github.com/opensearch-project/OpenSearch/pull/8731#issuecomment-1639032164). This PR appends `-SNAPSHOT` to the versions supplied to testclusters to instruct testclusters to download a SNAPSHOT which will always have the most up-to-date changes included.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/3020

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
