### PR TITLE
[Backport 2.11] Adds opensearch trigger bot to discerning merger list to allow automatic merges (#3474)

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -25,7 +25,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
           allowed-authors: |
-            dependabot%5Bbot%5D
+            dependabot[bot]
+            opensearch-trigger-bot[bot]
           allowed-files: |
             build.gradle
             .github/workflows/*.yml


### PR DESCRIPTION
Backports #3474 via commit 999339e7ea3043f6be9342685b7e7c70b5dd55ae)

Not sure why manual backport was required as there were no conflicts

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
