### PR TITLE
[Backport 2.x] dependabot: bump org.apache.ws.xmlschema:xmlschema-core from 2.3.0 to 2.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -566,7 +566,7 @@ dependencies {
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.2.1'
     runtimeOnly "org.glassfish.jaxb:txw2:${jaxb_version}"
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.5.1'
-    runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.2.5'
+    runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.1'
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.3'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.36.0'


### PR DESCRIPTION
Backport 283c3be8244dff5d6efc19ec10e82e81098dee4f from #3368 