### PR TITLE
[2.x] Add [2.x] to dependabot commit message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "dependabot:"
+      prefix: "[2.x] dependabot:"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "dependabot:"
+      prefix: "[2.x] dependabot:"
     ignore:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"


### PR DESCRIPTION
### Description

Prefixes the dependabot commit message with `[2.x]` for PRs against the 2.x branch.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
