### PR TITLE
[1.3] Update guava to address CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ configurations.all {
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.28"
         force "org.springframework:spring-expression:5.3.28"
-        force "com.google.guava:guava:30.0-jre"
+        force "com.google.guava:guava:32.0.1-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
@@ -102,7 +102,7 @@ dependencies {
     implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation 'com.google.guava:guava:30.0-jre'
+    implementation 'com.google.guava:guava:32.0.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.75'
@@ -417,4 +417,4 @@ task updateVersion {
         }
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-} 
+}

--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ configurations.all {
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.28"
         force "org.springframework:spring-expression:5.3.28"
-        force "com.google.guava:guava:32.0.1-jre"
+        force "com.google.guava:guava:32.1.1-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
@@ -102,7 +102,7 @@ dependencies {
     implementation 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
     implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
-    implementation 'com.google.guava:guava:32.0.1-jre'
+    implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.75'

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
@@ -12,189 +12,178 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 package org.opensearch.security.ssl.util;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
-public class SSLConnectionTestUtilTests {
-    private Socket socket;
-    private OutputStream outputStream;
-    private InputStream inputStream;
-    private OutputStreamWriter outputStreamWriter;
-    private InputStreamReader inputStreamReader;
+/**
+ * Utility class to test if the server supports SSL connections.
+ * SSL Check will be done by sending an OpenSearch Ping to see if server is replying to pings.
+ * Following that a custom client hello message will be sent to the server, if the server
+ * side has OpenSearchPortUnificationHandler it will reply with server hello message.
+ */
+public class SSLConnectionTestUtil {
 
-    @Before
-    public void setup() {
-        socket = Mockito.mock(Socket.class);
-        outputStream = Mockito.mock(OutputStream.class);
-        inputStream = Mockito.mock(InputStream.class);
-        outputStreamWriter = Mockito.mock(OutputStreamWriter.class);
-        inputStreamReader = Mockito.mock(InputStreamReader.class);
+    private static final Logger logger = LogManager.getLogger(SSLConnectionTestUtil.class);
+    public static final byte[] OPENSEARCH_PING_MSG = new byte[]{(byte) 'E', (byte) 'S', (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
+    public static final String DUAL_MODE_CLIENT_HELLO_MSG = "DUALCM";
+    public static final String DUAL_MODE_SERVER_HELLO_MSG = "DUALSM";
+    private static final int SOCKET_TIMEOUT_MILLIS = 10 * 1000;
+    private boolean opensearchPingReplyReceived;
+    private boolean dualSSLProbeReplyReceived;
+    private final String host;
+    private final int port;
+    private Socket overriddenSocket = null;
+    private OutputStreamWriter testOutputStreamWriter = null;
+    private InputStreamReader testInputStreamReader = null;
+
+    public SSLConnectionTestUtil(final String host, final int port) {
+        this.host = host;
+        this.port = port;
+        opensearchPingReplyReceived = false;
+        dualSSLProbeReplyReceived = false;
     }
 
-    @Test
-    public void testConnectionSSLAvailable() throws Exception {
-        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
-        Mockito.when(inputStreamReader.read())
-            .thenReturn((int)'D')
-            .thenReturn((int)'U')
-            .thenReturn((int)'A')
-            .thenReturn((int)'L')
-            .thenReturn((int)'S')
-            .thenReturn((int)'M')
-            .thenReturn(-1);
-        Mockito.doNothing().when(socket).close();
+    @VisibleForTesting
+    protected SSLConnectionTestUtil(final String host, final int port, final Socket overriddenSocket, final OutputStreamWriter testOutputStreamWriter,
+        final InputStreamReader testInputStreamReader) {
+        this.overriddenSocket = overriddenSocket;
+        this.testOutputStreamWriter = testOutputStreamWriter;
+        this.testInputStreamReader = testInputStreamReader;
 
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        Mockito.verify(socket, Mockito.times(1)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_AVAILABLE, result);
+        this.host = host;
+        this.port = port;
+        opensearchPingReplyReceived = false;
+        dualSSLProbeReplyReceived = false;
     }
 
-    @Test
-    public void testConnectionSSLNotAvailable() throws Exception {
-        setupMocksForClientHelloFailure();
-        setupMocksForOpenSearchPingSuccess();
-        Mockito.doNothing().when(socket).close();
-
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        verifyOpenSearchPingSend();
-        Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
-    }
-
-    @Test
-    public void testConnectionSSLNotAvailableIOException() throws Exception {
-        Mockito.doThrow(new IOException("Error while writing bytes to output stream"))
-            .when(outputStreamWriter)
-            .write(Mockito.anyString());
-        setupMocksForOpenSearchPingSuccess();
-        Mockito.doNothing().when(socket).close();
-
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        Mockito.verifyNoMoreInteractions(inputStreamReader);
-        verifyOpenSearchPingSend();
-        Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
-    }
-
-    @Test
-    public void testConnectionOpenSearchPingFailed() throws Exception {
-        setupMocksForClientHelloFailure();
-        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
-        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
-        Mockito.when(inputStream.read())
-            .thenReturn(-1);
-        Mockito.doNothing().when(socket).close();
-
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        verifyOpenSearchPingSend();
-        Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
-    }
-
-    @Test
-    public void testConnectionOpenSearchPingFailedInvalidReply() throws Exception {
-        setupMocksForClientHelloFailure();
-        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
-        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
-        Mockito.when(inputStream.read())
-            .thenReturn((int)'E')
-            .thenReturn((int)'E')
-            .thenReturn(0xFF)
-            .thenReturn(0xFF)
-            .thenReturn(0xFF)
-            .thenReturn(0xFF);
-        Mockito.doNothing().when(socket).close();
-
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        verifyOpenSearchPingSend();
-        Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
-    }
-
-    @Test
-    public void testConnectionOpenSearchPingFailedIOException() throws Exception {
-        setupMocksForClientHelloFailure();
-        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
-        Mockito.doThrow(new IOException("Error while writing bytes to output stream")).when(outputStream).write(Mockito.any(byte[].class));
-        Mockito.doNothing().when(socket).close();
-
-        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
-        SSLConnectionTestResult result = connectionTestUtil.testConnection();
-
-        verifyClientHelloSend();
-        verifyOpenSearchPingSend();
-        Mockito.verifyNoInteractions(inputStream);
-        Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
-    }
-
-    private void verifyClientHelloSend() throws IOException {
-        ArgumentCaptor<String> clientHelloMsgArgCaptor = ArgumentCaptor.forClass(String.class);
-        Mockito.verify(outputStreamWriter,
-            Mockito.times(1))
-            .write(clientHelloMsgArgCaptor.capture());
-        String msgWritten = clientHelloMsgArgCaptor.getValue();
-        String expectedMsg = "DUALCM";
-        Assert.assertEquals("Unexpected Dual SSL Client Hello message written to socket", expectedMsg, msgWritten);
-    }
-
-    private void verifyOpenSearchPingSend() throws IOException {
-        ArgumentCaptor<byte[]> argumentCaptor = ArgumentCaptor.forClass(byte[].class);
-        Mockito.verify(outputStream,
-            Mockito.times(1))
-            .write(argumentCaptor.capture());
-        byte[] bytesWritten = argumentCaptor.getValue();
-        byte[] expectedBytes = new byte[]{'E','S',(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF};
-        for(int i = 0; i < bytesWritten.length; i++) {
-            Assert.assertEquals("Unexpected OpenSearch Ping bytes written to socket", expectedBytes[i], bytesWritten[i]);
+    /**
+     * Test connection to server by performing the below steps:
+     * - Send Client Hello to check if the server replies with Server Hello which indicates that Server understands SSL
+     * - Send OpenSearch Ping to check if the server replies to the OpenSearch Ping message
+     *
+     * @return SSLConnectionTestResult i.e. OPENSEARCH_PING_FAILED or SSL_NOT_AVAILABLE or SSL_AVAILABLE
+     */
+    public SSLConnectionTestResult testConnection() {
+        if (sendDualSSLClientHello()) {
+            return SSLConnectionTestResult.SSL_AVAILABLE;
         }
+
+        if (sendOpenSearchPing()) {
+            return SSLConnectionTestResult.SSL_NOT_AVAILABLE;
+        }
+
+        return SSLConnectionTestResult.OPENSEARCH_PING_FAILED;
     }
 
-    private void setupMocksForClientHelloFailure() throws IOException {
-        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
-        Mockito.when(inputStreamReader.read())
-            .thenReturn(-1);
+    private boolean sendDualSSLClientHello() {
+        boolean dualSslSupported = false;
+        Socket socket = null;
+        try {
+            OutputStreamWriter outputStreamWriter;
+            InputStreamReader inputStreamReader;
+            if(overriddenSocket != null) {
+                socket = overriddenSocket;
+                outputStreamWriter = testOutputStreamWriter;
+                inputStreamReader = testInputStreamReader;
+            } else {
+                socket = new Socket(host, port);
+                outputStreamWriter = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
+                inputStreamReader = new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8);
+            }
+
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+            outputStreamWriter.write(DUAL_MODE_CLIENT_HELLO_MSG);
+            outputStreamWriter.flush();
+            logger.debug("Sent DualSSL Client Hello msg to {}", host);
+
+            StringBuilder sb = new StringBuilder();
+            int currentChar;
+            while ((currentChar = inputStreamReader.read()) != -1) {
+                sb.append((char) currentChar);
+            }
+
+            if (sb.toString().equals(DUAL_MODE_SERVER_HELLO_MSG)) {
+                logger.debug("Received DualSSL Server Hello msg from {}", host);
+                dualSslSupported = true;
+            }
+        } catch (IOException e) {
+            logger.debug("DualSSL client check failed for {}, exception {}", host, e.getMessage());
+        } finally {
+            logger.debug("Closing DualSSL check client socket for {}", host);
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    logger.error("Exception occurred while closing DualSSL check client socket for {}. Exception: {}", host, e.getMessage());
+                }
+            }
+        }
+        logger.debug("dualSslClient check with server {}, server supports ssl = {}", host, dualSslSupported);
+        return dualSslSupported;
     }
 
-    private void setupMocksForOpenSearchPingSuccess() throws IOException {
-        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
-        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
-        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
-        Mockito.when(inputStream.read())
-            .thenReturn((int)'E')
-            .thenReturn((int)'S')
-            .thenReturn(0xFF)
-            .thenReturn(0xFF)
-            .thenReturn(0xFF)
-            .thenReturn(0xFF);
+    private boolean sendOpenSearchPing() {
+        boolean pingSucceeded = false;
+        Socket socket = null;
+        try {
+            if(overriddenSocket != null) {
+                socket = overriddenSocket;
+            } else {
+                socket = new Socket(host, port);
+            }
+
+            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
+            OutputStream outputStream = socket.getOutputStream();
+            InputStream inputStream = socket.getInputStream();
+
+            logger.debug("Sending OpenSearch Ping to {}", host);
+            outputStream.write(OPENSEARCH_PING_MSG);
+            outputStream.flush();
+
+            int currentByte;
+            int byteBufIndex = 0;
+            byte[] response = new byte[6];
+            while ((byteBufIndex < 6) && ((currentByte = inputStream.read()) != -1)) {
+                response[byteBufIndex] = (byte) currentByte;
+                byteBufIndex++;
+            }
+            if (byteBufIndex == 6) {
+                logger.debug("Received reply for OpenSearch Ping. from {}", host);
+                pingSucceeded = true;
+                for(int i = 0; i < 6; i++) {
+                    if (response[i] != OPENSEARCH_PING_MSG[i]) {
+                        // Unexpected byte in response
+                        logger.error("Received unexpected byte in OpenSearch Ping reply from {}", host);
+                        pingSucceeded = false;
+                        break;
+                    }
+                }
+            }
+        } catch (IOException ex) {
+            logger.error("OpenSearch Ping failed for {}, exception: {}", host, ex.getMessage());
+        } finally {
+            logger.debug("Closing OpenSearch Ping client socket for connection to {}", host);
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    logger.error("Exception occurred while closing socket for {}. Exception: {}", host, e.getMessage());
+                }
+            }
+        }
+
+        logger.debug("OpenSearch Ping check to server {} result = {}", host, pingSucceeded);
+        return pingSucceeded;
     }
 }

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java
@@ -12,178 +12,189 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 package org.opensearch.security.ssl.util;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
-import java.nio.charset.StandardCharsets;
-import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
-/**
- * Utility class to test if the server supports SSL connections.
- * SSL Check will be done by sending an OpenSearch Ping to see if server is replying to pings.
- * Following that a custom client hello message will be sent to the server, if the server
- * side has OpenSearchPortUnificationHandler it will reply with server hello message.
- */
-public class SSLConnectionTestUtil {
+public class SSLConnectionTestUtilTests {
+    private Socket socket;
+    private OutputStream outputStream;
+    private InputStream inputStream;
+    private OutputStreamWriter outputStreamWriter;
+    private InputStreamReader inputStreamReader;
 
-    private static final Logger logger = LogManager.getLogger(SSLConnectionTestUtil.class);
-    public static final byte[] OPENSEARCH_PING_MSG = new byte[]{(byte) 'E', (byte) 'S', (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF};
-    public static final String DUAL_MODE_CLIENT_HELLO_MSG = "DUALCM";
-    public static final String DUAL_MODE_SERVER_HELLO_MSG = "DUALSM";
-    private static final int SOCKET_TIMEOUT_MILLIS = 10 * 1000;
-    private boolean opensearchPingReplyReceived;
-    private boolean dualSSLProbeReplyReceived;
-    private final String host;
-    private final int port;
-    private Socket overriddenSocket = null;
-    private OutputStreamWriter testOutputStreamWriter = null;
-    private InputStreamReader testInputStreamReader = null;
-
-    public SSLConnectionTestUtil(final String host, final int port) {
-        this.host = host;
-        this.port = port;
-        opensearchPingReplyReceived = false;
-        dualSSLProbeReplyReceived = false;
+    @Before
+    public void setup() {
+        socket = Mockito.mock(Socket.class);
+        outputStream = Mockito.mock(OutputStream.class);
+        inputStream = Mockito.mock(InputStream.class);
+        outputStreamWriter = Mockito.mock(OutputStreamWriter.class);
+        inputStreamReader = Mockito.mock(InputStreamReader.class);
     }
 
-    @VisibleForTesting
-    protected SSLConnectionTestUtil(final String host, final int port, final Socket overriddenSocket, final OutputStreamWriter testOutputStreamWriter,
-        final InputStreamReader testInputStreamReader) {
-        this.overriddenSocket = overriddenSocket;
-        this.testOutputStreamWriter = testOutputStreamWriter;
-        this.testInputStreamReader = testInputStreamReader;
+    @Test
+    public void testConnectionSSLAvailable() throws Exception {
+        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
+        Mockito.when(inputStreamReader.read())
+            .thenReturn((int)'D')
+            .thenReturn((int)'U')
+            .thenReturn((int)'A')
+            .thenReturn((int)'L')
+            .thenReturn((int)'S')
+            .thenReturn((int)'M')
+            .thenReturn(-1);
+        Mockito.doNothing().when(socket).close();
 
-        this.host = host;
-        this.port = port;
-        opensearchPingReplyReceived = false;
-        dualSSLProbeReplyReceived = false;
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        Mockito.verify(socket, Mockito.times(1)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_AVAILABLE, result);
     }
 
-    /**
-     * Test connection to server by performing the below steps:
-     * - Send Client Hello to check if the server replies with Server Hello which indicates that Server understands SSL
-     * - Send OpenSearch Ping to check if the server replies to the OpenSearch Ping message
-     *
-     * @return SSLConnectionTestResult i.e. OPENSEARCH_PING_FAILED or SSL_NOT_AVAILABLE or SSL_AVAILABLE
-     */
-    public SSLConnectionTestResult testConnection() {
-        if (sendDualSSLClientHello()) {
-            return SSLConnectionTestResult.SSL_AVAILABLE;
-        }
+    @Test
+    public void testConnectionSSLNotAvailable() throws Exception {
+        setupMocksForClientHelloFailure();
+        setupMocksForOpenSearchPingSuccess();
+        Mockito.doNothing().when(socket).close();
 
-        if (sendOpenSearchPing()) {
-            return SSLConnectionTestResult.SSL_NOT_AVAILABLE;
-        }
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
 
-        return SSLConnectionTestResult.OPENSEARCH_PING_FAILED;
+        verifyClientHelloSend();
+        verifyOpenSearchPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
     }
 
-    private boolean sendDualSSLClientHello() {
-        boolean dualSslSupported = false;
-        Socket socket = null;
-        try {
-            OutputStreamWriter outputStreamWriter;
-            InputStreamReader inputStreamReader;
-            if(overriddenSocket != null) {
-                socket = overriddenSocket;
-                outputStreamWriter = testOutputStreamWriter;
-                inputStreamReader = testInputStreamReader;
-            } else {
-                socket = new Socket(host, port);
-                outputStreamWriter = new OutputStreamWriter(socket.getOutputStream(), StandardCharsets.UTF_8);
-                inputStreamReader = new InputStreamReader(socket.getInputStream(), StandardCharsets.UTF_8);
-            }
+    @Test
+    public void testConnectionSSLNotAvailableIOException() throws Exception {
+        Mockito.doThrow(new IOException("Error while writing bytes to output stream"))
+            .when(outputStreamWriter)
+            .write(Mockito.anyString());
+        setupMocksForOpenSearchPingSuccess();
+        Mockito.doNothing().when(socket).close();
 
-            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
-            outputStreamWriter.write(DUAL_MODE_CLIENT_HELLO_MSG);
-            outputStreamWriter.flush();
-            logger.debug("Sent DualSSL Client Hello msg to {}", host);
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
 
-            StringBuilder sb = new StringBuilder();
-            int currentChar;
-            while ((currentChar = inputStreamReader.read()) != -1) {
-                sb.append((char) currentChar);
-            }
-
-            if (sb.toString().equals(DUAL_MODE_SERVER_HELLO_MSG)) {
-                logger.debug("Received DualSSL Server Hello msg from {}", host);
-                dualSslSupported = true;
-            }
-        } catch (IOException e) {
-            logger.debug("DualSSL client check failed for {}, exception {}", host, e.getMessage());
-        } finally {
-            logger.debug("Closing DualSSL check client socket for {}", host);
-            if (socket != null) {
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                    logger.error("Exception occurred while closing DualSSL check client socket for {}. Exception: {}", host, e.getMessage());
-                }
-            }
-        }
-        logger.debug("dualSslClient check with server {}, server supports ssl = {}", host, dualSslSupported);
-        return dualSslSupported;
+        verifyClientHelloSend();
+        Mockito.verifyNoMoreInteractions(inputStreamReader);
+        verifyOpenSearchPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
     }
 
-    private boolean sendOpenSearchPing() {
-        boolean pingSucceeded = false;
-        Socket socket = null;
-        try {
-            if(overriddenSocket != null) {
-                socket = overriddenSocket;
-            } else {
-                socket = new Socket(host, port);
-            }
+    @Test
+    public void testConnectionOpenSearchPingFailed() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn(-1);
+        Mockito.doNothing().when(socket).close();
 
-            socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
-            OutputStream outputStream = socket.getOutputStream();
-            InputStream inputStream = socket.getInputStream();
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
 
-            logger.debug("Sending OpenSearch Ping to {}", host);
-            outputStream.write(OPENSEARCH_PING_MSG);
-            outputStream.flush();
+        verifyClientHelloSend();
+        verifyOpenSearchPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+    }
 
-            int currentByte;
-            int byteBufIndex = 0;
-            byte[] response = new byte[6];
-            while ((byteBufIndex < 6) && ((currentByte = inputStream.read()) != -1)) {
-                response[byteBufIndex] = (byte) currentByte;
-                byteBufIndex++;
-            }
-            if (byteBufIndex == 6) {
-                logger.debug("Received reply for OpenSearch Ping. from {}", host);
-                pingSucceeded = true;
-                for(int i = 0; i < 6; i++) {
-                    if (response[i] != OPENSEARCH_PING_MSG[i]) {
-                        // Unexpected byte in response
-                        logger.error("Received unexpected byte in OpenSearch Ping reply from {}", host);
-                        pingSucceeded = false;
-                        break;
-                    }
-                }
-            }
-        } catch (IOException ex) {
-            logger.error("OpenSearch Ping failed for {}, exception: {}", host, ex.getMessage());
-        } finally {
-            logger.debug("Closing OpenSearch Ping client socket for connection to {}", host);
-            if (socket != null) {
-                try {
-                    socket.close();
-                } catch (IOException e) {
-                    logger.error("Exception occurred while closing socket for {}. Exception: {}", host, e.getMessage());
-                }
-            }
+    @Test
+    public void testConnectionOpenSearchPingFailedInvalidReply() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn((int)'E')
+            .thenReturn((int)'E')
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF);
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyOpenSearchPingSend();
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+    }
+
+    @Test
+    public void testConnectionOpenSearchPingFailedIOException() throws Exception {
+        setupMocksForClientHelloFailure();
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doThrow(new IOException("Error while writing bytes to output stream")).when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.doNothing().when(socket).close();
+
+        SSLConnectionTestUtil connectionTestUtil = new SSLConnectionTestUtil("127.0.0.1", 443, socket, outputStreamWriter, inputStreamReader);
+        SSLConnectionTestResult result = connectionTestUtil.testConnection();
+
+        verifyClientHelloSend();
+        verifyOpenSearchPingSend();
+        Mockito.verifyNoInteractions(inputStream);
+        Mockito.verify(socket, Mockito.times(2)).close();
+        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+    }
+
+    private void verifyClientHelloSend() throws IOException {
+        ArgumentCaptor<String> clientHelloMsgArgCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(outputStreamWriter,
+            Mockito.times(1))
+            .write(clientHelloMsgArgCaptor.capture());
+        String msgWritten = clientHelloMsgArgCaptor.getValue();
+        String expectedMsg = "DUALCM";
+        Assert.assertEquals("Unexpected Dual SSL Client Hello message written to socket", expectedMsg, msgWritten);
+    }
+
+    private void verifyOpenSearchPingSend() throws IOException {
+        ArgumentCaptor<byte[]> argumentCaptor = ArgumentCaptor.forClass(byte[].class);
+        Mockito.verify(outputStream,
+            Mockito.times(1))
+            .write(argumentCaptor.capture());
+        byte[] bytesWritten = argumentCaptor.getValue();
+        byte[] expectedBytes = new byte[]{'E','S',(byte)0xFF,(byte)0xFF,(byte)0xFF,(byte)0xFF};
+        for(int i = 0; i < bytesWritten.length; i++) {
+            Assert.assertEquals("Unexpected OpenSearch Ping bytes written to socket", expectedBytes[i], bytesWritten[i]);
         }
+    }
 
-        logger.debug("OpenSearch Ping check to server {} result = {}", host, pingSucceeded);
-        return pingSucceeded;
+    private void setupMocksForClientHelloFailure() throws IOException {
+        Mockito.doNothing().when(outputStreamWriter).write(Mockito.anyString());
+        Mockito.when(inputStreamReader.read())
+            .thenReturn(-1);
+    }
+
+    private void setupMocksForOpenSearchPingSuccess() throws IOException {
+        Mockito.when(socket.getOutputStream()).thenReturn(outputStream);
+        Mockito.when(socket.getInputStream()).thenReturn(inputStream);
+        Mockito.doNothing().when(outputStream).write(Mockito.any(byte[].class));
+        Mockito.when(inputStream.read())
+            .thenReturn((int)'E')
+            .thenReturn((int)'S')
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF)
+            .thenReturn(0xFF);
     }
 }

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConnectionTestUtilTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConnectionTestUtilTests.java
@@ -90,7 +90,7 @@ public class SSLConnectionTestUtilTests {
         SSLConnectionTestResult result = connectionTestUtil.testConnection();
 
         verifyClientHelloSend();
-        Mockito.verifyZeroInteractions(inputStreamReader);
+        Mockito.verifyNoMoreInteractions(inputStreamReader);
         verifyOpenSearchPingSend();
         Mockito.verify(socket, Mockito.times(2)).close();
         Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
@@ -152,7 +152,7 @@ public class SSLConnectionTestUtilTests {
 
         verifyClientHelloSend();
         verifyOpenSearchPingSend();
-        Mockito.verifyZeroInteractions(inputStream);
+        Mockito.verifyNoInteractions(inputStream);
         Mockito.verify(socket, Mockito.times(2)).close();
         Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
     }


### PR DESCRIPTION
### Description
Update guava to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).

Seems like this has been resolved for 2.x so this PR is for the 1.3 branch.

### Issues Resolved
https://github.com/opensearch-project/security/issues/2940

### Check List
- [ ] ~~New functionality includes testing~~
- [ ] ~~New functionality has been documented~~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
