### PR TITLE
bump com.github.wnameless.json:json-base from 2.4.0 to 2.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -496,7 +496,7 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"
     implementation "io.jsonwebtoken:jjwt-jackson:${jjwt_version}"
     // JSON flattener
-    implementation ("com.github.wnameless.json:json-base:2.4.0") {
+    implementation ("com.github.wnameless.json:json-base:2.4.1") {
         exclude group: "org.glassfish", module: "jakarta.json"
         exclude group: "com.google.code.gson", module: "gson"
         exclude group: "org.json", module: "json"


### PR DESCRIPTION
Manually re-creating dependabot's [PR](https://github.com/opensearch-project/security/pull/3042) off of the latest changes from main which has build fixes.

Is there a way we can open PRs with main at the push of a button?

