### PR TITLE
Wraps HTTPJwtAuthenticator jwtParserBuilder.build call with access controller to prevent AccessControlException

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -81,7 +81,17 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                 jwtParserBuilder = jwtParserBuilder.require("iss", requireIssuer);
             }
 
-            jwtParser = jwtParserBuilder.build();
+            final SecurityManager sm = System.getSecurityManager();
+            if (sm != null) {
+                sm.checkPermission(new SpecialPermission());
+            }
+            JwtParserBuilder finalJwtParserBuilder = jwtParserBuilder;
+            jwtParser = AccessController.doPrivileged(new PrivilegedAction<JwtParser>() {
+                @Override
+                public JwtParser run() {
+                    return finalJwtParserBuilder.build();
+                }
+            });
         }
     }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -69,29 +69,23 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         requireAudience = settings.get("required_audience");
         requireIssuer = settings.get("required_issuer");
 
-        JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);
+        final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);
         if (jwtParserBuilder == null) {
             jwtParser = null;
         } else {
             if (requireAudience != null) {
-                jwtParserBuilder = jwtParserBuilder.require("aud", requireAudience);
+                jwtParserBuilder.requireAudience(requireAudience);
             }
 
             if (requireIssuer != null) {
-                jwtParserBuilder = jwtParserBuilder.require("iss", requireIssuer);
+                jwtParserBuilder.requireIssuer(requireIssuer);
             }
 
             final SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkPermission(new SpecialPermission());
             }
-            JwtParserBuilder finalJwtParserBuilder = jwtParserBuilder;
-            jwtParser = AccessController.doPrivileged(new PrivilegedAction<JwtParser>() {
-                @Override
-                public JwtParser run() {
-                    return finalJwtParserBuilder.build();
-                }
-            });
+            jwtParser = AccessController.doPrivileged((PrivilegedAction<JwtParser>) jwtParserBuilder::build);
         }
     }
 


### PR DESCRIPTION
### Description
HTTPJwtAuthenticator fails initialization of JwtParser due to InvocationTargetException when calling jwtParserBuilder.build().
This is causing API calls with JWT token to fail.

It is root cause of failures identified in https://github.com/opensearch-project/security-dashboards-plugin/pull/1617 and only exists in 2.12.0

I verified manually by running `jwt_auth.test.ts` and making curl calls that this behavior works as expected on `main` and `2.11`

### Issues Resolved
- Unblocks https://github.com/opensearch-project/security-dashboards-plugin/pull/1617

### Testing
Manual Testing.

Spin up a 2.x cluster without this change & run jwt_auth.test.ts. They would fail with ```TimeoutError: Waiting for at least one element to be located By(xpath, //*[@id="osdOverviewPageHeader__title"])
    Wait timed out after 15011msError: Waiting for at least one element to be located By(xpath, //*[@id="osdOverviewPageHeader__title"])
    Wait timed out after 15011ms```
  
After this change, these tests should pass.

A similar change was made in https://github.com/opensearch-project/security/pull/3579 to unblock OBO Authenticator.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
