### PR TITLE
[Enhancement] Add a flag to setup default admin:admin in demo script

### DIFF
--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -342,11 +342,12 @@ if "%use_default_admin_password%"=="1" (
     ) else (
         for /f "delims=" %%a in ('type "%ADMIN_PASSWORD_FILE%"') do (
             set "ADMIN_PASSWORD=%%a"
-            goto :breakloop
+            goto breakloop
         )
-        :breakloop
     )
 )
+
+:breakloop
 
 if not defined ADMIN_PASSWORD (
     echo Unable to find the admin password for the cluster. Please set initialAdminPassword or create a file %ADMIN_PASSWORD_FILE% with a single line that contains the password.


### PR DESCRIPTION
### Description
Add a flag to setup default admin:admin in demo script
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

### Issues Resolved
* Relate https://github.com/opensearch-project/security/pull/3329
* Relate https://github.com/opensearch-project/opensearch-build/issues/4094

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
CI

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
