### PR TITLE
[BUG] Fix roles verification for roles mapping and internal users

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -84,11 +84,12 @@ public class RolesMappingApiAction extends AbstractApiAction {
 
             @Override
             public ValidationResult<SecurityConfiguration> onConfigChange(SecurityConfiguration securityConfiguration) throws IOException {
-                return EndpointValidator.super.onConfigChange(securityConfiguration).map(this::validateRoleForMapping);
+                return EndpointValidator.super.onConfigChange(securityConfiguration).map(this::validateRole);
             }
 
-            private ValidationResult<SecurityConfiguration> validateRoleForMapping(final SecurityConfiguration securityConfiguration)
+            private ValidationResult<SecurityConfiguration> validateRole(final SecurityConfiguration securityConfiguration)
                 throws IOException {
+                // check here that role is not hidden for the mapping
                 return loadConfiguration(CType.ROLES, false, false).map(
                     rolesConfiguration -> validateRoles(List.of(securityConfiguration.entityName()), rolesConfiguration)
                 ).map(ignore -> ValidationResult.success(securityConfiguration));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
@@ -78,12 +78,13 @@ public abstract class AbstractApiActionValidationTest {
         final var config = objectMapper.createObjectNode();
         config.set("_meta", objectMapper.createObjectNode().put("type", CType.ROLES.toLCString()).put("config_version", 2));
         config.set("kibana_read_only", objectMapper.createObjectNode().put("reserved", true));
+        config.set("some_hidden_role", objectMapper.createObjectNode().put("hidden", true));
+        config.set("all_access", objectMapper.createObjectNode().put("static", true)); // it reserved as well
         config.set("security_rest_api_access", objectMapper.createObjectNode().put("reserved", true));
 
         final var array = objectMapper.createArrayNode();
         restApiAdminPermissions().forEach(array::add);
         config.set("rest_api_admin_role", objectMapper.createObjectNode().set("cluster_permissions", array));
-
         config.set("regular_role", objectMapper.createObjectNode().set("cluster_permissions", objectMapper.createArrayNode().add("*")));
 
         rolesConfiguration = SecurityDynamicConfiguration.fromJson(objectMapper.writeValueAsString(config), CType.ROLES, 2, 1, 1);

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
@@ -72,13 +72,19 @@ public class RolesMappingApiActionValidationTest extends AbstractApiActionValida
         var result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("aaa", configuration));
         assertFalse(result.isValid());
         assertEquals(RestStatus.NOT_FOUND, result.status());
-        //reserved role is not ok
+        //static role is ok
+        result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("all_access", configuration));
+        assertTrue(result.isValid());
+        //reserved role is ok
         result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("kibana_read_only", configuration));
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertTrue(result.isValid());
         //just regular_role
         result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("regular_role", configuration));
         assertTrue(result.isValid());
+        //hidden role is not ok
+        result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("some_hidden_role", configuration));
+        assertFalse(result.isValid());
+        assertEquals(RestStatus.NOT_FOUND, result.status());
     }
 
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
@@ -28,6 +28,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -268,7 +269,7 @@ public class EndpointValidatorTest {
     }
 
     @Test
-    public void validateRolesForAdmin() {
+    public void validateRolesForAdmin() throws IOException {
         configureRoles(true);
         final var expectedResultForRoles = List.of(
             Triple.of("valid_role", true, RestStatus.OK),
@@ -287,12 +288,12 @@ public class EndpointValidatorTest {
     }
 
     @Test
-    public void validateRolesForRegularUser() {
+    public void validateRolesForRegularUser() throws IOException {
         configureRoles(false);
         final var expectedResultForRoles = List.of(
             Triple.of("valid_role", true, RestStatus.OK),
-            Triple.of("reserved_role", false, RestStatus.FORBIDDEN),
-            Triple.of("static_role", false, RestStatus.FORBIDDEN),
+            Triple.of("reserved_role", true, RestStatus.OK),
+            Triple.of("static_role", true, RestStatus.OK),
             Triple.of("hidden_role", false, RestStatus.NOT_FOUND),
             Triple.of("non_existing_role", false, RestStatus.NOT_FOUND)
         );
@@ -315,17 +316,12 @@ public class EndpointValidatorTest {
 
         when(configuration.exists("static_role")).thenReturn(true);
         when(configuration.isHidden("static_role")).thenReturn(false);
-        when(configuration.isStatic("static_role")).thenReturn(true);
 
         when(configuration.exists("reserved_role")).thenReturn(true);
         when(configuration.isHidden("reserved_role")).thenReturn(false);
-        when(configuration.isStatic("reserved_role")).thenReturn(false);
-        when(configuration.isReserved("reserved_role")).thenReturn(true);
 
         when(configuration.exists("valid_role")).thenReturn(true);
         when(configuration.isHidden("valid_role")).thenReturn(false);
-        when(configuration.isStatic("valid_role")).thenReturn(false);
-        when(configuration.isReserved("valid_role")).thenReturn(false);
     }
 
     @Test


### PR DESCRIPTION
### Description
The resent refactoring of the REST APIs: https://github.com/opensearch-project/security/pull/3123 introduce a regression in how roles-mapping verification has worked before. 
The old solution verified only hidden roles both for internal users and roles mapping, while new was too strict and forbid to do it for both.

This PR fixes the problem and uses the same logic as it was before. 

- In case of roles-mapping it verifies only a role associated with it that the role is not hidden.      
- In case of internal users it verifies that a role is not hidden and roles-mapping associated with the role is mutable

So verification was split and added to the corresponding ActionApi class which is more convenient as it was before.

Tests for such functionality were added as well.  
 
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
