### PR TITLE
Bump org.apache.zookeeper:zookeeper to 3.9.1 and io.netty:netty-tcnative-boringssl-static to 2.0.61.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -626,7 +626,7 @@ dependencies {
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.12'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
-    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.7.1'
+    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.9.1'
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -626,7 +626,9 @@ dependencies {
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.12'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
-    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.9.1'
+    testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.1') {
+        exclude(group:'ch.qos.logback', module: 'logback-classic' )
+    }
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -613,8 +613,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
-        testImplementation "io.netty:netty-tcnative-classes:2.0.54.Final"
-        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.54.Final:${osdetector.classifier}"
+        testImplementation "io.netty:netty-tcnative-classes:2.0.61.Final"
+        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.61.Final:${osdetector.classifier}"
     }
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'


### PR DESCRIPTION
### Description

Bump zookeeper to 3.9.1 and io.netty:netty-tcnative-boringssl-static to 2.0.61.Final to resolve whitesource check failure.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
