### PR TITLE
[Backport 2.x] Removes prefix from dependabot's commit message (#3548)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "[2.x] dependabot:"
+      prefix: "[2.x] "
     ignore:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"
@@ -15,4 +15,4 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "[2.x] dependabot:"
+      prefix: "[2.x] "


### PR DESCRIPTION
Backports https://github.com/opensearch-project/security/pull/3548 via https://github.com/opensearch-project/security/commit/2e7c3616d8f1325cb62be51af84e23da6a0f081d

Manual backport was needed since there were conflicts in the commit message between main and 2.x

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
