### PR TITLE
Rename tests

### DIFF
--- a/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTests.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTests.java
@@ -23,7 +23,7 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_P
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
 
-public class PasswordValidatorTest {
+public class PasswordValidatorTests {
 
     static final List<String> WEAK_PASSWORDS = ImmutableList.of("q", "5", "&", "admin", "123456", "password");
 

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTests.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTests.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class RequestContentValidatorTest {
+public class RequestContentValidatorTests {
 
     @Mock
     private HttpRequest httpRequest;


### PR DESCRIPTION
### Description
Renamed:
 - `PasswordValidatorTest` -> `PasswordValidatorTests`
 - `RequestContentValidatorTest` -> `RequestContentValidatorTests`
It looks like naming affects test coverage calculations 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
