### PR TITLE
Commands GET `cat/aliases` and POST `_rollover` will work on specified indices

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -116,7 +116,7 @@ public class DoNotFailOnForbiddenTests {
                 "indices:data/read/scroll",
                 "indices:monitor/settings/get",
                 "indices:monitor/stats",
-                    "indices:admin/aliases/get"
+                "indices:admin/aliases/get"
             )
             .on(MARVELOUS_SONGS)
     );
@@ -435,7 +435,7 @@ public class DoNotFailOnForbiddenTests {
             // High level client doesn't support _cat/_indices API
             Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
             List<String> aliases = new BufferedReader(new InputStreamReader(getAliasesResponse.getEntity().getContent())).lines()
-                    .collect(Collectors.toList());
+                .collect(Collectors.toList());
 
             // Does not fail on forbidden, but alias response only contains index which user has access to
             assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -108,7 +108,8 @@ public class PrivilegesEvaluator {
             "indices:admin/shards/search_shards",
             "indices:admin/resolve/index",
             "indices:monitor/settings/get",
-            "indices:monitor/stats"
+            "indices:monitor/stats",
+            "indices:admin/aliases/get"
         )
     );
 


### PR DESCRIPTION
### Description
Updates Get Aliases Request and Rollover to correctly look at the indices specified for these requests. This means that they will now work when a user has access to some specified set of indices, whereas before they would fail unless a user had permissions on all indices.

### Issues Resolved
#1861 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
