### PR TITLE
Remove unneeded decoding from AuthTokenProcessorHandler

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -242,7 +243,7 @@ class AuthTokenProcessorHandler {
         String exchangeKey = settings.get("exchange_key");
 
         if (!Strings.isNullOrEmpty(exchangeKey)) {
-            exchangeKey = padSecret(exchangeKey, JWSAlgorithm.HS512);
+            exchangeKey = padSecret(new String(Base64.getUrlDecoder().decode(exchangeKey), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
 
             return new OctetSequenceKey.Builder(exchangeKey.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
                 .keyUse(KeyUse.SIGNATURE)
@@ -256,7 +257,7 @@ class AuthTokenProcessorHandler {
                 );
             }
 
-            String k = padSecret(jwkSettings.get("k"), JWSAlgorithm.HS512);
+            String k = padSecret(new String(Base64.getUrlDecoder().decode(jwkSettings.get("k")), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
 
             return new OctetSequenceKey.Builder(k.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
                 .keyUse(KeyUse.SIGNATURE)

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -257,7 +257,10 @@ class AuthTokenProcessorHandler {
                 );
             }
 
-            String k = padSecret(new String(Base64.getUrlDecoder().decode(jwkSettings.get("k")), StandardCharsets.UTF_8), JWSAlgorithm.HS512);
+            String k = padSecret(
+                new String(Base64.getUrlDecoder().decode(jwkSettings.get("k")), StandardCharsets.UTF_8),
+                JWSAlgorithm.HS512
+            );
 
             return new OctetSequenceKey.Builder(k.getBytes(StandardCharsets.UTF_8)).algorithm(JWSAlgorithm.HS512)
                 .keyUse(KeyUse.SIGNATURE)

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -171,7 +171,7 @@ public class HTTPSamlAuthenticatorTest {
             .put(IDP_METADATA_URL, mockSamlIdpServer.getMetadataUri())
             .put("kibana_url", "http://wherever")
             .put("idp.entity_id", mockSamlIdpServer.getIdpEntityId())
-            .put("exchange_key", "abc")
+            .put("exchange_key", "6aff3042-1327-4f3d-82f0-40a157ac4464")
             .put("roles_key", "roles")
             .put("path.home", ".")
             .build();


### PR DESCRIPTION
### Description
Fixes bug where the SAMLAuthenticator expects the provided key to be base64 encoded otherwise it would cause saml-authenticator initialization to fail.

Front-end tests pass exchange-key in URL encoded format. Another solution to this would be to remove `getDecoder()` completely. This works and I've tested it locally as well.

I proceed with the approach to remove decoding as that was the state prior to library change.

The tests didn't catch this because they use `abc` as exchange_key. I've updated it to reflect the exchange key used in front-end tests: `6aff3042-1327-4f3d-82f0-40a157ac4464`. 

Backport of this PR will unblock frontend CI

### Issues Resolved

- Resolves: https://github.com/opensearch-project/security/issues/3604

### Testing
Existing tests.

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
