### PR TITLE
[Backport 2.x] Switch from `org.apache.cxf.rs.security.jose` to `com.nimbusds.jose.jwk`.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.5.0'
     implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.31'
 
     //JWT
     implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
@@ -587,9 +588,6 @@ dependencies {
 
     runtimeOnly 'net.minidev:accessors-smart:2.4.7'
 
-    implementation("org.apache.cxf:cxf-rt-rs-security-jose:${apache_cxf_version}") {
-        exclude(group: 'jakarta.activation', module: 'jakarta.activation-api')
-    }
     runtimeOnly "org.apache.cxf:cxf-core:${apache_cxf_version}"
     implementation "org.apache.cxf:cxf-rt-rs-json-basic:${apache_cxf_version}"
     runtimeOnly "org.apache.cxf:cxf-rt-security:${apache_cxf_version}"

--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -120,6 +120,7 @@
     </module>
     <module name="IllegalImport"> <!-- defaults to sun.* packages -->
       <property name="severity" value="error"/>
+      <property name="illegalPkgs" value="org.apache.cxf.rs.security.jose"/>
     </module>
     <module name="RedundantImport">
       <property name="severity" value="error"/>

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -16,6 +16,7 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.text.ParseException;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -23,8 +24,8 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -112,37 +113,34 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             return null;
         }
 
-        JwtToken jwt;
+        SignedJWT jwt;
+        JWTClaimsSet claimsSet;
 
         try {
             jwt = jwtVerifier.getVerifiedJwtToken(jwtString);
+            claimsSet = jwt.getJWTClaimsSet();
         } catch (AuthenticatorUnavailableException e) {
             log.info(e.toString());
             throw new OpenSearchSecurityException(e.getMessage(), RestStatus.SERVICE_UNAVAILABLE);
-        } catch (BadCredentialsException e) {
+        } catch (BadCredentialsException | ParseException e) {
             log.info("Extracting JWT token from {} failed", jwtString, e);
             return null;
         }
 
-        JwtClaims claims = jwt.getClaims();
-
-        final String subject = extractSubject(claims);
-
+        final String subject = extractSubject(claimsSet);
         if (subject == null) {
             log.error("No subject found in JWT token");
             return null;
         }
 
-        final String[] roles = extractRoles(claims);
-
+        final String[] roles = extractRoles(claimsSet);
         final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
 
-        for (Entry<String, Object> claim : claims.asMap().entrySet()) {
+        for (Entry<String, Object> claim : claimsSet.getClaims().entrySet()) {
             ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
         }
 
         return ac;
-
     }
 
     protected String getJwtTokenString(SecurityRequest request) {
@@ -174,7 +172,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     }
 
     @VisibleForTesting
-    public String extractSubject(JwtClaims claims) {
+    public String extractSubject(JWTClaimsSet claims) {
         String subject = claims.getSubject();
 
         if (subjectKey != null) {
@@ -204,7 +202,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
 
     @SuppressWarnings("unchecked")
     @VisibleForTesting
-    public String[] extractRoles(JwtClaims claims) {
+    public String[] extractRoles(JWTClaimsSet claims) {
         if (rolesKey == null) {
             return new String[0];
         }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -12,20 +12,23 @@
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import com.google.common.base.Strings;
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
+import com.nimbusds.jose.proc.SimpleSecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.BadJWTException;
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.cxf.rs.security.jose.jwa.SignatureAlgorithm;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.KeyType;
-import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
-import org.apache.cxf.rs.security.jose.jws.JwsJwtCompactConsumer;
-import org.apache.cxf.rs.security.jose.jws.JwsSignatureVerifier;
-import org.apache.cxf.rs.security.jose.jws.JwsUtils;
-import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
-import org.apache.cxf.rs.security.jose.jwt.JwtException;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
-import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.text.ParseException;
+import java.util.Collections;
 
 public class JwtVerifier {
 
@@ -43,31 +46,24 @@ public class JwtVerifier {
         this.requiredAudience = requiredAudience;
     }
 
-    public JwtToken getVerifiedJwtToken(String encodedJwt) throws BadCredentialsException {
+    public SignedJWT getVerifiedJwtToken(String encodedJwt) throws BadCredentialsException {
         try {
-            JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
-            JwtToken jwt = jwtConsumer.getJwtToken();
+            SignedJWT jwt = SignedJWT.parse(encodedJwt);
 
-            String escapedKid = jwt.getJwsHeaders().getKeyId();
+            String escapedKid = jwt.getHeader().getKeyID();
             String kid = escapedKid;
             if (!Strings.isNullOrEmpty(kid)) {
                 kid = StringEscapeUtils.unescapeJava(escapedKid);
             }
-            JsonWebKey key = keyProvider.getKey(kid);
+            JWK key = keyProvider.getKey(kid);
 
-            // Algorithm is not mandatory for the key material, so we set it to the same as the JWT
-            if (key.getAlgorithm() == null && key.getPublicKeyUse() == PublicKeyUse.SIGN && key.getKeyType() == KeyType.RSA) {
-                key.setAlgorithm(jwt.getJwsHeaders().getAlgorithm());
-            }
-
-            JwsSignatureVerifier signatureVerifier = getInitializedSignatureVerifier(key, jwt);
-
-            boolean signatureValid = jwtConsumer.verifySignatureWith(signatureVerifier);
+            JWSVerifier signatureVerifier = getInitializedSignatureVerifier(key, jwt);
+            boolean signatureValid = jwt.verify(signatureVerifier);
 
             if (!signatureValid && Strings.isNullOrEmpty(kid)) {
                 key = keyProvider.getKeyAfterRefresh(null);
                 signatureVerifier = getInitializedSignatureVerifier(key, jwt);
-                signatureValid = jwtConsumer.verifySignatureWith(signatureVerifier);
+                signatureValid = jwt.verify(signatureVerifier);
             }
 
             if (!signatureValid) {
@@ -77,18 +73,18 @@ public class JwtVerifier {
             validateClaims(jwt);
 
             return jwt;
-        } catch (JwtException e) {
+        } catch (JOSEException | ParseException | BadJWTException e) {
             throw new BadCredentialsException(e.getMessage(), e);
         }
     }
 
-    private void validateSignatureAlgorithm(JsonWebKey key, JwtToken jwt) throws BadCredentialsException {
-        if (Strings.isNullOrEmpty(key.getAlgorithm())) {
+    private void validateSignatureAlgorithm(JWK key, SignedJWT jwt) throws BadCredentialsException {
+        if (key.getAlgorithm() == null || jwt.getHeader().getAlgorithm() == null) {
             return;
         }
 
-        SignatureAlgorithm keyAlgorithm = SignatureAlgorithm.getAlgorithm(key.getAlgorithm());
-        SignatureAlgorithm tokenAlgorithm = SignatureAlgorithm.getAlgorithm(jwt.getJwsHeaders().getAlgorithm());
+        Algorithm keyAlgorithm = key.getAlgorithm();
+        Algorithm tokenAlgorithm = jwt.getHeader().getAlgorithm();
 
         if (!keyAlgorithm.equals(tokenAlgorithm)) {
             throw new BadCredentialsException(
@@ -97,11 +93,16 @@ public class JwtVerifier {
         }
     }
 
-    private JwsSignatureVerifier getInitializedSignatureVerifier(JsonWebKey key, JwtToken jwt) throws BadCredentialsException,
-        JwtException {
+    private JWSVerifier getInitializedSignatureVerifier(JWK key, SignedJWT jwt) throws BadCredentialsException, JOSEException {
 
         validateSignatureAlgorithm(key, jwt);
-        JwsSignatureVerifier result = JwsUtils.getSignatureVerifier(key, jwt.getJwsHeaders().getSignatureAlgorithm());
+        final JWSVerifier result;
+        if (key.getClass() == OctetSequenceKey.class) {
+            result = new DefaultJWSVerifierFactory().createJWSVerifier(jwt.getHeader(), key.toOctetSequenceKey().toSecretKey());
+        } else {
+            result = new DefaultJWSVerifierFactory().createJWSVerifier(jwt.getHeader(), key.toRSAKey().toRSAPublicKey());
+        }
+
         if (result == null) {
             throw new BadCredentialsException("Cannot verify JWT");
         } else {
@@ -109,26 +110,31 @@ public class JwtVerifier {
         }
     }
 
-    private void validateClaims(JwtToken jwt) throws JwtException {
-        JwtClaims claims = jwt.getClaims();
+    private void validateClaims(SignedJWT jwt) throws ParseException, BadJWTException {
+        JWTClaimsSet claims = jwt.getJWTClaimsSet();
 
         if (claims != null) {
-            JwtUtils.validateJwtExpiry(claims, clockSkewToleranceSeconds, false);
-            JwtUtils.validateJwtNotBefore(claims, clockSkewToleranceSeconds, false);
+            DefaultJWTClaimsVerifier<SimpleSecurityContext> claimsVerifier = new DefaultJWTClaimsVerifier<>(
+                requiredAudience,
+                null,
+                Collections.emptySet()
+            );
+            claimsVerifier.setMaxClockSkew(clockSkewToleranceSeconds);
+            claimsVerifier.verify(claims, null);
             validateRequiredAudienceAndIssuer(claims);
         }
     }
 
-    private void validateRequiredAudienceAndIssuer(JwtClaims claims) {
-        String audience = claims.getAudience();
+    private void validateRequiredAudienceAndIssuer(JWTClaimsSet claims) throws BadJWTException {
+        String audience = claims.getAudience().stream().findFirst().orElse("");
         String issuer = claims.getIssuer();
 
         if (!Strings.isNullOrEmpty(requiredAudience) && !requiredAudience.equals(audience)) {
-            throw new JwtException("Invalid audience");
+            throw new BadJWTException("Invalid audience");
         }
 
         if (!Strings.isNullOrEmpty(requiredIssuer) && !requiredIssuer.equals(issuer)) {
-            throw new JwtException("Invalid issuer");
+            throw new BadJWTException("Invalid issuer");
         }
     }
 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeyProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeyProvider.java
@@ -11,10 +11,10 @@
 
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
+import com.nimbusds.jose.jwk.JWK;
 
 public interface KeyProvider {
-    public JsonWebKey getKey(String kid) throws AuthenticatorUnavailableException, BadCredentialsException;
+    JWK getKey(String kid) throws AuthenticatorUnavailableException, BadCredentialsException;
 
-    public JsonWebKey getKeyAfterRefresh(String kid) throws AuthenticatorUnavailableException, BadCredentialsException;
+    JWK getKeyAfterRefresh(String kid) throws AuthenticatorUnavailableException, BadCredentialsException;
 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetProvider.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetProvider.java
@@ -11,9 +11,9 @@
 
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
+import com.nimbusds.jose.jwk.JWKSet;
 
 @FunctionalInterface
 public interface KeySetProvider {
-    JsonWebKeys get() throws AuthenticatorUnavailableException;
+    JWKSet get() throws AuthenticatorUnavailableException;
 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -13,7 +13,6 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.concurrent.TimeUnit;
 
 import com.nimbusds.jose.jwk.JWKSet;
 import joptsimple.internal.Strings;

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -18,6 +18,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -30,26 +32,26 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Strings;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.onelogin.saml2.authn.SamlResponse;
 import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.util.Util;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.KeyType;
-import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
-import org.apache.cxf.rs.security.jose.jws.JwsUtils;
-import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
-import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
-import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
+import org.opensearch.core.common.Strings;
+
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.core.common.bytes.BytesReference;
@@ -62,13 +64,14 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.api.AuthTokenProcessorAction;
 import org.opensearch.security.filter.SecurityResponse;
 
+import static org.opensearch.security.authtoken.jwt.KeyPaddingUtil.padSecret;
+
 class AuthTokenProcessorHandler {
     private static final Logger log = LogManager.getLogger(AuthTokenProcessorHandler.class);
     private static final Logger token_log = LogManager.getLogger("com.amazon.dlic.auth.http.saml.Token");
     private static final Pattern EXPIRY_SETTINGS_PATTERN = Pattern.compile("\\s*(\\w+)\\s*(?:\\+\\s*(\\w+))?\\s*");
 
     private Saml2SettingsProvider saml2SettingsProvider;
-    private JoseJwtProducer jwtProducer;
     private String jwtSubjectKey;
     private String jwtRolesKey;
     private String samlSubjectKey;
@@ -77,8 +80,8 @@ class AuthTokenProcessorHandler {
 
     private long expiryOffset = 0;
     private ExpiryBaseValue expiryBaseValue = ExpiryBaseValue.AUTO;
-    private JsonWebKey signingKey;
-    private JsonMapObjectReaderWriter jsonMapReaderWriter = new JsonMapObjectReaderWriter();
+    private JWK signingKey;
+    private JWSHeader jwsHeader;
     private Pattern samlRolesSeparatorPattern;
 
     AuthTokenProcessorHandler(Settings settings, Settings jwtSettings, Saml2SettingsProvider saml2SettingsProvider) throws Exception {
@@ -113,10 +116,7 @@ class AuthTokenProcessorHandler {
 
         this.initJwtExpirySettings(settings);
         this.signingKey = this.createJwkFromSettings(settings, jwtSettings);
-
-        this.jwtProducer = new JoseJwtProducer();
-        this.jwtProducer.setSignatureProvider(JwsUtils.getSignatureProvider(this.signingKey));
-
+        this.jwsHeader = this.createJwsHeaderFromSettings();
     }
 
     @SuppressWarnings("removal")
@@ -243,80 +243,68 @@ class AuthTokenProcessorHandler {
         }
     }
 
-    JsonWebKey createJwkFromSettings(Settings settings, Settings jwtSettings) throws Exception {
+    private JWSHeader createJwsHeaderFromSettings() {
+        JWSHeader.Builder jwsHeaderBuilder = new JWSHeader.Builder(JWSAlgorithm.HS512);
+        return jwsHeaderBuilder.build();
+    }
 
+    JWK createJwkFromSettings(Settings settings, Settings jwtSettings) throws Exception {
         String exchangeKey = settings.get("exchange_key");
 
         if (!Strings.isNullOrEmpty(exchangeKey)) {
+            exchangeKey = padSecret(new String(Base64.getDecoder().decode(exchangeKey), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
 
-            JsonWebKey jwk = new JsonWebKey();
-
-            jwk.setKeyType(KeyType.OCTET);
-            jwk.setAlgorithm("HS512");
-            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-            jwk.setProperty("k", exchangeKey);
-
-            return jwk;
+            return new OctetSequenceKey.Builder(exchangeKey.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
         } else {
-
             Settings jwkSettings = jwtSettings.getAsSettings("key");
 
-            if (jwkSettings.isEmpty()) {
+            if (!jwkSettings.hasValue("k") && !Strings.isNullOrEmpty(jwkSettings.get("k"))) {
                 throw new Exception(
                     "Settings for key exchange missing. Please specify at least the option exchange_key with a shared secret."
                 );
             }
 
-            JsonWebKey jwk = new JsonWebKey();
+            String k = padSecret(new String(Base64.getDecoder().decode(jwkSettings.get("k")), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
 
-            for (String key : jwkSettings.keySet()) {
-                jwk.setProperty(key, jwkSettings.get(key));
-            }
-
-            return jwk;
+            return new OctetSequenceKey.Builder(k.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
         }
     }
 
     private String createJwt(SamlResponse samlResponse) throws Exception {
-        JwtClaims jwtClaims = new JwtClaims();
-        JwtToken jwt = new JwtToken(jwtClaims);
-
-        jwtClaims.setNotBefore(System.currentTimeMillis() / 1000);
-        jwtClaims.setExpiryTime(getJwtExpiration(samlResponse));
-
-        jwtClaims.setProperty(this.jwtSubjectKey, this.extractSubject(samlResponse));
+        JWTClaimsSet.Builder jwtClaimsBuilder = new JWTClaimsSet.Builder().notBeforeTime(new Date())
+            .expirationTime(new Date(getJwtExpiration(samlResponse)))
+            .claim(this.jwtSubjectKey, this.extractSubject(samlResponse));
 
         if (this.samlSubjectKey != null) {
-            jwtClaims.setProperty("saml_ni", samlResponse.getNameId());
+            jwtClaimsBuilder.claim("saml_ni", samlResponse.getNameId());
         }
-
         if (samlResponse.getNameIdFormat() != null) {
-            jwtClaims.setProperty("saml_nif", SamlNameIdFormat.getByUri(samlResponse.getNameIdFormat()).getShortName());
+            jwtClaimsBuilder.claim("saml_nif", SamlNameIdFormat.getByUri(samlResponse.getNameIdFormat()).getShortName());
         }
 
         String sessionIndex = samlResponse.getSessionIndex();
 
         if (sessionIndex != null) {
-            jwtClaims.setProperty("saml_si", sessionIndex);
+            jwtClaimsBuilder.claim("saml_si", sessionIndex);
         }
 
         if (this.samlRolesKey != null && this.jwtRolesKey != null) {
             String[] roles = this.extractRoles(samlResponse);
 
-            jwtClaims.setProperty(this.jwtRolesKey, roles);
+            jwtClaimsBuilder.claim(this.jwtRolesKey, roles);
         }
+        JWTClaimsSet jwtClaims = jwtClaimsBuilder.build();
+        SignedJWT jwt = new SignedJWT(this.jwsHeader, jwtClaims);
+        jwt.sign(new DefaultJWSSignerFactory().createJWSSigner(this.signingKey));
 
-        String encodedJwt = this.jwtProducer.processJwt(jwt);
+        String encodedJwt = jwt.serialize();
 
         if (token_log.isDebugEnabled()) {
-            token_log.debug(
-                "Created JWT: "
-                    + encodedJwt
-                    + "\n"
-                    + jsonMapReaderWriter.toJson(jwt.getJwsHeaders())
-                    + "\n"
-                    + JwtUtils.claimsToJson(jwt.getClaims())
-            );
+            token_log.debug("Created JWT: " + encodedJwt + "\n" + jwt.getHeader().toString() + "\n" + jwt.getJWTClaimsSet().toString());
         }
 
         return encodedJwt;
@@ -326,10 +314,10 @@ class AuthTokenProcessorHandler {
         DateTime sessionNotOnOrAfter = samlResponse.getSessionNotOnOrAfter();
 
         if (this.expiryBaseValue == ExpiryBaseValue.NOW) {
-            return System.currentTimeMillis() / 1000 + this.expiryOffset;
+            return System.currentTimeMillis() + this.expiryOffset * 1000;
         } else if (this.expiryBaseValue == ExpiryBaseValue.SESSION) {
             if (sessionNotOnOrAfter != null) {
-                return sessionNotOnOrAfter.getMillis() / 1000 + this.expiryOffset;
+                return sessionNotOnOrAfter.getMillis() + this.expiryOffset * 1000;
             } else {
                 throw new Exception("Error while determining JWT expiration time: SamlResponse did not contain sessionNotOnOrAfter value");
             }
@@ -337,9 +325,9 @@ class AuthTokenProcessorHandler {
             // AUTO
 
             if (sessionNotOnOrAfter != null) {
-                return sessionNotOnOrAfter.getMillis() / 1000;
+                return sessionNotOnOrAfter.getMillis();
             } else {
-                return System.currentTimeMillis() / 1000 + (this.expiryOffset > 0 ? this.expiryOffset : 60 * 60);
+                return System.currentTimeMillis() + (this.expiryOffset > 0 ? this.expiryOffset * 1000 : 60 * 60_000);
             }
         }
     }
@@ -440,7 +428,7 @@ class AuthTokenProcessorHandler {
         SESSION
     }
 
-    public JsonWebKey getSigningKey() {
+    public JWK getSigningKey() {
         return signingKey;
     }
 }

--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -27,6 +27,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
+import com.nimbusds.jose.jwk.JWK;
 import com.onelogin.saml2.authn.AuthnRequest;
 import com.onelogin.saml2.logout.LogoutRequest;
 import com.onelogin.saml2.settings.Saml2Settings;
@@ -36,7 +37,6 @@ import net.shibboleth.utilities.java.support.component.ComponentInitializationEx
 import net.shibboleth.utilities.java.support.component.DestructableComponent;
 import net.shibboleth.utilities.java.support.xml.BasicParserPool;
 import org.apache.commons.lang3.StringEscapeUtils;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -480,12 +480,12 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
             return new KeyProvider() {
 
                 @Override
-                public JsonWebKey getKeyAfterRefresh(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
+                public JWK getKeyAfterRefresh(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
                     return authTokenProcessorHandler.getSigningKey();
                 }
 
                 @Override
-                public JsonWebKey getKey(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
+                public JWK getKey(String kid) throws AuthenticatorUnavailableException, BadCredentialsException {
                     return authTokenProcessorHandler.getSigningKey();
                 }
             };

--- a/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/JwtVendor.java
@@ -11,59 +11,58 @@
 
 package org.opensearch.security.authtoken.jwt;
 
-import java.time.Instant;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 
-import org.apache.cxf.jaxrs.json.basic.JsonMapObjectReaderWriter;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.KeyType;
-import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
-import org.apache.cxf.rs.security.jose.jws.JwsUtils;
-import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
-import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
-import org.apache.cxf.rs.security.jose.jwt.JwtUtils;
+import com.nimbusds.jose.JOSEException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.crypto.MACSigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.security.ssl.util.ExceptionUtils;
 
 import static org.opensearch.security.util.AuthTokenUtils.isKeyNull;
 
 public class JwtVendor {
     private static final Logger logger = LogManager.getLogger(JwtVendor.class);
 
-    private static JsonMapObjectReaderWriter jsonMapReaderWriter = new JsonMapObjectReaderWriter();
-
-    private final String claimsEncryptionKey;
-    private final JsonWebKey signingKey;
-    private final JoseJwtProducer jwtProducer;
+    private final JWK signingKey;
+    private final JWSSigner signer;
     private final LongSupplier timeProvider;
     private final EncryptionDecryptionUtil encryptionDecryptionUtil;
-    private final Integer defaultExpirySeconds = 300;
-    private final Integer maxExpirySeconds = 600;
+    private static final Integer DEFAULT_EXPIRY_SECONDS = 300;
+    private static final Integer MAX_EXPIRY_SECONDS = 600;
 
     public JwtVendor(final Settings settings, final Optional<LongSupplier> timeProvider) {
-        JoseJwtProducer jwtProducer = new JoseJwtProducer();
-        try {
-            this.signingKey = createJwkFromSettings(settings);
-        } catch (Exception e) {
-            throw ExceptionUtils.createJwkCreationException(e);
-        }
-        this.jwtProducer = jwtProducer;
+        final Tuple<JWK, JWSSigner> tuple = createJwkFromSettings(settings);
+        signingKey = tuple.v1();
+        signer = tuple.v2();
+
         if (isKeyNull(settings, "encryption_key")) {
             throw new IllegalArgumentException("encryption_key cannot be null");
         } else {
-            this.claimsEncryptionKey = settings.get("encryption_key");
-            this.encryptionDecryptionUtil = new EncryptionDecryptionUtil(claimsEncryptionKey);
+            this.encryptionDecryptionUtil = new EncryptionDecryptionUtil(settings.get("encryption_key"));
         }
         if (timeProvider.isPresent()) {
             this.timeProvider = timeProvider.get();
         } else {
-            this.timeProvider = () -> System.currentTimeMillis() / 1000;
+            this.timeProvider = () -> System.currentTimeMillis();
         }
     }
 
@@ -73,34 +72,32 @@ public class JwtVendor {
      *   PublicKeyUse: SIGN
      *   Encryption Algorithm: HS512
      * */
-    static JsonWebKey createJwkFromSettings(Settings settings) throws Exception {
+    static Tuple<JWK, JWSSigner> createJwkFromSettings(Settings settings) {
+        final OctetSequenceKey key;
         if (!isKeyNull(settings, "signing_key")) {
             String signingKey = settings.get("signing_key");
-
-            JsonWebKey jwk = new JsonWebKey();
-
-            jwk.setKeyType(KeyType.OCTET);
-            jwk.setAlgorithm("HS512");
-            jwk.setPublicKeyUse(PublicKeyUse.SIGN);
-            jwk.setProperty("k", signingKey);
-
-            return jwk;
+            key = new OctetSequenceKey.Builder(Base64.getDecoder().decode(signingKey)).algorithm(JWSAlgorithm.HS512)
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
         } else {
             Settings jwkSettings = settings.getAsSettings("jwt").getAsSettings("key");
 
             if (jwkSettings.isEmpty()) {
-                throw new Exception(
+                throw new OpenSearchException(
                     "Settings for signing key is missing. Please specify at least the option signing_key with a shared secret."
                 );
             }
 
-            JsonWebKey jwk = new JsonWebKey();
+            String signingKey = jwkSettings.get("k");
+            key = new OctetSequenceKey.Builder(Base64.getDecoder().decode(signingKey)).algorithm(JWSAlgorithm.HS512)
+                .keyUse(KeyUse.SIGNATURE)
+                .build();
+        }
 
-            for (String key : jwkSettings.keySet()) {
-                jwk.setProperty(key, jwkSettings.get(key));
-            }
-
-            return jwk;
+        try {
+            return new Tuple<>(key, new MACSigner(key));
+        } catch (KeyLengthException kle) {
+            throw new OpenSearchException(kle);
         }
     }
 
@@ -112,60 +109,53 @@ public class JwtVendor {
         List<String> roles,
         List<String> backendRoles,
         boolean roleSecurityMode
-    ) throws Exception {
-        final long nowAsMillis = timeProvider.getAsLong();
-        final Instant nowAsInstant = Instant.ofEpochMilli(timeProvider.getAsLong());
+    ) throws JOSEException, ParseException {
+        final Date now = new Date(timeProvider.getAsLong());
 
-        jwtProducer.setSignatureProvider(JwsUtils.getSignatureProvider(signingKey));
-        JwtClaims jwtClaims = new JwtClaims();
-        JwtToken jwt = new JwtToken(jwtClaims);
+        final JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
+        claimsBuilder.issuer(issuer);
+        claimsBuilder.issueTime(now);
+        claimsBuilder.subject(subject);
+        claimsBuilder.audience(audience);
+        claimsBuilder.notBeforeTime(now);
 
-        jwtClaims.setIssuer(issuer);
-
-        jwtClaims.setIssuedAt(nowAsMillis);
-
-        jwtClaims.setSubject(subject);
-
-        jwtClaims.setAudience(audience);
-
-        jwtClaims.setNotBefore(nowAsMillis);
-
-        if (expirySeconds > maxExpirySeconds) {
-            throw new Exception("The provided expiration time exceeds the maximum allowed duration of " + maxExpirySeconds + " seconds");
+        if (expirySeconds > MAX_EXPIRY_SECONDS) {
+            throw new IllegalArgumentException(
+                "The provided expiration time exceeds the maximum allowed duration of " + MAX_EXPIRY_SECONDS + " seconds"
+            );
         }
 
-        expirySeconds = (expirySeconds == null) ? defaultExpirySeconds : Math.min(expirySeconds, maxExpirySeconds);
+        expirySeconds = (expirySeconds == null) ? DEFAULT_EXPIRY_SECONDS : Math.min(expirySeconds, MAX_EXPIRY_SECONDS);
         if (expirySeconds <= 0) {
-            throw new Exception("The expiration time should be a positive integer");
+            throw new IllegalArgumentException("The expiration time should be a positive integer");
         }
-        long expiryTime = timeProvider.getAsLong() + expirySeconds;
-        jwtClaims.setExpiryTime(expiryTime);
+        final Date expiryTime = new Date(timeProvider.getAsLong() + expirySeconds * 1000);
+        claimsBuilder.expirationTime(expiryTime);
 
         if (roles != null) {
             String listOfRoles = String.join(",", roles);
-            jwtClaims.setProperty("er", encryptionDecryptionUtil.encrypt(listOfRoles));
+            claimsBuilder.claim("er", encryptionDecryptionUtil.encrypt(listOfRoles));
         } else {
-            throw new Exception("Roles cannot be null");
+            throw new IllegalArgumentException("Roles cannot be null");
         }
 
         if (!roleSecurityMode && backendRoles != null) {
             String listOfBackendRoles = String.join(",", backendRoles);
-            jwtClaims.setProperty("br", listOfBackendRoles);
+            claimsBuilder.claim("br", listOfBackendRoles);
         }
 
-        String encodedJwt = jwtProducer.processJwt(jwt);
+        final JWSHeader header = new JWSHeader.Builder(JWSAlgorithm.parse(signingKey.getAlgorithm().getName())).build();
+        final SignedJWT signedJwt = new SignedJWT(header, claimsBuilder.build());
+
+        // Sign the JWT so it can be serialized
+        signedJwt.sign(signer);
 
         if (logger.isDebugEnabled()) {
             logger.debug(
-                "Created JWT: "
-                    + encodedJwt
-                    + "\n"
-                    + jsonMapReaderWriter.toJson(jwt.getJwsHeaders())
-                    + "\n"
-                    + JwtUtils.claimsToJson(jwt.getClaims())
+                "Created JWT: " + signedJwt.serialize() + "\n" + signedJwt.getHeader().toJSONObject() + "\n" + signedJwt.getJWTClaimsSet()
             );
         }
 
-        return encodedJwt;
+        return signedJwt.serialize();
     }
 }

--- a/src/main/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtil.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtil.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.authtoken.jwt;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.util.ByteUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.nimbusds.jose.crypto.MACSigner.getMinRequiredSecretLength;
+
+public class KeyPaddingUtil {
+    public static String padSecret(String signingKey, JWSAlgorithm jwsAlgorithm) {
+        int requiredSecretLength;
+        try {
+            requiredSecretLength = getMinRequiredSecretLength(jwsAlgorithm);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+        int requiredByteLength = ByteUtils.byteLength(requiredSecretLength);
+        // padding the signing key with 0s to meet the minimum required length
+        return StringUtils.rightPad(signingKey, requiredByteLength, "\0");
+    }
+}

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -67,7 +67,7 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
-    public void testBadKey() throws Exception {
+    public void testBadKey() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             Settings.builder().put("signing_key", BaseEncoding.base64().encode(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 })),
@@ -78,7 +78,7 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
-    public void testTokenMissing() throws Exception {
+    public void testTokenMissing() {
 
         Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
 
@@ -108,6 +108,79 @@ public class HTTPJwtAuthenticatorTest {
             new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
             null
         );
+        Assert.assertNull(credentials);
+    }
+
+    /** Here is the original encoded jwt token generation with cxf library:
+     *
+     * String base64EncodedSecret = Base64.getEncoder().encodeToString(someSecret.getBytes(StandardCharsets.UTF_8));
+     * JwtClaims claims = new JwtClaims();
+     * claims.setNotBefore(854113533);
+     * claim.setExpiration(4853843133)
+     * claims.setSubject("horst");
+     * claims.setProperty("saml_nif", "u");
+     * claims.setProperty("saml_si", "MOCKSAML_3");
+     * JwsSignatureProvider jwsSignatureProvider = new HmacJwsSignatureProvider(base64EncodedSecret, SignatureAlgorithm.HS512);
+     * JweEncryptionProvider jweEncryptionProvider = null;
+     * JoseJwtProducer producer = new JoseJwtProducer();
+     * String encodedCxfJwt = producer.processJwt(jwtToken, jweEncryptionProvider, jwsSignatureProvider);
+     */
+    @Test
+    public void testParsePrevGeneratedJwt() {
+        String encodedCxfJwt =
+            "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJob3JzdCIsIm5iZiI6ODU0MTEzNTMzLCJzYW1sX25pZiI6InUiLCJleHAiOjQ4NTM4NDMxMzMsInNhbWxfc2kiOiJNT0NLU0FNTF8zIn0.MQ9lidZ774EPHjDNB43O4d2Q1SGtG4-lASoLXDPdtE0qJGvZOYDUCN3h2HxBIX5NmwXQQvjJ2PUzN6f6FgY0Iw";
+        Settings settings = Settings.builder()
+            .put(
+                "signing_key",
+                BaseEncoding.base64()
+                    .encode(
+                        "thisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDothisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDo"
+                            .getBytes(StandardCharsets.UTF_8)
+                    )
+            )
+            .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", "Bearer " + encodedCxfJwt);
+
+        AuthCredentials credentials = jwtAuth.extractCredentials(
+            new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("horst", credentials.getUsername());
+        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        Assert.assertEquals(5, credentials.getAttributes().size());
+        Assert.assertEquals("854113533", credentials.getAttributes().get("attr.jwt.nbf"));
+        Assert.assertEquals("4853843133", credentials.getAttributes().get("attr.jwt.exp"));
+    }
+
+    @Test
+    public void testFailToParsePrevGeneratedJwt() {
+        String jwsToken =
+            "eyJhbGciOiJIUzUxMiJ9.eyJuYmYiOjE2OTgxNTE4ODQsImV4cCI6MTY5ODE1NTQ4NCwic3ViIjoiaG9yc3QiLCJzYW1sX25pZiI6InUiLCJzYW1sX3NpIjoiTU9DS1NBTUxfMyIsInJvbGVzIjpudWxsfQ.E_MP8wVVu1P7_RATtjhnCvPft2gQTFdY5NlmRTCsrjdDXTUfxkswktWCB_k_wXDKCuNukNlSL2FSo3EV2VtUEQ";
+        Settings settings = Settings.builder()
+            .put(
+                "signing_key",
+                BaseEncoding.base64()
+                    .encode(
+                        "additionalDatathisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDothisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDo"
+                            .getBytes(StandardCharsets.UTF_8)
+                    )
+            )
+            .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Authorization", "Bearer " + jwsToken);
+
+        AuthCredentials credentials = jwtAuth.extractCredentials(
+            new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
+            null
+        );
+
         Assert.assertNull(credentials);
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -11,6 +11,7 @@
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.util.HashMap;
+import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.AfterClass;
@@ -52,14 +53,13 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
         AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_1), new HashMap<String, String>())
-                .asSecurityRequest(),
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_OCT_1), new HashMap<>()).asSecurityRequest(),
             null
         );
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -81,7 +81,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -187,7 +187,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
@@ -210,13 +210,13 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
 
     @Test
-    public void testRoles() throws Exception {
+    public void testRoles() {
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
             .put("roles_key", TestJwts.ROLES_CLAIM)
@@ -238,16 +238,14 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
-    public void testExp() throws Exception {
+    public void testExp() {
         Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
 
         HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
         AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(
-                ImmutableMap.of("Authorization", "Bearer " + TestJwts.MC_COY_EXPIRED_SIGNED_OCT_1),
-                new HashMap<String, String>()
-            ).asSecurityRequest(),
+            new FakeRestRequest(ImmutableMap.of("Authorization", "Bearer " + TestJwts.MC_COY_EXPIRED_SIGNED_OCT_1), new HashMap<>())
+                .asSecurityRequest(),
             null
         );
 
@@ -255,7 +253,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
-    public void testExpInSkew() throws Exception {
+    public void testExpInSkew() {
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
             .put("jwt_clock_skew_tolerance_seconds", "10")
@@ -270,8 +268,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         AuthCredentials creds = jwtAuth.extractCredentials(
             new FakeRestRequest(
-                ImmutableMap.of("Authorization", "bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
-                new HashMap<String, String>()
+                ImmutableMap.of("Authorization", "Bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+                new HashMap<>()
             ).asSecurityRequest(),
             null
         );
@@ -280,7 +278,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
-    public void testNbf() throws Exception {
+    public void testNbf() {
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
             .put("jwt_clock_skew_tolerance_seconds", "0")
@@ -295,8 +293,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         AuthCredentials creds = jwtAuth.extractCredentials(
             new FakeRestRequest(
-                ImmutableMap.of("Authorization", "bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
-                new HashMap<String, String>()
+                ImmutableMap.of("Authorization", "Bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+                new HashMap<>()
             ).asSecurityRequest(),
             null
         );
@@ -305,7 +303,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
-    public void testNbfInSkew() throws Exception {
+    public void testNbfInSkew() {
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
             .put("jwt_clock_skew_tolerance_seconds", "10")
@@ -320,8 +318,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
         AuthCredentials creds = jwtAuth.extractCredentials(
             new FakeRestRequest(
-                ImmutableMap.of("Authorization", "bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
-                new HashMap<String, String>()
+                ImmutableMap.of("Authorization", "Bearer " + TestJwts.createMcCoySignedOct1(notBeforeDate, expiringDate)),
+                new HashMap<>()
             ).asSecurityRequest(),
             null
         );
@@ -330,7 +328,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
-    public void testRS256() throws Exception {
+    public void testRS256() {
 
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
@@ -341,28 +339,26 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
         AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_RSA_1), new HashMap<String, String>())
-                .asSecurityRequest(),
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_RSA_1), new HashMap<>()).asSecurityRequest(),
             null
         );
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }
 
     @Test
-    public void testBadSignature() throws Exception {
+    public void testBadSignature() {
 
         Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
 
         HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
         AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_RSA_X), new HashMap<String, String>())
-                .asSecurityRequest(),
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_RSA_X), new HashMap<>()).asSecurityRequest(),
             null
         );
 
@@ -380,16 +376,14 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
 
         AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(
-                ImmutableMap.of("Authorization", TestJwts.PeculiarEscaping.MC_COY_SIGNED_RSA_1),
-                new HashMap<String, String>()
-            ).asSecurityRequest(),
+            new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.PeculiarEscaping.MC_COY_SIGNED_RSA_1), new HashMap<>())
+                .asSecurityRequest(),
             null
         );
 
         Assert.assertNotNull(creds);
         Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
         Assert.assertEquals(0, creds.getBackendRoles().size());
         Assert.assertEquals(4, creds.getAttributes().size());
     }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
@@ -52,8 +52,6 @@ import org.apache.http.protocol.HttpRequestHandler;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.network.SocketUtils;
 
-import static com.amazon.dlic.auth.http.jwt.keybyoidc.CxfTestTools.toJson;
-
 class MockIpdServer implements Closeable {
     final static String CTX_DISCOVER = "/discover";
     final static String CTX_KEYS = "/api/oauth/keys";
@@ -166,8 +164,7 @@ class MockIpdServer implements Closeable {
         );
     }
 
-    protected void handleKeysRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException,
-        IOException {
+    protected void handleKeysRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
         response.setStatusCode(200);
         response.setEntity(new StringEntity(jwks.toString(false)));
     }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/MockIpdServer.java
@@ -30,7 +30,7 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
 
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
+import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.http.HttpConnectionFactory;
 import org.apache.http.HttpException;
 import org.apache.http.HttpRequest;
@@ -62,13 +62,13 @@ class MockIpdServer implements Closeable {
     private final int port;
     private final String uri;
     private final boolean ssl;
-    private final JsonWebKeys jwks;
+    private final JWKSet jwks;
 
-    MockIpdServer(JsonWebKeys jwks) throws IOException {
+    MockIpdServer(JWKSet jwks) throws IOException {
         this(jwks, SocketUtils.findAvailableTcpPort(), false);
     }
 
-    MockIpdServer(JsonWebKeys jwks, int port, boolean ssl) throws IOException {
+    MockIpdServer(JWKSet jwks, int port, boolean ssl) throws IOException {
         this.port = port;
         this.uri = (ssl ? "https" : "http") + "://localhost:" + port;
         this.ssl = ssl;
@@ -166,9 +166,10 @@ class MockIpdServer implements Closeable {
         );
     }
 
-    protected void handleKeysRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException {
+    protected void handleKeysRequest(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException,
+        IOException {
         response.setStatusCode(200);
-        response.setEntity(new StringEntity(toJson(jwks)));
+        response.setEntity(new StringEntity(jwks.toString(false)));
     }
 
     private SSLContext createSSLContext() {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
@@ -15,8 +15,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,12 +27,12 @@ public class SelfRefreshingKeySetTest {
     public void basicTest() throws AuthenticatorUnavailableException, BadCredentialsException {
         SelfRefreshingKeySet selfRefreshingKeySet = new SelfRefreshingKeySet(new MockKeySetProvider());
 
-        JsonWebKey key1 = selfRefreshingKeySet.getKey("kid/a");
-        Assert.assertEquals(TestJwk.OCT_1_K, key1.getProperty("k"));
+        OctetSequenceKey key1 = (OctetSequenceKey) selfRefreshingKeySet.getKey("kid/a");
+        Assert.assertEquals(TestJwk.OCT_1_K, key1.getKeyValue().decodeToString());
         Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
 
-        JsonWebKey key2 = selfRefreshingKeySet.getKey("kid/b");
-        Assert.assertEquals(TestJwk.OCT_2_K, key2.getProperty("k"));
+        OctetSequenceKey key2 = (OctetSequenceKey) selfRefreshingKeySet.getKey("kid/b");
+        Assert.assertEquals(TestJwk.OCT_2_K, key2.getKeyValue().decodeToString());
         Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
 
         try {
@@ -51,11 +52,11 @@ public class SelfRefreshingKeySetTest {
 
         ExecutorService executorService = Executors.newCachedThreadPool();
 
-        Future<JsonWebKey> f1 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/a"));
+        Future<JWK> f1 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/a"));
 
         provider.waitForCalled();
 
-        Future<JsonWebKey> f2 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/b"));
+        Future<JWK> f2 = executorService.submit(() -> selfRefreshingKeySet.getKey("kid/b"));
 
         while (selfRefreshingKeySet.getQueuedGetCount() == 0) {
             Thread.sleep(10);
@@ -63,8 +64,8 @@ public class SelfRefreshingKeySetTest {
 
         provider.unblock();
 
-        Assert.assertEquals(TestJwk.OCT_1_K, f1.get().getProperty("k"));
-        Assert.assertEquals(TestJwk.OCT_2_K, f2.get().getProperty("k"));
+        Assert.assertEquals(TestJwk.OCT_1_K, ((OctetSequenceKey) f1.get()).getKeyValue().decodeToString());
+        Assert.assertEquals(TestJwk.OCT_2_K, ((OctetSequenceKey) f2.get()).getKeyValue().decodeToString());
 
         Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
         Assert.assertEquals(1, selfRefreshingKeySet.getQueuedGetCount());
@@ -74,7 +75,7 @@ public class SelfRefreshingKeySetTest {
     static class MockKeySetProvider implements KeySetProvider {
 
         @Override
-        public JsonWebKeys get() throws AuthenticatorUnavailableException {
+        public JWKSet get() throws AuthenticatorUnavailableException {
             return TestJwk.OCT_1_2_3;
         }
 
@@ -85,7 +86,7 @@ public class SelfRefreshingKeySetTest {
         private boolean called = false;
 
         @Override
-        public synchronized JsonWebKeys get() throws AuthenticatorUnavailableException {
+        public synchronized JWKSet get() throws AuthenticatorUnavailableException {
 
             called = true;
             notifyAll();

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -12,6 +12,7 @@
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
 import java.util.HashMap;
+import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
@@ -39,7 +40,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
             Assert.assertNotNull(creds);
             Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
             Assert.assertEquals(0, creds.getBackendRoles().size());
             Assert.assertEquals(4, creds.getAttributes().size());
 
@@ -89,7 +90,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
             Assert.assertNotNull(creds);
             Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
             Assert.assertEquals(0, creds.getBackendRoles().size());
             Assert.assertEquals(4, creds.getAttributes().size());
         } finally {
@@ -139,7 +140,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
             Assert.assertNotNull(creds);
             Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
             Assert.assertEquals(0, creds.getBackendRoles().size());
             Assert.assertEquals(4, creds.getAttributes().size());
 
@@ -167,7 +168,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
             Assert.assertNotNull(creds);
             Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
             Assert.assertEquals(0, creds.getBackendRoles().size());
             Assert.assertEquals(4, creds.getAttributes().size());
 
@@ -190,7 +191,7 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
             Assert.assertNotNull(creds);
             Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(TestJwts.TEST_AUDIENCE, creds.getAttributes().get("attr.jwt.aud"));
+            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
             Assert.assertEquals(0, creds.getBackendRoles().size());
             Assert.assertEquals(4, creds.getAttributes().size());
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwk.java
@@ -11,12 +11,16 @@
 
 package com.amazon.dlic.auth.http.jwt.keybyoidc;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKeys;
-import org.apache.cxf.rs.security.jose.jwk.KeyType;
-import org.apache.cxf.rs.security.jose.jwk.PublicKeyUse;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
 
 class TestJwk {
 
@@ -29,13 +33,13 @@ class TestJwk {
     static final String OCT_3_K =
         "r3aeW3OK7-B4Hs3hq9BmlT1D3jRiolH9PL82XUz9xAS7dniAdmvMnN5GkOc1vqibOe2T-CC_103UglDm9D0iU9S9zn6wTuQt1L5wfZIoHd9f5IjJ_YFEzZMvsoUY_-ji_0K_ugVvBPwi9JnBQHHS4zrgmP06dGjmcnZDcIf4W_iFas3lDYSXilL1V2QhNaynpSqTarpfBGSphKv4Zg2JhsX8xB0VSaTlEq4lF8pzvpWSxXCW9CtomhB80daSuTizrmSTEPpdN3XzQ2-Tovo1ieMOfDU4csvjEk7Bwc2ThjpnA8ucKQUYpUv9joBxKuCdUltssthWnetrogjYOn_xGA";
 
-    static final JsonWebKey OCT_1 = createOct("kid/a", "HS256", OCT_1_K);
-    static final JsonWebKey OCT_2 = createOct("kid/b", "HS256", OCT_2_K);
-    static final JsonWebKey OCT_3 = createOct("kid/c", "HS256", OCT_3_K);
-    static final JsonWebKey ESCAPED_SLASH_KID_OCT_1 = createOct("kid\\/_a", "HS256", OCT_1_K);
-    static final JsonWebKey FORWARD_SLASH_KID_OCT_1 = createOct("kid/_a", "HS256", OCT_1_K);
+    static final JWK OCT_1 = createOct("kid/a", "HS256", OCT_1_K);
+    static final JWK OCT_2 = createOct("kid/b", "HS256", OCT_2_K);
+    static final JWK OCT_3 = createOct("kid/c", "HS256", OCT_3_K);
+    static final JWK ESCAPED_SLASH_KID_OCT_1 = createOct("kid\\/_a", "HS256", OCT_1_K);
+    static final JWK FORWARD_SLASH_KID_OCT_1 = createOct("kid/_a", "HS256", OCT_1_K);
 
-    static final JsonWebKeys OCT_1_2_3 = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, ESCAPED_SLASH_KID_OCT_1);
+    static final JWKSet OCT_1_2_3 = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, ESCAPED_SLASH_KID_OCT_1);
 
     static final String RSA_1_D =
         "On8XGMmdM5Fm5hvuhQk-qAkIP2CoK5QMx0OH5m_WDzKXZv8lZ2eg89I4ehBiOKGdw1h_mjmWwTah-evpXV-BF5QpejPQqxkXS-8s5r2AvietQq32jl-gwIwZWTvfzjpT9On0YJZ4q01tMDj3r-YOLUW2xrz3za9tl6pPU_5kP63C-hoj1ybTwcC7ujbCPwhY6yAopMA1v10uVmCxsjsNikEjB6YePgHixez51wO3Z8mXNwefWukFWYJ5T7t4kHMSf5P_8FJZ14u5yvYZnngE_tJCyHFdIDb6UWsrgxomtlQU-SdZYK_NY6gw6mCkjjlqOoYqlsrRJ16kJ81Ds269oQ";
@@ -55,67 +59,53 @@ class TestJwk {
         "jDDVUMXOXDVcaRVAT5TtuiAsLxk7XAAwyyECfmySZul7D5XVLMtGe6rP2900q3nM4BaCEiuwXjmTCZDAGlFGs2a3eQ1vbBSv9_0KGHL-gZGFPNiv0v8aR7QzZ-abhGnRy5F52PlTWsypGgG_kQpF2t2TBotvYhvVPagAt4ljllDKvY1siOvS3nh4TqcUtWcbgQZEWPmaXuhx0eLmhQJca7UEw99YlGNew48AEzt7ZnfU0Qkz3JwSz7IcPx-NfIh6BN6LwAg_ASdoM3MR8rDOtLYavmJVhutrfOpE-4-fw1mf3eLYu7xrxIplSiOIsHunTUssnTiBkXAaGqGJs604Pw";
     static final String RSA_X_E = "AQAB";
 
-    static final JsonWebKey RSA_1 = createRsa("kid/1", "RS256", RSA_1_E, RSA_1_N, RSA_1_D);
-    static final JsonWebKey RSA_1_PUBLIC = createRsaPublic("kid/1", "RS256", RSA_1_E, RSA_1_N);
-    static final JsonWebKey RSA_1_PUBLIC_NO_ALG = createRsaPublic("kid/1", null, RSA_1_E, RSA_1_N);
-    static final JsonWebKey RSA_1_PUBLIC_WRONG_ALG = createRsaPublic("kid/1", "HS256", RSA_1_E, RSA_1_N);
+    static final JWK RSA_1 = createRsa("kid/1", "RS256", RSA_1_E, RSA_1_N, RSA_1_D);
 
-    static final JsonWebKey RSA_2 = createRsa("kid/2", "RS256", RSA_2_E, RSA_2_N, RSA_2_D);
-    static final JsonWebKey RSA_2_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_2_E, RSA_2_N);
+    static final JWK RSA_1_PUBLIC = createRsaPublic("kid/1", "RS256", RSA_1_E, RSA_1_N);
+    static final JWK RSA_1_PUBLIC_NO_ALG = createRsaPublic("kid/1", null, RSA_1_E, RSA_1_N);
+    static final JWK RSA_1_PUBLIC_WRONG_ALG = createRsaPublic("kid/1", "HS256", RSA_1_E, RSA_1_N);
 
-    static final JsonWebKey RSA_X = createRsa("kid/2", "RS256", RSA_X_E, RSA_X_N, RSA_X_D);
-    static final JsonWebKey RSA_X_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_X_E, RSA_X_N);
+    static final JWK RSA_2 = createRsa("kid/2", "RS256", RSA_2_E, RSA_2_N, RSA_2_D);
+    static final JWK RSA_2_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_2_E, RSA_2_N);
 
-    static final JsonWebKeys RSA_1_2_PUBLIC = createJwks(RSA_1_PUBLIC, RSA_2_PUBLIC);
+    static final JWK RSA_X = createRsa("kid/2", "RS256", RSA_X_E, RSA_X_N, RSA_X_D);
+    static final JWK RSA_X_PUBLIC = createRsaPublic("kid/2", "RS256", RSA_X_E, RSA_X_N);
+
+    static final JWKSet RSA_1_2_PUBLIC = createJwks(RSA_1_PUBLIC, RSA_2_PUBLIC);
 
     static class Jwks {
-        static final JsonWebKeys ALL = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, RSA_1_PUBLIC, RSA_2_PUBLIC);
-        static final JsonWebKeys RSA_1 = createJwks(RSA_1_PUBLIC);
-        static final JsonWebKeys RSA_2 = createJwks(RSA_2_PUBLIC);
-        static final JsonWebKeys RSA_1_NO_ALG = createJwks(RSA_1_PUBLIC_NO_ALG);
-        static final JsonWebKeys RSA_1_WRONG_ALG = createJwks(RSA_1_PUBLIC_WRONG_ALG);
+        static final JWKSet ALL = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, RSA_1_PUBLIC, RSA_2_PUBLIC);
+        static final JWKSet RSA_1 = createJwks(RSA_1_PUBLIC);
+        static final JWKSet RSA_2 = createJwks(RSA_2_PUBLIC);
+        static final JWKSet RSA_1_NO_ALG = createJwks(RSA_1_PUBLIC_NO_ALG);
+        static final JWKSet RSA_1_WRONG_ALG = createJwks(RSA_1_PUBLIC_WRONG_ALG);
     }
 
-    private static JsonWebKey createOct(String keyId, String algorithm, String k) {
-        JsonWebKey result = new JsonWebKey();
-
-        result.setKeyId(keyId);
-        result.setKeyType(KeyType.OCTET);
-        result.setAlgorithm(algorithm);
-        result.setPublicKeyUse(PublicKeyUse.SIGN);
-        result.setProperty("k", k);
-
-        return result;
+    private static JWK createOct(String keyId, String algorithm, String k) {
+        return new OctetSequenceKey.Builder(k.getBytes(StandardCharsets.UTF_8)).keyID(keyId)
+            .keyUse(KeyUse.SIGNATURE)
+            .algorithm(JWSAlgorithm.parse(algorithm))
+            .build();
     }
 
-    private static JsonWebKey createRsa(String keyId, String algorithm, String e, String n, String d) {
-        JsonWebKey result = new JsonWebKey();
-
-        result.setKeyId(keyId);
-        result.setKeyType(KeyType.RSA);
-        result.setAlgorithm(algorithm);
-        result.setPublicKeyUse(PublicKeyUse.SIGN);
+    private static JWK createRsa(String keyId, String algorithm, String e, String n, String d) {
+        RSAKey.Builder builder = new RSAKey.Builder(Base64URL.from(n), Base64URL.from(e)).keyUse(KeyUse.SIGNATURE)
+            .algorithm(algorithm == null ? null : JWSAlgorithm.parse(algorithm))
+            .keyID(keyId);
 
         if (d != null) {
-            result.setProperty("d", d);
+            builder.privateExponent(Base64URL.from(d));
         }
 
-        result.setProperty("e", e);
-        result.setProperty("n", n);
-
-        return result;
+        return builder.build();
     }
 
-    private static JsonWebKey createRsaPublic(String keyId, String algorithm, String e, String n) {
+    private static JWK createRsaPublic(String keyId, String algorithm, String e, String n) {
         return createRsa(keyId, algorithm, e, n, null);
     }
 
-    private static JsonWebKeys createJwks(JsonWebKey... array) {
-        JsonWebKeys result = new JsonWebKeys();
-
-        result.setKeys(Arrays.asList(array));
-
-        return result;
+    private static JWKSet createJwks(JWK... array) {
+        return new JWKSet(Arrays.asList(array));
     }
 
 }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -14,15 +14,18 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jws.JwsHeaders;
-import org.apache.cxf.rs.security.jose.jws.JwsSignatureProvider;
-import org.apache.cxf.rs.security.jose.jws.JwsUtils;
-import org.apache.cxf.rs.security.jose.jwt.JoseJwtProducer;
-import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
-import org.apache.cxf.rs.security.jose.jwt.JwtConstants;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.factories.DefaultJWSSignerFactory;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.logging.log4j.util.Strings;
+
+import static com.nimbusds.jwt.JWTClaimNames.EXPIRATION_TIME;
+import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 
 class TestJwts {
     static final String ROLES_CLAIM = "roles";
@@ -35,21 +38,21 @@ class TestJwts {
 
     static final String TEST_ISSUER = "TestIssuer";
 
-    static final JwtToken MC_COY = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+    static final JWTClaimsSet MC_COY = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
 
-    static final JwtToken MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+    static final JWTClaimsSet MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
 
-    static final JwtToken MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, null, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
+    static final JWTClaimsSet MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, null, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
 
-    static final JwtToken MC_COY_NO_ISSUER = create(MCCOY_SUBJECT, TEST_AUDIENCE, null, ROLES_CLAIM, TEST_ROLES_STRING);
+    static final JWTClaimsSet MC_COY_NO_ISSUER = create(MCCOY_SUBJECT, TEST_AUDIENCE, null, ROLES_CLAIM, TEST_ROLES_STRING);
 
-    static final JwtToken MC_COY_EXPIRED = create(
+    static final JWTClaimsSet MC_COY_EXPIRED = create(
         MCCOY_SUBJECT,
         TEST_AUDIENCE,
         TEST_ISSUER,
         ROLES_CLAIM,
         TEST_ROLES_STRING,
-        JwtConstants.CLAIM_EXPIRY,
+        EXPIRATION_TIME,
         10
     );
 
@@ -78,73 +81,82 @@ class TestJwts {
         static final String MC_COY_SIGNED_RSA_1 = createSignedWithPeculiarEscaping(MC_COY, TestJwk.RSA_1);
     }
 
-    static JwtToken create(String subject, String audience, String issuer, Object... moreClaims) {
-        JwtClaims claims = new JwtClaims();
+    static JWTClaimsSet create(String subject, String audience, String issuer, Object... moreClaims) {
+        JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
 
-        claims.setSubject(subject);
+        claimsBuilder.subject(subject);
         if (audience != null) {
-            claims.setAudience(audience);
+            claimsBuilder.audience(audience);
         }
         if (issuer != null) {
-            claims.setIssuer(issuer);
+            claimsBuilder.issuer(issuer);
         }
 
         if (moreClaims != null) {
             for (int i = 0; i < moreClaims.length; i += 2) {
-                claims.setClaim(String.valueOf(moreClaims[i]), moreClaims[i + 1]);
+                claimsBuilder.claim(String.valueOf(moreClaims[i]), moreClaims[i + 1]);
             }
         }
 
-        JwtToken result = new JwtToken(claims);
-
-        return result;
+        // JwtToken result = new JwtToken(claimsBuilder);
+        return claimsBuilder.build();
     }
 
-    static String createSigned(JwtToken baseJwt, JsonWebKey jwk) {
-        return createSigned(baseJwt, jwk, JwsUtils.getSignatureProvider(jwk));
+    static String createSigned(JWTClaimsSet jwtClaimsSet, JWK jwk) {
+        JWSHeader jwsHeader = new JWSHeader.Builder(new JWSAlgorithm(jwk.getAlgorithm().getName())).keyID(jwk.getKeyID()).build();
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        try {
+            JWSSigner signer = new DefaultJWSSignerFactory().createJWSSigner(jwk);
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+
+        return signedJWT.serialize();
     }
 
-    static String createSigned(JwtToken baseJwt, JsonWebKey jwk, JwsSignatureProvider signatureProvider) {
-        JwsHeaders jwsHeaders = new JwsHeaders();
-        JwtToken signedToken = new JwtToken(jwsHeaders, baseJwt.getClaims());
+    static String createSignedWithoutKeyId(JWTClaimsSet jwtClaimsSet, JWK jwk) {
+        JWSHeader jwsHeader = new JWSHeader.Builder(new JWSAlgorithm(jwk.getAlgorithm().getName())).keyID(jwk.getKeyID()).build();
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        try {
+            JWSSigner signer = new DefaultJWSSignerFactory().createJWSSigner(jwk);
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
 
-        jwsHeaders.setKeyId(jwk.getKeyId());
-
-        return new JoseJwtProducer().processJwt(signedToken, null, signatureProvider);
+        return signedJWT.serialize();
     }
 
-    static String createSignedWithoutKeyId(JwtToken baseJwt, JsonWebKey jwk) {
-        JwsHeaders jwsHeaders = new JwsHeaders();
-        JwtToken signedToken = new JwtToken(jwsHeaders, baseJwt.getClaims());
+    static String createSignedWithPeculiarEscaping(JWTClaimsSet jwtClaimsSet, JWK jwk) {
+        JWSHeader jwsHeader = new JWSHeader.Builder(new JWSAlgorithm(jwk.getAlgorithm().getName())).keyID(
+            jwk.getKeyID().replace("/", "\\/")
+        ).build();
+        SignedJWT signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        try {
+            JWSSigner signer = new DefaultJWSSignerFactory().createJWSSigner(jwk);
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
 
-        return new JoseJwtProducer().processJwt(signedToken, null, JwsUtils.getSignatureProvider(jwk));
-    }
-
-    static String createSignedWithPeculiarEscaping(JwtToken baseJwt, JsonWebKey jwk) {
-        JwsSignatureProvider signatureProvider = JwsUtils.getSignatureProvider(jwk);
-        JwsHeaders jwsHeaders = new JwsHeaders();
-        JwtToken signedToken = new JwtToken(jwsHeaders, baseJwt.getClaims());
-
-        // Depends on CXF not escaping the input string. This may fail for other frameworks or versions.
-        jwsHeaders.setKeyId(jwk.getKeyId().replace("/", "\\/"));
-
-        return new JoseJwtProducer().processJwt(signedToken, null, signatureProvider);
+        return signedJWT.serialize();
     }
 
     static String createMcCoySignedOct1(long nbf, long exp) {
-        JwtToken jwt_token = create(
+        JWTClaimsSet jwtClaimsSet = create(
             MCCOY_SUBJECT,
             TEST_AUDIENCE,
             TEST_ISSUER,
             ROLES_CLAIM,
             TEST_ROLES_STRING,
-            JwtConstants.CLAIM_NOT_BEFORE,
+            NOT_BEFORE,
             nbf,
-            JwtConstants.CLAIM_EXPIRY,
+            EXPIRATION_TIME,
             exp
         );
 
-        return createSigned(jwt_token, TestJwk.OCT_1);
+        return createSigned(jwtClaimsSet, TestJwk.OCT_1);
     }
 
 }

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -11,27 +11,40 @@
 
 package org.opensearch.security.authtoken.jwt;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+import com.google.common.io.BaseEncoding;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.cxf.rs.security.jose.jwk.JsonWebKey;
-import org.apache.cxf.rs.security.jose.jws.JwsJwtCompactConsumer;
-import org.apache.cxf.rs.security.jose.jwt.JwtToken;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
+import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.ConfigConstants;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.function.LongSupplier;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.jwk.JWK;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import static org.hamcrest.core.IsNull.notNullValue;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -43,62 +56,34 @@ public class JwtVendorTest {
     private Appender mockAppender;
     private ArgumentCaptor<LogEvent> logEventCaptor;
 
+    final static String signingKey =
+        "This is my super safe signing key that no one will ever be able to guess. It's would take billions of years and the world's most powerful quantum computer to crack";
+    final static String signingKeyB64Encoded = BaseEncoding.base64().encode(signingKey.getBytes(StandardCharsets.UTF_8));
+
     @Test
-    public void testCreateJwkFromSettingsThrowsException() {
-        Settings faultySettings = Settings.builder().put("key.someProperty", "badValue").build();
+    public void testCreateJwkFromSettings() {
+        final Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).build();
 
-        Exception thrownException = assertThrows(Exception.class, () -> new JwtVendor(faultySettings, null));
-
-        String expectedMessagePart = "An error occurred during the creation of Jwk: ";
-        assertTrue(thrownException.getMessage().contains(expectedMessagePart));
+        final Tuple<JWK, JWSSigner> jwk = JwtVendor.createJwkFromSettings(settings);
+        Assert.assertEquals("HS512", jwk.v1().getAlgorithm().getName());
+        Assert.assertEquals("sig", jwk.v1().getKeyUse().toString());
+        Assert.assertTrue(jwk.v1().toOctetSequenceKey().getKeyValue().decodeToString().startsWith(signingKey));
     }
 
     @Test
-    public void testJsonWebKeyPropertiesSetFromJwkSettings() throws Exception {
-        Settings settings = Settings.builder().put("jwt.key.key1", "value1").put("jwt.key.key2", "value2").build();
-
-        JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
-
-        assertEquals("value1", jwk.getProperty("key1"));
-        assertEquals("value2", jwk.getProperty("key2"));
-    }
-
-    @Test
-    public void testJsonWebKeyPropertiesSetFromSettings() {
-        Settings jwkSettings = Settings.builder().put("key1", "value1").put("key2", "value2").build();
-
-        JsonWebKey jwk = new JsonWebKey();
-        for (String key : jwkSettings.keySet()) {
-            jwk.setProperty(key, jwkSettings.get(key));
-        }
-
-        assertEquals("value1", jwk.getProperty("key1"));
-        assertEquals("value2", jwk.getProperty("key2"));
-    }
-
-    @Test
-    public void testCreateJwkFromSettings() throws Exception {
-        Settings settings = Settings.builder().put("signing_key", "abc123").build();
-
-        JsonWebKey jwk = JwtVendor.createJwkFromSettings(settings);
-        assertEquals("HS512", jwk.getAlgorithm());
-        assertEquals("sig", jwk.getPublicKeyUse().toString());
-        assertEquals("abc123", jwk.getProperty("k"));
+    public void testCreateJwkFromSettingsWithWeakKey() {
+        Settings settings = Settings.builder().put("signing_key", "abcd1234").build();
+        Throwable exception = Assert.assertThrows(OpenSearchException.class, () -> JwtVendor.createJwkFromSettings(settings));
+        assertThat(exception.getMessage(), containsString("The secret length must be at least 256 bits"));
     }
 
     @Test
     public void testCreateJwkFromSettingsWithoutSigningKey() {
         Settings settings = Settings.builder().put("jwt", "").build();
-        Throwable exception = assertThrows(RuntimeException.class, () -> {
-            try {
-                JwtVendor.createJwkFromSettings(settings);
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        assertEquals(
-            "java.lang.Exception: Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.",
-            exception.getMessage()
+        Throwable exception = Assert.assertThrows(RuntimeException.class, () -> JwtVendor.createJwkFromSettings(settings));
+        assertThat(
+            exception.getMessage(),
+            equalTo("Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.")
         );
     }
 
@@ -111,26 +96,26 @@ public class JwtVendorTest {
         List<String> backendRoles = List.of("Sales", "Support");
         String expectedRoles = "IT,HR";
         int expirySeconds = 300;
-        LongSupplier currentTime = () -> (long) 100;
-        String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
-        Long expectedExp = currentTime.getAsLong() + expirySeconds;
+        // 2023 oct 4, 10:00:00 AM GMT
+        LongSupplier currentTime = () -> 1696413600000L;
+        String claimsEncryptionKey = "1234567890123456";
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).put("encryption_key", claimsEncryptionKey).build();
 
         JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
-        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, true);
+        final String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, true);
 
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
-        JwtToken jwt = jwtConsumer.getJwtToken();
+        SignedJWT signedJWT = SignedJWT.parse(encodedJwt);
 
-        assertEquals("cluster_0", jwt.getClaim("iss"));
-        assertEquals("admin", jwt.getClaim("sub"));
-        assertEquals("audience_0", jwt.getClaim("aud"));
-        assertNotNull(jwt.getClaim("iat"));
-        assertNotNull(jwt.getClaim("exp"));
-        assertEquals(expectedExp, jwt.getClaim("exp"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("iss"), equalTo("cluster_0"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("sub"), equalTo("admin"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("aud").toString(), equalTo("[audience_0]"));
+        // 2023 oct 4, 10:00:00 AM GMT
+        assertThat(((Date) signedJWT.getJWTClaimsSet().getClaims().get("iat")).getTime(), is(1696413600000L));
+        // 2023 oct 4, 10:05:00 AM GMT
+        assertThat(((Date) signedJWT.getJWTClaimsSet().getClaims().get("exp")).getTime(), is(1696413900000L));
         EncryptionDecryptionUtil encryptionUtil = new EncryptionDecryptionUtil(claimsEncryptionKey);
-        assertEquals(expectedRoles, encryptionUtil.decrypt(jwt.getClaim("er").toString()));
-        assertNull(jwt.getClaim("br"));
+        assertThat(encryptionUtil.decrypt(signedJWT.getJWTClaimsSet().getClaims().get("er").toString()), equalTo(expectedRoles));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("br"), nullValue());
     }
 
     @Test
@@ -145,32 +130,29 @@ public class JwtVendorTest {
 
         int expirySeconds = 300;
         LongSupplier currentTime = () -> (long) 100;
-        String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
+        String claimsEncryptionKey = "1234567890123456";
         Settings settings = Settings.builder()
-            .put("signing_key", "abc123")
+            .put("signing_key", signingKeyB64Encoded)
             .put("encryption_key", claimsEncryptionKey)
             // CS-SUPPRESS-SINGLE: RegexpSingleline get Extensions Settings
-            .put(ConfigConstants.EXTENSIONS_BWC_PLUGIN_MODE, "true")
+            .put(ConfigConstants.EXTENSIONS_BWC_PLUGIN_MODE, true)
             // CS-ENFORCE-SINGLE
             .build();
-        Long expectedExp = currentTime.getAsLong() + expirySeconds;
+        final JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
+        final String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
 
-        JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
-        String encodedJwt = jwtVendor.createJwt(issuer, subject, audience, expirySeconds, roles, backendRoles, false);
+        SignedJWT signedJWT = SignedJWT.parse(encodedJwt);
 
-        JwsJwtCompactConsumer jwtConsumer = new JwsJwtCompactConsumer(encodedJwt);
-        JwtToken jwt = jwtConsumer.getJwtToken();
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("iss"), equalTo("cluster_0"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("sub"), equalTo("admin"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("aud").toString(), equalTo("[audience_0]"));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("iat"), is(notNullValue()));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("exp"), is(notNullValue()));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("br"), is(notNullValue()));
+        assertThat(signedJWT.getJWTClaimsSet().getClaims().get("br").toString(), equalTo(expectedBackendRoles));
 
-        assertEquals("cluster_0", jwt.getClaim("iss"));
-        assertEquals("admin", jwt.getClaim("sub"));
-        assertEquals("audience_0", jwt.getClaim("aud"));
-        assertNotNull(jwt.getClaim("iat"));
-        assertNotNull(jwt.getClaim("exp"));
-        assertEquals(expectedExp, jwt.getClaim("exp"));
         EncryptionDecryptionUtil encryptionUtil = new EncryptionDecryptionUtil(claimsEncryptionKey);
-        assertEquals(expectedRoles, encryptionUtil.decrypt(jwt.getClaim("er").toString()));
-        assertNotNull(jwt.getClaim("br"));
-        assertEquals(expectedBackendRoles, jwt.getClaim("br"));
+        assertThat(encryptionUtil.decrypt(signedJWT.getJWTClaimsSet().getClaims().get("er").toString()), equalTo(expectedRoles));
     }
 
     @Test
@@ -181,7 +163,7 @@ public class JwtVendorTest {
         List<String> roles = List.of("admin");
         Integer expirySeconds = -300;
         String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).put("encryption_key", claimsEncryptionKey).build();
         JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
 
         Throwable exception = assertThrows(RuntimeException.class, () -> {
@@ -191,7 +173,7 @@ public class JwtVendorTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals("java.lang.Exception: The expiration time should be a positive integer", exception.getMessage());
+        assertEquals("java.lang.IllegalArgumentException: The expiration time should be a positive integer", exception.getMessage());
     }
 
     @Test
@@ -204,7 +186,7 @@ public class JwtVendorTest {
         int expirySeconds = 900;
         LongSupplier currentTime = () -> (long) 100;
         String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).put("encryption_key", claimsEncryptionKey).build();
         JwtVendor jwtVendor = new JwtVendor(settings, Optional.of(currentTime));
 
         Throwable exception = assertThrows(RuntimeException.class, () -> {
@@ -215,7 +197,7 @@ public class JwtVendorTest {
             }
         });
         assertEquals(
-            "java.lang.Exception: The provided expiration time exceeds the maximum allowed duration of 600 seconds",
+            "java.lang.IllegalArgumentException: The provided expiration time exceeds the maximum allowed duration of 600 seconds",
             exception.getMessage()
         );
     }
@@ -228,7 +210,7 @@ public class JwtVendorTest {
         List<String> roles = List.of("admin");
         Integer expirySeconds = 300;
 
-        Settings settings = Settings.builder().put("signing_key", "abc123").build();
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).build();
 
         Throwable exception = assertThrows(RuntimeException.class, () -> {
             try {
@@ -248,7 +230,7 @@ public class JwtVendorTest {
         List<String> roles = null;
         Integer expirySeconds = 300;
         String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).put("encryption_key", claimsEncryptionKey).build();
         JwtVendor jwtVendor = new JwtVendor(settings, Optional.empty());
 
         Throwable exception = assertThrows(RuntimeException.class, () -> {
@@ -258,7 +240,7 @@ public class JwtVendorTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals("java.lang.Exception: Roles cannot be null", exception.getMessage());
+        assertEquals("java.lang.IllegalArgumentException: Roles cannot be null", exception.getMessage());
     }
 
     @Test
@@ -274,7 +256,7 @@ public class JwtVendorTest {
         // Mock settings and other required dependencies
         LongSupplier currentTime = () -> (long) 100;
         String claimsEncryptionKey = RandomStringUtils.randomAlphanumeric(16);
-        Settings settings = Settings.builder().put("signing_key", "abc123").put("encryption_key", claimsEncryptionKey).build();
+        Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).put("encryption_key", claimsEncryptionKey).build();
 
         String issuer = "cluster_0";
         String subject = "admin";

--- a/src/test/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtilTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.authtoken.jwt;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KeyPaddingUtilTest {
+
+    private String signingKey = "testKey";
+
+    @Test
+    public void testPadSecretForHS256() {
+        JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS256;
+        String paddedKey = KeyPaddingUtil.padSecret(signingKey, jwsAlgorithm);
+
+        // For HS256, HMAC using SHA-256, typical key length is 256 bits or 32 bytes
+        int expectedLength = 32;
+        assertEquals(expectedLength, paddedKey.length());
+    }
+
+    @Test
+    public void testPadSecretForHS384() {
+        JWSAlgorithm jwsAlgorithm = JWSAlgorithm.HS384;
+        String paddedKey = KeyPaddingUtil.padSecret(signingKey, jwsAlgorithm);
+
+        // For HS384, HMAC using SHA-384, typical key length is 384 bits or 48 bytes
+        int expectedLength = 48;
+        assertEquals(expectedLength, paddedKey.length());
+    }
+}


### PR DESCRIPTION
### Description
Switch from `org.apache.cxf.rs.security.jose` to `com.nimbusds.jose.jwk`.

### Issues Resolved
* Relate https://github.com/opensearch-project/security/issues/3267
* Resolve https://github.com/opensearch-project/security/issues/3555

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff
- [x]  Add a checkstyle rule to detect including references to org.apache.cxf.rs.security.jose
- [x] Remove all references to org.apache.cxf.rs.security.jose [[15]](https://github.com/search?q=repo%3Aopensearch-project%2Fsecurity+org.apache.cxf.rs.security.jose&type=code) files impacted
- [x] Replace all unfulfilled references with com.nimbusds.jose.* components
- [x] Add backwards combability tests for any features that have previously shipped

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
