### PR TITLE
[Backport 2.x] For read-only tenants filter with allow list

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/PrivilegesInterceptorImpl.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -62,6 +63,15 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
         "0-1"
     );
 
+    private static final ImmutableSet<String> READ_ONLY_ALLOWED_ACTIONS = ImmutableSet.of(
+        "indices:admin/get",
+        "indices:data/read/get",
+        "indices:data/read/search",
+        "indices:data/read/msearch",
+        "indices:data/read/mget",
+        "indices:data/read/mget[shard]"
+    );
+
     protected final Logger log = LogManager.getLogger(this.getClass());
 
     public PrivilegesInterceptorImpl(
@@ -90,7 +100,7 @@ public class PrivilegesInterceptorImpl extends PrivilegesInterceptor {
                 log.debug("request " + request.getClass());
             }
 
-            if (tenants.get(requestedTenant) == Boolean.FALSE && action.startsWith("indices:data/write")) {
+            if (tenants.get(requestedTenant) == Boolean.FALSE && !READ_ONLY_ALLOWED_ACTIONS.contains(action)) {
                 log.warn("Tenant {} is not allowed to write (user: {})", requestedTenant, user.getName());
                 return false;
             }

--- a/src/test/resources/multitenancy/roles_mapping.yml
+++ b/src/test/resources/multitenancy/roles_mapping.yml
@@ -184,3 +184,21 @@ opendistro_security_anonymous_multitenancy:
   - "opendistro_security_anonymous"
   and_backend_roles: []
   description: "PR#2459"
+opendistro_security_kibana_testindex:
+  reserved: false
+  hidden: false
+  backend_roles:
+  hosts: []
+  users:
+  - "user_a"
+  and_backend_roles: []
+  description: ""
+all_access:
+  reserved: false
+  hidden: false
+  backend_roles:
+  hosts: []
+  users:
+  - "admin"
+  and_backend_roles: []
+  description: "admin user can do everything"

--- a/src/test/resources/multitenancy/roles_tenants.yml
+++ b/src/test/resources/multitenancy/roles_tenants.yml
@@ -66,3 +66,7 @@ anonymous_tenant:
   reserved: false
   hidden: false
   description: "PR#2459"
+opendistro_security_anonymous:
+  reserved: false
+  hidden: false
+  description: "tenant that is writable for anonymous users"


### PR DESCRIPTION
When tenants were considered readonly an deny list was used, this could be prone to error, switch to an allow list instead.  Added tests to confirm prevent and new state.

(cherry picked from commit 0914f8ce51d25203a2a5dd9ba133d82e10cfed45)


### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
