### PR TITLE
Exclude sensitive info from the jackson serialization stacktraces

### DIFF
--- a/src/main/java/org/opensearch/security/DefaultObjectMapper.java
+++ b/src/main/java/org/opensearch/security/DefaultObjectMapper.java
@@ -57,6 +57,10 @@ public class DefaultObjectMapper {
 
     static {
         objectMapper.setSerializationInclusion(Include.NON_NULL);
+        // exclude sensitive information from the request body,
+        // if jackson cant parse the entity, e.g. passwords, hashes and so on,
+        // but provides which property is unknown
+        objectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
         // objectMapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
         defaulOmittingObjectMapper.setSerializationInclusion(Include.NON_DEFAULT);


### PR DESCRIPTION
### Description
If Jackson can't parse JSON body it throws `IOException` which contains the whole request body including hashes, passwords and so on. This property was added in 2.9 version, so the body will be excluded from logs. Instead, Jackson adds `UNKNOWN` for the source and provides the property name it can't parse.

So exception now looks like that:
```java
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "password" (class org.opensearch.security.securityconf.impl.v7.InternalUserV7), not marked as ignorable (10 known properties: "opendistro_security_roles", "enabled", "backend_roles", "service", "attributes", "reserved", "hidden", "description", "hash", "static"])
 at [Source: UNKNOWN; line: 1, column: 299] (through reference chain: org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration["test"]->org.opensearch.security.securityconf.impl.v7.InternalUserV7["password"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:1138) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:2224) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1709) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1687) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:320) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty.deserialize(SettableAnyProperty.java:198) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.SettableAnyProperty.deserializeAndSet(SettableAnyProperty.java:179) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1681) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:320) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4825) ~[jackson-databind-2.15.2.jar:2.15.2]
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3772) ~[jackson-databind-2.15.2.jar:2.15.2]
	at org.opensearch.security.DefaultObjectMapper.lambda$readValue$4(DefaultObjectMapper.java:209) ~[main/:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at org.opensearch.security.DefaultObjectMapper.readValue(DefaultObjectMapper.java:209) ~[main/:?]
	at org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration.fromJson(SecurityDynamicConfiguration.java:93) ~[main/:?]
	at org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration.fromJson(SecurityDynamicConfiguration.java:69) ~[main/:?]
	at org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration.fromNode(SecurityDynamicConfiguration.java:135) ~[main/:?]
	at org.opensearch.security.dlic.rest.api.AbstractApiAction.lambda$patchEntity$11(AbstractApiAction.java:245) ~[main/:?]
	at org.opensearch.security.dlic.rest.validation.ValidationResult.map(ValidationResult.java:55) ~[main/:?]
	at org.opensearch.security.dlic.rest.api.AbstractApiAction.lambda$patchEntity$12(AbstractApiAction.java:240) ~[main/:?]
	at org.opensearch.security.dlic.rest.api.AbstractApiAction.withJsonPatchException(AbstractApiAction.java:318) ~[main/:?]
	at org.opensearch.security.dlic.rest.api.AbstractApiAction.lambda$patchEntity$13(AbstractApiAction.java:232) ~[main/:?]
	at org.opensearch.security.dlic.rest.validation.ValidationResult.map(ValidationResult.java:55) ~[main/:?]
	at org.opensearch.security.dlic.rest.api.AbstractApiAction.lambda$patchEntity$14(AbstractApiAction.java:229) ~[main/:?]
	at org.opensearch.security.dlic.rest.support.Utils.withIOException(Utils.java:275) ~[main/:?]
```


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
