### PR TITLE
[Backport 2.x] bump com.diffplug.spotless to 6.21.0 and com.github.wnameless.json:json-base to 2.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.20.0'
+    id 'com.diffplug.spotless' version '6.21.0'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.3.0"
     id "org.gradle.test-retry" version "1.5.4"
@@ -496,7 +496,7 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"
     implementation "io.jsonwebtoken:jjwt-jackson:${jjwt_version}"
     // JSON flattener
-    implementation ("com.github.wnameless.json:json-base:2.4.1") {
+    implementation ("com.github.wnameless.json:json-base:2.4.2") {
         exclude group: "org.glassfish", module: "jakarta.json"
         exclude group: "com.google.code.gson", module: "gson"
         exclude group: "org.json", module: "json"


### PR DESCRIPTION
Manual backports of https://github.com/opensearch-project/security/pull/3295 and https://github.com/opensearch-project/security/pull/3293 to 2.x

The automatic backport PRs are stale and I don't have a way to update them via Github UI.

- https://github.com/opensearch-project/security/pull/3298
- https://github.com/opensearch-project/security/pull/3304