### PR TITLE
Refactors reRequestAuthentication to call notifyIpAuthFailureListener before sending the response to the channel

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/IpBruteForceAttacksPreventionWithDomainChallengeTests.java
+++ b/src/integrationTest/java/org/opensearch/security/IpBruteForceAttacksPreventionWithDomainChallengeTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.runner.RunWith;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class IpBruteForceAttacksPreventionWithDomainChallengeTests extends IpBruteForceAttacksPreventionTests {
+    @Override
+    public LocalCluster createCluster() {
+        return new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+            .anonymousAuth(false)
+            .authFailureListeners(listener)
+            .authc(AUTHC_HTTPBASIC_INTERNAL)
+            .users(USER_1, USER_2)
+            .build();
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -344,7 +344,7 @@ public class LocalOpenSearchCluster {
         String clusterManagerNodes = nodeByTypeToString(CLUSTER_MANAGER);
         String dataNodes = nodeByTypeToString(DATA);
         String clientNodes = nodeByTypeToString(CLIENT);
-        return "\nES Cluster "
+        return "\nOS Cluster "
             + clusterName
             + "\ncluster manager nodes: "
             + clusterManagerNodes

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -36,7 +36,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
 import org.opensearch.rest.BytesRestResponse;
-import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.auth.HTTPAuthenticator;
@@ -236,11 +235,10 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     protected abstract KeyProvider initKeyProvider(Settings settings, Path configPath) throws Exception;
 
     @Override
-    public boolean reRequestAuthentication(RestChannel channel, AuthCredentials authCredentials) {
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials authCredentials) {
         final BytesRestResponse wwwAuthenticateResponse = new BytesRestResponse(RestStatus.UNAUTHORIZED, "");
         wwwAuthenticateResponse.addHeader("WWW-Authenticate", "Bearer realm=\"OpenSearch Security\"");
-        channel.sendResponse(wwwAuthenticateResponse);
-        return true;
+        return wwwAuthenticateResponse;
     }
 
     public String getRequiredAudience() {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -31,7 +31,6 @@ import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.BytesRestResponse;
-import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.auth.HTTPAuthenticator;
@@ -171,11 +170,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
         final BytesRestResponse wwwAuthenticateResponse = new BytesRestResponse(RestStatus.UNAUTHORIZED, "");
         wwwAuthenticateResponse.addHeader("WWW-Authenticate", "Bearer realm=\"OpenSearch Security\"");
-        channel.sendResponse(wwwAuthenticateResponse);
-        return true;
+        return wwwAuthenticateResponse;
     }
 
     @Override

--- a/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -49,7 +49,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.env.Environment;
 import org.opensearch.rest.BytesRestResponse;
-import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.auth.HTTPAuthenticator;
@@ -280,8 +279,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
-
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
         final BytesRestResponse wwwAuthenticateResponse;
         XContentBuilder response = getNegotiateResponseBody();
 
@@ -291,16 +289,15 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
             wwwAuthenticateResponse = new BytesRestResponse(RestStatus.UNAUTHORIZED, EMPTY_STRING);
         }
 
-        if (creds == null || creds.getNativeCredentials() == null) {
+        if (credentials == null || credentials.getNativeCredentials() == null) {
             wwwAuthenticateResponse.addHeader("WWW-Authenticate", "Negotiate");
         } else {
             wwwAuthenticateResponse.addHeader(
                 "WWW-Authenticate",
-                "Negotiate " + Base64.getEncoder().encodeToString((byte[]) creds.getNativeCredentials())
+                "Negotiate " + Base64.getEncoder().encodeToString((byte[]) credentials.getNativeCredentials())
             );
         }
-        channel.sendResponse(wwwAuthenticateResponse);
-        return true;
+        return wwwAuthenticateResponse;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -287,7 +287,7 @@ public class BackendRegistry {
                         if (isTraceEnabled) {
                             log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                         }
-                        notifyIpAuthFailureListeners(request, authCredentials); // is this needed here??
+                        notifyIpAuthFailureListeners(request, authCredentials);
                         channel.sendResponse(restResponse);
                         return false;
                     }
@@ -306,7 +306,7 @@ public class BackendRegistry {
                     // credentials found in request but we need another client challenge
                     if (restResponse != null) {
                         // auditLog.logFailedLogin(ac.getUsername()+" <incomplete>", request); --noauditlog
-                        notifyIpAuthFailureListeners(request, ac); // is this needed here??
+                        notifyIpAuthFailureListeners(request, ac);
                         channel.sendResponse(restResponse);
                         return false;
                     } else {

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -230,7 +230,7 @@ public class BackendRegistry {
 
         User authenticatedUser = null;
 
-        AuthCredentials authCredenetials = null;
+        AuthCredentials authCredentials = null;
 
         HTTPAuthenticator firstChallengingHttpAuthenticator = null;
 
@@ -272,7 +272,7 @@ public class BackendRegistry {
                 continue;
             }
 
-            authCredenetials = ac;
+            authCredentials = ac;
 
             if (ac == null) {
                 // no credentials found in request
@@ -280,12 +280,18 @@ public class BackendRegistry {
                     continue;
                 }
 
-                if (authDomain.isChallenge() && httpAuthenticator.reRequestAuthentication(channel, null)) {
-                    auditLog.logFailedLogin("<NONE>", false, null, request);
-                    if (isTraceEnabled) {
-                        log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                if (authDomain.isChallenge()) {
+                    final BytesRestResponse restResponse = httpAuthenticator.reRequestAuthentication(request, null);
+                    if (restResponse != null) {
+                        auditLog.logFailedLogin("<NONE>", false, null, request);
+                        if (isTraceEnabled) {
+                            log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                        }
+                        notifyIpAuthFailureListeners(request, authCredentials); // is this needed here??
+                        channel.sendResponse(restResponse);
+                        return false;
                     }
-                    return false;
+
                 } else {
                     // no reRequest possible
                     if (isTraceEnabled) {
@@ -296,9 +302,12 @@ public class BackendRegistry {
             } else {
                 org.apache.logging.log4j.ThreadContext.put("user", ac.getUsername());
                 if (!ac.isComplete()) {
+                    final BytesRestResponse restResponse = httpAuthenticator.reRequestAuthentication(request, ac);
                     // credentials found in request but we need another client challenge
-                    if (httpAuthenticator.reRequestAuthentication(channel, ac)) {
+                    if (restResponse != null) {
                         // auditLog.logFailedLogin(ac.getUsername()+" <incomplete>", request); --noauditlog
+                        notifyIpAuthFailureListeners(request, ac); // is this needed here??
+                        channel.sendResponse(restResponse);
                         return false;
                     } else {
                         // no reRequest possible
@@ -376,7 +385,7 @@ public class BackendRegistry {
                 log.debug("User still not authenticated after checking {} auth domains", restAuthDomains.size());
             }
 
-            if (authCredenetials == null && anonymousAuthEnabled) {
+            if (authCredentials == null && anonymousAuthEnabled) {
                 final String tenant = Utils.coalesce(request.header("securitytenant"), request.header("security_tenant"));
                 User anonymousUser = new User(User.ANONYMOUS.getName(), new HashSet<String>(User.ANONYMOUS.getRoles()), null);
                 anonymousUser.setRequestedTenant(tenant);
@@ -388,6 +397,7 @@ public class BackendRegistry {
                 }
                 return true;
             }
+            BytesRestResponse challengeResponse = null;
 
             if (firstChallengingHttpAuthenticator != null) {
 
@@ -395,31 +405,28 @@ public class BackendRegistry {
                     log.debug("Rerequest with {}", firstChallengingHttpAuthenticator.getClass());
                 }
 
-                if (firstChallengingHttpAuthenticator.reRequestAuthentication(channel, null)) {
+                challengeResponse = firstChallengingHttpAuthenticator.reRequestAuthentication(request, null);
+                if (challengeResponse != null) {
                     if (isDebugEnabled) {
                         log.debug("Rerequest {} failed", firstChallengingHttpAuthenticator.getClass());
                     }
-
-                    log.warn(
-                        "Authentication finally failed for {} from {}",
-                        authCredenetials == null ? null : authCredenetials.getUsername(),
-                        remoteAddress
-                    );
-                    auditLog.logFailedLogin(authCredenetials == null ? null : authCredenetials.getUsername(), false, null, request);
-                    return false;
                 }
             }
 
             log.warn(
                 "Authentication finally failed for {} from {}",
-                authCredenetials == null ? null : authCredenetials.getUsername(),
+                authCredentials == null ? null : authCredentials.getUsername(),
                 remoteAddress
             );
-            auditLog.logFailedLogin(authCredenetials == null ? null : authCredenetials.getUsername(), false, null, request);
+            auditLog.logFailedLogin(authCredentials == null ? null : authCredentials.getUsername(), false, null, request);
 
-            notifyIpAuthFailureListeners(request, authCredenetials);
+            notifyIpAuthFailureListeners(request, authCredentials);
 
-            channel.sendResponse(new BytesRestResponse(RestStatus.UNAUTHORIZED, "Authentication finally failed"));
+            channel.sendResponse(
+                challengeResponse != null
+                    ? challengeResponse
+                    : new BytesRestResponse(RestStatus.UNAUTHORIZED, "Authentication finally failed")
+            );
             return false;
         }
 

--- a/src/main/java/org/opensearch/security/auth/HTTPAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/HTTPAuthenticator.java
@@ -28,7 +28,7 @@ package org.opensearch.security.auth;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.user.AuthCredentials;
 
@@ -71,15 +71,14 @@ public interface HTTPAuthenticator {
 
     /**
      * If the {@code extractCredentials()} call was not successful or the authentication flow needs another roundtrip this method
-     * will be called. If the custom HTTP authenticator does not support this method is a no-op and false should be returned.
-     *
+     * will be called. If the custom HTTP authenticator does not support this method is a no-op and null response should be returned.
      * If the custom HTTP authenticator does support re-request authentication or supports authentication flows with multiple roundtrips
-     * then the response should be sent (through the channel) and true must be returned.
+     * then the response will be returned which can then be sent via response channel.
      *
-     * @param channel The rest channel to sent back the response via {@code channel.sendResponse()}
+     * @param request
      * @param credentials The credentials from the prior authentication attempt
-     * @return false  if re-request is not supported/necessary, true otherwise.
-     * If true is returned {@code channel.sendResponse()} must be called so that the request completes.
+     * @return null if re-request is not supported/necessary, response object otherwise.
+     * If an object is returned {@code channel.sendResponse()} must be called so that the request completes.
      */
-    boolean reRequestAuthentication(final RestChannel channel, AuthCredentials credentials);
+    BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials);
 }

--- a/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
@@ -34,7 +34,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.BytesRestResponse;
-import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.auth.HTTPAuthenticator;
@@ -65,11 +64,10 @@ public class HTTPBasicAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
         final BytesRestResponse wwwAuthenticateResponse = new BytesRestResponse(RestStatus.UNAUTHORIZED, "Unauthorized");
         wwwAuthenticateResponse.addHeader("WWW-Authenticate", "Basic realm=\"OpenSearch Security\"");
-        channel.sendResponse(wwwAuthenticateResponse);
-        return true;
+        return wwwAuthenticateResponse;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/http/HTTPClientCertAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPClientCertAuthenticator.java
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
-import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.support.ConfigConstants;
@@ -98,8 +98,8 @@ public class HTTPClientCertAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
-        return false;
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/http/HTTPProxyAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPProxyAuthenticator.java
@@ -37,7 +37,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
-import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.support.ConfigConstants;
@@ -89,8 +89,8 @@ public class HTTPProxyAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
-        return false;
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -33,7 +33,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.authtoken.jwt.EncryptionDecryptionUtil;
@@ -243,8 +243,8 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
-        return false;
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
+        return null;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticator.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
-import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.http.HTTPProxyAuthenticator;
 import org.opensearch.security.user.AuthCredentials;
@@ -82,11 +81,6 @@ public class HTTPExtendedProxyAuthenticator extends HTTPProxyAuthenticator {
             }
         }
         return credentials.markComplete();
-    }
-
-    @Override
-    public boolean reRequestAuthentication(final RestChannel channel, AuthCredentials creds) {
-        return false;
     }
 
     @Override

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -47,6 +47,7 @@ import org.opensearch.common.io.stream.BytesStreamOutput;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.xcontent.MediaType;
 import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
@@ -141,7 +142,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -188,7 +190,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -236,7 +239,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -287,7 +291,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -338,7 +343,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -389,7 +395,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -436,7 +443,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -501,7 +509,8 @@ public class HTTPSamlAuthenticatorTest {
         );
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -552,7 +561,8 @@ public class HTTPSamlAuthenticatorTest {
         );
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         Assert.assertEquals(RestStatus.UNAUTHORIZED, tokenRestChannel.response.status());
     }
@@ -584,7 +594,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         Assert.assertEquals(401, tokenRestChannel.response.status().getStatus());
     }
@@ -613,7 +624,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         Assert.assertEquals(401, tokenRestChannel.response.status().getStatus());
     }
@@ -646,7 +658,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -693,7 +706,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -747,7 +761,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-        samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+        tokenRestChannel.sendResponse(authenticatorResponse);
 
         String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
         HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -850,7 +865,8 @@ public class HTTPSamlAuthenticatorTest {
 
             RestRequest restRequest = new FakeRestRequest(ImmutableMap.of(), new HashMap<String, String>());
             TestRestChannel restChannel = new TestRestChannel(restRequest);
-            samlAuthenticator.reRequestAuthentication(restChannel, null);
+            BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(restRequest, null);
+            restChannel.sendResponse(authenticatorResponse);
 
             Assert.assertNull(restChannel.response);
 
@@ -870,7 +886,8 @@ public class HTTPSamlAuthenticatorTest {
             RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
             TestRestChannel tokenRestChannel = new TestRestChannel(tokenRestRequest);
 
-            samlAuthenticator.reRequestAuthentication(tokenRestChannel, null);
+            authenticatorResponse = samlAuthenticator.reRequestAuthentication(tokenRestRequest, null);
+            tokenRestChannel.sendResponse(authenticatorResponse);
 
             String responseJson = new String(BytesReference.toBytes(tokenRestChannel.response.content()));
             HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
@@ -893,7 +910,8 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest restRequest = new FakeRestRequest(ImmutableMap.of(), new HashMap<String, String>());
         TestRestChannel restChannel = new TestRestChannel(restRequest);
 
-        samlAuthenticator.reRequestAuthentication(restChannel, null);
+        final BytesRestResponse authenticatorResponse = samlAuthenticator.reRequestAuthentication(restRequest, null);
+        restChannel.sendResponse(authenticatorResponse);
 
         List<String> wwwAuthenticateHeaders = restChannel.response.getHeaders().get("WWW-Authenticate");
 

--- a/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
@@ -22,26 +22,26 @@ import org.junit.Test;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.user.AuthCredentials;
 
+import java.net.InetAddress;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class AddressBasedRateLimiterTest {
 
-    private final static byte[] PASSWORD = new byte[] { '1', '2', '3' };
-
     @Test
     public void simpleTest() throws Exception {
         Settings settings = Settings.builder().put("allowed_tries", 3).build();
 
-        UserNameBasedRateLimiter rateLimiter = new UserNameBasedRateLimiter(settings, null);
+        AddressBasedRateLimiter rateLimiter = new AddressBasedRateLimiter(settings, null);
 
-        assertFalse(rateLimiter.isBlocked("a"));
-        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
-        assertFalse(rateLimiter.isBlocked("a"));
-        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
-        assertFalse(rateLimiter.isBlocked("a"));
-        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
-        assertTrue(rateLimiter.isBlocked("a"));
+        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
+        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
+        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
+        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
+        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
+        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
+        assertTrue(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
 
     }
 }

--- a/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/AddressBasedRateLimiterTest.java
@@ -20,7 +20,6 @@ package org.opensearch.security.auth.limiting;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
-import org.opensearch.security.user.AuthCredentials;
 
 import java.net.InetAddress;
 

--- a/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
@@ -17,8 +17,6 @@
 
 package org.opensearch.security.auth.limiting;
 
-import java.net.InetAddress;
-
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;

--- a/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
+++ b/src/test/java/org/opensearch/security/auth/limiting/UserNameBasedRateLimiterTest.java
@@ -22,25 +22,28 @@ import java.net.InetAddress;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.user.AuthCredentials;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class UserNameBasedRateLimiterTest {
 
+    private final static byte[] PASSWORD = new byte[] { '1', '2', '3' };
+
     @Test
     public void simpleTest() throws Exception {
         Settings settings = Settings.builder().put("allowed_tries", 3).build();
 
-        AddressBasedRateLimiter rateLimiter = new AddressBasedRateLimiter(settings, null);
+        UserNameBasedRateLimiter rateLimiter = new UserNameBasedRateLimiter(settings, null);
 
-        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
-        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
-        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
-        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
-        assertFalse(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
-        rateLimiter.onAuthFailure(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 }), null, null);
-        assertTrue(rateLimiter.isBlocked(InetAddress.getByAddress(new byte[] { 1, 2, 3, 4 })));
+        assertFalse(rateLimiter.isBlocked("a"));
+        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
+        assertFalse(rateLimiter.isBlocked("a"));
+        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
+        assertFalse(rateLimiter.isBlocked("a"));
+        rateLimiter.onAuthFailure(null, new AuthCredentials("a", PASSWORD), null);
+        assertTrue(rateLimiter.isBlocked("a"));
 
     }
 }

--- a/src/test/java/org/opensearch/security/cache/DummyHTTPAuthenticator.java
+++ b/src/test/java/org/opensearch/security/cache/DummyHTTPAuthenticator.java
@@ -16,7 +16,7 @@ import java.nio.file.Path;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.user.AuthCredentials;
@@ -39,8 +39,8 @@ public class DummyHTTPAuthenticator implements HTTPAuthenticator {
     }
 
     @Override
-    public boolean reRequestAuthentication(RestChannel channel, AuthCredentials credentials) {
-        return false;
+    public BytesRestResponse reRequestAuthentication(RestRequest request, AuthCredentials credentials) {
+        return null;
     }
 
     public static long getCount() {


### PR DESCRIPTION
### Description

* Category: Refactoring

Prior to this change, the ip auth failure listener was not called upon challengeAuthenticator check invocation, which caused AddressBasedRateLimiter to not be invoked. With this change AddressBasedRateLimiter will be invoked upon multiple wrong requests from an ip

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/2686

### Testing
Integration Testing (Adds a new test to verify the change)

When cluster was setup with Basic http challenge:

<details>
<summary>Before:</summary>

```console
java.lang.AssertionError: Expected status code is '401', but was '200'. Response body '{
  "user" : "User [name=simple-user-2, backend_roles=[], requestedTenant=null]",
  "user_name" : "simple-user-2",
  "user_requested_tenant" : null,
  "remote_address" : "127.0.0.3:54025",
  "backend_roles" : [ ],
  "custom_attribute_names" : [ ],
  "roles" : [
    "user_simple-user-2__all_access"
  ],
  "tenants" : {
    "simple-user-2" : true
  },
  "principal" : null,
  "peer_certificates" : "0",
  "sso_logout_url" : null
}
'.
Expected: <401>
     but: was <200>
	at __randomizedtesting.SeedInfo.seed([818958B6AA45DEE4:EB2D2AB7F1A10EE2]:0)
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.opensearch.test.framework.cluster.TestRestClient$HttpResponse.assertStatusCode(TestRestClient.java:432)
	at org.opensearch.security.IpBruteForceAttacksPreventionTests.shouldBlockIpAddress(IpBruteForceAttacksPreventionTests.java:91)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$3.evaluate(ThreadLeakControl.java:490)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSingleTest(RandomizedRunner.java:955)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$5.evaluate(RandomizedRunner.java:840)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$6.evaluate(RandomizedRunner.java:891)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$7.evaluate(RandomizedRunner.java:902)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$2.evaluate(ThreadLeakControl.java:426)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSuite(RandomizedRunner.java:716)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.access$200(RandomizedRunner.java:138)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:637)

```
</details>

<details>
<summary>After:</summary>

```console
BUILD SUCCESSFUL in 53s
6 actionable tasks: 6 executed
```
</details>

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
