### PR TITLE
Bump snappy-java to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,7 @@ configurations.all {
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
+        force "org.xerial.snappy:snappy-java:1.1.10.5"
     }
 }
 
@@ -127,6 +128,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'
     runtimeOnly 'org.apache.commons:commons-text:1.10.0'
+    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.5'
 
     testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"


### PR DESCRIPTION
### Description

Bump snappy-java to address the following potential vulnerabilities.

https://www.cve.org/CVERecord?id=CVE-2023-43642
https://www.cve.org/CVERecord?id=CVE-2023-34453
https://www.cve.org/CVERecord?id=CVE-2023-34454
https://www.cve.org/CVERecord?id=CVE-2023-34455

A similar change has already been pushed into the 2.x branches so this is effectively a backport.
https://github.com/opensearch-project/security/pull/3435

### Testing
Manually built and ran the security plugin according to the [developer guide](https://github.com/opensearch-project/security/blob/1.3/DEVELOPER_GUIDE.md#building).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
