### PR TITLE
[Backport 2.x] dependabot: bump org.gradle.test-retry from 1.5.4 to 1.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.21.0'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.3.0"
-    id "org.gradle.test-retry" version "1.5.4"
+    id "org.gradle.test-retry" version "1.5.5"
     id 'eclipse'
     id "com.github.spotbugs" version "5.1.3"
     id "com.google.osdetector" version "1.7.3"


### PR DESCRIPTION
Backport https://github.com/opensearch-project/security/commit/9caa098a52c1e155889d70a80127f92b25ac8a35 from https://github.com/opensearch-project/security/pull/3391