### PR TITLE
[Cleanup] Remove duplication in Netty4HttpRequestHeaderVerifier

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -184,7 +184,9 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
             if (API_AUTHTOKEN_SUFFIX.equals(suffix)) {
                 // Verficiation of SAML ASC endpoint only works with RestRequests
                 if (!(request instanceof OpenSearchRequest)) {
-                    throw new SecurityRequestChannelUnsupported();
+                    throw new SecurityRequestChannelUnsupported(
+                        API_AUTHTOKEN_SUFFIX + " not supported for request of type " + request.getClass().getName()
+                    );
                 } else {
                     final OpenSearchRequest openSearchRequest = (OpenSearchRequest) request;
                     final RestRequest restRequest = openSearchRequest.breakEncapsulationForRequest();
@@ -200,6 +202,9 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
                 new SecurityResponse(HttpStatus.SC_UNAUTHORIZED, Map.of("WWW-Authenticate", getWwwAuthenticateHeader(saml2Settings)), "")
             );
         } catch (Exception e) {
+            if (e instanceof SecurityRequestChannelUnsupported) {
+                throw (SecurityRequestChannelUnsupported) e;
+            }
             log.error("Error in reRequestAuthentication()", e);
             return Optional.empty();
         }

--- a/src/main/java/org/opensearch/security/filter/SecurityRequest.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRequest.java
@@ -25,29 +25,29 @@ import org.opensearch.rest.RestRequest.Method;
 public interface SecurityRequest {
 
     /** Collection of headers associated with the request */
-    public Map<String, List<String>> getHeaders();
+    Map<String, List<String>> getHeaders();
 
     /** The SSLEngine associated with the request */
-    public SSLEngine getSSLEngine();
+    SSLEngine getSSLEngine();
 
     /** The path of the request */
-    public String path();
+    String path();
 
     /** The method type of this request */
-    public Method method();
+    Method method();
 
     /** The remote address of the request, possible null */
-    public Optional<InetSocketAddress> getRemoteAddress();
+    Optional<InetSocketAddress> getRemoteAddress();
 
     /** The full uri of the request */
-    public String uri();
+    String uri();
 
     /** Finds the first value of the matching header or null */
-    default public String header(final String headerName) {
+    default String header(final String headerName) {
         final Optional<Map<String, List<String>>> headersMap = Optional.ofNullable(getHeaders());
         return headersMap.map(headers -> headers.get(headerName)).map(List::stream).flatMap(Stream::findFirst).orElse(null);
     }
 
     /** The parameters associated with this request */
-    public Map<String, String> params();
+    Map<String, String> params();
 }

--- a/src/main/java/org/opensearch/security/filter/SecurityRequestChannelUnsupported.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRequestChannelUnsupported.java
@@ -11,7 +11,12 @@
 
 package org.opensearch.security.filter;
 
-/** Thrown when a security rest channel is not supported */
-public class SecurityRequestChannelUnsupported extends RuntimeException {
+import org.opensearch.OpenSearchException;
 
+/** Thrown when a security rest channel is not supported */
+public class SecurityRequestChannelUnsupported extends OpenSearchException {
+
+    public SecurityRequestChannelUnsupported(String msg, Object... args) {
+        super(msg, args);
+    }
 }

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -30,7 +30,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -45,7 +44,6 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.rest.NamedRoute;
 import org.opensearch.rest.RestHandler;
-import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
 import org.opensearch.security.auth.BackendRegistry;
@@ -285,9 +283,7 @@ public class SecurityRestFilter {
             return;
         }
 
-        Matcher matcher = PATTERN_PATH_PREFIX.matcher(requestChannel.path());
-        final String suffix = matcher.matches() ? matcher.group(2) : null;
-        if (requestChannel.method() != Method.OPTIONS && !(HEALTH_SUFFIX.equals(suffix)) && !(WHO_AM_I_SUFFIX.equals(suffix))) {
+        if (!SecurityRestUtils.shouldSkipAuthentication(requestChannel)) {
             if (!registry.authenticate(requestChannel)) {
                 // another roundtrip
                 org.apache.logging.log4j.ThreadContext.remove("user");

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -47,7 +47,6 @@ import org.opensearch.rest.NamedRoute;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
 import org.opensearch.security.auth.BackendRegistry;

--- a/src/main/java/org/opensearch/security/filter/SecurityRestUtils.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestUtils.java
@@ -1,4 +1,27 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 package org.opensearch.security.filter;
+
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpRequest;
+
+import static org.opensearch.security.filter.SecurityRestFilter.HEALTH_SUFFIX;
+import static org.opensearch.security.filter.SecurityRestFilter.PATTERN_PATH_PREFIX;
+import static org.opensearch.security.filter.SecurityRestFilter.WHO_AM_I_SUFFIX;
+
+import java.util.regex.Matcher;
+
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.rest.RestUtils;
 
 public class SecurityRestUtils {
     public static String path(final String uri) {
@@ -8,5 +31,29 @@ public class SecurityRestUtils {
         } else {
             return uri;
         }
+    }
+
+    public static boolean shouldSkipAuthentication(HttpRequest request) {
+        String rawPath = path(request.uri());
+        String path = RestUtils.decodeComponent(rawPath);
+        Matcher matcher = PATTERN_PATH_PREFIX.matcher(path);
+        final String suffix = matcher.matches() ? matcher.group(2) : null;
+
+        boolean shouldSkipAuthentication = HttpMethod.OPTIONS.equals(request.method())
+            || HEALTH_SUFFIX.equals(suffix)
+            || WHO_AM_I_SUFFIX.equals(suffix);
+
+        return shouldSkipAuthentication;
+    }
+
+    public static boolean shouldSkipAuthentication(SecurityRequestChannel request) {
+        Matcher matcher = PATTERN_PATH_PREFIX.matcher(request.path());
+        final String suffix = matcher.matches() ? matcher.group(2) : null;
+
+        boolean shouldSkipAuthentication = (request.method() == Method.OPTIONS)
+            || HEALTH_SUFFIX.equals(suffix)
+            || WHO_AM_I_SUFFIX.equals(suffix);
+
+        return shouldSkipAuthentication;
     }
 }

--- a/src/main/java/org/opensearch/security/filter/SecurityRestUtils.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestUtils.java
@@ -11,9 +11,6 @@
 
 package org.opensearch.security.filter;
 
-import io.netty.handler.codec.http.HttpMethod;
-import io.netty.handler.codec.http.HttpRequest;
-
 import static org.opensearch.security.filter.SecurityRestFilter.HEALTH_SUFFIX;
 import static org.opensearch.security.filter.SecurityRestFilter.PATTERN_PATH_PREFIX;
 import static org.opensearch.security.filter.SecurityRestFilter.WHO_AM_I_SUFFIX;
@@ -21,7 +18,6 @@ import static org.opensearch.security.filter.SecurityRestFilter.WHO_AM_I_SUFFIX;
 import java.util.regex.Matcher;
 
 import org.opensearch.rest.RestRequest.Method;
-import org.opensearch.rest.RestUtils;
 
 public class SecurityRestUtils {
     public static String path(final String uri) {
@@ -31,19 +27,6 @@ public class SecurityRestUtils {
         } else {
             return uri;
         }
-    }
-
-    public static boolean shouldSkipAuthentication(HttpRequest request) {
-        String rawPath = path(request.uri());
-        String path = RestUtils.decodeComponent(rawPath);
-        Matcher matcher = PATTERN_PATH_PREFIX.matcher(path);
-        final String suffix = matcher.matches() ? matcher.group(2) : null;
-
-        boolean shouldSkipAuthentication = HttpMethod.OPTIONS.equals(request.method())
-            || HEALTH_SUFFIX.equals(suffix)
-            || WHO_AM_I_SUFFIX.equals(suffix);
-
-        return shouldSkipAuthentication;
     }
 
     public static boolean shouldSkipAuthentication(SecurityRequestChannel request) {

--- a/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
@@ -81,7 +81,7 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
         try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
             injectUser(msg, threadContext);
 
-            boolean shouldSkipAuthentication = SecurityRestUtils.shouldSkipAuthentication(msg);
+            boolean shouldSkipAuthentication = SecurityRestUtils.shouldSkipAuthentication(requestChannel);
 
             // If request channel is completed and a response is sent, then there was a failure during authentication
             restFilter.checkAndAuthenticateRequest(requestChannel);

--- a/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
@@ -81,8 +81,6 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
         try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
             injectUser(msg, threadContext);
 
-            boolean shouldSkipAuthentication = SecurityRestUtils.shouldSkipAuthentication(requestChannel);
-
             // If request channel is completed and a response is sent, then there was a failure during authentication
             restFilter.checkAndAuthenticateRequest(requestChannel);
 
@@ -91,6 +89,7 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
 
             requestChannel.getQueuedResponse().ifPresent(response -> ctx.channel().attr(EARLY_RESPONSE).set(response));
 
+            boolean shouldSkipAuthentication = SecurityRestUtils.shouldSkipAuthentication(requestChannel);
             boolean shouldDecompress = !shouldSkipAuthentication && requestChannel.getQueuedResponse().isEmpty();
 
             if (requestChannel.getQueuedResponse().isEmpty() || shouldSkipAuthentication) {

--- a/src/test/java/org/opensearch/security/filter/SecurityRestUtilsTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityRestUtilsTests.java
@@ -1,0 +1,63 @@
+package org.opensearch.security.filter;
+
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.junit.Test;
+import org.opensearch.http.netty4.Netty4HttpChannel;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class SecurityRestUtilsTests {
+
+    @Test
+    public void testShouldSkipAuthentication_positive() {
+        FullHttpRequest request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.OPTIONS, "/");
+        NettyRequestChannel requestChannel1 = new NettyRequestChannel(request1, mock(Netty4HttpChannel.class));
+
+        assertTrue(SecurityRestUtils.shouldSkipAuthentication(requestChannel1));
+
+        FullHttpRequest request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/_plugins/_security/health");
+        NettyRequestChannel requestChannel2 = new NettyRequestChannel(request2, mock(Netty4HttpChannel.class));
+
+        assertTrue(SecurityRestUtils.shouldSkipAuthentication(requestChannel2));
+
+        FullHttpRequest request3 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/_plugins/_security/whoami");
+        NettyRequestChannel requestChannel3 = new NettyRequestChannel(request3, mock(Netty4HttpChannel.class));
+
+        assertTrue(SecurityRestUtils.shouldSkipAuthentication(requestChannel3));
+    }
+
+    @Test
+    public void testShouldSkipAuthentication_negative() {
+        FullHttpRequest request1 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+        NettyRequestChannel requestChannel1 = new NettyRequestChannel(request1, mock(Netty4HttpChannel.class));
+
+        assertFalse(SecurityRestUtils.shouldSkipAuthentication(requestChannel1));
+
+        FullHttpRequest request2 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/_cluster/health");
+        NettyRequestChannel requestChannel2 = new NettyRequestChannel(request2, mock(Netty4HttpChannel.class));
+
+        assertFalse(SecurityRestUtils.shouldSkipAuthentication(requestChannel2));
+
+        FullHttpRequest request3 = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/my-index/_search");
+        NettyRequestChannel requestChannel3 = new NettyRequestChannel(request3, mock(Netty4HttpChannel.class));
+
+        assertFalse(SecurityRestUtils.shouldSkipAuthentication(requestChannel3));
+    }
+
+    @Test
+    public void testGetRawPath() {
+        String rawPathWithParams = "/_cluster/health?pretty";
+        String rawPathWithoutParams = "/my-index/search";
+
+        String path1 = SecurityRestUtils.path(rawPathWithParams);
+        String path2 = SecurityRestUtils.path(rawPathWithoutParams);
+
+        assertTrue("/_cluster/health".equals(path1));
+        assertTrue("/my-index/search".equals(path2));
+    }
+}


### PR DESCRIPTION
### Description

This PR removes some duplication in the Netty4HttpRequestHeaderVerifier around the `/_plugins/_security/api/authtoken` endpoint and also abstracts the logic for where authentication is skipped into helper methods.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
