### PR TITLE
Switch CodeQL to assemble artifacts using the same build as the rest of CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,11 +126,11 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 11
-    - uses: github/codeql-action/init@v1
+    - uses: github/codeql-action/init@v2
       with:
         languages: java
-    - run: ./gradlew clean build -Dbuild.snapshot=false -x test -x integrationTest
-    - uses: github/codeql-action/analyze@v1
+    - run: ./gradlew clean assemble
+    - uses: github/codeql-action/analyze@v2
 
   build-artifact-names:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Switch CodeQL to assemble artifacts using the same build as the rest of CI

- Bump CodeQL action version from v1 to v2

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/3131

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
