### PR TITLE
Only run CI on push for 'official' branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - 1.*
+      - 2.*
+  pull_request:
 
 env:
   GRADLE_OPTS: -Dhttp.keepAlive=false


### PR DESCRIPTION
### Description
CodeQL is throwing errors when run inside of branches created by dependabot requests.  Also we've had issue with a flood of CI checks that were redudant when inspecting pull request check results.  This should limit the 'doubling' up unless you are making a pull request from a fork's main branch.

![image](https://github.com/opensearch-project/security/assets/2754967/35fbddce-1670-44eb-8f6a-d2e8fcbde386)

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
