### PR TITLE
Security Plugin cannot startup due to AccessControlException: access denied

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -56,11 +56,6 @@ grant {
   permission java.net.NetPermission "getProxySelector";
   permission java.net.SocketPermission "*", "connect,accept,resolve";
 
-  // BouncyCastle permissions
-  permission java.security.SecurityPermission "putProviderProperty.BC";
-  permission java.security.SecurityPermission "insertProvider.BC";
-  permission java.security.SecurityPermission "removeProviderProperty.BC";
-
   permission java.lang.RuntimePermission "accessUserInformation";
   
   permission java.security.SecurityPermission "org.apache.xml.security.register";

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -35,7 +35,6 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.PrivilegedAction;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -60,7 +59,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.Weight;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
@@ -330,16 +328,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         if (sm != null) {
             sm.checkPermission(new SpecialPermission());
         }
-
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            @Override
-            public Object run() {
-                if (Security.getProvider("BC") == null) {
-                    Security.addProvider(new BouncyCastleProvider());
-                }
-                return null;
-            }
-        });
 
         final String advancedModulesEnabledKey = ConfigConstants.SECURITY_ADVANCED_MODULES_ENABLED;
         if (settings.hasValue(advancedModulesEnabledKey)) {


### PR DESCRIPTION

### Description
Fixing AccessControlException after https://github.com/opensearch-project/OpenSearch/pull/9289, we have 2 options here:
 1. since the `bcprov` moved to core, it will be loaded by core, the plugin should not try to enforce it
 2. plugin may try to enforce it but the core security policy should be extended to allow that

```
grant codeBase "${codebase.bcprov-jdk15to18}" {
  permission java.security.SecurityPermission "putProviderProperty.BC";
  permission java.security.SecurityPermission "insertProvider.BC";
  permission java.security.SecurityPermission "removeProviderProperty.BC";
};
```


* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/3309

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Covered by existing tests

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
