### PR TITLE
Fix build after Lucene upgrade and breaking XContentFactory changes

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -46,6 +46,7 @@ import org.apache.lucene.index.SortedDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
 import org.apache.lucene.index.TermState;
 import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
@@ -470,6 +471,24 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         @Override
         public void close() throws IOException {
             in.close();
+        }
+    }
+
+    private class DlsFlsStoredFields extends StoredFields {
+        private final StoredFields in;
+
+        public DlsFlsStoredFields(StoredFields storedFields) {
+            this.in = storedFields;
+        }
+
+        @Override
+        public void document(final int docID, StoredFieldVisitor visitor) throws IOException {
+            visitor = getDlsFlsVisitor(visitor);
+            try {
+                in.document(docID, visitor);
+            } finally {
+                finishVisitor(visitor);
+            }
         }
     }
 
@@ -1282,6 +1301,12 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
             return delegate.termState();
         }
 
+    }
+
+    @Override
+    public StoredFields storedFields() throws IOException {
+        ensureOpen();
+        return new DlsFlsStoredFields(in.storedFields());
     }
 
     private String getRuntimeActionName() {

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -141,7 +141,7 @@ public class ConfigHelper {
         BytesReference retVal;
         XContentParser parser = null;
         try {
-            parser = XContentFactory.xContent(mediaType).createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, reader);
+            parser = mediaType.xContent().createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, reader);
             parser.nextToken();
             final XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.copyCurrentStructure(parser);

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -1202,7 +1202,7 @@ public class SecurityAdmin {
         BytesReference retVal;
         XContentParser parser = null;
         try {
-            parser = XContentFactory.xContent(mediaType).createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, content);
+            parser = mediaType.xContent().createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, content);
             parser.nextToken();
             final XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.copyCurrentStructure(parser);

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.opensearch.common.Strings;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
@@ -300,7 +299,7 @@ public class RequestContentValidatorTest {
     }
 
     private JsonNode xContentToJsonNode(final ToXContent toXContent) throws IOException {
-        try (final var xContentBuilder = XContentFactory.contentBuilder(XContentType.JSON)) {
+        try (final var xContentBuilder = XContentFactory.jsonBuilder()) {
             toXContent.toXContent(xContentBuilder, ToXContent.EMPTY_PARAMS);
             return DefaultObjectMapper.readTree(Strings.toString(xContentBuilder));
         }

--- a/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
@@ -110,7 +110,7 @@ public class FileHelper {
 
         XContentParser parser = null;
         try {
-            parser = XContentFactory.xContent(XContentType.YAML)
+            parser = XContentType.YAML.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, new StringReader(loadFile(file)));
             parser.nextToken();
             final XContentBuilder builder = XContentFactory.jsonBuilder();
@@ -133,7 +133,7 @@ public class FileHelper {
 
         XContentParser parser = null;
         try {
-            parser = XContentFactory.xContent(XContentType.YAML)
+            parser = XContentType.YAML.xContent()
                 .createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, new StringReader(yaml));
             parser.nextToken();
             final XContentBuilder builder = XContentFactory.jsonBuilder();


### PR DESCRIPTION
There are multiple PRs in core affecting the security plugin that the security plugin needs to adapt to.

- https://github.com/opensearch-project/OpenSearch/pull/7792
- https://github.com/opensearch-project/OpenSearch/pull/8826
- https://github.com/opensearch-project/OpenSearch/pull/8668

I am opening a Draft PR that includes a fix for the Lucene-related test failures which was caused by https://github.com/opensearch-project/OpenSearch/pull/7792

Resolves: https://github.com/opensearch-project/security/issues/3064