### PR TITLE
[Bug Fix] Fix the demo configuration script and remove the admin credential from `internal_user.yml` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,7 @@ jobs:
             - "admin"
           description: "Demo admin user"
         EOL
+        cat /home/runner/work/security/security/config/internal_users.yml
       shell: bash
 
     - name: Add Admin Credential on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
     - name: Insert Admin Credential on Linux
       if: ${{ runner.os == 'Linux' }}
       run: |
-        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
+        cat <<'EOL' >> /home/runner/work/security/security/config/internal_users.yml
         admin:
-          hash: '$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG'
+          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
           reserved: true
           backend_roles:
           - "admin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
     - name: Set up JDK for build and test
       uses: actions/setup-java@v3
       with:
@@ -51,6 +57,32 @@ jobs:
 
     - name: Checkout security
       uses: actions/checkout@v4
+
+    - name: Insert Admin Credential on Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
+        admin:
+          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          reserved: true
+          backend_roles:
+          - "admin"
+          description: "Demo admin user"
+        EOL
+        cat /home/runner/work/security/security/config/internal_users.yml
+      shell: bash
+
+    - name: Add Admin Credential on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        $filePath = "D:\a\security\security\config\internal_users.yml"
+        Add-Content -Path $filePath -Value "admin:"
+        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path $filePath -Value "  reserved: true"
+        Add-Content -Path $filePath -Value "  backend_roles:"
+        Add-Content -Path $filePath -Value "  - `"admin`""
+        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
+      shell: pwsh
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     - name: Add Admin Credential on Windows
       if: ${{ runner.os == 'Windows' }}
       run: |
+        Get-Location
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "admin:"
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  reserved: true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       run: |
         cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
         admin:
-          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          hash: '$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG'
           reserved: true
           backend_roles:
           - "admin"
@@ -82,6 +82,7 @@ jobs:
         Add-Content -Path $filePath -Value "  backend_roles:"
         Add-Content -Path $filePath -Value "  - `"admin`""
         Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
+        type $filePath
       shell: pwsh
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    # Configure longpath names if on Windows
-    - name: Enable Longpaths if on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: git config --system core.longpaths true
-      shell: pwsh
-
     - name: Set up JDK for build and test
       uses: actions/setup-java@v3
       with:
@@ -57,31 +51,6 @@ jobs:
 
     - name: Checkout security
       uses: actions/checkout@v4
-
-    - name: Insert Admin Credential on Linux
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
-        admin:
-          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
-          reserved: true
-          backend_roles:
-            - "admin"
-          description: "Demo admin user"
-        EOL
-      shell: bash
-
-    - name: Add Admin Credential on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        $filePath = "D:\a\security\security\config\internal_users.yml"
-        Add-Content -Path $filePath -Value "admin:"
-        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path $filePath -Value "  reserved: true"
-        Add-Content -Path $filePath -Value "  backend_roles:"
-        Add-Content -Path $filePath -Value "  - `"admin`""
-        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
-      shell: pwsh
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2
@@ -122,6 +91,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
     - name: Set up JDK for build and test
       uses: actions/setup-java@v3
       with:
@@ -130,6 +105,31 @@ jobs:
 
     - name: Checkout security
       uses: actions/checkout@v4
+
+    - name: Insert Admin Credential on Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
+        admin:
+          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          reserved: true
+          backend_roles:
+            - "admin"
+          description: "Demo admin user"
+        EOL
+      shell: bash
+
+    - name: Add Admin Credential on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        $filePath = "D:\a\security\security\config\internal_users.yml"
+        Add-Content -Path $filePath -Value "admin:"
+        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path $filePath -Value "  reserved: true"
+        Add-Content -Path $filePath -Value "  backend_roles:"
+        Add-Content -Path $filePath -Value "  - `"admin`""
+        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
+      shell: pwsh
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,14 +68,12 @@ jobs:
     - name: Add Admin Credential on Windows
       if: ${{ runner.os == 'Windows' }}
       run: |
-        $currentDir = Get-Location
-        Write-Output "Current directory is: $currentDir"
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "admin:"
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  reserved: true"
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  backend_roles:"
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  - `"admin`""
-        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "admin:"
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  reserved: true"
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  backend_roles:"
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  - `"admin`""
+        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
       shell: pwsh
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+    # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
     - name: Set up JDK for build and test
       uses: actions/setup-java@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
       run: |
         cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
         admin:
-          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          hash: '$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG'
           reserved: true
           backend_roles:
           - "admin"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,15 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Add Admin Credential
-      if: ${{ runner.os == 'Linux' }}
       run: |
-        pwd
-        ls
+        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
+        admin:
+          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          reserved: true
+          backend_roles:
+            - "admin"
+          description: "Demo admin user"
+        EOL
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
     - name: Add Admin Credential on Windows
       if: ${{ runner.os == 'Windows' }}
       run: |
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "admin:"
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  reserved: true"
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  backend_roles:"
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  - `"admin`""
-        Add-Content -Path D:\a\security\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "admin:"
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  reserved: true"
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  backend_roles:"
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  - `"admin`""
+        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
       shell: pwsh
 
     - name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       run: |
         $filePath = "D:\a\security\security\config\internal_users.yml"
         Add-Content -Path $filePath -Value "admin:"
-        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path $filePath -Value "  hash: `"`$2a`$12`$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
         Add-Content -Path $filePath -Value "  reserved: true"
         Add-Content -Path $filePath -Value "  backend_roles:"
         Add-Content -Path $filePath -Value "  - `"admin`""
@@ -124,12 +124,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    # Configure longpath names if on Windows
-    - name: Enable Longpaths if on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: git config --system core.longpaths true
-      shell: pwsh
-
     - name: Set up JDK for build and test
       uses: actions/setup-java@v3
       with:
@@ -138,32 +132,6 @@ jobs:
 
     - name: Checkout security
       uses: actions/checkout@v4
-
-    - name: Insert Admin Credential on Linux
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
-        admin:
-          hash: '$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG'
-          reserved: true
-          backend_roles:
-          - "admin"
-          description: "Demo admin user"
-        EOL
-        cat /home/runner/work/security/security/config/internal_users.yml
-      shell: bash
-
-    - name: Add Admin Credential on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        $filePath = "D:\a\security\security\config\internal_users.yml"
-        Add-Content -Path $filePath -Value "admin:"
-        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path $filePath -Value "  reserved: true"
-        Add-Content -Path $filePath -Value "  backend_roles:"
-        Add-Content -Path $filePath -Value "  - `"admin`""
-        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
-      shell: pwsh
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v4
 
-    - name: Add Admin Credential on Linux
+    - name: Insert Admin Credential on Linux
       if: ${{ runner.os == 'Linux' }}
       run: |
         cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
@@ -74,13 +74,15 @@ jobs:
     - name: Add Admin Credential on Windows
       if: ${{ runner.os == 'Windows' }}
       run: |
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "admin:"
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  reserved: true"
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  backend_roles:"
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  - `"admin`""
-        Add-Content -Path D:\a\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
+        $filePath = "D:\a\security\security\config\internal_users.yml"
+        Add-Content -Path $filePath -Value "admin:"
+        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path $filePath -Value "  reserved: true"
+        Add-Content -Path $filePath -Value "  backend_roles:"
+        Add-Content -Path $filePath -Value "  - `"admin`""
+        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
       shell: pwsh
+
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,11 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v4
 
+    - name: Add Admin Credential
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        pwd
+
     - name: Build and Test
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
           reserved: true
           backend_roles:
-            - "admin"
+          - "admin"
           description: "Demo admin user"
         EOL
         cat /home/runner/work/security/security/config/internal_users.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
     - name: Checkout security
       uses: actions/checkout@v4
 
-    - name: Add Admin Credential
+    - name: Add Admin Credential on Linux
+      if: ${{ runner.os == 'Linux' }}
       run: |
         cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
         admin:
@@ -62,6 +63,18 @@ jobs:
             - "admin"
           description: "Demo admin user"
         EOL
+      shell: bash
+
+    - name: Add Admin Credential on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "admin:"
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  reserved: true"
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  backend_roles:"
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  - `"admin`""
+        Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  description: `"Demo admin user`""
+      shell: pwsh
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         pwd
+        ls
 
     - name: Build and Test
       uses: gradle/gradle-build-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
     - name: Add Admin Credential on Windows
       if: ${{ runner.os == 'Windows' }}
       run: |
-        Get-Location
+        $currentDir = Get-Location
+        Write-Output "Current directory is: $currentDir"
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "admin:"
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
         Add-Content -Path D:\a\work\security\security\config\internal_users.yml -Value "  reserved: true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      # Configure longpath names if on Windows
+    # Configure longpath names if on Windows
     - name: Enable Longpaths if on Windows
       if: ${{ runner.os == 'Windows' }}
       run: git config --system core.longpaths true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
         Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
       shell: pwsh
 
-
     - name: Build and Test
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,44 +15,12 @@ jobs:
         test-run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
-    # Configure longpath names if on Windows
-    - name: Enable Longpaths if on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: git config --system core.longpaths true
-      shell: pwsh
-
     - uses: actions/setup-java@v3
       with:
         distribution: temurin # Temurin is a distribution of adoptium
         java-version: ${{ matrix.jdk }}
 
-    - name: Checkout Security Repo
-      uses: actions/checkout@v4
-
-    - name: Insert Admin Credential on Linux
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
-        admin:
-          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
-          reserved: true
-          backend_roles:
-            - "admin"
-          description: "Demo admin user"
-        EOL
-      shell: bash
-
-    - name: Add Admin Credential on Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        $filePath = "D:\a\security\security\config\internal_users.yml"
-        Add-Content -Path $filePath -Value "admin:"
-        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
-        Add-Content -Path $filePath -Value "  reserved: true"
-        Add-Content -Path $filePath -Value "  backend_roles:"
-        Add-Content -Path $filePath -Value "  - `"admin`""
-        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
-      shell: pwsh
+    - uses: actions/checkout@v4
 
     - run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -15,12 +15,44 @@ jobs:
         test-run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
+    # Configure longpath names if on Windows
+    - name: Enable Longpaths if on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: git config --system core.longpaths true
+      shell: pwsh
+
     - uses: actions/setup-java@v3
       with:
         distribution: temurin # Temurin is a distribution of adoptium
         java-version: ${{ matrix.jdk }}
 
-    - uses: actions/checkout@v4
+    - name: Checkout Security Repo
+      uses: actions/checkout@v4
+
+    - name: Insert Admin Credential on Linux
+      if: ${{ runner.os == 'Linux' }}
+      run: |
+        cat <<EOL >> /home/runner/work/security/security/config/internal_users.yml
+        admin:
+          hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
+          reserved: true
+          backend_roles:
+            - "admin"
+          description: "Demo admin user"
+        EOL
+      shell: bash
+
+    - name: Add Admin Credential on Windows
+      if: ${{ runner.os == 'Windows' }}
+      run: |
+        $filePath = "D:\a\security\security\config\internal_users.yml"
+        Add-Content -Path $filePath -Value "admin:"
+        Add-Content -Path $filePath -Value "  hash: `"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG`""
+        Add-Content -Path $filePath -Value "  reserved: true"
+        Add-Content -Path $filePath -Value "  backend_roles:"
+        Add-Content -Path $filePath -Value "  - `"admin`""
+        Add-Content -Path $filePath -Value "  description: `"Demo admin user`""
+      shell: pwsh
 
     - run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test
 

--- a/config/internal_users.yml
+++ b/config/internal_users.yml
@@ -10,13 +10,6 @@ _meta:
 
 ## Demo users
 
-admin:
-  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG"
-  reserved: true
-  backend_roles:
-  - "admin"
-  description: "Demo admin user"
-
 anomalyadmin:
   hash: "$2y$12$TRwAAJgnNo67w3rVUz4FIeLx9Dy/llB79zf9I15CKJ9vkM4ZzAd3."
   reserved: false

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -367,7 +367,7 @@ echo   backend_roles: >> !INTERNAL_USERS_FILE!
 echo   - "admin" >> !INTERNAL_USERS_FILE!
 echo   description: "Demo admin user" >> !INTERNAL_USERS_FILE!
 
-echo Content appended to !INTERNAL_USERS_FILE!
+echo Admin user has been appended to !INTERNAL_USERS_FILE!
 endlocal
 
 :: network.host

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -359,17 +359,16 @@ if errorlevel 1 (
   exit /b 1
 )
 
-set "default_line=  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG""
-set "search=%default_line%"
-set "replace=  hash: "%HASHED_ADMIN_PASSWORD%""
+:: Append the admin credential to the end of the internal_users.yml file
+echo admin: >> !INTERNAL_USERS_FILE!
+echo   hash: "!HASHED_ADMIN_PASSWORD!" >> !INTERNAL_USERS_FILE!
+echo   reserved: true >> !INTERNAL_USERS_FILE!
+echo   backend_roles: >> !INTERNAL_USERS_FILE!
+echo   - "admin" >> !INTERNAL_USERS_FILE!
+echo   description: "Demo admin user" >> !INTERNAL_USERS_FILE!
 
-setlocal enableextensions
-for /f "delims=" %%i in ('type "%INTERNAL_USERS_FILE%" ^& break ^> "%INTERNAL_USERS_FILE%" ') do (
-    set "line=%%i"
-    setlocal enabledelayedexpansion
-    >>"%INTERNAL_USERS_FILE%" echo(!line:%search%=%replace%!
-    endlocal
-)
+echo Content appended to !INTERNAL_USERS_FILE!
+endlocal
 
 :: network.host
 >nul findstr /b /c:"network.host" "%OPENSEARCH_CONF_FILE%" && (

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -392,9 +392,6 @@ echo 'plugins.security.system_indices.indices: [".plugins-ml-config", ".plugins-
 ADMIN_PASSWORD_FILE="$OPENSEARCH_CONF_DIR/initialAdminPassword.txt"
 INTERNAL_USERS_FILE="$OPENSEARCH_CONF_DIR/opensearch-security/internal_users.yml"
 
-# Use sed to delete the block
-sed -i.bak '/^admin:/,/description: "Demo admin user"/d' $INTERNAL_USERS_FILE
-
 if [[ -n "$initialAdminPassword" ]]; then
   ADMIN_PASSWORD="$initialAdminPassword"
 elif [[ -f "$ADMIN_PASSWORD_FILE" && -s "$ADMIN_PASSWORD_FILE" ]]; then


### PR DESCRIPTION
### Description
By working with @DarshitChanpura for addressing the following issue: 
> https://github.com/opensearch-project/opensearch-build/issues/4094#issuecomment-1745785846

We need the initiation of the cluster to be failed once we encountered a failure of our demo configuration script. This PR introduces the method that if we failed to set up a admin credential during the set up of demo configuration script, it will lead to an absent of admin credential section in `internal_users.yml`, so that the initiation of the cluster will be failed.


* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug fix
* What is the old behavior before changes and new behavior after changes?
The cluster initiation will be succeed and keep using the `admin:admin` credential even if the there is an hard exit on the set up on demo configuration script.

### Issues Resolved
* Relate https://github.com/opensearch-project/opensearch-build/issues/4094
* Relate https://github.com/opensearch-project/security/pull/3329

### Testing
CI

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
