### PR TITLE
[Backport 2.x] Bump org.apache.zookeeper:zookeeper to 3.9.1, io.netty:netty-tcnative-boringssl-static to 2.0.61.Final and commons-io:commons-io to 2.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -620,8 +620,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
-        testImplementation "io.netty:netty-tcnative-classes:2.0.54.Final"
-        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.54.Final:${osdetector.classifier}"
+        testImplementation "io.netty:netty-tcnative-classes:2.0.61.Final"
+        testImplementation "io.netty:netty-tcnative-boringssl-static:2.0.61.Final:${osdetector.classifier}"
     }
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
@@ -633,7 +633,9 @@ dependencies {
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.11'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
-    testRuntimeOnly 'org.apache.zookeeper:zookeeper:3.7.1'
+    testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.1') {
+        exclude(group:'ch.qos.logback', module: 'logback-classic' )
+    }
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -574,7 +574,6 @@ dependencies {
 
     runtimeOnly 'com.google.guava:failureaccess:1.0.1'
     runtimeOnly 'org.apache.commons:commons-text:1.10.0'
-    implementation 'commons-io:commons-io:2.13.0'
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:2.8'
     runtimeOnly 'com.google.code.findbugs:jsr305:3.0.2'

--- a/build.gradle
+++ b/build.gradle
@@ -650,7 +650,7 @@ dependencies {
     integrationTestImplementation 'junit:junit:4.13.2'
     integrationTestImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     integrationTestImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
-    integrationTestImplementation 'commons-io:commons-io:2.13.0'
+    integrationTestImplementation 'commons-io:commons-io:2.14.0'
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -30,7 +30,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.Collections;
@@ -323,7 +322,7 @@ public class RestHelper {
             if (entity == null) { // head request does not have a entity
                 this.body = "";
             } else {
-                this.body = IOUtils.toString(entity.getContent(), StandardCharsets.UTF_8);
+                this.body = CharStreams.toString(new InputStreamReader(entity.getContent(), Charsets.UTF_8));
             }
             this.header = inner.getAllHeaders();
             this.statusCode = inner.getStatusLine().getStatusCode();

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -28,6 +28,7 @@ package org.opensearch.security.test.helper.rest;
 
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
@@ -45,7 +46,8 @@ import javax.net.ssl.SSLContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.io.IOUtils;
+import com.google.common.base.Charsets;
+import com.google.common.io.CharStreams;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -117,7 +119,7 @@ public class RestHelper {
                 throw new Exception("Statuscode " + response.getStatusLine().getStatusCode());
             }
 
-            return IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
+            return CharStreams.toString(new InputStreamReader(response.getEntity().getContent(), Charsets.UTF_8));
         } finally {
 
             if (response != null) {


### PR DESCRIPTION
Manual backport of #3532  & https://github.com/opensearch-project/security/pull/3431 to 2.x

I needed to remove the `implementation` dependency on `commons-io:commons-io` in 2.x. This dependency does not exist on main and was added in https://github.com/opensearch-project/security/pull/3092