### PR TITLE
Validate requests are not impacted during security cache invalidation

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
@@ -13,8 +13,6 @@ package org.opensearch.security.http;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.nimbusds.jose.util.StandardCharset;
 
-import org.apache.hc.client5.http.classic.methods.HttpDelete;
-import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpStatus;
@@ -59,8 +57,8 @@ public class AsyncTests {
     @Test
     public void testBulkAndCacheInvalidationMixed() throws Exception {
         String indexName = "test-index";
-        final String invalidateCachePath = "/_plugins/_security/api/cache";
-        final String nodesPath = "/_nodes";
+        final String invalidateCachePath = "_plugins/_security/api/cache";
+        final String nodesPath = "_nodes";
         final String bulkPath = "/_bulk";
         final String document = ("{ \"index\": { \"_index\": \"" + indexName + "\" }}\n{ \"foo\": \"bar\" }\n").repeat(5);
         final int parallelism = 5;
@@ -75,8 +73,7 @@ public class AsyncTests {
 
             allRequests.addAll(AsyncActions.generate(() -> {
                 countDownLatch.await();
-                final HttpDelete delete = new HttpDelete(client.getHttpServerUri() + invalidateCachePath);
-                return client.executeRequest(delete);
+                return client.delete(invalidateCachePath);
             }, parallelism, totalNumberOfRequests));
 
             allRequests.addAll(AsyncActions.generate(() -> {
@@ -88,8 +85,7 @@ public class AsyncTests {
 
             allRequests.addAll(AsyncActions.generate(() -> {
                 countDownLatch.await();
-                final HttpGet get = new HttpGet(client.getHttpServerUri() + nodesPath);
-                return client.executeRequest(get);
+                return client.get(nodesPath);
             }, parallelism, totalNumberOfRequests));
 
             // Make sure all requests start at the same time

--- a/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
@@ -11,12 +11,8 @@
 package org.opensearch.security.http;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import com.nimbusds.jose.util.StandardCharset;
 
-import org.apache.hc.client5.http.classic.methods.HttpPost;
-import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpStatus;
-import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +25,6 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
@@ -59,7 +54,7 @@ public class AsyncTests {
         String indexName = "test-index";
         final String invalidateCachePath = "_plugins/_security/api/cache";
         final String nodesPath = "_nodes";
-        final String bulkPath = "/_bulk";
+        final String bulkPath = "_bulk";
         final String document = ("{ \"index\": { \"_index\": \"" + indexName + "\" }}\n{ \"foo\": \"bar\" }\n").repeat(5);
         final int parallelism = 5;
         final int totalNumberOfRequests = 30;
@@ -78,9 +73,7 @@ public class AsyncTests {
 
             allRequests.addAll(AsyncActions.generate(() -> {
                 countDownLatch.await();
-                final HttpPost post = new HttpPost(client.getHttpServerUri() + bulkPath);
-                post.setEntity(new ByteArrayEntity(document.getBytes(StandardCharset.UTF_8), ContentType.APPLICATION_JSON));
-                return client.executeRequest(post);
+                return client.postJson(bulkPath, document);
             }, parallelism, totalNumberOfRequests));
 
             allRequests.addAll(AsyncActions.generate(() -> {
@@ -90,7 +83,6 @@ public class AsyncTests {
 
             // Make sure all requests start at the same time
             countDownLatch.countDown();
-            Collections.shuffle(allRequests);
 
             AsyncActions.getAll(allRequests, 30, TimeUnit.SECONDS).forEach((response) -> { response.assertStatusCode(HttpStatus.SC_OK); });
         }

--- a/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.http;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.nimbusds.jose.util.StandardCharset;
+
+import org.apache.hc.client5.http.classic.methods.HttpDelete;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensearch.security.IndexOperationsHelper;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.AsyncActions;
+import org.opensearch.test.framework.RolesMapping;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.cluster.TestRestClientConfiguration.getBasicAuthHeader;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class AsyncTests {
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").backendRoles("admin");
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().singleNode()
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .rolesMapping(new RolesMapping(ALL_ACCESS).backendRoles("admin"))
+        .anonymousAuth(false)
+        .nodeSettings(Map.of(ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED, List.of(ALL_ACCESS.getName())))
+        .build();
+
+    @Test
+    public void testIndexAndCacheInvalidationMixed() throws Exception {
+        String indexName = "test-index";
+        final String invalidateCachePath = "/_plugins/_security/api/cache";
+        final String nodesPath = "/_nodes";
+        final String bulkPath = "/_bulk";
+        final String document = ("{ \"index\": { \"_index\": \"" + indexName + "\" }}\n{ \"foo\": \"bar\" }\n").repeat(5);
+        final int parallelism = 5;
+        final int totalNumberOfRequests = 30;
+
+        try (final TestRestClient client = cluster.getRestClient()) {
+            IndexOperationsHelper.createIndex(cluster, indexName);
+
+            final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+            final var cacheInvalidationRequests = AsyncActions.generate(() -> {
+                countDownLatch.await();
+                System.err.println("Generation triggered invalidate cache requests");
+                final HttpDelete delete = new HttpDelete(client.getHttpServerUri() + invalidateCachePath);
+                return client.executeRequest(delete, getBasicAuthHeader(ADMIN_USER.getName(), ADMIN_USER.getPassword()));
+            }, parallelism, totalNumberOfRequests);
+
+            final var bulkRequests = AsyncActions.generate(() -> {
+                countDownLatch.await();
+                System.err.println("Generation triggered bulk requests");
+                final HttpPost post = new HttpPost(client.getHttpServerUri() + bulkPath);
+                post.setEntity(new ByteArrayEntity(document.getBytes(StandardCharset.UTF_8), ContentType.APPLICATION_JSON));
+                return client.executeRequest(post, getBasicAuthHeader(ADMIN_USER.getName(), ADMIN_USER.getPassword()));
+            }, parallelism, totalNumberOfRequests);
+
+            final var nodesRequests = AsyncActions.generate(() -> {
+                countDownLatch.await();
+                System.err.println("Generation triggered node requests");
+                final HttpGet get = new HttpGet(client.getHttpServerUri() + nodesPath);
+                return client.executeRequest(get, getBasicAuthHeader(ADMIN_USER.getName(), ADMIN_USER.getPassword()));
+            }, parallelism, totalNumberOfRequests);
+
+            // Make sure all requests start at the same time
+            countDownLatch.countDown();
+
+            List<CompletableFuture<HttpResponse>> allRequests = new ArrayList<CompletableFuture<HttpResponse>>();
+            allRequests.addAll(cacheInvalidationRequests);
+            allRequests.addAll(bulkRequests);
+            allRequests.addAll(nodesRequests);
+            Collections.shuffle(allRequests);
+            AsyncActions.getAll(allRequests, 150, TimeUnit.SECONDS).forEach((response) -> {
+                if (response.getStatusCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
+                    System.out.println("Response body: " + response.getBody());
+                }
+                assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            });
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
@@ -60,7 +60,7 @@ public class AsyncTests {
         .build();
 
     @Test
-    public void testIndexAndCacheInvalidationMixed() throws Exception {
+    public void testBulkAndCacheInvalidationMixed() throws Exception {
         String indexName = "test-index";
         final String invalidateCachePath = "/_plugins/_security/api/cache";
         final String nodesPath = "/_nodes";

--- a/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/AsyncTests.java
@@ -105,9 +105,6 @@ public class AsyncTests {
             allRequests.addAll(nodesRequests);
             Collections.shuffle(allRequests);
             AsyncActions.getAll(allRequests, 150, TimeUnit.SECONDS).forEach((response) -> {
-                if (response.getStatusCode() == HttpStatus.SC_INTERNAL_SERVER_ERROR) {
-                    System.out.println("Response body: " + response.getBody());
-                }
                 assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
             });
         }

--- a/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
@@ -40,7 +40,7 @@ public class BasicAuthTests {
     static final User TEST_USER = new User("test_user").password("s3cret");
 
     public static final String CUSTOM_ATTRIBUTE_NAME = "superhero";
-    static final User SUPER_USER = new User("super-user").password("super-password").attr(CUSTOM_ATTRIBUTE_NAME, true);
+    static final User SUPER_USER = new User("super-user").password("super-password").attr(CUSTOM_ATTRIBUTE_NAME, "true");
     public static final String NOT_EXISTING_USER = "not-existing-user";
     public static final String INVALID_PASSWORD = "secret-password";
 

--- a/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
@@ -55,8 +55,6 @@ public class AsyncActions {
         try {
             futuresCompleted.get(n, unit);
         } catch (final Exception ex) {
-            System.out.println("Got exception: " + ex.getMessage());
-            ex.printStackTrace();
             final long completedFuturesCount = futures.stream().filter(CompletableFuture::isDone).count();
             final String perfReport = calculatePerfReport(startTimeMs, completedFuturesCount);
             throw new RuntimeException(

--- a/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AsyncActions.java
@@ -55,6 +55,8 @@ public class AsyncActions {
         try {
             futuresCompleted.get(n, unit);
         } catch (final Exception ex) {
+            System.out.println("Got exception: " + ex.getMessage());
+            ex.printStackTrace();
             final long completedFuturesCount = futures.stream().filter(CompletableFuture::isDone).count();
             final String perfReport = calculatePerfReport(startTimeMs, completedFuturesCount);
             throw new RuntimeException(

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -29,7 +29,6 @@
 package org.opensearch.test.framework;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -256,7 +256,7 @@ public class TestSecurityConfig {
         }
     }
 
-    public static class User implements UserCredentialsHolder, ToXContentObject, Serializable, Writeable {
+    public static class User implements UserCredentialsHolder, ToXContentObject, Writeable {
 
         public final static TestSecurityConfig.User USER_ADMIN = new TestSecurityConfig.User("admin").roles(
             new Role("allaccess").indexPermissions("*").on("*").clusterPermissions("*")

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -58,9 +58,6 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.test.framework.cluster.OpenSearchClientProvider.UserCredentialsHolder;
-import org.opensearch.core.common.io.stream.StreamInput;
-import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.core.common.io.stream.Writeable;
 
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
@@ -255,7 +252,7 @@ public class TestSecurityConfig {
         }
     }
 
-    public static class User implements UserCredentialsHolder, ToXContentObject, Writeable {
+    public static class User implements UserCredentialsHolder, ToXContentObject {
 
         public final static TestSecurityConfig.User USER_ADMIN = new TestSecurityConfig.User("admin").roles(
             new Role("allaccess").indexPermissions("*").on("*").clusterPermissions("*")
@@ -271,18 +268,6 @@ public class TestSecurityConfig {
         public User(String name) {
             this.name = name;
             this.password = "secret";
-        }
-
-        public User(final StreamInput in) throws IOException {
-            super();
-            name = in.readString();
-            roles.addAll(in.readList(StreamInput::readString).stream().map(r -> new Role(r)).collect(Collectors.toList()));
-            requestedTenant = in.readString();
-            if (requestedTenant.isEmpty()) {
-                requestedTenant = null;
-            }
-            attributes = in.readMap(StreamInput::readString, StreamInput::readString);
-            backendRoles.addAll(in.readList(StreamInput::readString));
         }
 
         public User password(String password) {
@@ -347,15 +332,6 @@ public class TestSecurityConfig {
 
             xContentBuilder.endObject();
             return xContentBuilder;
-        }
-
-        @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            out.writeString(name);
-            out.writeStringCollection(roles.stream().map(r -> r.getName()).collect(Collectors.toList()));
-            out.writeString(requestedTenant == null ? "" : requestedTenant);
-            out.writeMap(attributes, StreamOutput::writeString, StreamOutput::writeString);
-            out.writeStringCollection(backendRoles == null ? Collections.emptyList() : new ArrayList<String>(backendRoles));
         }
     }
 


### PR DESCRIPTION
### Description

Opening a PR that adds a test to ensure that requests during a cache invalidation succeed and fail if any unsuccessful status code is detected. This is related to adding an automated test for https://github.com/opensearch-project/security/issues/1961

I'm currently encountering a couple of issues and am able to reproduce a separate concurrency error, but not the OptionalDataException.

This test will fail if both of these PRs are reverted:

- https://github.com/opensearch-project/security/pull/1970
- https://github.com/opensearch-project/security/pull/2765

When the above 2 PRs are reverted, the test case fails with:

```
Caused by: org.opensearch.OpenSearchException: Instance User [name=admin, backend_roles=[admin], requestedTenant=null] of class class org.opensearch.security.user.User is not serializable
        at org.opensearch.security.support.Base64CustomHelper.serializeObject(Base64CustomHelper.java:102) ~[main/:?]
        at org.opensearch.security.support.Base64Helper.serializeObject(Base64Helper.java:34) ~[main/:?]
        at org.opensearch.security.transport.SecurityInterceptor.ensureCorrectHeaders(SecurityInterceptor.java:312) ~[main/:?]
        at org.opensearch.security.transport.SecurityInterceptor.sendRequestDecorate(SecurityInterceptor.java:240) ~[main/:?]
        at org.opensearch.security.OpenSearchSecurityPlugin$6$2.sendRequest(OpenSearchSecurityPlugin.java:811) ~[main/:?]
        at org.opensearch.transport.TransportService.sendRequest(TransportService.java:913) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        ... 21 more
Caused by: java.lang.NullPointerException: Cannot invoke "String.length()" because "str" is null
        at org.opensearch.core.common.io.stream.StreamOutput.writeString(StreamOutput.java:443) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.common.io.stream.StreamOutput.writeCollection(StreamOutput.java:1187) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.core.common.io.stream.StreamOutput.writeStringCollection(StreamOutput.java:1199) ~[opensearch-core-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        at org.opensearch.security.user.User.writeTo(User.java:263) ~[main/:?]
        at org.opensearch.security.support.Base64CustomHelper.serializeObject(Base64CustomHelper.java:86) ~[main/:?]
        at org.opensearch.security.support.Base64Helper.serializeObject(Base64Helper.java:34) ~[main/:?]
        at org.opensearch.security.transport.SecurityInterceptor.ensureCorrectHeaders(SecurityInterceptor.java:312) ~[main/:?]
        at org.opensearch.security.transport.SecurityInterceptor.sendRequestDecorate(SecurityInterceptor.java:240) ~[main/:?]
        at org.opensearch.security.OpenSearchSecurityPlugin$6$2.sendRequest(OpenSearchSecurityPlugin.java:811) ~[main/:?]
        at org.opensearch.transport.TransportService.sendRequest(TransportService.java:913) ~[opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
        ... 21 more
```

This test provides assurances that there are no errors related to concurrency and cache invalidation. I had to update the integrationTest framework to add `backendRoles` onto the User object in the integration test suite. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Adds a test

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
