### PR TITLE
Re-enables CrossClusterSearchTests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        number: [1,2,3,4,5,6,7,8,9]
         jdk: [11, 17]
         platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        number: [1,2,3,4,5,6,7,8,9]
         jdk: [11, 17]
         platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
     runs-on: ${{ matrix.platform }}

--- a/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
+++ b/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
@@ -12,7 +12,6 @@ package org.opensearch.security;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Arrays;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
@@ -65,6 +64,7 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 * This is a parameterized test so that one test class is used to test security plugin behaviour when <code>ccsMinimizeRoundtrips</code>
 * option is enabled or disabled. Method {@link #parameters()} is a source of parameters values.
 */
+
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class CrossClusterSearchTests {
@@ -244,17 +244,18 @@ public class CrossClusterSearchTests {
             SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
             searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
 
-            List<Pair<String, String>> documentIdsList = Arrays.asList(
-                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
-                Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
-            );
-
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(3));
-            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
+                )
+            );
         }
     }
 
@@ -284,18 +285,19 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
 
-            List<Pair<String, String>> documentIdsList = Arrays.asList(
-                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-            );
-
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                )
+            );
         }
     }
 
@@ -313,18 +315,19 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
 
-            List<Pair<String, String>> documentIdsList = Arrays.asList(
-                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-            );
-
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
+            assertThat(
+                response,
+                searchHitsContainDocumentsInAnyOrder(
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                )
+            );
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
+++ b/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
@@ -12,13 +12,13 @@ package org.opensearch.security;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -65,7 +65,6 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 * This is a parameterized test so that one test class is used to test security plugin behaviour when <code>ccsMinimizeRoundtrips</code>
 * option is enabled or disabled. Method {@link #parameters()} is a source of parameters values.
 */
-@Ignore("Setting up two clusters at once seems to be prone to issues where they have port mismatches")
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class CrossClusterSearchTests {
@@ -245,18 +244,17 @@ public class CrossClusterSearchTests {
             SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
             searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(3));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 
@@ -286,19 +284,18 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 
@@ -316,19 +313,18 @@ public class CrossClusterSearchTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
 
+            List<Pair<String, String>> documentIdsList = Arrays.asList(
+                Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
+                Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
+                Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+            );
+
             SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
-            assertThat(
-                response,
-                searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
-                )
-            );
+            assertThat(response, searchHitsContainDocumentsInAnyOrder(documentIdsList));
         }
     }
 


### PR DESCRIPTION
### Description
This change addresses an issue that can arise when setting up two clusters at the same time whereby, port mismatches can occur as outlined in issue #3425. However, after much testing this issue does not appear to be tied to this integration test or it could be related to a windows environment issue.

* Category: Test fix
* Why these changes are required? : No changes are to be merged except the removal of @ignore given the findings of this tests. The integration test for CrossClusterSearchTests appears to have been fixed with unrelated changes to the main branch. 
* What is the old behavior before changes and new behavior after changes? : All the changes listed below except remove the commit that removes @ignore stemmed from an error on my end [please dismiss it] due to an issue in my working branch. However, it seems that the original issue might have been caused by the working environment or some other related factor. But, after verifying tests run correctly, the issue appears to be fully resolved. [ Verification: https://github.com/EduardoCorazon/security/actions/runs/6679334900]

### Issues Resolved
#3425 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
View attached exit criteria


### Exit Criteria
- [ ] Find the root cause of the failing cluster startup process [still unsure]
 - [x] Run the test at least 10 times and see no failures - [how to do this](https://github.com/opensearch-project/security/pull/3388/commits/a714cf5cd07c0fa624965ab0b1a7c34e5143b75e)

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
