### PR TITLE
Change log message from warning to trace on WWW-Authenticate challenge

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -283,8 +283,7 @@ public class BackendRegistry {
                 if (authDomain.isChallenge() && httpAuthenticator.reRequestAuthentication(channel, null)) {
                     auditLog.logFailedLogin("<NONE>", false, null, request);
                     if (isTraceEnabled) {
-                        log.trace(
-                            "No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                        log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                     }
                     return false;
                 } else {

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -282,7 +282,10 @@ public class BackendRegistry {
 
                 if (authDomain.isChallenge() && httpAuthenticator.reRequestAuthentication(channel, null)) {
                     auditLog.logFailedLogin("<NONE>", false, null, request);
-                    log.warn("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                    if (isTraceEnabled) {
+                        log.trace(
+                            "No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                    }
                     return false;
                 } else {
                     // no reRequest possible


### PR DESCRIPTION
### Description
Change warning message No 'Basic Authorization' header, send 401 and 'WWW-Authenticate Basic' to trace

### Issues Resolved
- Resolves #3273

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
