### PR TITLE
[Backport 2.x] Updates integTestRemote task to dynamically fetch common-utils version from build.gradle (#3122)

### DIFF
--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -20,7 +20,6 @@ function usage() {
     echo -e "-v OPENSEARCH_VERSION\t, no defaults"
     echo -e "-n SNAPSHOT\t, defaults to false"
     echo -e "-m CLUSTER_NAME\t, defaults to docker-cluster"
-    echo -e "-u COMMON_UTILS_VERSION\t, defaults to 2.9.0.0-SNAPSHOT"
     echo "--------------------------------------------------------------------------"
 }
 
@@ -99,12 +98,8 @@ if [ -z "$CLUSTER_NAME" ]
 then
   CLUSTER_NAME="docker-cluster"
 fi
-if [ -z "$COMMON_UTILS_VERSION" ]
-then
-  COMMON_UTILS_VERSION="2.9.0.0-SNAPSHOT"
-fi
 
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
 PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
-./gradlew integTestRemote -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dsecurity_enabled=$SECURITY_ENABLED -Dtests.clustername=$CLUSTER_NAME -Dhttps=true -Duser=$USERNAME -Dpassword=$PASSWORD -Dcommon_utils.version=$COMMON_UTILS_VERSION
+./gradlew integTestRemote -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dsecurity_enabled=$SECURITY_ENABLED -Dtests.clustername=$CLUSTER_NAME -Dhttps=true -Duser=$USERNAME -Dpassword=$PASSWORD


### PR DESCRIPTION
(cherry picked from commit 46989b57d9cdf969be9473d1ca6bcb61c7923135)

Backports #3122 


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
