### PR TITLE
Re-enables gradle build cache

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -33,9 +33,8 @@ runs:
         path: ${{ inputs.plugin-branch }}
 
     - name: Build
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: assemble
         build-root-directory: ${{ inputs.plugin-branch }}
 

--- a/.github/actions/run-bwc-suite/action.yaml
+++ b/.github/actions/run-bwc-suite/action.yaml
@@ -37,9 +37,8 @@ runs:
         plugin-branch: ${{ inputs.plugin-next-branch }}
 
     - name: Run BWC tests
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: |
           bwcTestSuite
           -Dtests.security.manager=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,9 +53,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build and Test
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: |
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
@@ -101,12 +100,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build and Test
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       continue-on-error: true # Until retries are enable do not fail the workflow https://github.com/opensearch-project/security/issues/2184
       with:
-        cache-disabled: true
-        arguments: |
-          integrationTest -Dbuild.snapshot=false
+        arguments: integrationTest -Dbuild.snapshot=false
 
   backward-compatibility:
     strategy:

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -24,9 +24,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: spotlessCheck
 
   checkstyle:
@@ -40,9 +39,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: checkstyleMain checkstyleTest
 
   spotbugs:
@@ -56,9 +54,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: spotbugsMain
 
   check-permissions-order:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -26,9 +26,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Assemble target plugin
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: assemble
 
       # Move and rename the plugin for installation
@@ -59,7 +58,6 @@ jobs:
           setup-script-name: setup
 
       - name: Run sanity tests
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=admin


### PR DESCRIPTION
### Description
Uses https://github.com/marketplace/actions/gradle-cache to replace `gradle-build-action`.

### Issues Resolved
- Resolves #3185 


### Testing
Passing CI

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
