### PR TITLE
[Backport 2.x] Support security config updates on the REST API using permission (#3264)

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -15,6 +15,7 @@ security_rest_api_full_access:
   cluster_permissions:
     - 'restapi:admin/actiongroups'
     - 'restapi:admin/allowlist'
+    - 'restapi:admin/config/update'
     - 'restapi:admin/internalusers'
     - 'restapi:admin/nodesdn'
     - 'restapi:admin/roles'

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAdminPrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RestApiAdminPrivilegesEvaluator.java
@@ -35,9 +35,11 @@ public class RestApiAdminPrivilegesEvaluator {
 
     protected final Logger logger = LogManager.getLogger(RestApiAdminPrivilegesEvaluator.class);
 
-    public final static String CERTS_INFO_ACTION = "certs";
+    public final static String CERTS_INFO_ACTION = "certs/info";
 
-    public final static String RELOAD_CERTS_ACTION = "reloadcerts";
+    public final static String RELOAD_CERTS_ACTION = "certs/reload";
+
+    public final static String SECURITY_CONFIG_UPDATE = "update";
 
     private final static String REST_API_PERMISSION_PREFIX = "restapi:admin";
 
@@ -61,21 +63,13 @@ public class RestApiAdminPrivilegesEvaluator {
     public final static Map<Endpoint, PermissionBuilder> ENDPOINTS_WITH_PERMISSIONS = ImmutableMap.<Endpoint, PermissionBuilder>builder()
         .put(Endpoint.ACTIONGROUPS, action -> buildEndpointPermission(Endpoint.ACTIONGROUPS))
         .put(Endpoint.ALLOWLIST, action -> buildEndpointPermission(Endpoint.ALLOWLIST))
+        .put(Endpoint.CONFIG, action -> buildEndpointActionPermission(Endpoint.CONFIG, action))
         .put(Endpoint.INTERNALUSERS, action -> buildEndpointPermission(Endpoint.INTERNALUSERS))
         .put(Endpoint.NODESDN, action -> buildEndpointPermission(Endpoint.NODESDN))
         .put(Endpoint.ROLES, action -> buildEndpointPermission(Endpoint.ROLES))
         .put(Endpoint.ROLESMAPPING, action -> buildEndpointPermission(Endpoint.ROLESMAPPING))
         .put(Endpoint.TENANTS, action -> buildEndpointPermission(Endpoint.TENANTS))
-        .put(Endpoint.SSL, action -> {
-            switch (action) {
-                case CERTS_INFO_ACTION:
-                    return buildEndpointActionPermission(Endpoint.SSL, "certs/info");
-                case RELOAD_CERTS_ACTION:
-                    return buildEndpointActionPermission(Endpoint.SSL, "certs/reload");
-                default:
-                    return null;
-            }
-        })
+        .put(Endpoint.SSL, action -> buildEndpointActionPermission(Endpoint.SSL, action))
         .build();
 
     private final ThreadContext threadContext;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
@@ -11,41 +11,40 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
-import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static org.opensearch.security.dlic.rest.api.RequestHandler.methodNotImplementedHandler;
-import static org.opensearch.security.dlic.rest.api.Responses.methodNotImplementedMessage;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
 public class SecurityConfigApiAction extends AbstractApiAction {
 
-    private static final List<Route> getRoutes = addRoutesPrefix(Collections.singletonList(new Route(Method.GET, "/securityconfig/")));
-
-    private static final List<Route> allRoutes = new ImmutableList.Builder<Route>().addAll(getRoutes)
-        .addAll(
-            addRoutesPrefix(ImmutableList.of(new Route(Method.PUT, "/securityconfig/config"), new Route(Method.PATCH, "/securityconfig/")))
+    private static final List<Route> routes = addRoutesPrefix(
+        List.of(
+            new Route(Method.GET, "/securityconfig"),
+            new Route(Method.PATCH, "/securityconfig"),
+            new Route(Method.PUT, "/securityconfig/config")
         )
-        .build();
+    );
 
     private final boolean allowPutOrPatch;
+
+    private final boolean restApiAdminEnabled;
 
     @Inject
     public SecurityConfigApiAction(
@@ -57,12 +56,13 @@ public class SecurityConfigApiAction extends AbstractApiAction {
         super(Endpoint.CONFIG, clusterService, threadPool, securityApiDependencies);
         allowPutOrPatch = securityApiDependencies.settings()
             .getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, false);
+        this.restApiAdminEnabled = securityApiDependencies.settings().getAsBoolean(SECURITY_RESTAPI_ADMIN_ENABLED, false);
         this.requestHandlersBuilder.configureRequestHandlers(this::securityConfigApiActionRequestHandlers);
     }
 
     @Override
     public List<Route> routes() {
-        return allowPutOrPatch ? allRoutes : getRoutes;
+        return routes;
     }
 
     @Override
@@ -74,20 +74,27 @@ public class SecurityConfigApiAction extends AbstractApiAction {
     protected void consumeParameters(RestRequest request) {}
 
     private void securityConfigApiActionRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {
-        requestHandlersBuilder.onChangeRequest(
-            Method.PUT,
-            request -> withAllowedEndpoint(request).map(ignore -> processPutRequest("config", request))
-        )
-            .onChangeRequest(Method.PATCH, request -> withAllowedEndpoint(request).map(this::processPatchRequest))
+        requestHandlersBuilder.withAccessHandler(this::accessHandler)
+            .verifyAccessForAllMethods()
+            .onChangeRequest(Method.PUT, request -> processPutRequest("config", request))
+            .onChangeRequest(Method.PATCH, this::processPatchRequest)
             .override(Method.DELETE, methodNotImplementedHandler)
             .override(Method.POST, methodNotImplementedHandler);
     }
 
-    ValidationResult<RestRequest> withAllowedEndpoint(final RestRequest request) {
-        if (!allowPutOrPatch) {
-            return ValidationResult.error(RestStatus.NOT_IMPLEMENTED, methodNotImplementedMessage(request.method()));
+    boolean accessHandler(final RestRequest request) {
+        switch (request.method()) {
+            case PATCH:
+            case PUT:
+                if (!restApiAdminEnabled) {
+                    return allowPutOrPatch;
+                } else {
+                    return securityApiDependencies.restApiAdminPrivilegesEvaluator()
+                        .isCurrentUserAdminFor(endpoint, SECURITY_CONFIG_UPDATE);
+                }
+            default:
+                return true;
         }
-        return ValidationResult.success(request);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -95,7 +95,7 @@ public class SecurityRestApiActions {
             new AllowlistApiAction(Endpoint.ALLOWLIST, clusterService, threadPool, securityApiDependencies),
             new AuditApiAction(clusterService, threadPool, securityApiDependencies),
             new MultiTenancyConfigApiAction(clusterService, threadPool, securityApiDependencies),
-            new SecuritySSLCertsAction(clusterService, threadPool, securityKeyStore, certificatesReloadEnabled, securityApiDependencies)
+            new SecuritySSLCertsApiAction(clusterService, threadPool, securityKeyStore, certificatesReloadEnabled, securityApiDependencies)
         );
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
@@ -13,29 +13,32 @@ package org.opensearch.security.dlic.rest.api;
 
 import org.junit.Test;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.security.util.FakeRestRequest;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION;
 
 public class SecurityConfigApiActionValidationTest extends AbstractApiActionValidationTest {
 
     @Test
-    public void withAllowedEndpoint() {
-        var securityConfigApiAction = new SecurityConfigApiAction(
+    public void accessHandlerForDefaultSettings() {
+        final var securityConfigApiAction = new SecurityConfigApiAction(
             clusterService,
             threadPool,
             new SecurityApiDependencies(null, configurationRepository, null, null, restApiAdminPrivilegesEvaluator, null, Settings.EMPTY)
         );
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertFalse(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertFalse(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
+    }
 
-        var result = securityConfigApiAction.withAllowedEndpoint(FakeRestRequest.builder().build());
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_IMPLEMENTED, result.status());
-
-        securityConfigApiAction = new SecurityConfigApiAction(
+    @Test
+    public void accessHandlerForUnsupportedSetting() {
+        final var securityConfigApiAction = new SecurityConfigApiAction(
             clusterService,
             threadPool,
             new SecurityApiDependencies(
@@ -45,11 +48,32 @@ public class SecurityConfigApiActionValidationTest extends AbstractApiActionVali
                 null,
                 restApiAdminPrivilegesEvaluator,
                 null,
-                Settings.builder().put(ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build()
+                Settings.builder().put(SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build()
             )
         );
-        result = securityConfigApiAction.withAllowedEndpoint(FakeRestRequest.builder().build());
-        assertTrue(result.isValid());
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
     }
 
+    @Test
+    public void accessHandlerForRestAdmin() {
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.CONFIG, RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE)).thenReturn(true);
+        final var securityConfigApiAction = new SecurityConfigApiAction(
+                clusterService,
+                threadPool,
+                new SecurityApiDependencies(
+                        null,
+                        configurationRepository,
+                        null,
+                        null,
+                        restApiAdminPrivilegesEvaluator,
+                        null,
+                        Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build()
+                )
+        );
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+        assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PATCH).build()));
+    }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api;
+
+import org.junit.Test;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.util.FakeRestRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RELOAD_CERTS_ACTION;
+
+public class SecuritySSLCertsApiActionValidationTest extends AbstractApiActionValidationTest {
+
+    @Test
+    public void withSecurityKeyStore() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        final var result = securitySSLCertsApiAction.withSecurityKeyStore();
+        assertFalse(result.isValid());
+        assertEquals(RestStatus.OK, result.status());
+    }
+
+    @Test
+    public void accessDenied() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, CERTS_INFO_ACTION)).thenReturn(false);
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, RELOAD_CERTS_ACTION)).thenReturn(false);
+        assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+
+        for (final var m : RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS) {
+            if (m != RestRequest.Method.GET && m != RestRequest.Method.PUT) {
+                assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(m).build()));
+            }
+        }
+    }
+
+    @Test
+    public void hasAccess() {
+        final var securitySSLCertsApiAction = new SecuritySSLCertsApiAction(
+            clusterService,
+            threadPool,
+            null,
+            true,
+            securityApiDependencies
+        );
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, CERTS_INFO_ACTION)).thenReturn(true);
+        when(restApiAdminPrivilegesEvaluator.isCurrentUserAdminFor(Endpoint.SSL, RELOAD_CERTS_ACTION)).thenReturn(true);
+        assertTrue(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
+        assertTrue(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
+
+        for (final var m : RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS) {
+            if (m != RestRequest.Method.GET && m != RestRequest.Method.PUT) {
+                assertFalse(securitySSLCertsApiAction.accessHandler(FakeRestRequest.builder().withMethod(m).build()));
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
@@ -51,7 +51,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         return PLUGINS_PREFIX;
     }
 
-    final int USER_SETTING_SIZE = 133; // Lines per account entry * number of accounts
+    final int USER_SETTING_SIZE = 140; // Lines per account entry * number of accounts
 
     private static final String ENABLED_SERVICE_ACCOUNT_BODY = "{"
         + " \"attributes\": { \"service\": \"true\", "
@@ -614,7 +614,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/" + CType.INTERNALUSERS.toLCString(), restApiAdminHeader);
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(133, settings.size());
+        Assert.assertEquals(USER_SETTING_SIZE, settings.size());
         verifyGet(restApiAdminHeader);
         verifyPut(restApiAdminHeader);
         verifyPatch(false, restApiAdminHeader);
@@ -632,7 +632,7 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/" + CType.INTERNALUSERS.toLCString(), restApiInternalUsersAdminHeader);
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(133, settings.size());
+        Assert.assertEquals(USER_SETTING_SIZE, settings.size());
         verifyGet(restApiInternalUsersAdminHeader);
         verifyPut(restApiInternalUsersAdminHeader);
         verifyPatch(false, restApiInternalUsersAdminHeader);

--- a/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsTest.java
+++ b/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsTest.java
@@ -53,6 +53,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RELOAD_CERTS_ACTION;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
 
 public class SecurityRolesPermissionsTest {
 
@@ -78,6 +79,8 @@ public class SecurityRolesPermissionsTest {
                 new SimpleEntry<>(restAdminApiRoleName(CERTS_INFO_ACTION), role(pb.build(CERTS_INFO_ACTION))),
                 new SimpleEntry<>(restAdminApiRoleName(RELOAD_CERTS_ACTION), role(pb.build(RELOAD_CERTS_ACTION)))
             );
+        } else if (e.getKey() == Endpoint.CONFIG) {
+            return Stream.of(new SimpleEntry<>(restAdminApiRoleName(SECURITY_CONFIG_UPDATE), role(pb.build(SECURITY_CONFIG_UPDATE))));
         } else {
             return Stream.of(new SimpleEntry<>(restAdminApiRoleName(endpoint), role(pb.build())));
         }
@@ -95,6 +98,8 @@ public class SecurityRolesPermissionsTest {
         return ENDPOINTS_WITH_PERMISSIONS.entrySet().stream().flatMap(entry -> {
             if (entry.getKey() == Endpoint.SSL) {
                 return Stream.of(entry.getValue().build(CERTS_INFO_ACTION), entry.getValue().build(RELOAD_CERTS_ACTION));
+            } else if (entry.getKey() == Endpoint.CONFIG) {
+                return Stream.of(entry.getValue().build(SECURITY_CONFIG_UPDATE));
             } else {
                 return Stream.of(entry.getValue().build());
             }
@@ -130,6 +135,11 @@ public class SecurityRolesPermissionsTest {
                         endpoint.name(),
                         securityRolesForRole.hasExplicitClusterPermissionPermission(permissionBuilder.build(RELOAD_CERTS_ACTION))
                     );
+                } else if (endpoint == Endpoint.CONFIG) {
+                    Assert.assertFalse(
+                        endpoint.name(),
+                        securityRolesForRole.hasExplicitClusterPermissionPermission(permissionBuilder.build(SECURITY_CONFIG_UPDATE))
+                    );
                 } else {
                     Assert.assertFalse(
                         endpoint.name(),
@@ -156,6 +166,11 @@ public class SecurityRolesPermissionsTest {
                         endpoint.name() + "/" + CERTS_INFO_ACTION,
                         securityRolesForRole.hasExplicitClusterPermissionPermission(permissionBuilder.build(RELOAD_CERTS_ACTION))
                     );
+                } else if (endpoint == Endpoint.CONFIG) {
+                    Assert.assertTrue(
+                        endpoint.name() + "/" + SECURITY_CONFIG_UPDATE,
+                        securityRolesForRole.hasExplicitClusterPermissionPermission(permissionBuilder.build(SECURITY_CONFIG_UPDATE))
+                    );
                 } else {
                     Assert.assertTrue(
                         endpoint.name(),
@@ -168,10 +183,10 @@ public class SecurityRolesPermissionsTest {
 
     @Test
     public void hasExplicitClusterPermissionPermissionForRestAdmin() {
-        // verify all endpoint except SSL
+        // verify all endpoint except SSL and verify CONFIG endpoints
         final Collection<Endpoint> noSslEndpoints = ENDPOINTS_WITH_PERMISSIONS.keySet()
             .stream()
-            .filter(e -> e != Endpoint.SSL)
+            .filter(e -> e != Endpoint.SSL && e != Endpoint.CONFIG)
             .collect(Collectors.toList());
         for (final Endpoint endpoint : noSslEndpoints) {
             final String permission = ENDPOINTS_WITH_PERMISSIONS.get(endpoint).build();
@@ -190,6 +205,15 @@ public class SecurityRolesPermissionsTest {
             );
             assertHasNoPermissionsForRestApiAdminOnePermissionRole(Endpoint.SSL, sslAllowRole);
         }
+        // verify CONFIG endpoint with 1 action
+        final SecurityRoles securityConfigAllowRole = configModel.getSecurityRoles()
+            .filter(ImmutableSet.of(restAdminApiRoleName(SECURITY_CONFIG_UPDATE)));
+        final PermissionBuilder permissionBuilder = ENDPOINTS_WITH_PERMISSIONS.get(Endpoint.CONFIG);
+        Assert.assertTrue(
+            Endpoint.SSL + "/" + SECURITY_CONFIG_UPDATE,
+            securityConfigAllowRole.hasExplicitClusterPermissionPermission(permissionBuilder.build(SECURITY_CONFIG_UPDATE))
+        );
+        assertHasNoPermissionsForRestApiAdminOnePermissionRole(Endpoint.CONFIG, securityConfigAllowRole);
     }
 
     void assertHasNoPermissionsForRestApiAdminOnePermissionRole(final Endpoint allowEndpoint, final SecurityRoles allowOnlyRoleForRole) {

--- a/src/test/resources/restapi/internal_users.yml
+++ b/src/test/resources/restapi/internal_users.yml
@@ -127,3 +127,9 @@ rest_api_admin_tenants:
   hidden: false
   backend_roles: []
   description: "REST API Tenats admin user"
+rest_api_admin_config_update:
+  hash: "$2y$12$capXg1HNP49Vxeb6ijzRnu5BLMUE0ZePq1l3MhF8tjnuxg614uaY6"
+  reserved: false
+  hidden: false
+  backend_roles: []
+  description: "REST API Config update admin user"

--- a/src/test/resources/restapi/roles.yml
+++ b/src/test/resources/restapi/roles.yml
@@ -398,6 +398,7 @@ rest_api_admin_full_access:
   cluster_permissions:
     - 'restapi:admin/actiongroups'
     - 'restapi:admin/allowlist'
+    - 'restapi:admin/config/update'
     - 'restapi:admin/internalusers'
     - 'restapi:admin/nodesdn'
     - 'restapi:admin/roles'
@@ -441,3 +442,7 @@ rest_api_admin_tenants_only:
   reserved: true
   cluster_permissions:
     - 'restapi:admin/tenants'
+rest_api_admin_config_update_only:
+  reserved: true
+  cluster_permissions:
+    - 'restapi:admin/config/update'

--- a/src/test/resources/restapi/roles_mapping.yml
+++ b/src/test/resources/restapi/roles_mapping.yml
@@ -195,6 +195,7 @@ opendistro_security_test:
   - "rest_api_admin_tenants"
   - "rest_api_admin_ssl_info"
   - "rest_api_admin_ssl_reloadcerts"
+  - "rest_api_admin_config_update"
   and_backend_roles: []
   description: "Migrated from v6"
 opendistro_security_role_starfleet_captains:
@@ -260,3 +261,7 @@ rest_api_admin_tenants_only:
   reserved: false
   hidden: true
   users: [rest_api_admin_tenants]
+rest_api_admin_config_update_only:
+  reserved: false
+  hidden: true
+  users: [rest_api_admin_config_update]


### PR DESCRIPTION
Backport e4a1b77e9259c019a8ef4728495260468954d6af from #3264 