### PR TITLE
Fixes CI failure due to dependency conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,6 +436,8 @@ configurations {
             // For integrationTest
             force "org.apache.httpcomponents:httpclient:4.5.13"
             force "org.apache.httpcomponents:httpcore:4.4.16"
+            force "com.google.errorprone:error_prone_annotations:2.22.0"
+            force "org.checkerframework:checker-qual:3.38.0"
         }
     }
 
@@ -451,7 +453,6 @@ sourceSets {
             srcDir file ('src/integrationTest/java')
             compileClasspath += sourceSets.main.output
             runtimeClasspath += sourceSets.main.output
-
         }
         resources {
             srcDir file('src/integrationTest/resources')


### PR DESCRIPTION
Unblocks CI on main by resolving the following:
```console
* What went wrong:
Execution failed for task ':integTestRemote'.
> Could not resolve all dependencies for configuration ':testRuntimeClasspath'.
   > Conflicts found for the following modules:
       - com.google.errorprone:error_prone_annotations between versions 2.22.0 and 2.10.0
       - org.checkerframework:checker-qual between versions 3.38.0 and 3.19.0
```

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
