### PR TITLE
OnBehalfOf tokens feature is disabled by default

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -359,7 +359,7 @@ public class ConfigV6 {
 
     public static class OnBehalfOfSettings {
         @JsonProperty("enabled")
-        private Boolean oboEnabled = Boolean.TRUE;
+        private Boolean oboEnabled = Boolean.FALSE;
         @JsonProperty("signing_key")
         private String signingKey;
         @JsonProperty("encryption_key")

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -148,6 +148,8 @@ public class ConfigV7 {
                 + authc
                 + ", authz="
                 + authz
+                + ", on_behalf_of="
+                + on_behalf_of
                 + "]";
         }
     }
@@ -482,7 +484,7 @@ public class ConfigV7 {
 
     public static class OnBehalfOfSettings {
         @JsonProperty("enabled")
-        private Boolean oboEnabled = Boolean.TRUE;
+        private Boolean oboEnabled = Boolean.FALSE;
         @JsonProperty("signing_key")
         private String signingKey;
         @JsonProperty("encryption_key")

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.security;
 
+import java.io.IOException;
+
 import com.google.common.collect.Lists;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.Assert;
@@ -221,24 +223,24 @@ public class SlowIntegrationTests extends SingleClusterTest {
             .put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
             .put("cluster.routing.allocation.exclude._ip", "127.0.0.1")
             .build();
-        setup(Settings.EMPTY, null, settings, false);
-        Thread.sleep(1000 * 30);
-        Assert.assertEquals(
-            ClusterHealthStatus.RED,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest()).actionGet().getStatus()
-        );
-        Thread.sleep(1000 * 30);
-        // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
-        // IP address
-        clusterHelper.nodeClient()
-            .admin()
-            .cluster()
-            .updateSettings(
-                new ClusterUpdateSettingsRequest().transientSettings(
-                    Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
-                )
-            );
-        this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
+        try {
+            setup(Settings.EMPTY, null, settings, false);
+            Assert.fail("Expected IOException here due to red cluster state");
+        } catch (IOException e) {
+            // Index request has a default timeout of 1 minute, adding buffer between nodes initialization and cluster health check
+            Thread.sleep(1000 * 80);
+            // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
+            // IP address
+            clusterHelper.nodeClient()
+                .admin()
+                .cluster()
+                .updateSettings(
+                    new ClusterUpdateSettingsRequest().transientSettings(
+                        Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
+                    )
+                );
+            this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
+        }
         RestHelper rh = nonSslRestHelper();
         Thread.sleep(10000);
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -26,8 +26,6 @@
 
 package org.opensearch.security;
 
-import java.io.IOException;
-
 import com.google.common.collect.Lists;
 import org.apache.hc.core5.http.HttpStatus;
 import org.junit.Assert;
@@ -223,24 +221,24 @@ public class SlowIntegrationTests extends SingleClusterTest {
             .put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
             .put("cluster.routing.allocation.exclude._ip", "127.0.0.1")
             .build();
-        try {
-            setup(Settings.EMPTY, null, settings, false);
-            Assert.fail("Expected IOException here due to red cluster state");
-        } catch (IOException e) {
-            // Index request has a default timeout of 1 minute, adding buffer between nodes initialization and cluster health check
-            Thread.sleep(1000 * 80);
-            // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
-            // IP address
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .updateSettings(
-                    new ClusterUpdateSettingsRequest().transientSettings(
-                        Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
-                    )
-                );
-            this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
-        }
+        setup(Settings.EMPTY, null, settings, false);
+        Thread.sleep(1000 * 30);
+        Assert.assertEquals(
+            ClusterHealthStatus.RED,
+            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest()).actionGet().getStatus()
+        );
+        Thread.sleep(1000 * 30);
+        // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
+        // IP address
+        clusterHelper.nodeClient()
+            .admin()
+            .cluster()
+            .updateSettings(
+                new ClusterUpdateSettingsRequest().transientSettings(
+                    Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
+                )
+            );
+        this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
         RestHelper rh = nonSslRestHelper();
         Thread.sleep(10000);
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());

--- a/src/test/java/org/opensearch/security/securityconf/impl/v6/ConfigV6Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v6/ConfigV6Test.java
@@ -106,4 +106,14 @@ public class ConfigV6Test {
         assertEquals(kibana, DefaultObjectMapper.readTree(json));
         assertEquals(kibana, DefaultObjectMapper.readValue(json, ConfigV6.Kibana.class));
     }
+
+    @Test
+    public void testOnBehalfOfSettings() {
+        ConfigV6.OnBehalfOfSettings oboSettings;
+
+        oboSettings = new ConfigV6.OnBehalfOfSettings();
+        Assert.assertEquals(oboSettings.getOboEnabled(), Boolean.FALSE);
+        Assert.assertNull(oboSettings.getSigningKey());
+        Assert.assertNull(oboSettings.getEncryptionKey());
+    }
 }

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
@@ -97,4 +97,14 @@ public class ConfigV7Test {
         assertEquals(kibana, DefaultObjectMapper.readTree(json));
         assertEquals(kibana, DefaultObjectMapper.readValue(json, ConfigV7.Kibana.class));
     }
+
+    @Test
+    public void testOnBehalfOfSettings() {
+        ConfigV7.OnBehalfOfSettings oboSettings;
+
+        oboSettings = new ConfigV7.OnBehalfOfSettings();
+        Assert.assertEquals(oboSettings.getOboEnabled(), Boolean.FALSE);
+        Assert.assertNull(oboSettings.getSigningKey());
+        Assert.assertNull(oboSettings.getEncryptionKey());
+    }
 }


### PR DESCRIPTION
### Description

Fixes test failures seen in multiple PRs:

- https://github.com/opensearch-project/security/actions/runs/6739586788/job/18321350189?pr=3637

```
org.opensearch.security.SlowIntegrationTests > testDelayInSecurityIndexInitialization FAILED
    java.lang.AssertionError: Expected IOException here due to red cluster state
        at __randomizedtesting.SeedInfo.seed([BD5A8547B6467745:994D254B5D5310AA]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.opensearch.security.SlowIntegrationTests.testDelayInSecurityIndexInitialization(SlowIntegrationTests.java:228)
```

and

```
  1> org.opensearch.OpenSearchException: Settings for signing key is missing. Please specify at least the option signing_key with a shared secret.
  1> 	at org.opensearch.security.authtoken.jwt.JwtVendor.createJwkFromSettings(JwtVendor.java:81) ~[main/:?]
  1> 	at org.opensearch.security.authtoken.jwt.JwtVendor.<init>(JwtVendor.java:52) ~[main/:?]
  1> 	at org.opensearch.security.identity.SecurityTokenManager.createJwtVendor(SecurityTokenManager.java:79) [main/:?]
  1> 	at org.opensearch.security.identity.SecurityTokenManager.onDynamicConfigModelChanged(SecurityTokenManager.java:70) [main/:?]
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test Fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
