### PR TITLE
[Reverts] Demo configuration script requires admin password

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -14,10 +14,6 @@ inputs:
     description: 'The name of the setup script you want to run i.e. "setup" (do not include file extension). Leave empty to indicate one should not be run.'
     required: false
 
-  admin-password:
-    description: 'The admin password uses for the cluster'
-    required: true
-
 runs:
   using: "composite"
   steps:
@@ -76,11 +72,6 @@ runs:
         'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
       shell: pwsh
 
-    - name: Write password to initialAdminPassword location
-      run:
-        echo ${{ inputs.admin-password }} >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/initialAdminPassword.txt
-      shell: bash
-
     # Run any configuration scripts
     - name: Run Setup Script for Linux
       if: ${{ runner.os == 'Linux' && inputs.setup-script-name != '' }}
@@ -115,13 +106,13 @@ runs:
     # Verify that the server is operational
     - name: Check OpenSearch Running on Linux
       if: ${{ runner.os != 'Windows'}}
-      run: curl https://localhost:9200/_cat/plugins -u 'admin:${{ inputs.admin-password }}' -k -v --fail-with-body
+      run: curl https://localhost:9200/_cat/plugins -u 'admin:admin' -k -v
       shell: bash
 
     - name: Check OpenSearch Running on Windows
       if: ${{ runner.os == 'Windows'}}
       run: |
-        $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:${{ inputs.admin-password }}")
+        $credentialBytes = [Text.Encoding]::ASCII.GetBytes("admin:admin")
         $encodedCredentials = [Convert]::ToBase64String($credentialBytes)
         $baseCredentials = "Basic $encodedCredentials"
         $Headers = @{ Authorization = $baseCredentials }

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -16,9 +16,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - id: random-password
-        uses: peternied/random-name@v1
-
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
@@ -54,10 +51,9 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           setup-script-name: setup
-          admin-password: ${{ steps.random-password.outputs.generated_name }}
 
       - name: Run sanity tests
         uses: gradle/gradle-build-action@v2
         with:
           cache-disabled: true
-          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.random-password.outputs.generated_name }} -i
+          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=admin

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -153,52 +153,35 @@ extension_hw_greet:
     - "hw-user"
 ```
 
-### Initializing admin user with custom password
-
-A password is required for the admin account to run the demo setup. You can do this with one of the following 2 options:
-1. By setting an environment variable. `export initialAdminPassword=<custom-admin-password>`
-2. By adding a single line as password in a file `initialAdminPassword.txt` under `$OPENSEARCH_HOME/config` directory.
-
-If neither of these are provided, the password defaults to `admin`. However, this will be removed in future releases, and a custom password will be required in order to use demo config.
-
-
-### Installing demo configuration
-
 To install the demo certificates and default configuration, answer `y` to the first two questions and `n` to the last one. The log should look like below:
 
 
 ```bash
-➜  export initialAdminPassword=blebleble
-➜  ./tools/install_demo_configuration.sh -y -i -s
-**************************************************************************
-** This tool will be deprecated in the next major release of OpenSearch **
-** https://github.com/opensearch-project/security/issues/1755           **
-**************************************************************************
+./tools/install_demo_configuration.sh
 OpenSearch Security Demo Installer
  ** Warning: Do not use on production or public reachable systems **
-Basedir: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT
-OpenSearch install type: .tar.gz on
-OpenSearch config dir: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT/config
-OpenSearch config file: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT/config/opensearch.yml
-OpenSearch bin dir: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT/bin
-OpenSearch plugins dir: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT/plugins
-OpenSearch lib dir: /Users/XXXXX/opensearch-3.0.0-SNAPSHOT/lib
-Detected OpenSearch Version: x-content-3.0.0-SNAPSHOT
-Detected OpenSearch Security Version: 3.0.0.0-SNAPSHOT
+Install demo certificates? [y/N] y
+Initialize Security Modules? [y/N] y
+Cluster mode requires maybe additional setup of:
+  - Virtual memory (vm.max_map_count)
 
-   ***************************************************
-   ***   ADMIN PASSWORD SET TO: blebleble    ***
-   ***************************************************
-**************************************************************************
-** This tool will be deprecated in the next major release of OpenSearch **
-** https://github.com/opensearch-project/security/issues/1755           **
-**************************************************************************
+Enable cluster mode? [y/N] n
+Basedir: /Users/XXXXX/Test/opensearch-*
+OpenSearch install type: .tar.gz on
+OpenSearch config dir: /Users/XXXXX/Test/opensearch-*/config
+OpenSearch config file: /Users/XXXXX/Test/opensearch-*/config/opensearch.yml
+OpenSearch bin dir: /Users/XXXXX/Test/opensearch-*/bin
+OpenSearch plugins dir: /Users/XXXXX/Test/opensearch-*/plugins
+OpenSearch lib dir: /Users/XXXXX/Test/opensearch-*/lib
+Detected OpenSearch Version: x-content-*
+Detected OpenSearch Security Version: *
+
 ### Success
 ### Execute this script now on all your nodes and then start all nodes
 ### OpenSearch Security will be automatically initialized.
 ### If you like to change the runtime configuration
-### change the files in ../../../config/opensearch-security and execute:
-"/Users/XXXXX/opensearch-3.0.0-SNAPSHOT/plugins/opensearch-security/tools/securityadmin.sh" -cd "/Users/XXXXX/opensearch-3.0.0-SNAPSHOT/config/opensearch-security" -icl -key "/Users/XXXXX/config/kirk-key.pem" -cert "/Users/XXXXX/opensearch-3.0.0-SNAPSHOT/config/kirk.pem" -cacert "/Users/XXXXX/opensearch-3.0.0-SNAPSHOT/config/root-ca.pem" -nhnv
+### change the files in ../config and execute:
+"/Users/XXXXX/Test/opensearch-*/plugins/opensearch-security/tools/securityadmin.sh" -cd "/Users/XXXXX/Test/opensearch-*/config/opensearch-security/" -icl -key "/Users/XXXXX/Test/opensearch-*/config/kirk-key.pem" -cert "/Users/XXXXX/Test/opensearch-*/config/kirk.pem" -cacert "/Users/XXXXX/Test/opensearch-*/config/root-ca.pem" -nhnv
 ### or run ./securityadmin_demo.sh
 ### To use the Security Plugin ConfigurationGUI
 ### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/admin.

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -75,7 +75,6 @@ cd %CUR%
 echo Basedir: %BASE_DIR%
 
 set "OPENSEARCH_CONF_FILE=%BASE_DIR%config\opensearch.yml"
-set "INTERNAL_USERS_FILE"=%BASE_DIR%config\opensearch-security\internal_users.yml"
 set "OPENSEARCH_CONF_DIR=%BASE_DIR%config\"
 set "OPENSEARCH_BIN_DIR=%BASE_DIR%bin\"
 set "OPENSEARCH_PLUGINS_DIR=%BASE_DIR%plugins\"
@@ -319,57 +318,6 @@ echo plugins.security.check_snapshot_restore_write_privileges: true >> "%OPENSEA
 echo plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"] >> "%OPENSEARCH_CONF_FILE%"
 echo plugins.security.system_indices.enabled: true >> "%OPENSEARCH_CONF_FILE%"
 echo plugins.security.system_indices.indices: [".plugins-ml-config", ".plugins-ml-connector", ".plugins-ml-model-group", ".plugins-ml-model", ".plugins-ml-task", ".plugins-ml-conversation-meta", ".plugins-ml-conversation-interactions", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".ql-datasources", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".opensearch-knn-models", ".geospatial-ip2geo-data*"] >> "%OPENSEARCH_CONF_FILE%"
-
-setlocal enabledelayedexpansion
-
-set "ADMIN_PASSWORD_FILE=%OPENSEARCH_CONF_DIR%initialAdminPassword.txt"
-set "INTERNAL_USERS_FILE=%OPENSEARCH_CONF_DIR%opensearch-security\internal_users.yml"
-
-echo "what is in the config directory"  
-dir %OPENSEARCH_CONF_DIR%
-
-echo "what is in the password file"
-type "%ADMIN_PASSWORD_FILE%"
-
-
-if "%initialAdminPassword%" NEQ "" (
-  set "ADMIN_PASSWORD=!initialAdminPassword!"
-) else (
-  for /f %%a in ('type "%ADMIN_PASSWORD_FILE%"') do set "ADMIN_PASSWORD=%%a"
-)
-
-if not defined ADMIN_PASSWORD (
-  echo Unable to find the admin password for the cluster. Please set initialAdminPassword or create a file %ADMIN_PASSWORD_FILE% with a single line that contains the password.
-  exit /b 1
-)
-
-echo "   ***************************************************"
-echo "   ***   ADMIN PASSWORD SET TO: %ADMIN_PASSWORD%   ***"
-echo "   ***************************************************"
-
-set "HASH_SCRIPT=%OPENSEARCH_PLUGINS_DIR%\opensearch-security\tools\hash.bat"
-
-REM Run the command and capture its output
-for /f %%a in ('%HASH_SCRIPT% -p !ADMIN_PASSWORD!') do (
-  set "HASHED_ADMIN_PASSWORD=%%a"
-)
-
-if errorlevel 1 (
-  echo Failed to hash the admin password
-  exit /b 1
-)
-
-set "default_line=  hash: "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG""
-set "search=%default_line%"
-set "replace=  hash: "%HASHED_ADMIN_PASSWORD%""
-
-setlocal enableextensions
-for /f "delims=" %%i in ('type "%INTERNAL_USERS_FILE%" ^& break ^> "%INTERNAL_USERS_FILE%" ') do (
-    set "line=%%i"
-    setlocal enabledelayedexpansion
-    >>"%INTERNAL_USERS_FILE%" echo(!line:%search%=%replace%!
-    endlocal
-)
 
 :: network.host
 >nul findstr /b /c:"network.host" "%OPENSEARCH_CONF_FILE%" && (

--- a/tools/install_demo_configuration.bat
+++ b/tools/install_demo_configuration.bat
@@ -339,14 +339,8 @@ if "%initialAdminPassword%" NEQ "" (
 )
 
 if not defined ADMIN_PASSWORD (
-REM Commenting this out in favor of: https://github.com/opensearch-project/security/issues/3489
-REM  echo Unable to find the admin password for the cluster. Please set initialAdminPassword or create a file %ADMIN_PASSWORD_FILE% with a single line that contains the password.
-REM  exit /b 1
-    set "ADMIN_PASSWORD=admin"
-    echo "Unable to find custom admin password. Continuing with the default password for admin."
-    echo "You can set the custom admin password in one of the following two ways:"
-    echo "1. Run 'export initialAdminPassword=<your_password>' before script execution."
-    echo "2. Create a file $ADMIN_PASSWORD_FILE with a single line that contains the password."
+  echo Unable to find the admin password for the cluster. Please set initialAdminPassword or create a file %ADMIN_PASSWORD_FILE% with a single line that contains the password.
+  exit /b 1
 )
 
 echo "   ***************************************************"

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -397,14 +397,8 @@ if [[ -n "$initialAdminPassword" ]]; then
 elif [[ -f "$ADMIN_PASSWORD_FILE" && -s "$ADMIN_PASSWORD_FILE" ]]; then
   ADMIN_PASSWORD=$(head -n 1 "$ADMIN_PASSWORD_FILE")
 else
-#  Commenting in favor of: https://github.com/opensearch-project/security/issues/3489
-#  echo "Unable to find the admin password for the cluster. Please run 'export initialAdminPassword=<your_password>' or create a file $ADMIN_PASSWORD_FILE with a single line that contains the password."
-#  exit 1
-  ADMIN_PASSWORD="admin"
-  echo "Unable to find custom admin password. Continuing with the default password for admin."
-  echo "You can set the custom admin password in one of the following two ways:"
-  echo "1. Run 'export initialAdminPassword=<your_password>' before script execution."
-  echo "2. Create a file $ADMIN_PASSWORD_FILE with a single line that contains the password."
+  echo "Unable to find the admin password for the cluster. Please run 'export initialAdminPassword=<your_password>' or create a file $ADMIN_PASSWORD_FILE with a single line that contains the password."
+  exit 1
 fi
 
 echo "   ***************************************************"

--- a/tools/install_demo_configuration.sh
+++ b/tools/install_demo_configuration.sh
@@ -108,7 +108,6 @@ if [ -d "$BASE_DIR" ]; then
 else
     echo "DEBUG: basedir does not exist"
 fi
-
 OPENSEARCH_CONF_FILE="$BASE_DIR/config/opensearch.yml"
 OPENSEARCH_BIN_DIR="$BASE_DIR/bin"
 OPENSEARCH_PLUGINS_DIR="$BASE_DIR/plugins"
@@ -387,43 +386,6 @@ echo "plugins.security.check_snapshot_restore_write_privileges: true" | $SUDO_CM
 echo 'plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 echo 'plugins.security.system_indices.enabled: true' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
 echo 'plugins.security.system_indices.indices: [".plugins-ml-config", ".plugins-ml-connector", ".plugins-ml-model-group", ".plugins-ml-model", ".plugins-ml-task", ".plugins-ml-conversation-meta", ".plugins-ml-conversation-interactions", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".ql-datasources", ".opendistro-asynchronous-search-response*", ".replication-metadata-store", ".opensearch-knn-models", ".geospatial-ip2geo-data*"]' | $SUDO_CMD tee -a "$OPENSEARCH_CONF_FILE" > /dev/null
-
-## Read the admin password from the file or use the initialAdminPassword if set
-ADMIN_PASSWORD_FILE="$OPENSEARCH_CONF_DIR/initialAdminPassword.txt"
-INTERNAL_USERS_FILE="$OPENSEARCH_CONF_DIR/opensearch-security/internal_users.yml"
-
-if [[ -n "$initialAdminPassword" ]]; then
-  ADMIN_PASSWORD="$initialAdminPassword"
-elif [[ -f "$ADMIN_PASSWORD_FILE" && -s "$ADMIN_PASSWORD_FILE" ]]; then
-  ADMIN_PASSWORD=$(head -n 1 "$ADMIN_PASSWORD_FILE")
-else
-  echo "Unable to find the admin password for the cluster. Please run 'export initialAdminPassword=<your_password>' or create a file $ADMIN_PASSWORD_FILE with a single line that contains the password."
-  exit 1
-fi
-
-echo "   ***************************************************"
-echo "   ***   ADMIN PASSWORD SET TO: $ADMIN_PASSWORD    ***"
-echo "   ***************************************************"
-
-$SUDO_CMD chmod +x "$OPENSEARCH_PLUGINS_DIR/opensearch-security/tools/hash.sh"
-
-# Use the Hasher script to hash the admin password
-HASHED_ADMIN_PASSWORD=$($OPENSEARCH_PLUGINS_DIR/opensearch-security/tools/hash.sh -p "$ADMIN_PASSWORD" | tail -n 1)
-
-if [ $? -ne 0 ]; then
-  echo "Hash the admin password failure, see console for details"
-  exit 1
-fi
-
-# Find the line number containing 'admin:' in the internal_users.yml file
-ADMIN_HASH_LINE=$(grep -n 'admin:' "$INTERNAL_USERS_FILE" | cut -f1 -d:)
-
-awk -v hashed_admin_password="$HASHED_ADMIN_PASSWORD" '
-  /^ *hash: *"\$2a\$12\$VcCDgh2NDk07JGN0rjGbM.Ad41qVR\/YFJcgHp0UGns5JDymv..TOG"/ {
-    sub(/"\$2a\$12\$VcCDgh2NDk07JGN0rjGbM.Ad41qVR\/YFJcgHp0UGns5JDymv..TOG"/, "\"" hashed_admin_password "\"");
-  }
-  { print }
-' "$INTERNAL_USERS_FILE" > temp_file && mv temp_file "$INTERNAL_USERS_FILE"
 
 #network.host
 if $SUDO_CMD grep --quiet -i "^network.host" "$OPENSEARCH_CONF_FILE"; then


### PR DESCRIPTION
Reverts
- #3493
- #3490 
- #3414

Due to build breaks, we are reverting all changes related to admin:admin password change from 2.11

- Resolves https://github.com/opensearch-project/security/issues/3511

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
