### PR TITLE
[Backports 1.x] Adds opensearch trigger bot to discerning merger list to allow automatic merges (#3474)

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -1,0 +1,32 @@
+name: automatic-merges
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Plugin Install
+      - Code Hygiene
+    types: completed
+
+jobs:
+  automatic-merge-version-bumps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: find-triggering-pr
+        uses: peternied/find-triggering-pr@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: peternied/discerning-merger@v1
+        if: steps.find-triggering-pr.outputs.pr-number != null
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
+          allowed-authors: |
+            dependabot[bot]
+            opensearch-trigger-bot[bot]
+          allowed-files: |
+            build.gradle
+            .github/workflows/*.yml


### PR DESCRIPTION
Backports #3474  via commit 999339e7ea3043f6be9342685b7e7c70b5dd55ae

Since the original file was not present in 1.3 line, this PR adds the file too. (Essentially backports https://github.com/opensearch-project/security/pull/3408 as well)

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
