### PR TITLE
Allow for automatic merging of dependabot changes after checks pass

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -1,0 +1,31 @@
+name: automatic-merges
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Plugin Install
+      - Code Hygiene
+    types: completed
+
+jobs:
+  automatic-merge-version-bumps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: find-triggering-pr
+        uses: peternied/find-triggering-pr@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: peternied/discerning-merger@v1
+        if: steps.find-triggering-pr.outputs.pr-number != null
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
+          allowed-authors: |
+            dependabot%5Bbot%5D
+          allowed-files: |
+            build.gradle
+            .github/workflows/*.yml


### PR DESCRIPTION
### Description
Allow for automatic merging of dependabot changes after checks pass

### Issues Resolved
- Related https://github.com/opensearch-project/OpenSearch/issues/10211

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
