### PR TITLE
Minor comments follow up for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,8 +398,6 @@ tasks.withType(JavaCompile) {
 }
 
 tasks.test.finalizedBy(jacocoTestReport)  // report is always generated after tests run
-tasks.jacocoTestReport.dependsOn(test) // tests are required to run before generating the report
-
 
 allprojects {
     tasks.withType(Javadoc).all { enabled = false }
@@ -435,9 +433,9 @@ configurations {
             force "org.xerial.snappy:snappy-java:1.1.10.5"
             force "com.google.guava:guava:${guava_version}"
 
-            // TODO: Seems like this should be removable
-            force "org.apache.httpcomponents:httpclient-cache:4.5.13"
+            // For integrationTest
             force "org.apache.httpcomponents:httpclient:4.5.13"
+            force "org.apache.httpcomponents:httpclient-cache:4.5.13"
             force "org.apache.httpcomponents:fluent-hc:4.5.13"
             force "org.apache.httpcomponents:httpcore:4.4.16"
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
@@ -457,7 +455,6 @@ sourceSets {
             srcDir file ('src/integrationTest/java')
             compileClasspath += sourceSets.main.output
             runtimeClasspath += sourceSets.main.output
-
         }
         resources {
             srcDir file('src/integrationTest/resources')
@@ -472,9 +469,7 @@ sourceSets {
 task integrationTest(type: Test) {
     doFirst {
         // Only run resources tests on resource-test CI environments or locally
-        if (System.getenv('CI_ENVIRONMENT') == 'resource-test' || System.getenv('CI_ENVIRONMENT') == null) {
-            include '**/ResourceFocusedTests.class'
-        } else {
+        if (System.getenv('CI_ENVIRONMENT') != 'resource-test' && System.getenv('CI_ENVIRONMENT') != null) {
             exclude '**/ResourceFocusedTests.class'
         }
         // Only run with retries while in CI systems

--- a/build.gradle
+++ b/build.gradle
@@ -434,8 +434,8 @@ configurations {
             force "com.google.guava:guava:${guava_version}"
 
             // For integrationTest
-            force "org.apache.httpcomponents:httpclient:4.5.13"
             force "org.apache.httpcomponents:httpclient-cache:4.5.13"
+            force "org.apache.httpcomponents:httpclient:4.5.13"
             force "org.apache.httpcomponents:fluent-hc:4.5.13"
             force "org.apache.httpcomponents:httpcore:4.4.16"
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"


### PR DESCRIPTION
### Description
- Remove an unused JVM setting for integration tests
- Fixed an issue where you couldn't run non-resource tests unless you had CI_ENVIRONMENT set to normal on your machine (Already fixed in main)
- Fixed an issue where code coverage was always run after tests completed (Already fixed in main)

### Issues Resolved
- Related https://github.com/opensearch-project/security/pull/3388

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
