### PR TITLE
SAML login usernames do not allow \h, and instead allow the usage of \\h with ensured JWT consistency

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -284,7 +284,9 @@ class AuthTokenProcessorHandler {
         jwtClaims.setNotBefore(System.currentTimeMillis() / 1000);
         jwtClaims.setExpiryTime(getJwtExpiration(samlResponse));
 
-        jwtClaims.setProperty(this.jwtSubjectKey, this.extractSubject(samlResponse));
+        String subject = this.extractSubject(samlResponse);
+        String processedSubject = subject.replaceAll("(\\\\*)\\\\h", "\\\\\\\\h");
+        jwtClaims.setProperty(this.jwtSubjectKey, processedSubject);
 
         if (this.samlSubjectKey != null) {
             jwtClaims.setProperty("saml_ni", samlResponse.getNameId());
@@ -310,12 +312,12 @@ class AuthTokenProcessorHandler {
 
         if (token_log.isDebugEnabled()) {
             token_log.debug(
-                "Created JWT: "
-                    + encodedJwt
-                    + "\n"
-                    + jsonMapReaderWriter.toJson(jwt.getJwsHeaders())
-                    + "\n"
-                    + JwtUtils.claimsToJson(jwt.getClaims())
+                    "Created JWT: "
+                            + encodedJwt
+                            + "\n"
+                            + jsonMapReaderWriter.toJson(jwt.getJwsHeaders())
+                            + "\n"
+                            + JwtUtils.claimsToJson(jwt.getClaims())
             );
         }
 

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -285,6 +285,11 @@ class AuthTokenProcessorHandler {
         jwtClaims.setExpiryTime(getJwtExpiration(samlResponse));
 
         String subject = this.extractSubject(samlResponse);
+
+        if (!subject.matches("^(?!.*(?<!\\\\)\\\\h).*$")) {
+            throw new IllegalArgumentException("Illegal escape sequence" + (char) 92 +  "h detected in subject.");
+        }
+
         String processedSubject = subject.replaceAll("(\\\\*)\\\\h", "\\\\\\\\h");
         jwtClaims.setProperty(this.jwtSubjectKey, processedSubject);
 

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -908,52 +908,6 @@ public class HTTPSamlAuthenticatorTest {
             .withHeaders(ImmutableMap.of("Content-Type", "application/json"))
             .build();
     }
-    @Test
-    public void testJwtWithBackslashHInUsername() throws Exception {
-        String[] testUsernames = {
-                "username\\hexample",
-                "username\\\\hexample",
-                "username\\\\\\hexample",
-                "username\\\\\\\\\\hexample"
-        };
-
-        for (String testUsername : testUsernames) {
-            mockSamlIdpServer.setSignResponses(true);
-            mockSamlIdpServer.loadSigningKeys("saml/kirk-keystore.jks", "kirk");
-            mockSamlIdpServer.setAuthenticateUser(testUsername);
-            mockSamlIdpServer.setEndpointQueryString(null);
-
-            Settings settings = Settings.builder()
-                    .put(IDP_METADATA_URL, mockSamlIdpServer.getMetadataUri())
-                    .put("kibana_url", "http://wherever")
-                    .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
-                    .put("exchange_key", "abc")
-                    .put("roles_key", "roles")
-                    .put("path.home", ".")
-                    .build();
-
-            HTTPSamlAuthenticator samlAuthenticator = new HTTPSamlAuthenticator(settings, null);
-
-            AuthenticateHeaders authenticateHeaders = getAutenticateHeaders(samlAuthenticator);
-            String encodedSamlResponse = mockSamlIdpServer.handleSsoGetRequestURI(authenticateHeaders.location);
-            RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
-
-            String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-            HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-                    responseJson,
-                    new TypeReference<HashMap<String, Object>>() {
-                    }
-            );
-
-            String authorization = (String) response.get("authorization");
-            Assert.assertNotNull("Expected authorization attribute in JSON for input: " + testUsername, authorization);
-
-            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(authorization.replaceAll("\\s*bearer\\s*", ""));
-            JwtToken jwt = jwtConsumer.getJwtToken();
-
-            Assert.assertEquals("username\\hexample", jwt.getClaim("sub"));
-        }
-    }
 
     @Test
     public void testJwtWithBackslashHInUsername() throws Exception {


### PR DESCRIPTION
### Description
Addressed an issue where SAML login would fail for usernames containing `\h`. While usernames with `\h` remain unsupported, this fix ensures that `\\h` can be used as a consistent alternative. Usernames with an even number of backslashes followed by `h` will always be treated as having just `\\h`.

**Category:** Bug fix

**Reason for Change:** 
Usernames containing `\h` were found to cause invalid JWT token generation, as detailed in [Issue 2531](https://github.com/opensearch-project/security/issues/2531). However, `\\h` produces valid JWT tokens. Due to inconsistent handling of backslashes (owing to their use as escape characters in string literals), it's crucial to establish a consistent approach. Hence, any even number of backslashes before `h` will now be treated as `\\h`.

**Behavioral Change:**
- **Previous Behavior:** SAML login fails when the username contains `\h`.
- **New Behavior:** SAML login succeeds for usernames with `\\h` and fails for `\h`.

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/2531

### Testing
A test `testJwtWithBackslashHInUsername` was added in `src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java` to validate the behavior with various username patterns. This test iterates over an array of test usernames, ranging from "username\hexample" to "username\\\\\\\\hexample", to ensure that only the `\\h` format is valid.

In addition to the automated tests, manual testing was conducted where tokens were created with usernames containing `\h` (which consistently failed) and `\\h` (which succeeded). The validity of these tokens was further confirmed using the [jwt.io site created by Okta](https://jwt.io/).

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. More information on the Developer Certificate of Origin and signing off on commits can be found [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
