### PR TITLE
Add code coverage exclusions on false positives

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%
+      # Exclusions to prevent false positives triggered
+      # Tracking with https://github.com/opensearch-project/security/issues/3137
+      keyset:
+        paths:
+          - "src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
+        target: auto
+        threshold: 10%
+      securityinterceptor:
+        paths:
+          - "src/main/java/org/opensearch/security/transport/SecurityInterceptor.java"
+        target: auto
+        threshold: 10%
+      sslnettytransport:
+        paths:
+          - "src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java"
+        target: auto
+        threshold: 10%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,18 +3,20 @@ coverage:
     project:
       # Exclusions to prevent false positives triggered
       # Tracking with https://github.com/opensearch-project/security/issues/3137
-      default:
+      default: false
+      plugin:
+        paths:
+          - "!src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
+          - "!src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java"
+          - "!src/main/java/org/opensearch/security/transport/SecurityInterceptor.java"
+          - "!src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java"
+          - "!src/main/java/org/opensearch/security/configuration/StaticResourceException.java"
+          - "!src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java"
+          - "!src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java"
+          - "!src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java"
+          - "src/main"
         target: auto
         threshold: 0%
-        paths:
-          - "^src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
-          - "^src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java"
-          - "^src/main/java/org/opensearch/security/transport/SecurityInterceptor.java"
-          - "^src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java"
-          - "^src/main/java/org/opensearch/security/configuration/StaticResourceException.java"
-          - "^src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java"
-          - "^src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java"
-          - "^src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java"
       inconsistent-coverage-files:
         paths:
           - "src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
@@ -27,6 +29,11 @@ coverage:
           - "src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java"
         target: auto
         threshold: 50%
+      tests:
+        paths:
+          - "src/integrationTest"
+          - "src/test"
+        target: 100%
 
 comment:
   layout: "reach, diff, flags, files"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,21 @@
 coverage:
   status:
     project:
+      # Exclusions to prevent false positives triggered
+      # Tracking with https://github.com/opensearch-project/security/issues/3137
       default:
         target: auto
         threshold: 0%
-      # Exclusions to prevent false positives triggered
-      # Tracking with https://github.com/opensearch-project/security/issues/3137
-      inconsistant-coverage-files:
+        paths:
+          - "^src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
+          - "^src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java"
+          - "^src/main/java/org/opensearch/security/transport/SecurityInterceptor.java"
+          - "^src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java"
+          - "^src/main/java/org/opensearch/security/configuration/StaticResourceException.java"
+          - "^src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java"
+          - "^src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java"
+          - "^src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java"
+      inconsistent-coverage-files:
         paths:
           - "src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
           - "src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java"

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,21 +6,18 @@ coverage:
         threshold: 0%
       # Exclusions to prevent false positives triggered
       # Tracking with https://github.com/opensearch-project/security/issues/3137
-      keyset:
+      inconsistant-coverage-files:
         paths:
           - "src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySet.java"
-        target: auto
-        threshold: 10%
-      securityinterceptor:
-        paths:
+          - "src/main/java/com/amazon/dlic/auth/ldap2/LDAPConnectionFactoryFactory.java"
           - "src/main/java/org/opensearch/security/transport/SecurityInterceptor.java"
-        target: auto
-        threshold: 10%
-      sslnettytransport:
-        paths:
+          - "src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java"
+          - "src/main/java/org/opensearch/security/configuration/StaticResourceException.java"
+          - "src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java"
           - "src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java"
+          - "src/main/java/org/opensearch/security/ssl/util/SSLConnectionTestUtil.java"
         target: auto
-        threshold: 10%
+        threshold: 50%
 
 comment:
   layout: "reach, diff, flags, files"


### PR DESCRIPTION
### Description
Adding code coverage exclusions on files that are creating code coverage measurement issues.

### Issues Resolved
- Related https://github.com/opensearch-project/security/issues/3137

### Testing
Will be checking the codecov output on this PR and expect it to come back clean.  Might need to iterate a couple times to make sure the max threshold % amount is correct.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
