### PR TITLE
Fix TraceableTcpTransportChannel classcast exception

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -86,7 +86,6 @@ import org.opensearch.client.indices.ResizeResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -95,7 +94,6 @@ import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.test.framework.AuditCompliance;
 import org.opensearch.test.framework.AuditConfiguration;
 import org.opensearch.test.framework.AuditFilters;
@@ -372,16 +370,6 @@ public class SearchOperationTest {
             UPDATE_DELETE_USER,
             USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES,
             USER_ALLOWED_TO_CREATE_INDEX
-        )
-        .nodeSettings(
-            Map.of(
-                FeatureFlags.TELEMETRY_SETTING.getKey(),
-                true,
-                TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(),
-                true,
-                TelemetrySettings.METRICS_FEATURE_ENABLED_SETTING.getKey(),
-                true
-            )
         )
         .audit(
             new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -374,7 +374,14 @@ public class SearchOperationTest {
             USER_ALLOWED_TO_CREATE_INDEX
         )
         .nodeSettings(
-            Map.of(FeatureFlags.TELEMETRY_SETTING.getKey(), true, TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(), true)
+            Map.of(
+                FeatureFlags.TELEMETRY_SETTING.getKey(),
+                true,
+                TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(),
+                true,
+                TelemetrySettings.METRICS_FEATURE_ENABLED_SETTING,
+                true
+            )
         )
         .audit(
             new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -379,7 +379,7 @@ public class SearchOperationTest {
                 true,
                 TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(),
                 true,
-                TelemetrySettings.METRICS_FEATURE_ENABLED_SETTING,
+                TelemetrySettings.METRICS_FEATURE_ENABLED_SETTING.getKey(),
                 true
             )
         )

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -86,6 +86,7 @@ import org.opensearch.client.indices.ResizeResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.FeatureFlags;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.MatchQueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -94,6 +95,7 @@ import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.repositories.RepositoryMissingException;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.telemetry.TelemetrySettings;
 import org.opensearch.test.framework.AuditCompliance;
 import org.opensearch.test.framework.AuditConfiguration;
 import org.opensearch.test.framework.AuditFilters;
@@ -370,6 +372,9 @@ public class SearchOperationTest {
             UPDATE_DELETE_USER,
             USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES,
             USER_ALLOWED_TO_CREATE_INDEX
+        )
+        .nodeSettings(
+            Map.of(FeatureFlags.TELEMETRY_SETTING.getKey(), true, TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(), true)
         )
         .audit(
             new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))

--- a/src/integrationTest/java/org/opensearch/security/TracingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/TracingTests.java
@@ -1,0 +1,79 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.security;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.Client;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.common.util.FeatureFlags;
+import org.opensearch.telemetry.TelemetrySettings;
+import org.opensearch.test.framework.AuditCompliance;
+import org.opensearch.test.framework.AuditConfiguration;
+import org.opensearch.test.framework.AuditFilters;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TracingTests {
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .nodeSettings(
+            Map.of(
+                FeatureFlags.TELEMETRY_SETTING.getKey(),
+                true,
+                TelemetrySettings.TRACER_FEATURE_ENABLED_SETTING.getKey(),
+                true,
+                TelemetrySettings.METRICS_FEATURE_ENABLED_SETTING.getKey(),
+                true
+            )
+        )
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    @Test
+    public void indexDocumentAndSearch() throws IOException {
+        try (Client internalClient = cluster.getInternalNodeClient()) {
+            // Create a document to search
+            internalClient.prepareIndex("index-1").setRefreshPolicy(IMMEDIATE).setSource(Map.of("foo", "bar")).get();
+        }
+
+        try (final RestHighLevelClient restClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+            final SearchResponse response = restClient.search(new SearchRequest(), DEFAULT);
+            assertThat(response.getHits().getTotalHits().value, equalTo(1L));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
+++ b/src/main/java/org/opensearch/security/filter/OpenSearchRequest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import javax.net.ssl.SSLEngine;
 
-import org.opensearch.http.netty4.Netty4HttpChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
 
@@ -42,21 +41,11 @@ public class OpenSearchRequest implements SecurityRequest {
 
     @Override
     public SSLEngine getSSLEngine() {
-        if (underlyingRequest == null
-            || underlyingRequest.getHttpChannel() == null
-            || !(underlyingRequest.getHttpChannel() instanceof Netty4HttpChannel)) {
+        if (underlyingRequest == null || underlyingRequest.getHttpChannel() == null) {
             return null;
         }
 
-        // We look for Ssl_handler called `ssl_http` in the outbound pipeline of Netty channel first, and if its not
-        // present we look for it in inbound channel. If its present in neither we return null, else we return the sslHandler.
-        final Netty4HttpChannel httpChannel = (Netty4HttpChannel) underlyingRequest.getHttpChannel();
-        SslHandler sslhandler = (SslHandler) httpChannel.getNettyChannel().pipeline().get("ssl_http");
-        if (sslhandler == null && httpChannel.inboundPipeline() != null) {
-            sslhandler = (SslHandler) httpChannel.inboundPipeline().get("ssl_http");
-        }
-
-        return sslhandler != null ? sslhandler.engine() : null;
+        return underlyingRequest.getHttpChannel().get("ssl_http", SslHandler.class).map(SslHandler::engine).orElse(null);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -37,9 +37,9 @@ import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.BaseTcpTransportChannel;
 import org.opensearch.transport.TaskTransportChannel;
 import org.opensearch.transport.TcpChannel;
-import org.opensearch.transport.TcpTransportChannel;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
@@ -113,9 +113,9 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
 
             if (channel instanceof TaskTransportChannel) {
                 final TransportChannel inner = ((TaskTransportChannel) channel).getChannel();
-                nettyChannel = (Netty4TcpChannel) ((TcpTransportChannel) inner).getChannel();
-            } else if (channel instanceof TcpTransportChannel) {
-                final TcpChannel inner = ((TcpTransportChannel) channel).getChannel();
+                nettyChannel = (Netty4TcpChannel) ((BaseTcpTransportChannel) inner).getChannel();
+            } else if (channel instanceof BaseTcpTransportChannel) {
+                final TcpChannel inner = ((BaseTcpTransportChannel) channel).getChannel();
                 nettyChannel = (Netty4TcpChannel) inner;
             } else {
                 throw new Exception("Invalid channel of type " + channel.getClass() + " (" + channel.getChannelType() + ")");

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -37,13 +37,9 @@ import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.BaseTcpTransportChannel;
-import org.opensearch.transport.TaskTransportChannel;
-import org.opensearch.transport.TcpChannel;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
-import org.opensearch.transport.netty4.Netty4TcpChannel;
 
 public class SecuritySSLRequestHandler<T extends TransportRequest> implements TransportRequestHandler<T> {
 
@@ -108,21 +104,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
         }
 
         try {
-
-            Netty4TcpChannel nettyChannel = null;
-
-            if (channel instanceof TaskTransportChannel) {
-                final TransportChannel inner = ((TaskTransportChannel) channel).getChannel();
-                nettyChannel = (Netty4TcpChannel) ((BaseTcpTransportChannel) inner).getChannel();
-            } else if (channel instanceof BaseTcpTransportChannel) {
-                final TcpChannel inner = ((BaseTcpTransportChannel) channel).getChannel();
-                nettyChannel = (Netty4TcpChannel) inner;
-            } else {
-                throw new Exception("Invalid channel of type " + channel.getClass() + " (" + channel.getChannelType() + ")");
-            }
-
-            final SslHandler sslhandler = (SslHandler) nettyChannel.getNettyChannel().pipeline().get("ssl_server");
-
+            final SslHandler sslhandler = channel.get("ssl_server", SslHandler.class).orElse(null);
             if (sslhandler == null) {
                 if (SSLConfig.isDualModeEnabled()) {
                     log.info("Communication in dual mode. Skipping SSL handler check");


### PR DESCRIPTION
### Description
Fix the TraceableTcpTransportChannel class cast exception when enabling the feature opensearch.experimental.feature.telemetry.enabled. Issue reported here - https://github.com/opensearch-project/security/issues/3464#issuecomment-1753641505
### Issues Resolved
#3515

Reference Chnage - https://github.com/opensearch-project/OpenSearch/blob/8e5e54e87f6f86a2425a5c767e208767ba3df14c/server/src/main/java/org/opensearch/transport/RequestHandlerRegistry.java#L101

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
