### PR TITLE
[Backport 1.x] Fix permissions issues while reading keys in PKCS#1 format

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -65,6 +65,8 @@ grant {
   permission java.security.SecurityPermission "insertProvider.BC";
   permission java.security.SecurityPermission "removeProviderProperty.BC";
   permission java.util.PropertyPermission "jdk.tls.rejectClientInitiatedRenegotiation", "write";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   


### PR DESCRIPTION
Backport to 1.x from #3289

We did not do it, while 1.x version has the same problem as 2.x branch. Moved only permissions.
