### PR TITLE
[2.x] Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependabot:"
+    ignore:
+      # For all packages, ignore all major versions to minimize breaking issues
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "dependabot:"
+


### PR DESCRIPTION
### Description

Adds dependabot.yml to 2.x branch. This PR adds dependabot.yml directly to 2.x branch. With all of the dependabot PRs against main, labels like `backport 2.x`, `backport 1.x` and `backport 1.3` must be added to the PR in order to trigger backport bot to backport the PR to the respective branches. This process is manual and causes drifts between release branches if the labels are not added to the PR.

I am creating a PR to add dependabot.yml directly in 2.x and 1.x to keep all of the release branches up to date. 

The PR against 1.x includes an automatic label of `backport 1.3` so that 1.x and 1.3 can stay synchronized.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
