### PR TITLE
[Backport] [2.x] dependabot: bump com.google.errorprone:error_prone_annotations from 2.21.1 to 2.22.0 (#3393)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -524,7 +524,7 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.16.0'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.5'
-    runtimeOnly 'com.google.errorprone:error_prone_annotations:2.20.0'
+    runtimeOnly 'com.google.errorprone:error_prone_annotations:2.22.0'
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.0'
     runtimeOnly 'org.ow2.asm:asm:9.5'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3393 to `2.x