### PR TITLE
[WIP] Reenable gradle build cache

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -33,9 +33,8 @@ runs:
         path: ${{ inputs.plugin-branch }}
 
     - name: Build
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: assemble
         build-root-directory: ${{ inputs.plugin-branch }}
 

--- a/.github/actions/run-bwc-suite/action.yaml
+++ b/.github/actions/run-bwc-suite/action.yaml
@@ -37,9 +37,8 @@ runs:
         plugin-branch: ${{ inputs.plugin-next-branch }}
 
     - name: Run BWC tests
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: |
           bwcTestSuite
           -Dtests.security.manager=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
         platform: [windows-latest, ubuntu-latest]
         jdk: [11, 17]
+        number: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -88,6 +89,7 @@ jobs:
       matrix:
         jdk: [11, 17]
         platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
+        number: [1,2,3,4,5,6,7,8,9,10]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -114,6 +116,7 @@ jobs:
       matrix:
         jdk: [17]
         platform: [ubuntu-latest]
+        number: [1,2,3,4,5,6,7,8,9,10]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -155,6 +158,7 @@ jobs:
       matrix:
         jdk: [11, 17]
         platform: [ubuntu-latest, windows-latest]
+        number: [1,2,3,4,5,6,7,8,9,10]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build and Test
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: |
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
@@ -102,11 +101,10 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build and Test
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
+      continue-on-error: true # Until retries are enable do not fail the workflow https://github.com/opensearch-project/security/issues/2184
       with:
-        cache-disabled: true
-        arguments: |
-          integrationTest -Dbuild.snapshot=false
+        arguments: integrationTest -Dbuild.snapshot=false
 
   resource-tests:
     env:
@@ -129,9 +127,8 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Build and Test
-      uses: gradle/gradle-build-action@v2
+      uses: burrunan/gradle-cache-action@v1
       with:
-        cache-disabled: true
         arguments: |
             integrationTest -Dbuild.snapshot=false --tests org.opensearch.security.ResourceFocusedTests
 
@@ -147,9 +144,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build BWC tests
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: |
             -p bwc-test build -x test -x integTest
 

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -24,9 +24,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: spotlessCheck
 
   checkstyle:
@@ -40,9 +39,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: checkstyleMain checkstyleTest checkstyleIntegrationTest
 
   spotbugs:
@@ -56,9 +54,8 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 11
 
-      - uses: gradle/gradle-build-action@v2
+      - uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: spotbugsMain
 
   check-permissions-order:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -29,9 +29,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Assemble target plugin
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
           arguments: assemble
 
       # Move and rename the plugin for installation
@@ -63,7 +62,6 @@ jobs:
           admin-password: ${{ steps.random-password.outputs.generated_name }}
 
       - name: Run sanity tests
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         with:
-          cache-disabled: true
-          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.random-password.outputs.generated_name }} -i
+          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=-Dpassword=${{ steps.random-password.outputs.generated_name }}


### PR DESCRIPTION
### Description
Uses https://github.com/marketplace/actions/gradle-cache to replace `gradle-build-action`.

### Issues Resolved
- Resolves #3185 


### Testing
Passing CI

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
