### PR TITLE
Only run the backport job on merged pull requests

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   backport:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -25,6 +26,5 @@ jobs:
         uses: VachaShah/backport@v2.2.0
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          branch_name: backport/backport-${{ github.event.number }}
           head_template: backport/backport-<%= number %>-to-<%= base %>
           failure_labels: backport-failed


### PR DESCRIPTION
### Description
Only run the backport job on merged pull requests

### Issues Resolved
From the GitHub Action log, we'd see an error about branch_name not being used, and the error that backports should only run on merged PRs.  This should reduce noisy failures in our logs.
```
Warning: Unexpected input(s) 'branch_name', valid inputs are ['body_template', 'files_to_skip', 'github_token', 'head_template', 'label_pattern', 'labels_template', 'title_template', 'failure_labels']
Run VachaShah/backport@v[2](https://github.com/opensearch-project/security/actions/runs/5802658423/job/15729398925?pr=3132#step:3:2).2.0
Error: Error: For security reasons, this action should only run on merged PRs.
```
Example [[workflow failure]](https://github.com/opensearch-project/security/actions/runs/5802658423/job/15729398925?pr=3132), see more [[failures]](https://github.com/opensearch-project/security/actions/workflows/backport.yml).


### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).