### PR TITLE
Disable codecov from failing CI if there is an upload issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         action: codecov/codecov-action@v3
         with: |
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           files: ./build/reports/jacoco/test/jacocoTestReport.xml
 
     - uses: actions/upload-artifact@v3


### PR DESCRIPTION
### Description
Seeing a ton of CI failures due to code coverage upload failures.  I'd like to fix this - but I'd rather keep the builds flowing in until we have a better solution.

E.g: https://github.com/opensearch-project/security/actions/runs/6153593099/job/16697726519?pr=3339

- Related https://github.com/opensearch-project/security/issues/2649

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
