### PR TITLE
Adds random password generation capability to demo config install scripts

### DIFF
--- a/tools/generate-password.bat
+++ b/tools/generate-password.bat
@@ -1,0 +1,23 @@
+@echo off
+setlocal enableDelayedExpansion
+
+REM Set the directory of the current script
+set "SCRIPT_DIR=%~dp0"
+
+REM Set the desired password length
+set "length=16"
+
+REM Define the character set for the password
+set "characters=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+REM Initialize the password variable
+set "password="
+
+REM Loop to generate the random password
+for /l %%i in (1,1,%length%) do (
+    set /a "index=!random! %% 62"
+    for %%c in (!index!) do (
+        set "char=!characters:~%%c,1!"
+        set "password=!password!!char!"
+    )
+)

--- a/tools/generate-password.sh
+++ b/tools/generate-password.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+length="$1"
+if [ -z "$length" ]; then
+    length=12  # Default password length
+fi
+
+# Define the character set for the password
+characters="A-Za-z0-9"
+
+# Use /dev/urandom to generate random bytes and tr to shuffle them
+LC_ALL=C tr -dc "$characters" < /dev/urandom | head -c "$length"


### PR DESCRIPTION
### Description
As a follow to changes made in demo config script, this PR adds a script to generate a random 16 character password if the flag to generate random password `-g` is passed. It will only generate and set admin password when following conditions are true:
- initialAdminPassword variable is not set as env variable
- initialAdminPassword.txt doesn't exist
- `-g` flag is passed to the script

If `-g` is not passed and other two conditions are false, the install demo config script would fail.

Related to: https://github.com/opensearch-project/security/issues/1576

### Testing
Manual testing:

<details>
<summary>Windows install logs:</summary>

```console
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************

OpenSearch Security Demo Installer
 ** Warning: Do not use on production or public reachable systems **

Basedir: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\
OpenSearch install type: .zip on Windows_NT
OpenSearch config dir: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\
OpenSearch config file: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\opensearch.yml
OpenSearch bin dir: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\bin\
OpenSearch plugins dir: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\plugins\
OpenSearch lib dir: C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\lib\
Detected OpenSearch Version: 3.0.0
Detected OpenSearch Security Version: 3.0.0.0
"what is in the config directory"  
 Volume in drive C has no label.
 Volume Serial Number is E61A-B1DE

 Directory of C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config

10/05/2023  06:48 PM    <DIR>          .
10/05/2023  06:33 PM    <DIR>          ..
10/05/2023  06:48 PM             1,707 esnode-key.pem
10/05/2023  06:48 PM             1,532 esnode.pem
08/31/2023  03:27 PM             2,747 jvm.options
08/31/2023  03:27 PM    <DIR>          jvm.options.d
10/05/2023  06:48 PM             1,707 kirk-key.pem
10/05/2023  06:48 PM             1,658 kirk.pem
08/31/2023  03:27 PM            14,808 log4j2.properties
08/31/2023  05:37 PM    <DIR>          opensearch-security
08/31/2023  05:33 PM               196 opensearch.keystore
10/05/2023  06:48 PM             6,416 opensearch.yml
10/05/2023  06:48 PM             1,719 root-ca.pem
               9 File(s)         32,490 bytes
               4 Dir(s)  169,389,215,744 bytes free
"what is in the password file"
"   ***************************************************"
"   ***   ADMIN PASSWORD SET TO: BoXO6rWKjVJUqpUC  ***"
"   ***************************************************"
### Success
### Execute this script now on all your nodes and then start all nodes
### OpenSearch Security will be automatically initialized.
### If you like to change the runtime configuration 
### change the files in ../../../config/opensearch-security and execute: 
 
C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\plugins\opensearch-security\tools\securityadmin.bat -cd C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\opensearch-security -icl -key C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\kirk-key.pem -cert C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\kirk.pem -cacert C:\Users\Administrator\Documents\localDistro\opensearch-3.0.0-SNAPSHOT\config\root-ca.pem -nhnv 
### or run ./securityadmin_demo.bat
### To use the Security Plugin ConfigurationGUI
### [Ignore the SSL certificate warning because we installed self-signed demo certificates]

```
</details>

<details>
<summary>Windows curl ouput after password change:</summary>

```console
C:\Users\Administrator>curl -XGET https://localhost:9200/ -k -u admin:admin
Unauthorized
C:\Users\Administrator>curl -XGET https://localhost:9200/ -k -u admin:BoXO6rWKjVJUqpUC
{
  "name" : "EC2AMAZ-SPV3HQH",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "QhnbMcigR6KKTj-XZtr21w",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "zip",
    "build_hash" : "bb38ed4836496ac70258c2472668325a012ea3ed",
    "build_date" : "2023-08-31T15:25:32.930646600Z",
    "build_snapshot" : true,
    "lucene_version" : "9.8.0",
    "minimum_wire_compatibility_version" : "2.10.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```
</details>


<details>
<summary>Mac install_demo_config log:</summary>

```console
➜  opensearch-security ./tools/install_demo_configuration.sh -y -i -s -g
./tools/install_demo_configuration.sh: line 3: ./generate-password.sh: No such file or directory
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
OpenSearch Security Demo Installer
 ** Warning: Do not use on production or public reachable systems **
Basedir: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT
OpenSearch install type: .tar.gz on
OpenSearch config dir: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config
OpenSearch config file: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config/opensearch.yml
OpenSearch bin dir: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/bin
OpenSearch plugins dir: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/plugins
OpenSearch lib dir: /Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/lib
Detected OpenSearch Version: x-content-3.0.0-SNAPSHOT
Detected OpenSearch Security Version: 3.0.0.0-SNAPSHOT

   ***************************************************
   ***   ADMIN PASSWORD SET TO: Mari4UfLQajoASVo    ***
   ***************************************************
**************************************************************************
** This tool will be deprecated in the next major release of OpenSearch **
** https://github.com/opensearch-project/security/issues/1755           **
**************************************************************************
### Success
### Execute this script now on all your nodes and then start all nodes
### OpenSearch Security will be automatically initialized.
### If you like to change the runtime configuration
### change the files in ../../../config/opensearch-security and execute:
"/Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/plugins/opensearch-security/tools/securityadmin.sh" -cd "/Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config/opensearch-security" -icl -key "/Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config/kirk-key.pem" -cert "/Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config/kirk.pem" -cacert "/Users/dchanp/Documents/amazon/testing-playground/test/binaries/opensearch-3.0.0-SNAPSHOT/config/root-ca.pem" -nhnv
### or run ./securityadmin_demo.sh
### To use the Security Plugin ConfigurationGUI
### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/admin.
### (Ignore the SSL certificate warning because we installed self-signed demo certificates)
```
</details>

<details>
<summary>Mac curl output after password change:</summary>

```console
➜  ~ curl -XGET 'https://[::1]:9200/' -k -u admin:admin

Unauthorized%
➜  ~ curl -XGET 'https://[::1]:9200/' -k -u admin:Mari4UfLQajoASVo

{
  "name" : "3c06300b34da.ant.amazon.com",
  "cluster_name" : "opensearch",
  "cluster_uuid" : "Zw9pjloBTiiqzfusz2nyLQ",
  "version" : {
    "distribution" : "opensearch",
    "number" : "3.0.0-SNAPSHOT",
    "build_type" : "tar",
    "build_hash" : "d656e3db592f29466d35452867caa241f5429485",
    "build_date" : "2023-09-28T15:29:27.870375Z",
    "build_snapshot" : true,
    "lucene_version" : "9.8.0",
    "minimum_wire_compatibility_version" : "2.11.0",
    "minimum_index_compatibility_version" : "2.0.0"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```
</details>

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
