### PR TITLE
Fix permissions issues while reading keys in PKCS#1 format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -486,7 +486,7 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.5.0'
-    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
+    implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
 
     //JWT
@@ -567,7 +567,7 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.3'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.36.0'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
+    runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -486,7 +486,7 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.5.0'
-    implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
+    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
 
     //JWT
@@ -567,7 +567,7 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.3'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.36.0'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
+    runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 

--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -37,7 +37,6 @@ grant {
   permission java.util.PropertyPermission "*","read,write";
 
   //Enable when we switch to UnboundID LDAP SDK
-  //permission java.util.PropertyPermission "*", "read,write";
   //permission java.lang.RuntimePermission "setFactory";
   //permission javax.net.ssl.SSLPermission "setHostnameVerifier";
 
@@ -60,11 +59,12 @@ grant {
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
   permission java.security.SecurityPermission "removeProviderProperty.BC";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   
   permission java.security.SecurityPermission "org.apache.xml.security.register";
-  permission java.util.PropertyPermission "org.apache.xml.security.ignoreLineBreaks", "write";
   
   permission java.lang.RuntimePermission "createClassLoader";
   

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -972,12 +972,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
             final SslContextBuilder _sslContextBuilder = AccessController.doPrivileged(new PrivilegedExceptionAction<SslContextBuilder>() {
                 @Override
                 public SslContextBuilder run() throws Exception {
-                    return configureSSLServerContextBuilder(
-                            SslContextBuilder.forServer(_key, _cert),
-                            sslProvider,
-                            ciphers,
-                            authMode
-                    );
+                    return configureSSLServerContextBuilder(SslContextBuilder.forServer(_key, _cert), sslProvider, ciphers, authMode);
                 }
             });
 
@@ -987,7 +982,11 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
             return buildSSLContext0(_sslContextBuilder);
         } catch (final PrivilegedActionException e) {
-            throw (SSLException) e.getCause();
+            if (e.getCause() instanceof SSLException) {
+                throw (SSLException) e.getCause();
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -1010,12 +1009,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
             final SslContextBuilder _sslContextBuilder = AccessController.doPrivileged(new PrivilegedExceptionAction<SslContextBuilder>() {
                 @Override
                 public SslContextBuilder run() throws Exception {
-                    return configureSSLServerContextBuilder(
-                            SslContextBuilder.forServer(_cert, _key, pwd),
-                            sslProvider,
-                            ciphers,
-                            authMode
-                    );
+                    return configureSSLServerContextBuilder(SslContextBuilder.forServer(_cert, _key, pwd), sslProvider, ciphers, authMode);
                 }
             });
 
@@ -1025,7 +1019,11 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
 
             return buildSSLContext0(_sslContextBuilder);
         } catch (final PrivilegedActionException e) {
-            throw (SSLException) e.getCause();
+            if (e.getCause() instanceof SSLException) {
+                throw (SSLException) e.getCause();
+            } else {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -1118,7 +1116,11 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
                 }
             });
         } catch (final PrivilegedActionException e) {
-            throw (SSLException) e.getCause();
+            if (e.getCause() instanceof SSLException) {
+                throw (SSLException) e.getCause();
+            } else {
+                throw new RuntimeException(e);
+            }
         }
 
         return sslContext;

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -976,7 +976,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
                 }
             });
 
-            if (_trustedCerts != null) {
+            if (_trustedCerts != null && _trustedCerts.length > 0) {
                 _sslContextBuilder.trustManager(_trustedCerts);
             }
 


### PR DESCRIPTION
### Description

Netty has logic to use the BouncyCastlePemReader if BouncyCastle is located on the class path. The BouncyCastle provider loaded properly in netty, but was failing to read the private key with permissions issues that failed silently. With netty, if one PemReader fails they will fall back to the next which is only capable of reading keys in the PKCS#8 format. 

The regression in PKCS#1 keys happened when bouncycastle was upgraded from jdk15on to jdk15to18.

This PR adds permissions to ensure that netty can read the PKCS#1 keys.

This PR also cleans up the policy file to have a single entry for `permission java.util.PropertyPermission "*","read,write";` because the other entries are redundant.

Open Questions:

- There is a test in SSLTest to ensure PKCS#1 keys can be read. Why did that test not catch this?

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/3281

### Testing

Used the same certs from the SSLTest for PKCS#1 keys. Before the change the 2.9.0 cluster could not be brought up, after the change the cluster starts successfully.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
