### PR TITLE
[Build Break] Update custom serialization min supported version

### DIFF
--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -326,7 +326,7 @@ public class ConfigConstants {
     public static final String TENANCY_GLOBAL_TENANT_DEFAULT_NAME = "";
 
     public static final String USE_JDK_SERIALIZATION = "plugins.security.use_jdk_serialization";
-    public static final Version FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION = Version.V_3_0_0;
+    public static final Version FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION = Version.V_2_11_0;
 
     // On-behalf-of endpoints settings
     // CS-SUPPRESS-SINGLE: RegexpSingleline get Extensions Settings

--- a/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
@@ -66,11 +66,16 @@ public class SecuritySSLRequestHandlerTests {
         TransportChannel transportChannel = mock(TransportChannel.class);
         Task task = mock(Task.class);
         doNothing().when(transportChannel).sendResponse(ArgumentMatchers.any(Exception.class));
-        when(transportChannel.getVersion()).thenReturn(Version.V_2_11_0);
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_10_0);
         when(transportChannel.getChannelType()).thenReturn("transport");
 
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
         Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
+        threadPool.getThreadContext().stashContext();
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_11_0);
+        Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
+        Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
         when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);


### PR DESCRIPTION
### Description
Update custom serialization min supported version, should be 2.11.0 since the features backport [1] was merged.

- [1] https://github.com/opensearch-project/security/pull/3444 

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/3456

⚠️ I will be bypassing approval to merge this change to unblock the pipeline as soon as all of the `backward-compatibility*` tests have passed.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
