### PR TITLE
[Backport 2.x] dependabot: bump aws-actions/configure-aws-credentials from 3 to 4

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
Backport bec360afd7973c7acff8e92e34906d241c72affd from #3370 