### PR TITLE
Automatically update GitHub Actions dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,9 @@ updates:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependabot:"


### PR DESCRIPTION
### Description
Automatically update GitHub Actions dependencies with dependabot.  Noticed this was possible when I was reading the notice around CodeQL's v1 deprecation, [[codeql-action-v1-is-now-deprecated]](https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/#can-i-use-dependabot-to-help-me-with-this-upgrade).

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
