### PR TITLE
[Backport 1.x] Removes prefix from dependabot's commit message (#3548)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "[1.x] dependabot:"
+      prefix: "[1.x] "
     ignore:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"
@@ -17,6 +17,6 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "[1.x] dependabot:"
+      prefix: "[1.x] "
     labels:
       - "backport 1.3"


### PR DESCRIPTION
Backports #3548 via 2e7c3616d8f1325cb62be51af84e23da6a0f081d

Manual backport was needed since there were conflicts in the commit message between main and 1.x

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
