### PR TITLE
[Backport 2.x] Clean up sysouts and replace with logger statements where necessary (#3231)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,6 +323,7 @@ jacocoTestReport {
 
 checkstyle {
     configFile file("checkstyle/sun_checks.xml")
+    configFile file("checkstyle/println_checks.xml")
 }
 
 opensearchplugin {

--- a/checkstyle/println_checks.xml
+++ b/checkstyle/println_checks.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="src/main/java/org/opensearch/security/tools/*"/>
+    </module>
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java"/>
+    </module>
+    <module name="TreeWalker">
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="System.out.println"/>
+            <property name="ignoreCase" value="true"/>
+            <property name="message" value="Do not use System.out.println" />
+            <property name="severity" value="error"/>
+        </module>
+    </module>
+</module>

--- a/checkstyle/sun_checks.xml
+++ b/checkstyle/sun_checks.xml
@@ -215,4 +215,5 @@
     <property name="checkFormat" value="$1"/>
   </module>
 
+  <module name="PrintlnModule"/>
 </module>

--- a/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -98,8 +98,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
                         }
                     } catch (Throwable e) {
                         log.error("Unable to enable krb_debug due to ", e);
-                        System.err.println("Unable to enable krb_debug due to " + ExceptionsHelper.stackTrace(e));
-                        System.out.println("Unable to enable krb_debug due to " + ExceptionsHelper.stackTrace(e));
+                        log.debug("Unable to enable krb_debug due to " + ExceptionsHelper.stackTrace(e));
                     }
 
                     System.setProperty(KrbConstants.USE_SUBJECT_CREDS_ONLY_PROP, "false");

--- a/src/main/java/org/opensearch/security/auditlog/sink/DebugSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/DebugSink.java
@@ -11,10 +11,14 @@
 
 package org.opensearch.security.auditlog.sink;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.impl.AuditMessage;
 
 public final class DebugSink extends AuditLogSink {
+
+    final Logger log = LogManager.getLogger(DebugSink.class);
 
     public DebugSink(String name, Settings settings, AuditLogSink fallbackSink) {
         super(name, settings, null, fallbackSink);
@@ -27,7 +31,7 @@ public final class DebugSink extends AuditLogSink {
 
     @Override
     public boolean doStore(final AuditMessage msg) {
-        System.out.println("AUDIT_LOG: " + msg.toPrettyString());
+        log.info("AUDIT_LOG: " + msg.toPrettyString());
         return true;
     }
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -253,8 +253,6 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             log.debug("Static roles loaded ({})", staticRoles.getCEntries().size());
 
             if (actionGroups.containsAny(staticActionGroups)) {
-                System.out.println("static: " + actionGroups.getCEntries());
-                System.out.println("Static Action Groups:" + staticActionGroups.getCEntries());
                 throw new StaticResourceException("Cannot override static action groups");
             }
             if (!actionGroups.add(staticActionGroups) && !staticActionGroups.getCEntries().isEmpty()) {

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -158,8 +158,6 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
             final String renegoMsg =
                 "Client side initiated TLS renegotiation enabled. This can open a vulnerablity for DoS attacks through client side initiated TLS renegotiation.";
             log.warn(renegoMsg);
-            System.out.println(renegoMsg);
-            System.err.println(renegoMsg);
         } else {
             if (!rejectClientInitiatedRenegotiation) {
 
@@ -225,8 +223,6 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
 
         if (!httpSSLEnabled && !transportSSLEnabled) {
             log.error("SSL not activated for http and/or transport.");
-            System.out.println("SSL not activated for http and/or transport.");
-            System.err.println("SSL not activated for http and/or transport.");
         }
 
         if (ExternalSecurityKeyStore.hasExternalSslContext(settings)) {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -173,8 +173,7 @@ public class SSLRequestHelper {
                     }
                     principal = principalExtractor == null ? null : principalExtractor.extractPrincipal(x509Certs[0], Type.HTTP);
                 } else if (engine.getNeedClientAuth()) {
-                    final OpenSearchException ex = new OpenSearchException("No client certificates found but such are needed (SG 9).");
-                    throw ex;
+                    throw new OpenSearchException("No client certificates found but such are needed (SG 9).");
                 }
 
             } catch (final SSLPeerUnverifiedException e) {

--- a/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
+++ b/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
@@ -132,7 +132,6 @@ public class AuditConfigMigrater {
                     + " Please remove the deprecated keys from your opensearch.yml or replace with the generated file after reviewing."
             );
         } catch (final Exception e) {
-            e.printStackTrace();
             formatter.printHelp("audit_config_migrater.sh", options, true);
             System.exit(-1);
         }

--- a/src/main/java/org/opensearch/security/tools/Migrater.java
+++ b/src/main/java/org/opensearch/security/tools/Migrater.java
@@ -190,7 +190,6 @@ public class Migrater {
         } catch (Exception e) {
             System.out.println("Unable to write " + file.getAbsolutePath() + ". This is unexpected and we will abort migration.");
             System.out.println("    Details: " + e.getMessage());
-            e.printStackTrace();
         }
 
         return false;

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -1649,7 +1649,6 @@ public class SecurityAdmin {
 
         } catch (Exception e) {
             System.out.println("ERR: Unable to migrate config files due to " + e);
-            e.printStackTrace();
             return -1;
         }
 
@@ -1866,7 +1865,6 @@ public class SecurityAdmin {
 
             return value;
         } catch (Exception e) {
-            e.printStackTrace();
             return "ERR: Unable to handle response due to " + e;
         }
     }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -37,9 +37,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         if (mockIdpServer != null) {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception e) {}
         }
     }
 
@@ -311,7 +309,6 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         long expiringDate = 20 + System.currentTimeMillis() / 1000;
         long notBeforeDate = 5 + System.currentTimeMillis() / 1000;
-        ;
 
         AuthCredentials creds = jwtAuth.extractCredentials(
             new FakeRestRequest(

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetrieverTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetrieverTest.java
@@ -53,9 +53,7 @@ public class KeySetRetrieverTest {
         if (mockIdpServer != null) {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -45,9 +45,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 
@@ -69,9 +67,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 
@@ -96,9 +92,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 
@@ -120,9 +114,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 
@@ -174,9 +166,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception e) {}
         }
 
         mockIdpServer = new MockIpdServer(TestJwk.Jwks.RSA_2);
@@ -198,9 +188,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         } finally {
             try {
                 mockIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -112,9 +112,7 @@ public class HTTPSamlAuthenticatorTest {
         if (mockSamlIdpServer != null) {
             try {
                 mockSamlIdpServer.close();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored) {}
         }
     }
 

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
@@ -53,7 +53,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSL() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
@@ -63,7 +62,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSLFail() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode());
@@ -87,7 +85,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
                 encodeBasicHeader("spock", "spocksecret")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.subschemaSubentry"));

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -1081,7 +1081,6 @@ public class LdapBackendTest {
         );
         Assert.assertNotNull(user);
         Assert.assertEquals("cn=cabc,ou=people,o=TEST", user.getName());
-        System.out.println(user.getUserEntry().getAttribute("cn"));
     }
 
     @AfterClass

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
@@ -53,7 +53,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSL() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config_ldap2.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
@@ -63,7 +62,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSLFail() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config_ldap2.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode());
@@ -87,7 +85,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
                 encodeBasicHeader("spock", "spocksecret")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.subschemaSubentry"));

--- a/src/test/java/org/opensearch/security/AggregationTests.java
+++ b/src/test/java/org/opensearch/security/AggregationTests.java
@@ -114,7 +114,6 @@ public class AggregationTests extends SingleClusterTest {
                 encodeBasicHeader("nagilum", "nagilum")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");
@@ -134,7 +133,6 @@ public class AggregationTests extends SingleClusterTest {
                 encodeBasicHeader("nagilum", "nagilum")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");
@@ -154,7 +152,6 @@ public class AggregationTests extends SingleClusterTest {
                 encodeBasicHeader("worf", "worf")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");
@@ -168,11 +165,11 @@ public class AggregationTests extends SingleClusterTest {
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePostRequest(
+            rh.executePostRequest(
                 "_search?pretty",
                 "{\"size\":0,\"aggs\":{\"myindices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
                 encodeBasicHeader("worf", "worf")
-            )).getStatusCode()
+            ).getStatusCode()
         );
 
     }

--- a/src/test/java/org/opensearch/security/ConfigTests.java
+++ b/src/test/java/org/opensearch/security/ConfigTests.java
@@ -33,7 +33,6 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.security.securityconf.Migration;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
-import org.opensearch.security.securityconf.impl.v6.ActionGroupsV6;
 import org.opensearch.security.securityconf.impl.v6.ConfigV6;
 import org.opensearch.security.securityconf.impl.v6.InternalUserV6;
 import org.opensearch.security.securityconf.impl.v6.RoleMappingsV6;
@@ -52,7 +51,7 @@ public class ConfigTests {
 
     @Test
     public void testEmptyConfig() throws Exception {
-        Assert.assertTrue(SecurityDynamicConfiguration.empty().deepClone() != SecurityDynamicConfiguration.empty());
+        Assert.assertNotSame(SecurityDynamicConfiguration.empty().deepClone(), SecurityDynamicConfiguration.empty());
     }
 
     @Test
@@ -63,25 +62,18 @@ public class ConfigTests {
             (SecurityDynamicConfiguration<RoleMappingsV6>) load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING)
         );
 
-        System.out.println(Strings.toString(XContentType.JSON, rolesResult.v2(), true, false));
-        System.out.println(Strings.toString(XContentType.JSON, rolesResult.v1(), true, false));
-
         SecurityDynamicConfiguration<ActionGroupsV7> actionGroupsResult = Migration.migrateActionGroups(
-            (SecurityDynamicConfiguration<ActionGroupsV6>) load("./legacy/securityconfig_v6/action_groups.yml", CType.ACTIONGROUPS)
+            load("./legacy/securityconfig_v6/action_groups.yml", CType.ACTIONGROUPS)
         );
-        System.out.println(Strings.toString(XContentType.JSON, actionGroupsResult, true, false));
         SecurityDynamicConfiguration<ConfigV7> configResult = Migration.migrateConfig(
             (SecurityDynamicConfiguration<ConfigV6>) load("./legacy/securityconfig_v6/config.yml", CType.CONFIG)
         );
-        System.out.println(Strings.toString(XContentType.JSON, configResult, true, false));
         SecurityDynamicConfiguration<InternalUserV7> internalUsersResult = Migration.migrateInternalUsers(
             (SecurityDynamicConfiguration<InternalUserV6>) load("./legacy/securityconfig_v6/internal_users.yml", CType.INTERNALUSERS)
         );
-        System.out.println(Strings.toString(XContentType.JSON, internalUsersResult, true, false));
         SecurityDynamicConfiguration<RoleMappingsV7> rolemappingsResult = Migration.migrateRoleMappings(
             (SecurityDynamicConfiguration<RoleMappingsV6>) load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING)
         );
-        System.out.println(Strings.toString(XContentType.JSON, rolemappingsResult, true, false));
     }
 
     @Test
@@ -110,13 +102,10 @@ public class ConfigTests {
         final String adjustedFilePath = SingleClusterTest.TEST_RESOURCE_RELATIVE_PATH + file;
         JsonNode jsonNode = YAML.readTree(Files.readString(new File(adjustedFilePath).toPath(), StandardCharsets.UTF_8));
         int configVersion = 1;
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST %%%%%%%");
         if (jsonNode.get("_meta") != null) {
             Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
-
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST: CONFIG VERSION: " + configVersion + "%%%%%%%");
 
         SecurityDynamicConfiguration<?> dc = load(file, cType);
         Assert.assertNotNull(dc);
@@ -132,12 +121,10 @@ public class ConfigTests {
         JsonNode jsonNode = YAML.readTree(Files.readString(new File(adjustedFilePath).toPath(), StandardCharsets.UTF_8));
         int configVersion = 1;
 
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST LOAD: CONFIG VERSION: %%%%%%%");
         if (jsonNode.get("_meta") != null) {
             Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST: CONFIG VERSION: " + configVersion + "%%%%%%%");
         return SecurityDynamicConfiguration.fromNode(jsonNode, cType, configVersion, 0, 0);
     }
 }

--- a/src/test/java/org/opensearch/security/HealthTests.java
+++ b/src/test/java/org/opensearch/security/HealthTests.java
@@ -48,13 +48,11 @@ public class HealthTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -70,7 +68,6 @@ public class HealthTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
@@ -79,7 +76,6 @@ public class HealthTests extends SingleClusterTest {
             HttpStatus.SC_SERVICE_UNAVAILABLE,
             (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode()
         );
-        System.out.println(res.getBody());
         assertContains(res, "*DOWN*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*UP*");

--- a/src/test/java/org/opensearch/security/HttpIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/HttpIntegrationTests.java
@@ -315,7 +315,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
         HttpResponse res = rh.executeGetRequest("_search?pretty", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"value\" : 11"));
-        Assert.assertTrue(!res.getBody().contains(".opendistro_security"));
+        Assert.assertFalse(res.getBody().contains(".opendistro_security"));
 
         res = rh.executeGetRequest("_nodes/stats?pretty", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
@@ -325,8 +325,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertFalse(res.getBody().contains("\"nodes\" : { }"));
 
         res = rh.executePostRequest("*/_upgrade", "", encodeBasicHeader("nagilum", "nagilum"));
-        System.out.println(res.getBody());
-        System.out.println(res.getStatusReason());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
@@ -339,7 +337,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("writer", "writer"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"errors\":false"));
         Assert.assertTrue(res.getBody().contains("\"status\":201"));
@@ -433,11 +430,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
+
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertNotContains(res, "*\"compression\":\"false\"*");
         assertContains(res, "*\"compression\":\"true\"*");
     }
@@ -454,11 +450,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
+
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*\"compression\":\"false\"*");
         assertNotContains(res, "*\"compression\":\"true\"*");
     }
@@ -479,12 +474,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
 
         resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty=true");
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody().contains("\"remote_address\" : \"")); // check pretty print
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
 
         resc = rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("nagilum", "nagilum"));
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody().contains("nagilum"));
         Assert.assertFalse(resc.getBody().contains("opendistro_security_anonymous"));
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
@@ -553,9 +546,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         rh.keystore = "kirk-keystore.jks";
         Assert.assertEquals(HttpStatus.SC_CREATED, rh.executePutRequest(".opendistro_security/_doc/y", "{}").getStatusCode());
-        HttpResponse res;
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/authinfo")).getStatusCode());
-        System.out.println(res.getBody());
+        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode());
     }
 
     @Test
@@ -858,7 +849,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
         );
 
         HttpResponse resc = rh.executeGetRequest("_cat/indices/public", encodeBasicHeader("bug108", "nagilum"));
-        System.out.println(resc.getBody());
         // Assert.assertTrue(resc.getBody().contains("green"));
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
 
@@ -887,7 +877,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             rh.executeGetRequest("kirk/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()
         );
 
-        System.out.println("ok");
         // all
 
     }
@@ -908,7 +897,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         HttpResponse res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("bulk", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"errors\":false"));
         Assert.assertTrue(res.getBody().contains("\"status\":201"));
@@ -930,7 +918,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("bulk_test_user", "nagilum"));
-        System.out.println(res.getBody());
         JsonNode jsonNode = readTree(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(jsonNode.get("errors").booleanValue());
@@ -966,7 +953,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));
         res = rh.executePostRequest(
@@ -974,7 +960,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}",
             encodeBasicHeader("557", "nagilum")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));
     }
@@ -1032,13 +1017,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         final RestHelper rh = nonSslRestHelper();
 
-        System.out.println("###1");
         HttpResponse res = rh.executeGetRequest("/esb-prod-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println("###2");
         res = rh.executeGetRequest("/esb-alias-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println("###3");
         res = rh.executeGetRequest("/esb-prod-all/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
     }
@@ -1120,7 +1102,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
 
         res = rh.executeGetRequest("_opendistro/_security/tenantinfo?pretty", encodeBasicHeader("kibanaserver", "kibanaserver"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\".kibana_-1139640511_admin1\" : \"admin_1\""));
         Assert.assertTrue(res.getBody().contains("\".kibana_-1386441176_praxisrw\" : \"praxisrw\""));

--- a/src/test/java/org/opensearch/security/IndexIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IndexIntegrationTests.java
@@ -156,16 +156,16 @@ public class IndexIntegrationTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"lorem\", \"_id\" : \"5\" } }"
             + System.lineSeparator();
 
-        System.out.println("############ _bulk");
+        // _bulk
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true&pretty=true", bulkBody, encodeBasicHeader("worf", "worf"));
-        System.out.println(res.getBody());
+
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"errors\" : true"));
         Assert.assertTrue(res.getBody().contains("\"status\" : 201"));
         Assert.assertTrue(res.getBody().contains("no permissions for"));
 
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        // check shards
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
     }
 
@@ -372,51 +372,45 @@ public class IndexIntegrationTests extends SingleClusterTest {
         HttpResponse res = null;
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
-                .getStatusCode()
+            rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         // nonexistent index with permissions
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (res = rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
-                .getStatusCode()
+            rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         // existent index without permissions
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/nopermindex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
-                .getStatusCode()
+            rh.executeGetRequest("/nopermindex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         // nonexistent index without permissions
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest(
-                "/does-not-exist-and-no-perm/_search",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
+            rh.executeGetRequest("/does-not-exist-and-no-perm/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                .getStatusCode()
         );
 
         // nonexistent and existent index with permissions
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (res = rh.executeGetRequest("/logstash-nonex,logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
+            rh.executeGetRequest("/logstash-nonex,logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
                 .getStatusCode()
         );
 
         // existent index with permissions
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
-                .getStatusCode()
+            rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         // nonexistent index with failed login
         Assert.assertEquals(
             HttpStatus.SC_UNAUTHORIZED,
-            (res = rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("nouser", "nosuer"))).getStatusCode()
+            rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("nouser", "nosuer")).getStatusCode()
         );
 
         // nonexistent index with no login
@@ -424,102 +418,93 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/_all/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/_all/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/*/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/*/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest(
-                "/nopermindex,logstash-1,nonexist/_search",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
-        );
-
-        Assert.assertEquals(
-            HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
+            rh.executeGetRequest("/nopermindex,logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
                 .getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))).getStatusCode()
-        );
-
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "/%3Clogstash-%7Bnow%2Fd%7D%3E/_search",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
+            rh.executeGetRequest("/logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                .getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/%3Cnonex-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
+            rh.executeGetRequest("/nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+        );
+
+        Assert.assertEquals(
+            HttpStatus.SC_OK,
+            rh.executeGetRequest("/%3Clogstash-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                .getStatusCode()
+        );
+
+        Assert.assertEquals(
+            HttpStatus.SC_FORBIDDEN,
+            rh.executeGetRequest("/%3Cnonex-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
                 .getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
+            rh.executeGetRequest(
                 "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-*/_search",
                 encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
+            ).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
+            rh.executeGetRequest(
                 "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-1/_search",
                 encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
+            ).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_CREATED,
-            (res = rh.executePutRequest("/logstash-b/_doc/1", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum")))
+            rh.executePutRequest("/logstash-b/_doc/1", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+        );
+
+        Assert.assertEquals(
+            HttpStatus.SC_OK,
+            rh.executePutRequest("/%3Clogstash-cnew-%7Bnow%2Fd%7D%3E", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
                 .getStatusCode()
         );
 
         Assert.assertEquals(
-            HttpStatus.SC_OK,
-            (res = rh.executePutRequest(
-                "/%3Clogstash-cnew-%7Bnow%2Fd%7D%3E",
-                "{}",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
-        );
-
-        Assert.assertEquals(
             HttpStatus.SC_CREATED,
-            (res = rh.executePutRequest(
+            rh.executePutRequest(
                 "/%3Clogstash-new-%7Bnow%2Fd%7D%3E/_doc/1",
                 "{}",
                 encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            )).getStatusCode()
+            ).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/_cat/indices?v", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
         );
-
-        System.out.println(res.getBody());
-        Assert.assertTrue(res.getBody().contains("logstash-b"));
-        Assert.assertTrue(res.getBody().contains("logstash-new-20"));
-        Assert.assertTrue(res.getBody().contains("logstash-cnew-20"));
-        Assert.assertFalse(res.getBody().contains("<"));
+        String body = res.getBody();
+        Assert.assertTrue(body.contains("logstash-b"));
+        Assert.assertTrue(body.contains("logstash-new-20"));
+        Assert.assertTrue(body.contains("logstash-cnew-20"));
+        Assert.assertFalse(body.contains("<"));
     }
 
     @Test
@@ -571,7 +556,7 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePostRequest("/mysgi/_doc", "{}", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            rh.executePostRequest("/mysgi/_doc", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
         );
         Assert.assertEquals(
             HttpStatus.SC_OK,
@@ -579,28 +564,28 @@ public class IndexIntegrationTests extends SingleClusterTest {
         );
         assertContains(res, "*\"hits\" : {*\"value\" : 0,*\"hits\" : [ ]*");
 
-        System.out.println("#### add alias to allowed index");
+        // add alias to allowed index
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executePutRequest("/logstash-1/_alias/alog1", "", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePutRequest("/logstash-1/_alias/alog1", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### add alias to not existing (no perm)");
+        // add alias to not existing (no perm)
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePutRequest("/nonexitent/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePutRequest("/nonexitent/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### add alias to not existing (with perm)");
+        // add alias to not existing (with perm)
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (res = rh.executePutRequest("/logstash-nonex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePutRequest("/logstash-nonex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### add alias to not allowed index");
+        // add alias to not allowed index
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePutRequest("/nopermindex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePutRequest("/nopermindex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
         String aliasRemoveIndex = "{"
@@ -610,36 +595,36 @@ public class IndexIntegrationTests extends SingleClusterTest {
             + "]"
             + "}";
 
-        System.out.println("#### remove_index");
+        // remove_index
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePostRequest("/_aliases", aliasRemoveIndex, encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePostRequest("/_aliases", aliasRemoveIndex, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### get alias for permitted index");
+        // get alias for permitted index
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-1/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/logstash-1/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### get alias for all indices");
+        // get alias for all indices
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
-        System.out.println("#### get alias no perm");
+        // get alias no perm
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("/_alias/nopermalias", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("/_alias/nopermalias", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
 
         String alias = "{" + "\"aliases\": {" + "\"alias1\": {}" + "}" + "}";
 
-        System.out.println("#### create alias along with index");
+        // create alias along with index
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePutRequest("/beats-withalias", alias, encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode()
+            rh.executePutRequest("/beats-withalias", alias, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
         );
     }
 
@@ -737,10 +722,8 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("/*:noperm/_search", encodeBasicHeader("ccsresolv", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res.getBody());
         res = rh.executeGetRequest("/*:noexists/_search", encodeBasicHeader("ccsresolv", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res.getBody());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -76,18 +76,16 @@ public class IntegrationTests extends SingleClusterTest {
                 ).actionGet();
         }
 
-        System.out.println("########search");
+        // search
         HttpResponse res;
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
         );
 
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
+        // search scroll
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executePostRequest(
@@ -97,7 +95,7 @@ public class IntegrationTests extends SingleClusterTest {
             )).getStatusCode()
         );
 
-        System.out.println("########search done");
+        // search done
 
     }
 
@@ -245,7 +243,6 @@ public class IntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse resc = rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("picard", "picard"));
-        System.out.println(resc.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
         Assert.assertFalse(resc.getBody().contains("type2"));
 
@@ -287,7 +284,6 @@ public class IntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "userwhonotexists"),
             encodeBasicHeader("spock", "spock")
         );
-        System.out.println(resp.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resp.getStatusCode());
 
         resp = rh.executeGetRequest(
@@ -321,7 +317,6 @@ public class IntegrationTests extends SingleClusterTest {
         // opendistro_security_shakespeare -> picard
 
         HttpResponse resc = rh.executeGetRequest("shakespeare/_search", encodeBasicHeader("picard", "picard"));
-        System.out.println(resc.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
         Assert.assertTrue(resc.getBody().contains("\"content\":1"));
 
@@ -417,7 +412,6 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("\"content\":1"));
         Assert.assertFalse(res.getBody().contains("\"content\":2"));
@@ -435,7 +429,6 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"content\":1"));
         Assert.assertTrue(res.getBody().contains("\"content\":2"));
@@ -535,7 +528,6 @@ public class IntegrationTests extends SingleClusterTest {
             "{\"doc\" : {\"content\":2}}",
             encodeBasicHeader("user_c", "user_c")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
     }
 
@@ -611,7 +603,6 @@ public class IntegrationTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
@@ -621,7 +612,6 @@ public class IntegrationTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
@@ -639,10 +629,9 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
-        System.out.println("#### msearch");
+        // msearch
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -652,7 +641,6 @@ public class IntegrationTests extends SingleClusterTest {
 
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -685,7 +673,7 @@ public class IntegrationTests extends SingleClusterTest {
             + "]"
             + "}";
 
-        System.out.println("#### mget");
+        // mget
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("\"content\" : \"indexa\""));
@@ -713,7 +701,6 @@ public class IntegrationTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
 
@@ -721,7 +708,6 @@ public class IntegrationTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
@@ -729,70 +715,59 @@ public class IntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (resc = rh.executeGetRequest("permitnotexistentindex/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("permitnotexistentindex/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("permitnotexistentindex*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("permitnotexistentindex*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (resc = rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
-        System.out.println("#### _all/_mapping/field/*");
+        // _all/_mapping/field/*
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
         );
-        System.out.println(resc.getBody());
     }
 
     @Test
@@ -865,15 +840,13 @@ public class IntegrationTests extends SingleClusterTest {
         HttpResponse resc;
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode()
+            rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         String msearchBody = "{\"index\":\"indexa\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
@@ -883,19 +856,18 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
-        System.out.println("#### msearch a");
+        // msearch a
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
 
-        System.out.println("#### msearch b");
+        // msearch b
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
+
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -910,9 +882,9 @@ public class IntegrationTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println("#### msearch b2");
+        // msearch b2
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        System.out.println(resc.getBody());
+
         Assert.assertEquals(200, resc.getStatusCode());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
@@ -962,80 +934,69 @@ public class IntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
-            (resc = rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
-        System.out.println("#### _all/_mapping/field/*");
+        // _all/_mapping/field/*
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
         );
-        System.out.println(resc.getBody());
-        System.out.println("#### _mapping/field/*");
+        // _mapping/field/*
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
         );
-        System.out.println(resc.getBody());
-        System.out.println("#### */_mapping/field/*");
+        // */_mapping/field/*
         Assert.assertEquals(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
         );
-        System.out.println(resc.getBody());
     }
 
     @Test
@@ -1097,7 +1058,7 @@ public class IntegrationTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \".opendistro_security\", \"_id\" : \"config\" } }\n";
         res = rh.executePostRequest("_bulk?refresh=true&pretty", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
         JsonNode jsonNode = readTree(res.getBody());
-        System.out.println(res.getBody());
+
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertEquals(403, jsonNode.get("items").get(0).get("index").get("status").intValue());
         Assert.assertEquals(403, jsonNode.get("items").get(1).get("index").get("status").intValue());

--- a/src/test/java/org/opensearch/security/SecurityAdminTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminTests.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -52,9 +53,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -83,9 +88,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -102,9 +111,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "spock-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "spock-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -120,9 +133,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "node-0-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "node-0-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -149,9 +166,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -165,10 +186,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         RestHelper rh = restHelper();
 
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode());
-        // System.out.println(res.getBody());
-        // assertContains(res, "*UP*");
-        // assertContains(res, "*strict*");
-        // assertNotContains(res, "*DOWN*");
     }
 
     @Test
@@ -184,9 +201,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -201,7 +222,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -220,9 +240,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -238,9 +262,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -256,9 +284,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -276,7 +308,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -295,9 +326,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -315,7 +350,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -334,15 +368,23 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
         argsAsList.add(clusterInfo.clustername);
         argsAsList.add("-f");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "roles_invalidxcontent.yml").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "roles_invalidxcontent.yml"))
+                .toFile()
+                .getAbsolutePath()
+        );
         argsAsList.add("-t");
         argsAsList.add("roles");
         argsAsList.add("-nhnv");
@@ -354,7 +396,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -375,10 +416,8 @@ public class SecurityAdminTests extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println(
-            rh.executePutRequest(".opendistro_security/_doc/roles", FileHelper.loadFile("roles_invalidxcontent.yml")).getBody()
-        );
-        ;
+
+        rh.executePutRequest(".opendistro_security/_doc/roles", FileHelper.loadFile("roles_invalidxcontent.yml"));
         Assert.assertEquals(
             HttpStatus.SC_OK,
             rh.executePutRequest(".opendistro_security/_doc/roles", "{\"roles\":\"dummy\"}").getStatusCode()
@@ -388,9 +427,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");
@@ -507,9 +550,13 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         List<String> argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "truststore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-ks");
-        argsAsList.add(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks").toFile().getAbsolutePath());
+        argsAsList.add(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath(prefix + "kirk-keystore.jks")).toFile().getAbsolutePath()
+        );
         argsAsList.add("-p");
         argsAsList.add(String.valueOf(clusterInfo.httpPort));
         argsAsList.add("-cn");

--- a/src/test/java/org/opensearch/security/TaskTests.java
+++ b/src/test/java/org/opensearch/security/TaskTests.java
@@ -45,7 +45,6 @@ public class TaskTests extends SingleClusterTest {
                 new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().split("X-Opaque-Id").length > 2);
         Assert.assertTrue(!res.getBody().contains("failures"));
     }

--- a/src/test/java/org/opensearch/security/TracingTests.java
+++ b/src/test/java/org/opensearch/security/TracingTests.java
@@ -75,24 +75,24 @@ public class TracingTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ write into mapping 1");
+        // write into mapping 1
         String data1 = FileHelper.loadFile("data1.json");
-        System.out.println(rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 2");
-        System.out.println(rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
+        // write into mapping 2");
+        rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 3");
+        // write into mapping 3
         String parent = FileHelper.loadFile("data2.json");
         String child = FileHelper.loadFile("data3.json");
-        System.out.println(rh.executePutRequest("myindex3/_doc/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex3/_doc/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex3/_doc/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex3/_doc/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 4");
-        System.out.println(rh.executePutRequest("myindex4/_doc/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex4/_doc/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum")));
+        // write into mapping 4
+        rh.executePutRequest("myindex4/_doc/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex4/_doc/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum"));
     }
 
     @Test
@@ -211,10 +211,10 @@ public class TracingTests extends SingleClusterTest {
         // setup complex mapping with parent child and nested fields
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        // check shards
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -226,9 +226,9 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -240,48 +240,48 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ cat indices");
+        // cat indices
         // cluster:monitor/state
         // cluster:monitor/health
         // indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _search");
+        // _search
         // indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ get 1");
+        // get 1
         // indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum"));
+        // get 5
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum"));
+        // get 17
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index (+create index)");
+        // index (+create index)
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index only");
+        // index only
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete");
+        // delete
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ msearch");
+        // msearch
         String msearchBody = "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -295,9 +295,9 @@ public class TracingTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ mget");
+        // mget
         String mgetBody = "{"
             + "\"docs\" : ["
             + "{"
@@ -319,12 +319,12 @@ public class TracingTests extends SingleClusterTest {
             + "]"
             + "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete by query");
+        // delete by query
         String dbqBody = "{" + "" + "  \"query\": { " + "    \"match\": {" + "      \"content\": 12" + "    }" + "  }" + "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum"));
 
         Thread.sleep(5000);
     }
@@ -384,19 +384,19 @@ public class TracingTests extends SingleClusterTest {
 
         }
 
-        System.out.println("########pause1");
+        // pause1
         Thread.sleep(5000);
-        System.out.println("########end pause1");
+        // end pause1
 
-        System.out.println("########search");
+        // search
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
-        System.out.println("########search done");
+        // search done
 
-        System.out.println("########pause2");
+        // pause2
         Thread.sleep(5000);
-        System.out.println("########end pause2");
+        // end pause2
 
-        System.out.println("############ _bulk");
+        // _bulk
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -416,8 +416,8 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"field1\" : \"value1\" }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")).getBody());
-        System.out.println("############ _end");
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")).getBody();
+        // _end
         Thread.sleep(5000);
     }
 
@@ -436,18 +436,16 @@ public class TracingTests extends SingleClusterTest {
                 ).actionGet();
         }
 
-        System.out.println("########search");
+        // search
         HttpResponse res;
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
         );
 
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
+        // search scroll
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executePostRequest(
@@ -456,9 +454,7 @@ public class TracingTests extends SingleClusterTest {
                 encodeBasicHeader("nagilum", "nagilum")
             )).getStatusCode()
         );
-
-        System.out.println("########search done");
-
+        // search done
     }
 
     @Test
@@ -483,10 +479,10 @@ public class TracingTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        // check shards
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -498,9 +494,9 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -512,75 +508,68 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ cat indices");
+        // cat indices
         // cluster:monitor/state
         // cluster:monitor/health
         // indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _search");
+        // _search
         // indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ get 1");
+        // get 1
         // indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum"));
+        // get 5
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum"));
+        // get 17
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index (+create index)");
+        // index (+create index)
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index only");
+        // index only
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum")));
+        // rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ update");
+        // update
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(
-            rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}", encodeBasicHeader("nagilum", "nagilum"))
-        );
-
-        System.out.println("############ update2");
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}", encodeBasicHeader("nagilum", "nagilum"));
+        // update2
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(
-            rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":44, \"b\":55}}", encodeBasicHeader("nagilum", "nagilum"))
-        );
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":44, \"b\":55}}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ update3");
+        // update3
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(
-            rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"b\":66}}", encodeBasicHeader("nagilum", "nagilum"))
-        );
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"b\":66}}", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete");
+        // delete
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ reindex");
+        // reindex
         String reindex = "{"
             + "  \"source\": {"
             + "    \"index\": \"a\""
@@ -590,9 +579,9 @@ public class TracingTests extends SingleClusterTest {
             + "  }"
             + "}";
 
-        System.out.println(rh.executePostRequest("_reindex", reindex, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_reindex", reindex, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ msearch");
+        // msearch
         String msearchBody = "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -606,9 +595,9 @@ public class TracingTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ mget");
+        // mget
         String mgetBody = "{"
             + "\"docs\" : ["
             + "{"
@@ -630,12 +619,12 @@ public class TracingTests extends SingleClusterTest {
             + "]"
             + "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete by query");
+        // delete by query
         String dbqBody = "{" + "" + "  \"query\": { " + "    \"match\": {" + "      \"content\": 12" + "    }" + "  }" + "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum"));
 
         Thread.sleep(5000);
     }

--- a/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -12,7 +12,6 @@
 package org.opensearch.security.auditlog;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.http.Header;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.DefaultObjectMapper;

--- a/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -11,9 +11,6 @@
 
 package org.opensearch.security.auditlog;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.Header;
 
@@ -26,6 +23,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.opensearch.security.auditlog.config.AuditConfig.DEPRECATED_KEYS;
 
@@ -72,15 +72,15 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
         return builder.put(additionalSettings).build();
     }
 
-    protected void setupStarfleetIndex() throws Exception {
+    protected void setupStarfleetIndex() {
         final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
         rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
-        rh.executePutRequest("sf", null, new Header[0]);
-        rh.executePutRequest("sf/public/0?refresh", "{\"number\" : \"NCC-1701-D\"}", new Header[0]);
-        rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
-        rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}", new Header[0]);
+        rh.executePutRequest("sf", null);
+        rh.executePutRequest("sf/public/0?refresh", "{\"number\" : \"NCC-1701-D\"}");
+        rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}");
+        rh.executePutRequest("sf/public/0?refresh", "{\"some\" : \"value\"}");
         rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }
@@ -107,13 +107,11 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
             JsonNode node = DefaultObjectMapper.objectMapper.readTree(json);
 
             if (node.get("audit_request_body") != null) {
-                System.out.println("    Check audit_request_body for validity: " + node.get("audit_request_body").asText());
                 DefaultObjectMapper.objectMapper.readTree(node.get("audit_request_body").asText());
             }
 
             return true;
         } catch (Exception e) {
-            e.printStackTrace();
             return false;
         }
     }
@@ -128,13 +126,12 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
         updateAuditConfig(AuditTestUtils.createAuditPayload(settings));
     }
 
-    protected void updateAuditConfig(final String payload) throws Exception {
+    protected void updateAuditConfig(final String payload) {
         final boolean sendAdminCertificate = rh.sendAdminCertificate;
         final String keystore = rh.keystore;
         rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
-        RestHelper.HttpResponse response = rh.executePutRequest("_opendistro/_security/api/audit/config", payload, new Header[0]);
-        System.out.println(response);
+        rh.executePutRequest("_opendistro/_security/api/audit/config", payload);
         rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -125,7 +125,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         try {
             messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
                 rh.executePutRequest("emp/_doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}");
-                System.out.println(rh.executeGetRequest("_cat/shards?v"));
+                rh.executeGetRequest("_cat/shards?v");
             }, 7);
         } catch (final MessagesNotFoundException ex) {
             // indices:admin/mapping/auto_put can be logged twice, this handles if they were not found

--- a/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -49,7 +49,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             encodeBasicHeader("admin", "admin")
         );
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() + "", TestAuditlogImpl.messages.size() == 1);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -84,7 +83,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body);
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() + "", TestAuditlogImpl.messages.size() == 1);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -116,10 +114,8 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println("----rest");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_all_access?pretty");
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -146,7 +142,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         setup(additionalSettings);
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
 
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -172,14 +167,12 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         setup(additionalSettings);
         TestAuditlogImpl.clear();
         String body = "{ \"password\":\"some new password\",\"backend_roles\":[\"role1\",\"role2\"] }";
-        System.out.println("exec");
         HttpResponse response = rh.executePutRequest(
             "_opendistro/_security/api/internalusers/compuser?pretty",
             body,
             encodeBasicHeader("admin", "admin")
         );
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(response.getBody(), HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() + "", TestAuditlogImpl.messages.isEmpty());
     }
@@ -206,16 +199,15 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println("req");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/internalusers/admin?pretty");
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() + "", TestAuditlogImpl.messages.size() == 1);
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_INTERNAL_CONFIG_READ"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_INTERNAL_CONFIG_WRITE"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("UPDATE"));
+        Assert.assertTrue(auditLogImpl.contains("audit_request_effective_user"));
+        Assert.assertTrue(auditLogImpl.contains("COMPLIANCE_INTERNAL_CONFIG_READ"));
+        Assert.assertFalse(auditLogImpl.contains("COMPLIANCE_INTERNAL_CONFIG_WRITE"));
+        Assert.assertFalse(auditLogImpl.contains("UPDATE"));
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/helper/SlowSink.java
+++ b/src/test/java/org/opensearch/security/auditlog/helper/SlowSink.java
@@ -24,9 +24,7 @@ public class SlowSink extends AuditLogSink {
     public boolean doStore(AuditMessage msg) {
         try {
             Thread.sleep(3000);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        } catch (InterruptedException ignored) {}
 
         return true;
     }

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
@@ -87,7 +87,6 @@ public class AuditlogTest {
         TestAuditlogImpl.clear();
         al.logSSLException(null, new Exception("test rest"));
         al.logSSLException(null, new Exception("test rest"), null, null);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(2, TestAuditlogImpl.messages.size());
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
@@ -192,7 +192,6 @@ public class DisabledCategoriesTest {
         List<AuditCategory> allButDisablesCategories = new LinkedList<>(Arrays.asList(AuditCategory.values()));
         allButDisablesCategories.removeAll(Arrays.asList(disabledCategories));
 
-        System.out.println(result + "###" + disabledCategoriesString);
         Assert.assertFalse(categoriesPresentInLog(result, disabledCategories));
         Assert.assertTrue(
             categoriesPresentInLog(result, filterComplianceCategories(allButDisablesCategories.toArray(new AuditCategory[] {})))
@@ -205,7 +204,6 @@ public class DisabledCategoriesTest {
         result = result.replaceAll(" ", "");
         for (AuditCategory category : categories) {
             if (!result.contains("\"" + AuditMessage.CATEGORY + "\":\"" + category.name() + "\"")) {
-                System.out.println("MISSING: " + category.name());
                 return false;
             }
         }

--- a/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
@@ -73,13 +73,13 @@ public class TracingTests extends SingleClusterTest {
             }
         }
 
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("admin", "admin")));
+        // check shards
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("admin", "admin")));
+        // check shards
+        rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -91,9 +91,9 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ _bulk");
+        // _bulk
         bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -105,67 +105,65 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"2\" } }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ cat indices");
+        // cat indices
         // cluster:monitor/state
         // cluster:monitor/health
         // indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ _search");
+        // _search
         // indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ get 1");
+        // get 1
         // indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("admin", "admin")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("admin", "admin")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("admin", "admin"));
+        // get 5
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("admin", "admin"));
+        // get 17
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index (+create index)");
+        // index (+create index)
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index only");
+        // index only
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("u/b/2?refresh=true", "{}", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index updates");
+        // index updates
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":1, \"m\":1}", encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"m\":1, \"z\":1}", encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"z\":4}", encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5, \"z\":5}", encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5}", encodeBasicHeader("admin", "admin")));
-        System.out.println("############ update");
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":1, \"m\":1}", encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"m\":1, \"z\":1}", encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"z\":4}", encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5, \"z\":5}", encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5}", encodeBasicHeader("admin", "admin"));
+        // update
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(
-            rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}", encodeBasicHeader("admin", "admin"))
-        );
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ delete");
+        // delete
         // indices:data/write/index
         // indices:data/write/bulk
         // indices:admin/create
         // indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("admin", "admin")));
+        rh.executeDeleteRequest("u/b/2?refresh=true", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ reindex");
+        // reindex
         String reindex = "{"
             + "  \"source\": {"
             + "    \"index\": \"a\""
@@ -175,9 +173,9 @@ public class TracingTests extends SingleClusterTest {
             + "  }"
             + "}";
 
-        System.out.println(rh.executePostRequest("_reindex", reindex, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_reindex", reindex, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ msearch");
+        // msearch
         String msearchBody = "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -191,9 +189,9 @@ public class TracingTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ mget");
+        // mget
         String mgetBody = "{"
             + "\"docs\" : ["
             + "{"
@@ -215,12 +213,12 @@ public class TracingTests extends SingleClusterTest {
             + "]"
             + "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ delete by query");
+        // delete by query
         String dbqBody = "{" + "" + "  \"query\": { " + "    \"match\": {" + "      \"content\": 12" + "    }" + "  }" + "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("admin", "admin"));
         Thread.sleep(5000);
     }
 
@@ -279,19 +277,19 @@ public class TracingTests extends SingleClusterTest {
 
         }
 
-        System.out.println("########pause1");
+        // pause1
         Thread.sleep(5000);
-        System.out.println("########end pause1");
+        // end pause1
 
-        System.out.println("########search");
+        // search
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")).getStatusCode());
-        System.out.println("########search done");
+        // search done
 
-        System.out.println("########pause2");
+        // pause2
         Thread.sleep(5000);
-        System.out.println("########end pause2");
+        // end pause2
 
-        System.out.println("############ _bulk");
+        // _bulk
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -311,8 +309,8 @@ public class TracingTests extends SingleClusterTest {
             + "{ \"field1\" : \"value1\" }"
             + System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")).getBody());
-        System.out.println("############ _end");
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin"));
+        // _end
         Thread.sleep(5000);
     }
 
@@ -331,18 +329,16 @@ public class TracingTests extends SingleClusterTest {
                 ).actionGet();
         }
 
-        System.out.println("########search");
+        // search
         HttpResponse res;
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
 
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
+        // search scroll
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executePostRequest(
@@ -352,7 +348,7 @@ public class TracingTests extends SingleClusterTest {
             )).getStatusCode()
         );
 
-        System.out.println("########search done");
+        // search done
 
     }
 
@@ -391,38 +387,36 @@ public class TracingTests extends SingleClusterTest {
                 .actionGet();
         }
 
-        System.out.println("############ write into mapping 1");
+        // write into mapping 1
         String data1 = FileHelper.loadFile("auditlog/data1.json");
         String data2 = FileHelper.loadFile("auditlog/data1mod.json");
-        System.out.println(rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println("############ write into mapping diffing");
-        System.out.println(rh.executePutRequest("myindex1/_doc/1?refresh", data2, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
+        // write into mapping diffing
+        rh.executePutRequest("myindex1/_doc/1?refresh", data2, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 2");
-        System.out.println(rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex2/_doc/2?refresh", data2, encodeBasicHeader("admin", "admin")));
+        // write into mapping 2
+        rh.executePutRequest("myindex2/_doc/2?refresh", data1, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex2/_doc/2?refresh", data2, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 3");
+        // write into mapping 3
         String parent = FileHelper.loadFile("auditlog/data2.json");
         String child = FileHelper.loadFile("auditlog/data3.json");
-        System.out.println(rh.executePutRequest("myindex3/_doc/1?refresh", parent, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex3/_doc/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex3/_doc/1?refresh", parent, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex3/_doc/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 4");
-        System.out.println(rh.executePutRequest("myindex4/_doc/1?refresh", parent, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex4/_doc/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin")));
+        // write into mapping 4
+        rh.executePutRequest("myindex4/_doc/1?refresh", parent, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex4/_doc/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ get");
-        System.out.println(
-            rh.executeGetRequest(
-                "myindex1/_doc/1?pretty=true&_source=true&_source_include=*.id&_source_exclude=entities&stored_fields=tags,counter",
-                encodeBasicHeader("admin", "admin")
-            ).getBody()
+        // get
+        rh.executeGetRequest(
+            "myindex1/_doc/1?pretty=true&_source=true&_source_include=*.id&_source_exclude=entities&stored_fields=tags,counter",
+            encodeBasicHeader("admin", "admin")
         );
 
-        System.out.println("############ search");
-        System.out.println(rh.executeGetRequest("myindex1/_search", encodeBasicHeader("admin", "admin")).getStatusCode());
+        // search
+        rh.executeGetRequest("myindex1/_search", encodeBasicHeader("admin", "admin"));
 
     }
 
@@ -454,7 +448,7 @@ public class TracingTests extends SingleClusterTest {
                 .actionGet();
         }
 
-        System.out.println("############ immutable 1");
+        // immutable 1
         String data1 = FileHelper.loadFile("auditlog/data1.json");
         String data2 = FileHelper.loadFile("auditlog/data1mod.json");
         HttpResponse res = rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
@@ -468,7 +462,7 @@ public class TracingTests extends SingleClusterTest {
         Assert.assertFalse(res.getBody().contains("city"));
         Assert.assertTrue(res.getBody().contains("\"found\":true,"));
 
-        System.out.println("############ immutable 2");
+        // immutable 2
         res = rh.executePutRequest("myindex2/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(201, res.getStatusCode());
         res = rh.executePutRequest("myindex2/_doc/1?refresh", data2, encodeBasicHeader("admin", "admin"));

--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -169,15 +169,15 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(String.valueOf(TestAuditlogImpl.messages.size()), TestAuditlogImpl.messages.size() >= 2);
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("GRANTED_PRIVILEGES"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/read/search"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("TRANSPORT"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\"audit_request_effective_user\" : \"admin\""));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("REST"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().toLowerCase().contains("authorization"));
+        Assert.assertTrue(auditLogImpl.contains("GRANTED_PRIVILEGES"));
+        Assert.assertTrue(auditLogImpl.contains("AUTHENTICATED"));
+        Assert.assertTrue(auditLogImpl.contains("indices:data/read/search"));
+        Assert.assertTrue(auditLogImpl.contains("TRANSPORT"));
+        Assert.assertTrue(auditLogImpl.contains("\"audit_request_effective_user\" : \"admin\""));
+        Assert.assertTrue(auditLogImpl.contains("REST"));
+        Assert.assertFalse(auditLogImpl.toLowerCase().contains("authorization"));
         Assert.assertEquals(
             TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID),
             TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID)
@@ -202,15 +202,15 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertEquals(2, TestAuditlogImpl.messages.size());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("GRANTED_PRIVILEGES"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/read/search"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("TRANSPORT"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\"audit_request_effective_user\" : \"admin\""));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("REST"));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().toLowerCase().contains("authorization"));
+        Assert.assertTrue(auditLogImpl.contains("GRANTED_PRIVILEGES"));
+        Assert.assertTrue(auditLogImpl.contains("AUTHENTICATED"));
+        Assert.assertTrue(auditLogImpl.contains("indices:data/read/search"));
+        Assert.assertTrue(auditLogImpl.contains("TRANSPORT"));
+        Assert.assertTrue(auditLogImpl.contains("\"audit_request_effective_user\" : \"admin\""));
+        Assert.assertTrue(auditLogImpl.contains("REST"));
+        Assert.assertFalse(auditLogImpl.toLowerCase().contains("authorization"));
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
 
@@ -334,17 +334,17 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
     public void testUnauthenticated() throws Exception {
 
-        System.out.println("#### testUnauthenticated");
+        /// testUnauthenticated
         HttpResponse response = rh.executeGetRequest("_search");
         Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
         Thread.sleep(1500);
         Assert.assertEquals(1, TestAuditlogImpl.messages.size());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("FAILED_LOGIN"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("<NONE>"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("/_search"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(AuditMessage.UTC_TIMESTAMP));
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("FAILED_LOGIN"));
+        Assert.assertTrue(auditLogImpl.contains("<NONE>"));
+        Assert.assertTrue(auditLogImpl.contains("/_search"));
+        Assert.assertTrue(auditLogImpl.contains(AuditMessage.UTC_TIMESTAMP));
+        Assert.assertFalse(auditLogImpl.contains("AUTHENTICATED"));
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
 
     }
@@ -409,22 +409,22 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             + "{\"size\":0,\"query\":{\"match_all\":{}}}"
             + System.lineSeparator();
 
-        System.out.println("##### msaerch");
+        // msaerch
         HttpResponse response = rh.executePostRequest("_msearch?pretty", msearch, encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(response.getStatusReason(), HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("indices:data/read/msearch"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("indices:data/read/search"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("match_all"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_trace_task_id"));
-        Assert.assertEquals(TestAuditlogImpl.sb.toString(), 4, TestAuditlogImpl.messages.size());
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().toLowerCase().contains("authorization"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl, auditLogImpl.contains("indices:data/read/msearch"));
+        Assert.assertTrue(auditLogImpl, auditLogImpl.contains("indices:data/read/search"));
+        Assert.assertTrue(auditLogImpl, auditLogImpl.contains("match_all"));
+        Assert.assertTrue(auditLogImpl.contains("audit_trace_task_id"));
+        Assert.assertEquals(auditLogImpl, 4, TestAuditlogImpl.messages.size());
+        Assert.assertFalse(auditLogImpl.toLowerCase().contains("authorization"));
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
 
     public void testBulkAuth() throws Exception {
 
-        System.out.println("#### testBulkAuth");
+        // testBulkAuth
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -447,15 +447,15 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             + System.lineSeparator();
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("admin", "admin"));
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"errors\":false"));
         Assert.assertTrue(response.getBody().contains("\"status\":201"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:admin/auto_create"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/write/bulk"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("IndexRequest"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_trace_task_parent_id"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_trace_task_id"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("indices:admin/auto_create"));
+        Assert.assertTrue(auditLogImpl.contains("indices:data/write/bulk"));
+        Assert.assertTrue(auditLogImpl.contains("IndexRequest"));
+        Assert.assertTrue(auditLogImpl.contains("audit_trace_task_parent_id"));
+        Assert.assertTrue(auditLogImpl.contains("audit_trace_task_id"));
         // may vary because we log shardrequests which are not predictable here
         Assert.assertTrue(TestAuditlogImpl.messages.size() >= 17);
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
@@ -485,16 +485,15 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             + System.lineSeparator();
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("worf", "worf"));
-        System.out.println(response.getBody());
 
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"errors\":true"));
         Assert.assertTrue(response.getBody().contains("\"status\":200"));
         Assert.assertTrue(response.getBody().contains("\"status\":403"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("MISSING_PRIVILEGES"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/write/bulk[s]"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("IndexRequest"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("MISSING_PRIVILEGES"));
+        Assert.assertTrue(auditLogImpl.contains("indices:data/write/bulk[s]"));
+        Assert.assertTrue(auditLogImpl.contains("IndexRequest"));
         // may vary because we log shardrequests which are not predictable here
         Assert.assertTrue(TestAuditlogImpl.messages.size() >= 7);
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
@@ -513,10 +512,10 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executePutRequest("_cluster/settings", json, encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("cluster:admin/settings/update"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices.recovery.*"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("AUTHENTICATED"));
+        Assert.assertTrue(auditLogImpl.contains("cluster:admin/settings/update"));
+        Assert.assertTrue(auditLogImpl.contains("indices.recovery.*"));
         // may vary because we log may hit cluster manager directly or not
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 1);
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
@@ -612,11 +611,11 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executeGetRequest("sf/_search?pretty", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet_academy"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet_library"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("sf"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("starfleet_academy"));
+        Assert.assertTrue(auditLogImpl.contains("starfleet_library"));
+        Assert.assertTrue(auditLogImpl.contains("starfleet"));
+        Assert.assertTrue(auditLogImpl.contains("sf"));
         Assert.assertEquals(2, TestAuditlogImpl.messages.size());
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
@@ -676,9 +675,9 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             )).getStatusCode()
         );
         Thread.sleep(1000);
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("InternalScrollSearchRequest"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("MISSING_PRIVILEGES"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("InternalScrollSearchRequest"));
+        Assert.assertTrue(auditLogImpl.contains("MISSING_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
@@ -711,10 +710,10 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
         HttpResponse response = rh.executeGetRequest("thealias/_search?pretty", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("thealias"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_trace_resolved_indices"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("vulcangov"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("thealias"));
+        Assert.assertTrue(auditLogImpl.contains("audit_trace_resolved_indices"));
+        Assert.assertTrue(auditLogImpl.contains("vulcangov"));
         Assert.assertEquals(1, TestAuditlogImpl.messages.size());
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
         TestAuditlogImpl.clear();
@@ -740,10 +739,10 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             encodeBasicHeader("admin", "admin")
         );
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("YWRtaW46YWRtaW4"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("BAD_HEADERS"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("xxx"));
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertFalse(auditLogImpl.contains("YWRtaW46YWRtaW4"));
+        Assert.assertTrue(auditLogImpl.contains("BAD_HEADERS"));
+        Assert.assertTrue(auditLogImpl.contains("xxx"));
         Assert.assertEquals(1, TestAuditlogImpl.messages.size());
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
         TestAuditlogImpl.clear();
@@ -774,10 +773,10 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executePostRequest("index2/_close?pretty", "", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:admin/close"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:admin/delete"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.messages.size() >= 2);
+        String auditLogImpl = TestAuditlogImpl.sb.toString();
+        Assert.assertTrue(auditLogImpl.contains("indices:admin/close"));
+        Assert.assertTrue(auditLogImpl.contains("indices:admin/delete"));
+        Assert.assertTrue(auditLogImpl, TestAuditlogImpl.messages.size() >= 2);
         Assert.assertTrue(validateMsgs(TestAuditlogImpl.messages));
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
@@ -106,10 +106,8 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
-
     }
 
     @Test
@@ -152,7 +150,6 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }
@@ -192,7 +189,6 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog-*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -143,7 +143,6 @@ public class SinkProviderTLSTest {
     }
 
     private void assertStringContainsAllKeysAndValues(String in) {
-        System.out.println(in);
         Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
         Assert.assertTrue(in, in.contains(AuditMessage.CATEGORY));
         Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));

--- a/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -19,6 +19,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.concurrent.TimeUnit;
+import java.util.Objects;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
@@ -75,7 +76,7 @@ public class WebhookAuditLogTest {
         MockWebhookAuditLog auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, fallback);
         auditlog.store(msg);
         // Webhook sink has failed ...
-        Assert.assertEquals(null, auditlog.webhookFormat);
+        Assert.assertNull(auditlog.webhookFormat);
         // ... so message must be stored in fallback
         Assert.assertEquals(1, fallback.messages.size());
         Assert.assertEquals(msg, fallback.messages.get(0));
@@ -103,7 +104,7 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
         Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
-        Assert.assertTrue(auditlog.payload, !auditlog.payload.startsWith("{\"text\":"));
+        Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
 
         // provide faulty format, defaults to TEXT
         settings = Settings.builder()
@@ -119,7 +120,7 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
         Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
-        Assert.assertTrue(auditlog.payload, !auditlog.payload.startsWith("{\"text\":"));
+        Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         auditlog.close();
 
         // TEXT
@@ -136,7 +137,7 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
         Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
-        Assert.assertTrue(auditlog.payload, !auditlog.payload.startsWith("{\"text\":"));
+        Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains("audit_request_remote_address"));
 
@@ -152,10 +153,9 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        System.out.println(auditlog.payload);
         Assert.assertEquals(WebhookFormat.JSON, auditlog.webhookFormat);
         Assert.assertEquals(ContentType.APPLICATION_JSON, auditlog.webhookFormat.getContentType());
-        Assert.assertTrue(auditlog.payload, !auditlog.payload.startsWith("{\"text\":"));
+        Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains("audit_request_remote_address"));
 
@@ -193,13 +193,12 @@ public class WebhookAuditLogTest {
             .put("path.home", ".")
             .build();
         LoggingSink fallback = new LoggingSink("test", Settings.EMPTY, null, null);
-        ;
         MockWebhookAuditLog auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, fallback);
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
-        Assert.assertEquals(null, auditlog.url);
-        Assert.assertEquals(null, auditlog.payload);
-        Assert.assertEquals(null, auditlog.webhookUrl);
+        Assert.assertNull(auditlog.url);
+        Assert.assertNull(auditlog.payload);
+        Assert.assertNull(auditlog.webhookUrl);
         // message must be stored in fallback
         Assert.assertEquals(1, fallback.messages.size());
         Assert.assertEquals(msg, fallback.messages.get(0));
@@ -220,7 +219,6 @@ public class WebhookAuditLogTest {
             .build();
 
         LoggingSink fallback = new LoggingSink("test", Settings.EMPTY, null, null);
-        ;
         WebhookSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
@@ -254,12 +252,11 @@ public class WebhookAuditLogTest {
             .build();
 
         LoggingSink fallback = new LoggingSink("test", Settings.EMPTY, null, null);
-        ;
         WebhookSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.startsWith("{\"text\":"));
         assertStringContainsAllKeysAndValues(handler.body);
         // no message stored on fallback
@@ -279,9 +276,8 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
-        System.out.println(handler.body);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertFalse(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
         handler.reset();
@@ -299,8 +295,8 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
         handler.reset();
@@ -318,9 +314,9 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body.equals(""));
-        Assert.assertTrue(!handler.body.contains("{"));
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertEquals("", handler.body);
+        Assert.assertFalse(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(URLDecoder.decode(handler.uri, StandardCharsets.UTF_8.displayName()));
         handler.reset();
 
@@ -337,8 +333,8 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("GET"));
-        Assert.assertEquals(null, handler.body);
+        Assert.assertEquals("GET", handler.method);
+        Assert.assertNull(handler.body);
         assertStringContainsAllKeysAndValues(URLDecoder.decode(handler.uri, StandardCharsets.UTF_8.displayName()));
         server.shutdown(3l, TimeUnit.SECONDS);
     }
@@ -366,13 +362,12 @@ public class WebhookAuditLogTest {
             .build();
 
         LoggingSink fallback = new LoggingSink("test", Settings.EMPTY, null, null);
-        ;
         WebhookSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
-        Assert.assertTrue(handler.method == null);
-        Assert.assertTrue(handler.body == null);
-        Assert.assertTrue(handler.uri == null);
+        Assert.assertNull(handler.method);
+        Assert.assertNull(handler.body);
+        Assert.assertNull(handler.uri);
         // ... so message must be stored in fallback
         Assert.assertEquals(1, fallback.messages.size());
         Assert.assertEquals(msg, fallback.messages.get(0));
@@ -409,7 +404,6 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertNull(handler.method);
         Assert.assertNull(handler.body);
-        Assert.assertNull(handler.body);
         // message must be stored in fallback
         Assert.assertEquals(1, fallback.messages.size());
         Assert.assertEquals(msg, fallback.messages.get(0));
@@ -424,8 +418,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -443,8 +437,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -463,7 +457,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
 
         server.shutdown(3l, TimeUnit.SECONDS);
@@ -501,8 +494,8 @@ public class WebhookAuditLogTest {
             .build();
         AuditLogSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -520,8 +513,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -542,7 +535,6 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertNull(handler.method);
         Assert.assertNull(handler.body);
-        Assert.assertNull(handler.body);
 
         // test default with wrong/no filepath and no fallback to Security settings, must fail
         handler.reset();
@@ -556,7 +548,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
 
         // test default with existing but wrong PEM, no fallback
@@ -574,7 +565,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
 
         // test default with existing but wrong PEM, fallback present but pemtrustedcas_filepath takes precedence and must fail
@@ -596,7 +586,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
         server.shutdown(3l, TimeUnit.SECONDS);
     }
@@ -634,8 +623,8 @@ public class WebhookAuditLogTest {
             .build();
         AuditLogSink auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -653,8 +642,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -674,7 +663,6 @@ public class WebhookAuditLogTest {
         auditlog.store(msg);
         Assert.assertNull(handler.method);
         Assert.assertNull(handler.body);
-        Assert.assertNull(handler.body);
 
         // test default with wrong/no filepath and no fallback to Security settings, must fail
         handler.reset();
@@ -687,7 +675,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
 
         // test default with existing but wrong PEM, no fallback
@@ -705,7 +692,6 @@ public class WebhookAuditLogTest {
         auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
         Assert.assertNull(handler.method);
-        Assert.assertNull(handler.body);
         Assert.assertNull(handler.body);
 
         server.shutdown(3l, TimeUnit.SECONDS);
@@ -745,8 +731,8 @@ public class WebhookAuditLogTest {
 
         AuditLogSink auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertTrue(handler.method.equals("POST"));
-        Assert.assertTrue(handler.body != null);
+        Assert.assertEquals("POST", handler.method);
+        Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
 
@@ -757,13 +743,17 @@ public class WebhookAuditLogTest {
     private SSLContext createSSLContext() throws Exception {
         final TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         final KeyStore trustStore = KeyStore.getInstance("JKS");
-        InputStream trustStream = new FileInputStream(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks").toFile());
+        InputStream trustStream = new FileInputStream(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks")).toFile()
+        );
         trustStore.load(trustStream, "changeit".toCharArray());
         tmf.init(trustStore);
 
         final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         final KeyStore keyStore = KeyStore.getInstance("JKS");
-        InputStream keyStream = new FileInputStream(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks").toFile());
+        InputStream keyStream = new FileInputStream(
+            Objects.requireNonNull(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks")).toFile()
+        );
 
         keyStore.load(keyStream, "changeit".toCharArray());
         kmf.init(keyStore, "changeit".toCharArray());
@@ -774,7 +764,6 @@ public class WebhookAuditLogTest {
     }
 
     private void assertStringContainsAllKeysAndValues(String in) {
-        System.out.println(in);
         Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
         Assert.assertTrue(in, in.contains(AuditMessage.CATEGORY));
         Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));

--- a/src/test/java/org/opensearch/security/cache/CachingTest.java
+++ b/src/test/java/org/opensearch/security/cache/CachingTest.java
@@ -43,13 +43,10 @@ public class CachingTest extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig(), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
@@ -64,13 +61,10 @@ public class CachingTest extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
@@ -88,32 +82,26 @@ public class CachingTest extends SingleClusterTest {
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser2")
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(4, DummyHTTPAuthenticator.getCount());
         Assert.assertEquals(3, DummyAuthorizer.getCount());
         Assert.assertEquals(4, DummyAuthenticationBackend.getAuthCount());
         Assert.assertEquals(2, DummyAuthenticationBackend.getExistsCount());
-
     }
-
 }

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -81,7 +81,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
     protected boolean ccsMinimizeRoundtrips() {
         return false;
-    };
+    }
 
     private static class ClusterTransportClientSettings extends Tuple<Settings, Settings> {
 
@@ -145,7 +145,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         RestHelper rh = new RestHelper(clusterInfo, httpsEnabled, httpsEnabled, getResourceFolder());
         rh.sendAdminCertificate = httpsEnabled;
         rh.keystore = "restapi/kirk-keystore.jks";
-        System.out.println("### " + ch.getClusterName() + " complete ###");
         return new Tuple<>(clusterInfo, rh);
     }
 
@@ -197,45 +196,41 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### query 1");
+        // query 1
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
 
-        System.out.println("###################### query 4");
+        // query 4
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:xx,xx/xx/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(ccs.getBody());
         // TODO fix exception nesting
         // Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, ccs.getStatusCode());
         // Assert.assertTrue(ccs.getBody().contains("Can not filter indices; index cross_cluster_two:xx exists but there is also a remote
         // cluster named: cross_cluster_two"));
 
-        System.out.println("###################### query 5");
+        // query 5
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:abcnonext/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("index_not_found_exception"));
 
-        System.out.println("###################### query 6");
+        // query 6
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
@@ -296,58 +291,52 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### query 1");
+        // query 1
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 2");
+        // query 2
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 3");
+        // query 3
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 4");
+        // query 4
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 5");
+        // query 5
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twutter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 6");
+        // query 6
         String msearchBody = "{}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -358,10 +347,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 7");
+        // query 7
         msearchBody = "{}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -372,68 +360,58 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_all/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth*/_search",
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf", "worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
@@ -441,21 +419,18 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "*:/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
@@ -463,57 +438,49 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
                 + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("#### Alias both");
+        // Alias both
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "notexist,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
         // TODO Fix for 25.0 to resolve coordalias (Indices options)
 
@@ -521,9 +488,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("crusherw", "crusherw")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
-
     }
 
     @Test
@@ -578,54 +543,49 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### query 1");
+        // query 1
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 2");
+        // query 2
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 3");
+        // query 3
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("twutter"));
 
-        System.out.println("###################### query 4");
+        // query 4
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 5");
+        // query 5
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twutter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 6");
+        // query 6
         String msearchBody = "{}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -636,10 +596,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 7");
+        // query 7
         msearchBody = "{}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -650,50 +609,42 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_all/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("#####*");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*,*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
@@ -703,40 +654,34 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "*cross*:*twit*,*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,t*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth*/_search",
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf", "worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
@@ -744,21 +689,18 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "*:/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
@@ -766,56 +708,48 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
                 + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("crusherw", "crusherw")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
     }
 
@@ -843,14 +777,13 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### query 1");
+        // query 1
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
@@ -896,9 +829,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### kibana indices agg");
+        // kibana indices agg
         String dashboardsIndicesAgg = "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "*/_search?pretty",
@@ -1033,9 +966,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### kibana indices agg");
+        // kibana indices agg
         String dashboardsIndicesAgg = "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "*/_search?pretty",
@@ -1164,9 +1097,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### aggs");
+        // aggs
         final String agg = "{\"size\":0,\"aggs\":{\"clusteragg\":{\"terms\":{\"field\":\"cluster.keyword\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "*:*,*/_search?pretty",
@@ -1290,9 +1223,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             ).actionGet();
         }
 
-        HttpResponse ccs = null;
+        HttpResponse ccs;
 
-        System.out.println("###################### aggs");
+        // aggs
         final String agg = "{\"size\":0,\"aggs\":{\"clusteragg\":{\"terms\":{\"field\":\"cluster.keyword\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfound,*/_search?pretty",
@@ -1416,7 +1349,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         assertThat(ccs.getBody(), containsString("Transport client authentication no longer supported"));
     }
@@ -1440,7 +1372,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertThat(ccs.getBody(), not(containsString("security_exception")));
         assertThat(ccs.getBody(), containsString("\"timed_out\" : false"));
@@ -1467,7 +1398,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertThat(ccs.getBody(), not(containsString("security_exception")));
         assertThat(ccs.getBody(), containsString("\"timed_out\" : false"));
@@ -1521,7 +1451,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         OpenSearchSecurityException exception = null;
 
-        System.out.println("###################### with invalid role injection");
+        // with invalid role injection
         // 1. With invalid roles injection
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "invalid_user|invalid_role";
         try (
@@ -1548,7 +1478,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         Assert.assertNotNull(exception);
         Assert.assertTrue(exception.getMessage().contains("no permissions for"));
 
-        System.out.println("###################### with valid role injection");
+        // with valid role injection
         // 2. With valid roles injection
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "valid_user|opendistro_security_all_access";
         try (

--- a/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
@@ -126,18 +126,14 @@ public class RemoteReindexTests extends AbstractSecurityUnitTest {
             + "\"index\": \"twutter\""
             + "}"
             + "}";
-
-        System.out.println(reindex);
-
         HttpResponse ccs = null;
 
-        System.out.println("###################### reindex");
+        // reindex
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "_reindex?pretty",
             reindex,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("created\" : 1"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
@@ -44,7 +44,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
             Thread.sleep(1000);
 
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail(e.toString());
         }
 
@@ -66,7 +65,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
 
         Assert.assertTrue(res.getBody().contains("win 8"));
         Assert.assertTrue(res.getBody().contains("win xp"));
@@ -88,10 +86,9 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
         for (int i = 0; i < 10; i++) {
             Assert.assertEquals(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc1", "password")))
+                rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc1", "password"))
                     .getStatusCode()
             );
-            System.out.println(res.getBody());
         }
 
         for (int i = 0; i < 10; i++) {
@@ -101,7 +98,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
                 (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc", "password")))
                     .getStatusCode()
             );
-            System.out.println(res.getBody());
 
             Assert.assertFalse(res.getBody().contains("\"aaa"));
 
@@ -124,7 +120,7 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
 
             Assert.assertEquals(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+                rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin")).getStatusCode()
             );
 
         }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
@@ -80,7 +80,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}"
             + "}";
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
@@ -104,7 +103,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
@@ -128,12 +126,10 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
         Assert.assertTrue(res.getBody().contains("XXX"));
-
     }
 
     @Test
@@ -217,7 +213,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked_custom", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("cust1"));
@@ -232,7 +227,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         );
         Assert.assertTrue(res.getBody().contains("***.100.1.XXX"));
         Assert.assertTrue(res.getBody().contains("123.123.1.XXX"));
-
     }
 
     @Test
@@ -278,5 +272,4 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("***.100.1.XXX"));
         Assert.assertTrue(res.getBody().contains("123.123.1.XXX"));
     }
-
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
@@ -66,7 +66,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -81,7 +80,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
                 encodeBasicHeader("opendistro_security_logstash", "password")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -102,7 +100,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -114,7 +111,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
                 encodeBasicHeader("opendistro_security_logstash", "password")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -131,7 +127,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -144,7 +139,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -164,7 +158,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -176,7 +169,6 @@ public class DateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
@@ -65,7 +65,6 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
@@ -73,7 +72,6 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }
@@ -88,7 +86,6 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_BAD_REQUEST,
             (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("'now' is not allowed in DLS queries"));
         Assert.assertTrue(res.getBody().contains("error"));
 
@@ -96,7 +93,6 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
@@ -58,13 +58,13 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
             ClusterConfiguration.DEFAULT
         );
         initialize(cl2, cl2Info, new DynamicSecurityConfig().setSecurityRoles(remoteRoles));
-        System.out.println("### cl2 complete ###");
+        // cl2 complete
 
         // cl1 is coordinating
         cl1Info = cl1.startCluster(minimumSecuritySettings(crossClusterNodeSettings(cl2Info)), ClusterConfiguration.DEFAULT);
-        System.out.println("### cl1 start ###");
+        // l1 start
         initialize(cl1, cl1Info, new DynamicSecurityConfig().setSecurityRoles("roles_983.yml"));
-        System.out.println("### cl1 initialized ###");
+        // cl1 initialized
     }
 
     @After
@@ -144,27 +144,27 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
+        // query 1
         // on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:humanresources/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("human_resources_trainee", "password")
         );
-        System.out.println(ccs.getBody());
+        String body = ccs.getBody();
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
-        Assert.assertFalse(ccs.getBody().contains("crl1"));
-        Assert.assertTrue(ccs.getBody().contains("crl2"));
-        Assert.assertTrue(ccs.getBody().contains("\"value\" : 1,\n      \"relation"));
-        Assert.assertFalse(ccs.getBody().contains("CEO"));
-        Assert.assertFalse(ccs.getBody().contains("salary0"));
-        Assert.assertFalse(ccs.getBody().contains("secret0"));
-        Assert.assertTrue(ccs.getBody().contains("someoneelse"));
-        Assert.assertTrue(ccs.getBody().contains("__fn__crl2"));
-        Assert.assertTrue(ccs.getBody().contains("salary1"));
-        Assert.assertFalse(ccs.getBody().contains("secret1"));
-        Assert.assertFalse(ccs.getBody().contains("AnotherSecredField"));
-        Assert.assertFalse(ccs.getBody().contains("xxx1"));
-        Assert.assertEquals(ccs.getHeaders().toString(), 1, ccs.getHeaders().size());
+        Assert.assertFalse(body.contains("crl1"));
+        Assert.assertTrue(body.contains("crl2"));
+        Assert.assertTrue(body.contains("\"value\" : 1,\n      \"relation"));
+        Assert.assertFalse(body.contains("CEO"));
+        Assert.assertFalse(body.contains("salary0"));
+        Assert.assertFalse(body.contains("secret0"));
+        Assert.assertTrue(body.contains("someoneelse"));
+        Assert.assertTrue(body.contains("__fn__crl2"));
+        Assert.assertTrue(body.contains("salary1"));
+        Assert.assertFalse(body.contains("secret1"));
+        Assert.assertFalse(body.contains("AnotherSecredField"));
+        Assert.assertFalse(body.contains("xxx1"));
+        Assert.assertEquals(ccs.getHeaders().toString(), 3, ccs.getHeaders().size());
     }
 
     @Test
@@ -231,13 +231,12 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
+        // query 1
         // on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:humanresources/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("human_resources_trainee", "password")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
@@ -360,13 +359,12 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
+        // query 1
         // on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:humanresources,humanresources/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("human_resources_trainee", "password")
         );
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
@@ -164,7 +164,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
         Assert.assertFalse(body.contains("secret1"));
         Assert.assertFalse(body.contains("AnotherSecredField"));
         Assert.assertFalse(body.contains("xxx1"));
-        Assert.assertEquals(ccs.getHeaders().toString(), 3, ccs.getHeaders().size());
+        Assert.assertEquals(ccs.getHeaders().toString(), 1, ccs.getHeaders().size());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
@@ -88,7 +88,6 @@ public class DlsNestedTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"my_nested_object\" : {"));
         Assert.assertTrue(res.getBody().contains("\"field\" : \"my_nested_object\","));
@@ -96,7 +95,6 @@ public class DlsNestedTest extends AbstractDlsFlsTest {
 
         // Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin",
         // "admin"))).getStatusCode());
-        // System.out.println(res.getBody());
         // Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n \"relation"));
         // Assert.assertTrue(res.getBody().contains("\"value\" : 1510.0"));
         // Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
@@ -66,7 +66,6 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 5,\n      \"relation"));
 
         Assert.assertEquals(
@@ -74,7 +73,6 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
 
         Assert.assertEquals(
@@ -82,7 +80,6 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/prop-mapped/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"amount\" : 6060"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
@@ -21,7 +21,6 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
-import org.opensearch.core.common.Strings;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 public class DlsTest extends AbstractDlsFlsTest {
@@ -46,10 +45,8 @@ public class DlsTest extends AbstractDlsFlsTest {
             Thread.sleep(3000);
         } catch (InterruptedException e) {
             // TODO Auto-generated catch block
-            e.printStackTrace();
         }
-        System.out.println("q");
-        System.out.println(Strings.toString(XContentType.JSON, tc.search(new SearchRequest().indices(".opendistro_security")).actionGet()));
+        tc.search(new SearchRequest().indices(".opendistro_security")).actionGet();
         tc.search(new SearchRequest().indices("deals")).actionGet();
         tc.search(new SearchRequest().indices("terms")).actionGet();
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
@@ -43,7 +43,6 @@ public class Fls983Test extends AbstractDlsFlsTest {
             (res = rh.executePostRequest("/.kibana/_update/0?pretty", doc, encodeBasicHeader("human_resources_trainee", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("updated"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
@@ -79,7 +79,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -96,7 +95,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -113,7 +111,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -130,7 +127,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
@@ -192,7 +192,6 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("user_combined", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("customer"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
@@ -109,7 +109,6 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));
         Assert.assertTrue(res.getBody().contains("response"));
@@ -121,7 +120,6 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("fls_exists", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));
         Assert.assertTrue(res.getBody().contains("c-missing2-0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
@@ -76,7 +76,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
             tc.admin().indices().refresh(new RefreshRequest("deals")).actionGet();
         } catch (IOException e) {
-            e.printStackTrace();
             Assert.fail(e.toString());
         }
 
@@ -140,8 +139,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("field2\""));
         Assert.assertTrue(res.getBody().contains("field50\""));
         Assert.assertTrue(res.getBody().contains("field997\""));
-
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -199,8 +196,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field2\""));
         Assert.assertFalse(res.getBody().contains("field50\""));
         Assert.assertFalse(res.getBody().contains("field997\""));
-
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -258,8 +253,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field2\""));
         Assert.assertFalse(res.getBody().contains("field50\""));
         Assert.assertFalse(res.getBody().contains("field997\""));
-
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -314,7 +307,5 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("field0\""));
         Assert.assertTrue(res.getBody().contains("field50\""));
         Assert.assertTrue(res.getBody().contains("field997\""));
-
-        System.out.println(sw.prettyPrint());
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
@@ -77,7 +77,6 @@ public class FlsTest extends AbstractDlsFlsTest {
                 encodeBasicHeader("dept_manager_fls_reversed_fields", "password")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("customer.name"));
         Assert.assertFalse(res.getBody().contains("zip"));
@@ -120,7 +119,6 @@ public class FlsTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("name"));
         Assert.assertFalse(res.getBody().contains("zip"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
@@ -54,7 +54,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -67,7 +66,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -87,7 +85,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash-2016/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -99,7 +96,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
                 encodeBasicHeader("opendistro_security_logstash", "password")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -116,7 +112,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -129,7 +124,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
                 .getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -149,7 +143,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -161,7 +154,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
@@ -50,7 +50,7 @@ public class MFlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        System.out.println("### normal search");
+        // normal search
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest("deals,finance/_search?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
@@ -75,7 +75,7 @@ public class MFlsTest extends AbstractDlsFlsTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println("### msearch");
+        // msearch
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
@@ -102,7 +102,7 @@ public class MFlsTest extends AbstractDlsFlsTest {
             + "]"
             + "}";
 
-        System.out.println("### mget");
+        // mget
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -75,8 +75,6 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
             .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("restapi/truststore.jks"))
             .put(nodeOverride);
 
-        System.out.println(builder.toString());
-
         setup(Settings.EMPTY, new DynamicSecurityConfig(), builder.build(), init);
         rh = restHelper();
         rh.keystore = "restapi/kirk-keystore.jks";

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
@@ -177,7 +177,6 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", body.get("user_name"));
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());        // check admin user exists
-        System.out.println(response.getBody());
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "admin" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("admin", "admin"));
         assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
@@ -72,9 +72,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         super.tearDown();
         try {
             updateStaticResourceReadonly(Collections.emptyList());
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        } catch (IOException ignored) {}
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
@@ -54,7 +54,6 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/roles");
         Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
         String errorString = response.getBody();
-        System.out.println(errorString);
         Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
 
         // GET roles

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -303,8 +303,6 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
             testCrudScenarios(HttpStatus.SC_OK, nonAdminCredsHeader);
         }
 
-        System.out.println(TestAuditlogImpl.sb.toString());
-
         final Map<AuditCategory, Long> expectedCategoryCounts = ImmutableMap.of(
             AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ,
             4L,

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
@@ -52,15 +52,12 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         rh.sendAdminCertificate = true;
         // check roles exists
         HttpResponse response = rh.executePutRequest(ENDPOINT + "/roles/admin", FileHelper.loadFile("restapi/simple_role.json"));
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         response = rh.executePutRequest(ENDPOINT + "/roles/lala", "{ \"cluster_permissions\": [\"*\"] }");
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         response = rh.executePutRequest(ENDPOINT + "/roles/empty", "{ \"cluster_permissions\": [] }");
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
     }
 
@@ -363,7 +360,6 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", header);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         settings = DefaultObjectMapper.readTree(response.getBody());
         Assert.assertEquals(1, settings.size());
         Assert.assertEquals(
@@ -749,7 +745,6 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         response = rh.executePatchRequest(ENDPOINT + "/roles", createPatchRestAdminPermissionsPayload("add"), restApiHeader);
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
         response = rh.executePatchRequest(ENDPOINT + "/roles", createPatchRestAdminPermissionsPayload("remove"), restApiHeader);
-        System.out.println("RESPONSE: " + response.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
     }
 

--- a/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
@@ -119,13 +119,11 @@ public class MultitenancyTests extends SingleClusterTest {
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         String msearchBody = "{\"index\":\"indexa\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
@@ -135,19 +133,17 @@ public class MultitenancyTests extends SingleClusterTest {
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
-        System.out.println("#### msearch a");
+        // msearch a
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
 
-        System.out.println("#### msearch b");
+        // msearch b
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -162,9 +158,8 @@ public class MultitenancyTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        System.out.println("#### msearch b2");
+        // msearch b2
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        System.out.println(resc.getBody());
         Assert.assertEquals(200, resc.getStatusCode());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
@@ -226,49 +221,41 @@ public class MultitenancyTests extends SingleClusterTest {
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_NOT_FOUND,
             (resc = rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_FORBIDDEN,
             (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
         );
-        System.out.println(resc.getBody());
 
     }
 
@@ -311,7 +298,6 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("hr_employee", "hr_employee")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertEquals(".kibana_1592542611_humanresources_1", DefaultObjectMapper.readTree(res.getBody()).get("_index").asText());
 
         Assert.assertEquals(
@@ -322,14 +308,12 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("hr_employee", "hr_employee")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(WildcardMatcher.from("*human_resources*").test(res.getBody()));
 
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest(".kibana_1592542611_humanresources_1/_alias", encodeBasicHeader("admin", "admin"))).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertNotNull(
             DefaultObjectMapper.readTree(res.getBody())
                 .get(".kibana_1592542611_humanresources_1")
@@ -369,7 +353,7 @@ public class MultitenancyTests extends SingleClusterTest {
 
         final RestHelper rh = nonSslRestHelper();
 
-        System.out.println("#### search");
+        // search
         HttpResponse res;
         String body = "{\"query\" : {\"term\" : { \"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}}}";
         Assert.assertEquals(
@@ -381,13 +365,12 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### msearch");
+        // msearch
         body = "{\"index\":\".kibana\", \"ignore_unavailable\": false}"
             + System.lineSeparator()
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
@@ -402,13 +385,12 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### get");
+        // get
         Assert.assertEquals(
             HttpStatus.SC_OK,
             (res = rh.executeGetRequest(
@@ -417,13 +399,12 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### mget");
+        // mget
         body = "{\"docs\" : [{\"_index\" : \".kibana\",\"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}]}";
         Assert.assertEquals(
             HttpStatus.SC_OK,
@@ -434,12 +415,11 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### index");
+        // index
         body = "{"
             + "\"type\" : \"index-pattern\","
             + "\"updated_at\" : \"2017-09-29T08:56:59.066Z\","
@@ -455,12 +435,11 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("\"result\" : \"created\""));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### bulk");
+        // bulk
         body = "{ \"index\" : { \"_index\" : \".kibana\", \"_id\" : \"b1\" } }"
             + System.lineSeparator()
             + "{ \"field1\" : \"value1\" }"
@@ -479,7 +458,6 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("admin", "admin")
             )).getStatusCode()
         );
-        // System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
         Assert.assertTrue(res.getBody().contains("\"errors\" : false"));
@@ -525,8 +503,6 @@ public class MultitenancyTests extends SingleClusterTest {
             (res = rh.executeGetRequest(".kibana/_doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode()
         );
 
-        System.out.println(res.getBody());
-
     }
 
     @Test
@@ -565,7 +541,6 @@ public class MultitenancyTests extends SingleClusterTest {
                 encodeBasicHeader("kibanaro", "kibanaro")
             )).getStatusCode()
         );
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains(".kibana_-900636979_kibanaro"));
     }
 

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -124,7 +124,6 @@ public class OpenSSLTest extends SSLTest {
 
         // Set<String> openSSLAvailCiphers = new
         // HashSet<>(OpenSsl.availableCipherSuites());
-        // System.out.println("OpenSSL available ciphers: "+openSSLAvailCiphers);
         // ECDHE-RSA-AES256-SHA, ECDH-ECDSA-AES256-SHA, DH-DSS-DES-CBC-SHA,
         // ADH-AES256-SHA256, ADH-CAMELLIA128-SHA
 
@@ -135,7 +134,6 @@ public class OpenSSLTest extends SSLTest {
             }
         }
 
-        System.out.println("OpenSSL secure ciphers: " + openSSLSecureCiphers);
         Assert.assertTrue(openSSLSecureCiphers.size() > 0);
     }
 

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -110,18 +110,18 @@ public class SSLTest extends SingleClusterTest {
         rh.sendAdminCertificate = true;
         rh.keystore = "node-untspec5-keystore.p12";
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true"));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true").contains("EMAILADDRESS=unt@tst.com")
-        );
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true").contains("local_certificates_list"));
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true");
+        Assert.assertTrue(res.contains("EMAILADDRESS=unt@tst.com"));
+        Assert.assertTrue(res.contains("local_certificates_list"));
         Assert.assertFalse(
             rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=false").contains("local_certificates_list")
         );
         Assert.assertFalse(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("local_certificates_list"));
-        Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/settings?pretty").contains("\"opendistro_security\""));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/settings?pretty").contains("keystore_filepath"));
+
+        res = rh.executeSimpleRequest("_nodes/settings?pretty");
+        Assert.assertTrue(res.contains(clusterInfo.clustername));
+        Assert.assertFalse(res.contains("\"opendistro_security\""));
+        Assert.assertFalse(res.contains("keystore_filepath"));
         // Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
 
     }
@@ -130,8 +130,6 @@ public class SSLTest extends SingleClusterTest {
     public void testCipherAndProtocols() throws Exception {
 
         Security.setProperty("jdk.tls.disabledAlgorithms", "");
-        System.out.println("Disabled algos: " + Security.getProperty("jdk.tls.disabledAlgorithms"));
-        System.out.println("allowOpenSSL: " + allowOpenSSL);
 
         Settings settings = Settings.builder()
             .put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED, false)
@@ -226,15 +224,6 @@ public class SSLTest extends SingleClusterTest {
                 Assert.assertEquals("SSL_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
             }
         } catch (OpenSearchSecurityException e) {
-            System.out.println(
-                "EXPECTED "
-                    + e.getClass().getSimpleName()
-                    + " for "
-                    + System.getProperty("java.specification.version")
-                    + ": "
-                    + e.toString()
-            );
-            e.printStackTrace();
             Assert.assertTrue(
                 "Check if error contains 'no valid cipher suites' -> " + e.toString(),
                 e.toString().contains("no valid cipher suites")
@@ -273,13 +262,13 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/settings?pretty").contains("\"opendistro_security\""));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
+
+        res = rh.executeSimpleRequest("_nodes/settings?pretty");
+        Assert.assertTrue(res.contains(clusterInfo.clustername));
+        Assert.assertFalse(res.contains("\"opendistro_security\""));
     }
 
     @Test
@@ -323,17 +312,15 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
-        Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_count\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_count\" : 0"));
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
+        String res2 = rh.executeSimpleRequest("_nodes/settings?pretty");
+        Assert.assertTrue(res2.contains(clusterInfo.clustername));
+        Assert.assertFalse(res2.contains("\"tx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res2.contains("\"rx_count\" : 0"));
+        Assert.assertFalse(res2.contains("\"rx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res2.contains("\"tx_count\" : 0"));
 
     }
 
@@ -377,14 +364,11 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         // Assert.assertTrue(!executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("null"));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
     }
 
     @Test
@@ -430,12 +414,10 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
     }
 
     @Test
@@ -485,14 +467,11 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         // Assert.assertTrue(!executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("null"));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
     }
 
     @Test
@@ -585,8 +564,6 @@ public class SSLTest extends SingleClusterTest {
             setupSslOnlyMode(settings);
             Assert.fail();
         } catch (Exception e1) {
-            e1.printStackTrace();
-            System.out.println("##1 " + e1.toString());
             Throwable e = ExceptionUtils.getRootCause(e1);
             Assert.assertTrue(e.toString(), e.toString().contains("no valid cipher"));
         }
@@ -621,7 +598,6 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = false;
 
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         Assert.assertTrue(
             rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
@@ -656,7 +632,6 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = false;
 
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         Assert.assertFalse(
             rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
@@ -696,10 +671,8 @@ public class SSLTest extends SingleClusterTest {
             Assert.fail();
         } catch (SocketException | SSLException e) {
             // expected
-            System.out.println("Expected SSLHandshakeException " + e.toString());
         } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail("Unexpected exception " + e.toString());
+            Assert.fail("Unexpected exception " + e);
         }
     }
 
@@ -733,7 +706,6 @@ public class SSLTest extends SingleClusterTest {
         rh.sendAdminCertificate = false;
         rh.enableHTTPClientSSLv3Only = true;
 
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
     }
 
@@ -785,10 +757,12 @@ public class SSLTest extends SingleClusterTest {
             Assert.assertEquals(4, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
         }
 
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_count\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_count\" : 0"));
+        String res = rh.executeSimpleRequest("_nodes/stats?pretty");
+
+        Assert.assertFalse(res.contains("\"tx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_count\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"tx_count\" : 0"));
     }
 
     @Test
@@ -804,7 +778,6 @@ public class SSLTest extends SingleClusterTest {
         // example
         // TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
         // TLS_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-        System.out.println("JDK enabled ciphers: " + jdkEnabledCiphers);
         Assert.assertTrue(jdkEnabledCiphers.size() > 0);
     }
 
@@ -1029,10 +1002,11 @@ public class SSLTest extends SingleClusterTest {
             Assert.assertEquals(4, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
         }
 
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_count\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_count\" : 0"));
+        String res = rh.executeSimpleRequest("_nodes/stats?pretty");
+        Assert.assertFalse(res.contains("\"tx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_count\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"tx_count\" : 0"));
     }
 
     @Test
@@ -1119,17 +1093,16 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
-        Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_count\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_count\" : 0"));
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
+
+        res = rh.executeSimpleRequest("_nodes/stats?pretty");
+        Assert.assertTrue(res.contains(clusterInfo.clustername));
+        Assert.assertFalse(res.contains("\"tx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_count\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"tx_count\" : 0"));
 
     }
 
@@ -1186,17 +1159,16 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
-        Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_count\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"rx_size_in_bytes\" : 0"));
-        Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_count\" : 0"));
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
+
+        res = rh.executeSimpleRequest("_nodes/settings?pretty");
+        Assert.assertTrue(res.contains(clusterInfo.clustername));
+        Assert.assertFalse(res.contains("\"tx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_count\" : 0"));
+        Assert.assertFalse(res.contains("\"rx_size_in_bytes\" : 0"));
+        Assert.assertFalse(res.contains("\"tx_count\" : 0"));
 
     }
 
@@ -1301,12 +1273,9 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
-        Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
+        String res = rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
+        Assert.assertTrue(res.contains("TLS"));
+        Assert.assertTrue(res.contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE"));
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
-        Assert.assertTrue(
-            rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE")
-        );
     }
 }

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -101,12 +101,11 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
     protected static boolean withRemoteCluster;
 
     static {
+        final Logger log = LogManager.getLogger(AbstractSecurityUnitTest.class);
 
-        System.out.println(
-            "OS: " + System.getProperty("os.name") + " " + System.getProperty("os.arch") + " " + System.getProperty("os.version")
-        );
-        System.out.println("Java Version: " + System.getProperty("java.version") + " " + System.getProperty("java.vendor"));
-        System.out.println(
+        log.info("OS: " + System.getProperty("os.name") + " " + System.getProperty("os.arch") + " " + System.getProperty("os.version"));
+        log.info("Java Version: " + System.getProperty("java.version") + " " + System.getProperty("java.vendor"));
+        log.info(
             "JVM Impl.: "
                 + System.getProperty("java.vm.version")
                 + " "
@@ -114,10 +113,10 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
                 + " "
                 + System.getProperty("java.vm.name")
         );
-        System.out.println("Open SSL available: " + OpenSsl.isAvailable());
-        System.out.println("Open SSL version: " + OpenSsl.versionString());
+        log.info("Open SSL available: " + OpenSsl.isAvailable());
+        log.info("Open SSL version: " + OpenSsl.versionString());
         withRemoteCluster = Boolean.parseBoolean(System.getenv("TESTARG_unittests_with_remote_cluster"));
-        System.out.println("With remote cluster: " + withRemoteCluster);
+        log.info("With remote cluster: " + withRemoteCluster);
         // System.setProperty("security.display_lic_none","true");
     }
 

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -169,7 +169,7 @@ public final class ClusterHelper {
         freePorts.stream().skip(internalNodeSettings.size()).limit(internalNodeSettings.size()).forEach(el -> httpPorts.add(el));
         final Iterator<Integer> httpPortsIt = httpPorts.iterator();
 
-        System.out.println(
+        log.info(
             "tcpClusterManagerPorts: "
                 + tcpClusterManagerPortsOnly
                 + "/tcpAllPorts: "
@@ -213,7 +213,6 @@ public final class ClusterHelper {
                 settingsForNode = nodeSettingsBuilder.build();
             }
             PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode, settingsForNode, setting.getPlugins());
-            System.out.println(node.settings());
 
             new Thread(new Runnable() {
 
@@ -223,7 +222,6 @@ public final class ClusterHelper {
                         node.start();
                         latch.countDown();
                     } catch (Exception e) {
-                        e.printStackTrace();
                         log.error("Unable to start node: ", e);
                         err.set(e);
                         latch.countDown();
@@ -253,14 +251,12 @@ public final class ClusterHelper {
                 settingsForNode = nodeSettingsBuilder.build();
             }
             PluginAwareNode node = new PluginAwareNode(setting.clusterManagerNode, settingsForNode, setting.getPlugins());
-            System.out.println(node.settings());
 
             new Thread(() -> {
                 try {
                     node.start();
                     latch.countDown();
                 } catch (Exception e) {
-                    e.printStackTrace();
                     log.error("Unable to start node: ", e);
                     err.set(e);
                     latch.countDown();

--- a/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/file/FileHelper.java
@@ -172,8 +172,6 @@ public class FileHelper {
 
             br.close();
             fw.close();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        } catch (IOException ignored) {}
     }
 }

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -400,16 +400,6 @@ public class RestHelper {
                 + "]";
         }
 
-        private static void findArrayAccessor(String input) {
-            final Pattern r = Pattern.compile("(.+?)\\[(\\d+)\\]");
-            final Matcher m = r.matcher(input);
-            if (m.find()) {
-                System.out.println("'" + input + "'\t Name was: " + m.group(1) + ",\t index position: " + m.group(2));
-            } else {
-                System.out.println("'" + input + "'\t No Match");
-            }
-        }
-
         /**
          * Given a json path with dots delimiated returns the object at the leaf
          */

--- a/src/test/java/org/opensearch/security/test/helper/rules/SecurityTestWatcher.java
+++ b/src/test/java/org/opensearch/security/test/helper/rules/SecurityTestWatcher.java
@@ -26,17 +26,21 @@
 
 package org.opensearch.security.test.helper.rules;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 public class SecurityTestWatcher extends TestWatcher {
+
+    protected final Logger log = LogManager.getLogger(this.getClass());
 
     @Override
     protected void starting(final Description description) {
         final String methodName = description.getMethodName();
         String className = description.getClassName();
         className = className.substring(className.lastIndexOf('.') + 1);
-        System.out.println("---------------- Starting JUnit-test: " + className + " " + methodName + " ----------------");
+        log.info("---------------- Starting JUnit-test: " + className + " " + methodName + " ----------------");
     }
 
     @Override
@@ -44,12 +48,12 @@ public class SecurityTestWatcher extends TestWatcher {
         final String methodName = description.getMethodName();
         String className = description.getClassName();
         className = className.substring(className.lastIndexOf('.') + 1);
-        System.out.println(">>>> " + className + " " + methodName + " FAILED due to " + e);
+        log.info(">>>> " + className + " " + methodName + " FAILED due to " + e);
     }
 
     @Override
     protected void finished(final Description description) {
-        // System.out.println("-----------------------------------------------------------------------------------------");
+        // do nothing
     }
 
 }


### PR DESCRIPTION
Backports #3231.

Needed manual backport because of http5 imports and server `shutdown` (2.x) vs `awaitTermination` (main) method calls in test.

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
