### PR TITLE
Updates auto release notes workflow to fetch notes from main

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,12 @@ jobs:
         id: tag
         uses: dawidd6/action-get-tag@v1
       - uses: actions/checkout@v4
+      - name: Download release notes
+        run: |
+          curl -s -o release-notes.md https://raw.githubusercontent.com/opensearch-project/security/main/release-notes/opensearch-security.release-notes-${{ steps.tag.outputs.tag }}.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: ncipollo/release-action@v1
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
-          bodyFile: release-notes/opensearch-security.release-notes-${{steps.tag.outputs.tag}}.md
+          bodyFile: release-notes.md


### PR DESCRIPTION
### Description
Before this change release notes workflow required release notes to be present in tag, with this change release notes will not need to be backported. They can be but will not need to be.



### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
