### PR TITLE
[Backport 2.x] Add missing license header (#3467)

### DIFF
--- a/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.security.transport;
 
 import org.junit.Assert;


### PR DESCRIPTION
Backport fb82bbbfcc133fa4ae0bba227c881f7a6ebbe7bd from #3467 