### PR TITLE
Allow adding URL to the cluster

### DIFF
--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -178,6 +178,7 @@ public class HttpClient implements Closeable {
         this.keystoreAlias = keystoreAlias;
 
         HttpHost[] hosts = Arrays.stream(servers)
+            .map(s -> s.replaceAll("https://|http://", ""))
             .map(s -> s.split(":"))
             .map(s -> new HttpHost(ssl ? "https" : "http", s[0], Integer.parseInt(s[1])))
             .collect(Collectors.toList())

--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -13,6 +13,9 @@ package org.opensearch.security.httpclient;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -52,7 +55,7 @@ import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
+import org.apache.lucene.document.InetAddressPoint;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
@@ -178,9 +181,7 @@ public class HttpClient implements Closeable {
         this.keystoreAlias = keystoreAlias;
 
         HttpHost[] hosts = Arrays.stream(servers)
-            .map(s -> s.replaceAll("https://|http://", ""))
-            .map(s -> s.split(":"))
-            .map(s -> new HttpHost(ssl ? "https" : "http", s[0], Integer.parseInt(s[1])))
+            .map(server -> new HttpHost(ssl ? "https" : "http", server))
             .collect(Collectors.toList())
             .toArray(new HttpHost[0]);
 

--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -179,25 +179,24 @@ public class HttpClient implements Closeable {
         this.supportedCipherSuites = supportedCipherSuites;
         this.keystoreAlias = keystoreAlias;
 
-        /* 
+        /*
         * pattern helps to get the port number after last colon.
         * \d matches a  digit equivalent to [0-9].
         */
         Pattern pattern = Pattern.compile(":(\\d+)");
-        
-        HttpHost[] hosts = Arrays.stream(servers)
-            .map(server -> {
-                int lastIndexColon = server.lastIndexOf(':');
-                String url = server.substring(0, lastIndexColon);
-                String uri = server.substring(lastIndexColon);
-                Matcher matcher = pattern.matcher(uri);
-                if (matcher.find()) {
-                    int port = Integer.parseInt(matcher.group(1));
-                    return new HttpHost(ssl ? "https" : "http", url, port);
-                } else {
-                    return null;
-                }
-            })
+
+        HttpHost[] hosts = Arrays.stream(servers).map(server -> {
+            int lastIndexColon = server.lastIndexOf(':');
+            String url = server.substring(0, lastIndexColon);
+            String uri = server.substring(lastIndexColon);
+            Matcher matcher = pattern.matcher(uri);
+            if (matcher.find()) {
+                int port = Integer.parseInt(matcher.group(1));
+                return new HttpHost(ssl ? "https" : "http", url, port);
+            } else {
+                return null;
+            }
+        })
             .filter(Objects::nonNull) // Filter out null values
             .collect(Collectors.toList())
             .toArray(HttpHost[]::new);

--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -13,9 +13,6 @@ package org.opensearch.security.httpclient;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.URI;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -55,7 +52,7 @@ import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.InetAddressPoint;
+
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;

--- a/src/test/java/org/opensearch/security/httpclient/HttpClientTest.java
+++ b/src/test/java/org/opensearch/security/httpclient/HttpClientTest.java
@@ -30,7 +30,10 @@ public class HttpClientTest extends SingleClusterTest {
     @Test
     public void testPlainConnection() throws Exception {
 
-        final Settings settings = Settings.builder().put("plugins.security.ssl.http.enabled", false).build();
+        final Settings settings = Settings.builder()
+            .put("plugins.security.ssl.http.enabled", false)
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
+            .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
 
@@ -84,6 +87,7 @@ public class HttpClientTest extends SingleClusterTest {
             .put(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_ALIAS, "node-0")
             .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks"))
             .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks"))
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
             .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
@@ -123,6 +127,7 @@ public class HttpClientTest extends SingleClusterTest {
             .put(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_ALIAS, "node-0")
             .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks"))
             .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks"))
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
             .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);

--- a/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
+++ b/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
@@ -20,13 +20,15 @@ plugins.security:
             'localhost:9201',
             'localhost:9202',
             'localhost:9202/opensearch',
-            '127.0.0.1',
             '127.0.0.1:9200',
             '127.0.0.1:9200/opensearch',
             'my-opensearch-cluster.company.com:9200',
             'my-opensearch-cluster.company.com:9200/opensearch',
             'https://my-opensearch-cluster.company.com:9200',
-            'https://my-opensearch-cluster.company.com:9200/opensearch']
+            'https://my-opensearch-cluster.company.com:9200/opensearch',
+            '[::1]:9200',
+            '[::1]:9200/opensearch',
+          ]
           index: auditlog
           username: auditloguser
           password: auditlogpassword

--- a/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
+++ b/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
@@ -16,14 +16,17 @@ plugins.security:
         type: external_opensearch
         config:
           http_endpoints: [
+            'localhost',
             'localhost:9200',
             'localhost:9201',
             'localhost:9202',
             'localhost:9202/opensearch',
+            '127.0.0.1',
             '127.0.0.1:9200',
             '127.0.0.1:9200/opensearch',
             'my-opensearch-cluster.company.com:9200',
             'my-opensearch-cluster.company.com:9200/opensearch',
+            'http://my-opensearch-cluster.company.com',
             'https://my-opensearch-cluster.company.com:9200',
             'https://my-opensearch-cluster.company.com:9200/opensearch',
             '[::1]:9200',

--- a/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
+++ b/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
@@ -15,7 +15,18 @@ plugins.security:
       endpoint2:
         type: external_opensearch
         config:
-          http_endpoints: ['localhost:9200','localhost:9201','localhost:9202']
+          http_endpoints: [
+            'localhost:9200',
+            'localhost:9201',
+            'localhost:9202',
+            'localhost:9202/opensearch',
+            '127.0.0.1',
+            '127.0.0.1:9200',
+            '127.0.0.1:9200/opensearch',
+            'my-opensearch-cluster.company.com:9200',
+            'my-opensearch-cluster.company.com:9200/opensearch',
+            'https://my-opensearch-cluster.company.com:9200',
+            'https://my-opensearch-cluster.company.com:9200/opensearch']
           index: auditlog
           username: auditloguser
           password: auditlogpassword


### PR DESCRIPTION
### Description
Allow adding URLs to the OpenSearch cluster with support for both http:// and https:// for external logs.

### Issues Resolved
- #3321 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Tested using *RouterTest.java* and manual testing.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
