### PR TITLE
[Backport 2.x] dependabot: bump org.springframework:spring-core from 5.3.29 to 5.3.30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -607,7 +607,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.3'
-    testRuntimeOnly ('org.springframework:spring-core:5.3.27') {
+    testRuntimeOnly ('org.springframework:spring-core:5.3.30') {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.11'


### PR DESCRIPTION
Backport https://github.com/opensearch-project/security/commit/b52e762bc449f67d5332a9702040c0f18b2eb986 from https://github.com/opensearch-project/security/pull/3390