### PR TITLE
CrossClusterSearchTests refactor and testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+      number: [1,2,3,4,5,6,7,8,9]
         jdk: [17]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}

--- a/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
+++ b/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
@@ -12,6 +12,7 @@ package org.opensearch.security;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
@@ -243,18 +244,17 @@ public class CrossClusterSearchTests {
             SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
             searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(3));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 
@@ -284,19 +284,18 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 
@@ -314,19 +313,18 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 


### PR DESCRIPTION
### Description
This PR is a response to Issue #3425 

* Category: Test fix
* The changes include refactoring so as to fix the warning "Type safety: A generic array of Pair<String,String> is created for a varargs parameter" and verify testing is not flaky.
* Testing was conducted through `CI_ENVIRONMENT=normal ./gradlew integrationTest --tests org.opensearch.security.CrossClusterSearchTests` due to a temporary change.

### Original Issue:
**Description**
It looks like the cross cluster setup that evolves multiple clusters coming online and communicating with one another have issues that make them fragile.

**Repo**

1. Go to `src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java`
2. Find the `@Ignore` entry on the class
3. Delete that attribute
4. Run the tests with `./gradlew integrationTest --tests org.opensearch.security.CrossClusterSearchTests`

### Exit Criteria
 - [x] Find the root cause of the failing cluster startup process
 - [x] Run the test at least 10 times and see no failures - [how to do this](https://github.com/opensearch-project/security/pull/3388/commits/a714cf5cd07c0fa624965ab0b1a7c34e5143b75e)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
