### PR TITLE
Prevent raw request body as output in serialization error messages

### DIFF
--- a/src/main/java/org/opensearch/security/DefaultObjectMapper.java
+++ b/src/main/java/org/opensearch/security/DefaultObjectMapper.java
@@ -61,6 +61,8 @@ public class DefaultObjectMapper {
         // if jackson cant parse the entity, e.g. passwords, hashes and so on,
         // but provides which property is unknown
         objectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
+        defaulOmittingObjectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
+        YAML_MAPPER.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
         // objectMapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
         defaulOmittingObjectMapper.setSerializationInclusion(Include.NON_DEFAULT);

--- a/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
+++ b/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
@@ -45,6 +45,7 @@ public class NonValidatingObjectMapper {
     private static final ObjectMapper nonValidatingObjectMapper = new ObjectMapper();
 
     static {
+        nonValidatingObjectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
         nonValidatingObjectMapper.setSerializationInclusion(Include.NON_NULL);
         nonValidatingObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, false);
         nonValidatingObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -65,12 +66,7 @@ public class NonValidatingObjectMapper {
         }
 
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<T>() {
-                @Override
-                public T run() throws Exception {
-                    return nonValidatingObjectMapper.readValue(string, jt);
-                }
-            });
+            return AccessController.doPrivileged((PrivilegedExceptionAction<T>) () -> nonValidatingObjectMapper.readValue(string, jt));
         } catch (final PrivilegedActionException e) {
             throw (IOException) e.getCause();
         }


### PR DESCRIPTION
### Description
Same as https://github.com/opensearch-project/security/pull/3195.

Excluded sensitive info for java stacktrace:
- YAML object mapper as well
- NonValidatingObjectMapper
- defaulOmittingObjectMapper

More details see https://github.com/FasterXML/jackson-core/wiki/JsonParser-Features#misc-other

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
