### PR TITLE
Retry code coverage upload on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,15 @@ jobs:
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
     - name: Coverage
-      uses: codecov/codecov-action@v3
+      uses: Wandalen/wretry.action@v1.3.0
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./build/reports/jacoco/test/jacocoTestReport.xml
+        attempt_limit: 3
+        attempt_delay: 2000
+        action: codecov/codecov-action@v3
+        with: |
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
 
     - uses: actions/upload-artifact@v3
       if: always()


### PR DESCRIPTION
### Description
Noticed in several results of
https://github.com/opensearch-project/security/actions/runs/5978371801/job/16220344142?pr=3123 that the code coverage upload had failed silently, and the annotations make it look like many tests were not executed.  Since in this job there were 9 failures at the same time, adding retry mechanism as well to prevent blind restarting of workflows.

### Additional background
Solution sourced from this stackoverflow question "How to automatically retry github action jobs on failure?" [1]
- [1] https://stackoverflow.com/questions/71574593/how-to-automatically-retry-github-action-jobs-on-failure

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
