### PR TITLE
Skip role immutable check for Roles Mappings APIs

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -89,9 +89,7 @@ public class RolesMappingApiAction extends AbstractApiAction {
 
             private ValidationResult<SecurityConfiguration> validateRoleForMapping(final SecurityConfiguration securityConfiguration)
                 throws IOException {
-                return loadConfiguration(CType.ROLES, false, false).map(
-                    rolesConfiguration -> validateRoles(List.of(securityConfiguration.entityName()), rolesConfiguration)
-                ).map(ignore -> ValidationResult.success(securityConfiguration));
+                return loadConfiguration(CType.ROLES, false, false).map(ignore -> ValidationResult.success(securityConfiguration));
             }
 
             @Override

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
@@ -58,27 +58,4 @@ public class RolesMappingApiActionValidationTest extends AbstractApiActionValida
          assertEquals(RestStatus.FORBIDDEN, result.status());
     }
 
-    @Test
-    public void onConfigChangeShouldCheckRoles() throws Exception {
-        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.ROLESMAPPING)).thenReturn(false);
-        when(restApiAdminPrivilegesEvaluator.containsRestApiAdminPermissions(any(Object.class))).thenCallRealMethod();
-        when(configurationRepository.getConfigurationsFromIndex(List.of(CType.ROLES), false))
-                .thenReturn(Map.of(CType.ROLES, rolesConfiguration));
-        final var rolesApiActionEndpointValidator =
-                new RolesMappingApiAction(clusterService, threadPool,
-                        securityApiDependencies).createEndpointValidator();
-
-        // no role
-        var result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("aaa", configuration));
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_FOUND, result.status());
-        //reserved role is not ok
-        result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("kibana_read_only", configuration));
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
-        //just regular_role
-        result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("regular_role", configuration));
-        assertTrue(result.isValid());
-    }
-
 }


### PR DESCRIPTION
### Description

@willyborankin I'm opening up a Draft PR that fixes this issue locally, but wanted to get your input too. There are security-dashboards-tests failing because they cannot clean up test data by using the patch API to modify the `all_access` roles mapping and the request fails with this error:

```
> curl -XPATCH https://admin:admin@localhost:9200/_plugins/_security/api/rolesmapping/all_access --insecure -H "Content-Type: application/json" --data '
[
        {
        "op": "remove",
        "path": "/users",
        "users": ["jwt_test"]
        }
]
'
{"status":"FORBIDDEN","message":"Resource 'all_access' is static."}
```

I believe the fix is to skip the `validateRoles` check on the RolesMapping API. Essentially roles can be static or hidden, but roles mappings cannot be. Any roles mapping is editable.

Test failures seen on this PR: https://github.com/opensearch-project/security-dashboards-plugin/pull/1568
Example integ test run with test failures: https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/6031350472/job/16364885321?pr=1568

This failure is related to the recent change to refactor the REST APIs: https://github.com/opensearch-project/security/pull/3123

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
