### PR TITLE
[Refactor] Change HTTP routes for Audit and Config PUT methods  

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -309,8 +309,13 @@ public abstract class AbstractApiAction extends BaseRestHandler {
     }
 
     protected final ValidationResult<SecurityConfiguration> processPutRequest(final RestRequest request) throws IOException {
-        return endpointValidator.withRequiredEntityName(nameParam(request))
-            .map(entityName -> loadConfigurationWithRequestContent(entityName, request))
+        return processPutRequest(nameParam(request), request);
+    }
+
+    protected final ValidationResult<SecurityConfiguration> processPutRequest(final String entityName, final RestRequest request)
+        throws IOException {
+        return endpointValidator.withRequiredEntityName(entityName)
+            .map(ignore -> loadConfigurationWithRequestContent(entityName, request))
             .map(endpointValidator::onConfigChange)
             .map(this::addEntityToConfig);
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
@@ -11,12 +11,7 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 import com.google.common.collect.ImmutableList;
-
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -32,8 +27,11 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import static org.opensearch.security.dlic.rest.api.RequestHandler.methodNotImplementedHandler;
-import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;
 import static org.opensearch.security.dlic.rest.api.Responses.methodNotImplementedMessage;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
@@ -43,7 +41,7 @@ public class SecurityConfigApiAction extends AbstractApiAction {
 
     private static final List<Route> allRoutes = new ImmutableList.Builder<Route>().addAll(getRoutes)
         .addAll(
-            addRoutesPrefix(ImmutableList.of(new Route(Method.PUT, "/securityconfig/{name}"), new Route(Method.PATCH, "/securityconfig/")))
+            addRoutesPrefix(ImmutableList.of(new Route(Method.PUT, "/securityconfig/config"), new Route(Method.PATCH, "/securityconfig/")))
         )
         .build();
 
@@ -72,10 +70,13 @@ public class SecurityConfigApiAction extends AbstractApiAction {
         return CType.CONFIG;
     }
 
+    @Override
+    protected void consumeParameters(RestRequest request) {}
+
     private void securityConfigApiActionRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {
         requestHandlersBuilder.onChangeRequest(
             Method.PUT,
-            request -> withAllowedEndpoint(request).map(this::withConfigEntityNameOnly).map(ignore -> processPutRequest(request))
+            request -> withAllowedEndpoint(request).map(ignore -> processPutRequest("config", request))
         )
             .onChangeRequest(Method.PATCH, request -> withAllowedEndpoint(request).map(this::processPatchRequest))
             .override(Method.DELETE, methodNotImplementedHandler)
@@ -87,14 +88,6 @@ public class SecurityConfigApiAction extends AbstractApiAction {
             return ValidationResult.error(RestStatus.NOT_IMPLEMENTED, methodNotImplementedMessage(request.method()));
         }
         return ValidationResult.success(request);
-    }
-
-    ValidationResult<String> withConfigEntityNameOnly(final RestRequest request) {
-        final var name = nameParam(request);
-        if (!"config".equals(name)) {
-            return ValidationResult.error(RestStatus.BAD_REQUEST, badRequestMessage("name must be config"));
-        }
-        return ValidationResult.success(name);
     }
 
     @Override

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
@@ -20,7 +20,6 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.util.FakeRestRequest;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -49,17 +48,6 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
             final var result = auditApiAction.withEnabledAuditApi(FakeRestRequest.builder().withMethod(m).build());
             assertTrue(result.isValid());
         }
-    }
-
-    @Test
-    public void configEntityNameOnly() {
-        final var auditApiAction = new AuditApiAction(clusterService, threadPool, securityApiDependencies);
-        var result = auditApiAction.withConfigEntityNameOnly(FakeRestRequest.builder().withParams(Map.of("name", "aaaaa")).build());
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
-
-        result = auditApiAction.withConfigEntityNameOnly(FakeRestRequest.builder().withParams(Map.of("name", "config")).build());
-        assertTrue(result.isValid());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionTest.java
@@ -24,14 +24,14 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
-public class SecurityConfigApiTest extends AbstractRestApiUnitTest {
+public class SecurityConfigApiActionTest extends AbstractRestApiUnitTest {
     private final String ENDPOINT;
 
     protected String getEndpointPrefix() {
         return PLUGINS_PREFIX;
     }
 
-    public SecurityConfigApiTest() {
+    public SecurityConfigApiActionTest() {
         ENDPOINT = getEndpointPrefix() + "/api";
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
@@ -17,26 +17,11 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.util.FakeRestRequest;
 
-import java.util.Map;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class SecurityConfigApiActionValidationTest extends AbstractApiActionValidationTest {
-
-    @Test
-    public void configEntityNameOnly() {
-        final var securityConfigApiAction = new SecurityConfigApiAction(clusterService, threadPool, securityApiDependencies);
-        var result = securityConfigApiAction.withConfigEntityNameOnly(
-            FakeRestRequest.builder().withParams(Map.of("name", "aaaaa")).build()
-        );
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
-
-        result = securityConfigApiAction.withConfigEntityNameOnly(FakeRestRequest.builder().withParams(Map.of("name", "config")).build());
-        assertTrue(result.isValid());
-    }
 
     @Test
     public void withAllowedEndpoint() {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/legacy/LegacySecurityConfigApiActionTests.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/legacy/LegacySecurityConfigApiActionTests.java
@@ -11,11 +11,11 @@
 
 package org.opensearch.security.dlic.rest.api.legacy;
 
-import org.opensearch.security.dlic.rest.api.SecurityConfigApiTest;
+import org.opensearch.security.dlic.rest.api.SecurityConfigApiActionTest;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 
-public class LegacySecurityConfigApiTests extends SecurityConfigApiTest {
+public class LegacySecurityConfigApiActionTests extends SecurityConfigApiActionTest {
     @Override
     protected String getEndpointPrefix() {
         return LEGACY_OPENDISTRO_PREFIX;


### PR DESCRIPTION
### Description
Change routs for audit and security configuration PUT methods. 
The previous configuration used the `{name}` parameter which is confusing since `config` the only allowed value for this parameter. This PR changes routes' configuration and removes useless validation for them.  

Note: We do not need to change documentation for endpoints and keep backward compatibility. e.g. Audit endpoint  https://opensearch.org/docs/latest/security/access-control/api/#audit-logs

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
