### PR TITLE
[Refactor] Remove json-path from deps and use JsonPointer instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,10 +507,6 @@ dependencies {
     //Password generation
     implementation 'org.passay:passay:1.6.3'
 
-    //JSON path
-    implementation 'com.jayway.jsonpath:json-path:2.8.0'
-    implementation 'net.minidev:json-smart:2.5.0'
-
     implementation "org.apache.kafka:kafka-clients:${kafka_version}"
 
     runtimeOnly 'net.minidev:accessors-smart:2.5.0'

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
@@ -137,7 +136,7 @@ public class AuditApiAction extends AbstractApiAction {
     private final List<String> readonlyFields;
 
     public static class AuditRequestContentValidator extends RequestContentValidator {
-        private static final Set<AuditCategory> DISABLED_REST_CATEGORIES = ImmutableSet.of(
+        public static final Set<AuditCategory> DISABLED_REST_CATEGORIES = Set.of(
             AuditCategory.BAD_HEADERS,
             AuditCategory.SSL_EXCEPTION,
             AuditCategory.AUTHENTICATED,
@@ -146,7 +145,7 @@ public class AuditApiAction extends AbstractApiAction {
             AuditCategory.MISSING_PRIVILEGES
         );
 
-        private static final Set<AuditCategory> DISABLED_TRANSPORT_CATEGORIES = ImmutableSet.of(
+        public static final Set<AuditCategory> DISABLED_TRANSPORT_CATEGORIES = Set.of(
             AuditCategory.BAD_HEADERS,
             AuditCategory.SSL_EXCEPTION,
             AuditCategory.AUTHENTICATED,

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import org.junit.Test;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.auditlog.config.AuditConfig;
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.compliance.ComplianceConfig;
+import org.opensearch.security.util.FakeRestRequest;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class AuditApiActionRequestContentValidatorTest extends AbstractApiActionValidationTest {
+
+    @Test
+    public void validateAuditDisabledRestCategories() throws IOException {
+        InjectableValues.Std injectableValues = new InjectableValues.Std();
+        injectableValues.addValue(Settings.class, Settings.EMPTY);
+        DefaultObjectMapper.inject(injectableValues);
+        final var auditApiActionRequestContentValidator = new AuditApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+
+        final var disabledTransportCategories = AuditApiAction.AuditRequestContentValidator.DISABLED_TRANSPORT_CATEGORIES.stream()
+            .map(Enum::name)
+            .collect(Collectors.toList());
+        final var auditConfig = new AuditConfig(
+            true,
+            AuditConfig.Filter.from(Map.of("disabled_rest_categories", disabledTransportCategories)),
+            ComplianceConfig.DEFAULT
+        );
+        final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
+        var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
+        assertFalse(result.isValid());
+        assertEquals(RestStatus.BAD_REQUEST, result.status());
+    }
+
+    @Test
+    public void validateAuditDisabledTransportCategories() throws IOException {
+        InjectableValues.Std injectableValues = new InjectableValues.Std();
+        injectableValues.addValue(Settings.class, Settings.EMPTY);
+        DefaultObjectMapper.inject(injectableValues);
+        final var auditApiActionRequestContentValidator = new AuditApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+
+        final var disabledRestCategories = Stream.of(AuditCategory.COMPLIANCE_DOC_WRITE, AuditCategory.COMPLIANCE_DOC_READ)
+            .map(Enum::name)
+            .collect(Collectors.toList());
+        final var auditConfig = new AuditConfig(
+            true,
+            AuditConfig.Filter.from(Map.of("disabled_transport_categories", disabledRestCategories)),
+            ComplianceConfig.DEFAULT
+        );
+        final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
+        var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
+        assertFalse(result.isValid());
+        assertEquals(RestStatus.BAD_REQUEST, result.status());
+    }
+}

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionRequestContentValidatorTest.java
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.security.util.FakeRestRequest;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class RolesApiActionRequestContentValidatorTest extends AbstractApiActionValidationTest {
+
+    @Test
+    public void doesNotValidateMaskedFields() throws IOException {
+
+        final var requestContentValidator = new RolesApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+
+        // no masked fields
+        final var noMaskedFields = objectMapper.createObjectNode()
+            .set(
+                "index_permissions",
+                objectMapper.createArrayNode()
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("a*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("b*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .set("allowed_actions", objectMapper.createArrayNode().add("write"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("c*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read").add("write"))
+
+                    )
+            );
+
+        var result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(noMaskedFields.toString())).build()
+        );
+        assertTrue(result.isValid());
+        result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(noMaskedFields.toString())).build(),
+            noMaskedFields
+        );
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void validateOnlySpecifiedMaskedFields() throws IOException {
+        final var requestContentValidator = new RolesApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+        final var specifiedMaskedFields = objectMapper.createObjectNode()
+            .set(
+                "index_permissions",
+                objectMapper.createArrayNode()
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("a*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .<ObjectNode>set("masked_fields", objectMapper.nullNode())
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("b*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .set("allowed_actions", objectMapper.createArrayNode().add("write"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("c*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .<ObjectNode>set("masked_fields", objectMapper.createArrayNode().add("aaa::").add("bbb"))
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read").add("write"))
+
+                    )
+            );
+        var result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(specifiedMaskedFields.toString())).build()
+        );
+        assertFalse(result.isValid());
+        var errorMessage = xContentToJsonNode(result.errorMessage());
+        assertTrue(errorMessage.toString(), errorMessage.toString().contains("aaa::"));
+
+        result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(specifiedMaskedFields.toString())).build(),
+            specifiedMaskedFields
+        );
+        assertFalse(result.isValid());
+        errorMessage = xContentToJsonNode(result.errorMessage());
+        assertTrue(errorMessage.toString(), errorMessage.toString().contains("aaa::"));
+    }
+
+    @Test
+    public void validateAllMaskedFields() throws IOException {
+        final var requestContentValidator = new RolesApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+        final var invalidMaskedFields = objectMapper.createObjectNode()
+            .set(
+                "index_permissions",
+                objectMapper.createArrayNode()
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("a*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .<ObjectNode>set("masked_fields", objectMapper.createArrayNode().add("aaa").add("bbb"))
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("b*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .<ObjectNode>set("masked_fields", objectMapper.createArrayNode().add("aaa::").add("bbb::").add("ccc:::"))
+                            .set("allowed_actions", objectMapper.createArrayNode().add("write"))
+                    )
+                    .add(
+                        objectMapper.createObjectNode()
+                            .<ObjectNode>set("index_patterns", objectMapper.createArrayNode().add("c*"))
+                            .put("dls", "")
+                            .<ObjectNode>set("fls", objectMapper.createArrayNode())
+                            .<ObjectNode>set("masked_fields", objectMapper.createArrayNode().add("ddd::").add("eee"))
+                            .set("allowed_actions", objectMapper.createArrayNode().add("read").add("write"))
+
+                    )
+            );
+        var result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(invalidMaskedFields.toString())).build()
+        );
+        assertFalse(result.isValid());
+        var errorMessage = xContentToJsonNode(result.errorMessage()).toString();
+        assertTrue(errorMessage, errorMessage.contains("aaa::"));
+        assertTrue(errorMessage, errorMessage.contains("bbb::"));
+        assertTrue(errorMessage, errorMessage.contains("ccc:::"));
+        assertTrue(errorMessage, errorMessage.contains("ddd::"));
+
+        result = requestContentValidator.validate(
+            FakeRestRequest.builder().withContent(new BytesArray(invalidMaskedFields.toString())).build(),
+            invalidMaskedFields
+        );
+        assertFalse(result.isValid());
+        errorMessage = xContentToJsonNode(result.errorMessage()).toString();
+        assertTrue(errorMessage, errorMessage.contains("aaa::"));
+        assertTrue(errorMessage, errorMessage.contains("bbb::"));
+        assertTrue(errorMessage, errorMessage.contains("ccc:::"));
+        assertTrue(errorMessage, errorMessage.contains("ddd::"));
+    }
+}


### PR DESCRIPTION
### Description
After RFC 6901 was introduced
and the implementation was added to Jackson,
there is no need to keep the `com.jayway.jsonpath:json-path` library in our source code,
so we can replace current validation with Jackson's `JsonPointer` class.

Besides added missing tests for:
 - `RoleRequestContentValidator`
 - `AuditRequestContentValidator`

### Issues Resolved
https://github.com/opensearch-project/security/issues/3245

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
