### PR TITLE
Support security config updates on the REST API using permission

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -15,6 +15,7 @@ security_rest_api_full_access:
   cluster_permissions:
     - 'restapi:admin/actiongroups'
     - 'restapi:admin/allowlist'
+    - 'restapi:admin/config/update'
     - 'restapi:admin/internalusers'
     - 'restapi:admin/nodesdn'
     - 'restapi:admin/roles'

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -27,33 +27,6 @@
 package org.opensearch.security;
 
 // CS-SUPPRESS-SINGLE: RegexpSingleline Extensions manager used to allow/disallow TLS connections to extensions
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.LinkOption;
-import java.nio.file.Path;
-import java.nio.file.attribute.PosixFilePermission;
-import java.security.AccessController;
-import java.security.MessageDigest;
-import java.security.PrivilegedAction;
-import java.security.Security;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import org.apache.logging.log4j.LogManager;
@@ -61,13 +34,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
-import org.opensearch.core.action.ActionResponse;
 import org.opensearch.action.search.PitService;
 import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.support.ActionFilter;
@@ -80,7 +51,6 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.common.lifecycle.Lifecycle;
 import org.opensearch.common.lifecycle.LifecycleComponent;
 import org.opensearch.common.lifecycle.LifecycleListener;
-import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.network.NetworkModule;
 import org.opensearch.common.network.NetworkService;
@@ -93,14 +63,18 @@ import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.common.util.BigArrays;
 import org.opensearch.common.util.PageCacheRecycler;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.index.Index;
 import org.opensearch.core.indices.breaker.CircuitBreakerService;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
 import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.HttpServerTransport.Dispatcher;
-import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexModule;
 import org.opensearch.index.cache.query.QueryCache;
 import org.opensearch.indices.IndicesService;
@@ -111,7 +85,6 @@ import org.opensearch.plugins.MapperPlugin;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.script.ScriptService;
 import org.opensearch.search.internal.InternalScrollSearchRequest;
 import org.opensearch.search.internal.ReaderContext;
@@ -140,6 +113,7 @@ import org.opensearch.security.configuration.DlsFlsValveImpl;
 import org.opensearch.security.configuration.PrivilegesInterceptorImpl;
 import org.opensearch.security.configuration.Salt;
 import org.opensearch.security.configuration.SecurityFlsDlsIndexSearcherWrapper;
+import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.security.dlic.rest.api.SecurityRestApiActions;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.filter.SecurityFilter;
@@ -190,10 +164,42 @@ import org.opensearch.transport.TransportInterceptor;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportRequestOptions;
-import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.TransportService;
 import org.opensearch.watcher.ResourceWatcherService;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.AccessController;
+import java.security.MessageDigest;
+import java.security.PrivilegedAction;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
+import static org.opensearch.security.setting.DeprecatedSettings.checkForDeprecatedSetting;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION;
 // CS-ENFORCE-SINGLE
 
 public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
@@ -332,20 +338,23 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             sm.checkPermission(new SpecialPermission());
         }
 
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            @Override
-            public Object run() {
-                if (Security.getProvider("BC") == null) {
-                    Security.addProvider(new BouncyCastleProvider());
-                }
-                return null;
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            if (Security.getProvider("BC") == null) {
+                Security.addProvider(new BouncyCastleProvider());
             }
+            return null;
         });
 
         final String advancedModulesEnabledKey = ConfigConstants.SECURITY_ADVANCED_MODULES_ENABLED;
         if (settings.hasValue(advancedModulesEnabledKey)) {
             deprecationLogger.deprecate("Setting {} is ignored.", advancedModulesEnabledKey);
         }
+
+        checkForDeprecatedSetting(
+            settings,
+            SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION,
+            ENDPOINTS_WITH_PERMISSIONS.get(Endpoint.CONFIG).build(SECURITY_CONFIG_UPDATE) + " permission"
+        );
 
         log.info("Clustername: {}", settings.get("cluster.name", "opensearch"));
 
@@ -1788,7 +1797,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             );
             settings.add(
                 Setting.boolSetting(
-                    ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION,
+                    SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION,
                     false,
                     Property.NodeScope,
                     Property.Filtered

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAdminPrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAdminPrivilegesEvaluator.java
@@ -35,9 +35,11 @@ public class RestApiAdminPrivilegesEvaluator {
 
     protected final Logger logger = LogManager.getLogger(RestApiAdminPrivilegesEvaluator.class);
 
-    public final static String CERTS_INFO_ACTION = "certs";
+    public final static String CERTS_INFO_ACTION = "certs/info";
 
-    public final static String RELOAD_CERTS_ACTION = "reloadcerts";
+    public final static String RELOAD_CERTS_ACTION = "certs/reload";
+
+    public final static String SECURITY_CONFIG_UPDATE = "update";
 
     private final static String REST_API_PERMISSION_PREFIX = "restapi:admin";
 
@@ -61,21 +63,13 @@ public class RestApiAdminPrivilegesEvaluator {
     public final static Map<Endpoint, PermissionBuilder> ENDPOINTS_WITH_PERMISSIONS = ImmutableMap.<Endpoint, PermissionBuilder>builder()
         .put(Endpoint.ACTIONGROUPS, action -> buildEndpointPermission(Endpoint.ACTIONGROUPS))
         .put(Endpoint.ALLOWLIST, action -> buildEndpointPermission(Endpoint.ALLOWLIST))
+        .put(Endpoint.CONFIG, action -> buildEndpointActionPermission(Endpoint.CONFIG, action))
         .put(Endpoint.INTERNALUSERS, action -> buildEndpointPermission(Endpoint.INTERNALUSERS))
         .put(Endpoint.NODESDN, action -> buildEndpointPermission(Endpoint.NODESDN))
         .put(Endpoint.ROLES, action -> buildEndpointPermission(Endpoint.ROLES))
         .put(Endpoint.ROLESMAPPING, action -> buildEndpointPermission(Endpoint.ROLESMAPPING))
         .put(Endpoint.TENANTS, action -> buildEndpointPermission(Endpoint.TENANTS))
-        .put(Endpoint.SSL, action -> {
-            switch (action) {
-                case CERTS_INFO_ACTION:
-                    return buildEndpointActionPermission(Endpoint.SSL, "certs/info");
-                case RELOAD_CERTS_ACTION:
-                    return buildEndpointActionPermission(Endpoint.SSL, "certs/reload");
-                default:
-                    return null;
-            }
-        })
+        .put(Endpoint.SSL, action -> buildEndpointActionPermission(Endpoint.SSL, action))
         .build();
 
     private final ThreadContext threadContext;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
@@ -86,10 +86,8 @@ public class SecurityConfigApiAction extends AbstractApiAction {
         switch (request.method()) {
             case PATCH:
             case PUT:
-                if (!allowPutOrPatch && !restApiAdminEnabled) {
-                    return false;
-                } else if (allowPutOrPatch && !restApiAdminEnabled) {
-                    return true;
+                if (!restApiAdminEnabled) {
+                    return allowPutOrPatch;
                 } else {
                     return securityApiDependencies.restApiAdminPrivilegesEvaluator()
                         .isCurrentUserAdminFor(endpoint, SECURITY_CONFIG_UPDATE);

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -95,7 +95,7 @@ public class SecurityRestApiActions {
             new AllowlistApiAction(Endpoint.ALLOWLIST, clusterService, threadPool, securityApiDependencies),
             new AuditApiAction(clusterService, threadPool, securityApiDependencies),
             new MultiTenancyConfigApiAction(clusterService, threadPool, securityApiDependencies),
-            new SecuritySSLCertsAction(clusterService, threadPool, securityKeyStore, certificatesReloadEnabled, securityApiDependencies)
+            new SecuritySSLCertsApiAction(clusterService, threadPool, securityKeyStore, certificatesReloadEnabled, securityApiDependencies)
         );
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
@@ -13,29 +13,32 @@ package org.opensearch.security.dlic.rest.api;
 
 import org.junit.Test;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.security.util.FakeRestRequest;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION;
 
 public class SecurityConfigApiActionValidationTest extends AbstractApiActionValidationTest {
 
     @Test
-    public void withAllowedEndpoint() {
-        var securityConfigApiAction = new SecurityConfigApiAction(
+    public void accessHandlerForDefaultSettings() {
+        final var securityConfigApiAction = new SecurityConfigApiAction(
             clusterService,
             threadPool,
             new SecurityApiDependencies(null, configurationRepository, null, null, restApiAdminPrivilegesEvaluator, null, Settings.EMPTY)
         );
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertFalse(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertFalse(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
+    }
 
-        var result = securityConfigApiAction.withAllowedEndpoint(FakeRestRequest.builder().build());
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_IMPLEMENTED, result.status());
-
-        securityConfigApiAction = new SecurityConfigApiAction(
+    @Test
+    public void accessHandlerForUnsupportedSetting() {
+        final var securityConfigApiAction = new SecurityConfigApiAction(
             clusterService,
             threadPool,
             new SecurityApiDependencies(
@@ -45,11 +48,32 @@ public class SecurityConfigApiActionValidationTest extends AbstractApiActionVali
                 null,
                 restApiAdminPrivilegesEvaluator,
                 null,
-                Settings.builder().put(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build()
+                Settings.builder().put(SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build()
             )
         );
-        result = securityConfigApiAction.withAllowedEndpoint(FakeRestRequest.builder().build());
-        assertTrue(result.isValid());
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
     }
 
+    @Test
+    public void accessHandlerForRestAdmin() {
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.CONFIG, RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE)).thenReturn(true);
+        final var securityConfigApiAction = new SecurityConfigApiAction(
+                clusterService,
+                threadPool,
+                new SecurityApiDependencies(
+                        null,
+                        configurationRepository,
+                        null,
+                        null,
+                        restApiAdminPrivilegesEvaluator,
+                        null,
+                        Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build()
+                )
+        );
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
+    }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api;
+
+import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.util.FakeRestRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RELOAD_CERTS_ACTION;
+
+public class SecuritySSLCertsApiActionValidationTest extends AbstractApiActionValidationTest {
+
+    @Test
+    public void withSecurityKeyStore() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        final var result = securitySSLCertsApiAction.withSecurityKeyStore();
+        assertFalse(result.isValid());
+        assertEquals(RestStatus.OK, result.status());
+    }
+
+    @Test
+    public void accessDenied() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, CERTS_INFO_ACTION)).thenReturn(false);
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, RELOAD_CERTS_ACTION)).thenReturn(false);
+        assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+
+        for (final var m : RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS) {
+            if (m != RestRequest.Method.GET && m != RestRequest.Method.PUT) {
+                assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(m).build()));
+            }
+        }
+    }
+
+    @Test
+    public void hasAccess() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, CERTS_INFO_ACTION)).thenReturn(true);
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, RELOAD_CERTS_ACTION)).thenReturn(true);
+        assertTrue(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+
+        for (final var m : RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS) {
+            if (m != RestRequest.Method.GET && m != RestRequest.Method.PUT) {
+                assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(m).build()));
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
@@ -54,7 +54,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         return PLUGINS_PREFIX;
     }
 
-    final int USER_SETTING_SIZE = 7 * 19; // Lines per account entry * number of accounts
+    final int USER_SETTING_SIZE = 7 * 20; // Lines per account entry * number of accounts
 
     private static final String ENABLED_SERVICE_ACCOUNT_BODY = "{"
         + " \"attributes\": { \"service\": \"true\", "
@@ -98,7 +98,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/" + CType.INTERNALUSERS.toLCString());
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(133, settings.size());
+        Assert.assertEquals(USER_SETTING_SIZE, settings.size());
         response = rh.executePatchRequest(
             ENDPOINT + "/internalusers",
             "[{ \"op\": \"add\", \"path\": \"/newuser\", "
@@ -153,7 +153,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendAdminCertificate = true;
         final int SERVICE_ACCOUNTS_IN_SETTINGS = 1;
-        final int INTERNAL_ACCOUNTS_IN_SETTINGS = 19;
+        final int INTERNAL_ACCOUNTS_IN_SETTINGS = 20;
         final String serviceAccountName = "JohnDoeService";
         HttpResponse response;
 
@@ -845,7 +845,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh.executeGetRequest("_plugins/_security/api/" + CType.INTERNALUSERS.toLCString());
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(133, settings.size());
+        Assert.assertEquals(USER_SETTING_SIZE, settings.size());
 
         addUserWithPassword(
             "admin",

--- a/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsTest.java
+++ b/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsTest.java
@@ -183,7 +183,7 @@ public class SecurityRolesPermissionsTest {
 
     @Test
     public void hasExplicitClusterPermissionPermissionForRestAdmin() {
-        // verify all endpoint except SSL
+        // verify all endpoint except SSL and verify CONFIG endpoints
         final Collection<Endpoint> noSslEndpoints = ENDPOINTS_WITH_PERMISSIONS.keySet()
             .stream()
             .filter(e -> e != Endpoint.SSL && e != Endpoint.CONFIG)

--- a/src/test/resources/restapi/internal_users.yml
+++ b/src/test/resources/restapi/internal_users.yml
@@ -127,3 +127,9 @@ rest_api_admin_tenants:
   hidden: false
   backend_roles: []
   description: "REST API Tenats admin user"
+rest_api_admin_config_update:
+  hash: "$2y$12$capXg1HNP49Vxeb6ijzRnu5BLMUE0ZePq1l3MhF8tjnuxg614uaY6"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  description: "REST API Config update admin user"

--- a/src/test/resources/restapi/roles.yml
+++ b/src/test/resources/restapi/roles.yml
@@ -398,6 +398,7 @@ rest_api_admin_full_access:
   cluster_permissions:
     - 'restapi:admin/actiongroups'
     - 'restapi:admin/allowlist'
+    - 'restapi:admin/config/update'
     - 'restapi:admin/internalusers'
     - 'restapi:admin/nodesdn'
     - 'restapi:admin/roles'
@@ -441,3 +442,7 @@ rest_api_admin_tenants_only:
   reserved: true
   cluster_permissions:
     - 'restapi:admin/tenants'
+rest_api_admin_config_update_only:
+  reserved: true
+  cluster_permissions:
+    - 'restapi:admin/config/update'

--- a/src/test/resources/restapi/roles_mapping.yml
+++ b/src/test/resources/restapi/roles_mapping.yml
@@ -195,6 +195,7 @@ opendistro_security_test:
   - "rest_api_admin_tenants"
   - "rest_api_admin_ssl_info"
   - "rest_api_admin_ssl_reloadcerts"
+  - "rest_api_admin_config_update"
   and_backend_roles: []
   description: "Migrated from v6"
 opendistro_security_role_starfleet_captains:
@@ -260,3 +261,7 @@ rest_api_admin_tenants_only:
   reserved: false
   hidden: true
   users: [rest_api_admin_tenants]
+rest_api_admin_config_update_only:
+  reserved: false
+  hidden: true
+  users: [rest_api_admin_config_update]


### PR DESCRIPTION
### Description
Instead of setting `SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION` settings to update security configuration using `PATCH` or `PUT` a new permission was added: `restapi:admin/config/update`.

So far I decided to keep this flag as it is due to a backward compatibility and log a deprecation message that these settings will be removed in the future. Maybe it is better to remove it completely.

Besides, added the missed test for `SecurityConfigApiAction`

### Issues Resolved
https://github.com/opensearch-project/security/issues/2577

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
