### PR TITLE
Use DelegatingRestHandler to delegate to the original handler

### DIFF
--- a/src/main/java/org/opensearch/security/filter/DelegatingRestHandler.java
+++ b/src/main/java/org/opensearch/security/filter/DelegatingRestHandler.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.filter;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Delegating RestHandler that delegates all implementations to original handler
+ *
+ * @opensearch.api
+ */
+public class DelegatingRestHandler implements RestHandler {
+
+    protected final RestHandler delegate;
+
+    public DelegatingRestHandler(RestHandler delegate) {
+        Objects.requireNonNull(delegate, "RestHandler delegate can not be null");
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+        delegate.handleRequest(request, channel, client);
+    }
+
+    @Override
+    public boolean canTripCircuitBreaker() {
+        return delegate.canTripCircuitBreaker();
+    }
+
+    @Override
+    public boolean supportsContentStream() {
+        return delegate.supportsContentStream();
+    }
+
+    @Override
+    public boolean allowsUnsafeBuffers() {
+        return delegate.allowsUnsafeBuffers();
+    }
+
+    @Override
+    public List<Route> routes() {
+        return delegate.routes();
+    }
+
+    @Override
+    public List<DeprecatedRoute> deprecatedRoutes() {
+        return delegate.deprecatedRoutes();
+    }
+
+    @Override
+    public List<ReplacedRoute> replacedRoutes() {
+        return delegate.replacedRoutes();
+    }
+
+    @Override
+    public boolean allowSystemIndexAccessByDefault() {
+        return delegate.allowSystemIndexAccessByDefault();
+    }
+
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+}

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -44,7 +44,6 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.client.node.NodeClient;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.rest.DelegatingRestHandler;
 import org.opensearch.rest.NamedRoute;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;

--- a/src/test/java/org/opensearch/security/filter/DelegatingRestHandlerTests.java
+++ b/src/test/java/org/opensearch/security/filter/DelegatingRestHandlerTests.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.filter;
+
+import org.junit.Test;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.rest.RestRequest;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+public class DelegatingRestHandlerTests {
+
+    @Test
+    public void testDelegatingRestHandlerShouldActAsOriginal() throws Exception {
+        RestHandler rh = new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) throws Exception {
+                new BytesRestResponse(RestStatus.OK, BytesRestResponse.TEXT_CONTENT_TYPE, BytesArray.EMPTY);
+            }
+        };
+        RestHandler handlerSpy = spy(rh);
+        DelegatingRestHandler drh = new DelegatingRestHandler(handlerSpy);
+
+        List<Method> overridableMethods = Arrays.stream(RestHandler.class.getMethods())
+            .filter(
+                m -> !(Modifier.isPrivate(m.getModifiers()) || Modifier.isStatic(m.getModifiers()) || Modifier.isFinal(m.getModifiers()))
+            )
+            .collect(Collectors.toList());
+
+        for (Method method : overridableMethods) {
+            int argCount = method.getParameterCount();
+            Object[] args = new Object[argCount];
+            for (int i = 0; i < argCount; i++) {
+                args[i] = any();
+            }
+            if (args.length > 0) {
+                method.invoke(drh, args);
+            } else {
+                method.invoke(drh);
+            }
+            method.invoke(verify(handlerSpy, times(1)), args);
+        }
+        verifyNoMoreInteractions(handlerSpy);
+    }
+}


### PR DESCRIPTION
### Description

Utilizes the DelegatingRestHandler from the companion core PR to ensure that the security plugin delegates to implementations of the wrapped Rest Handler.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/3422

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
