### PR TITLE
[Backport] [2.x] Bump org.apache.httpcomponents:fluent-hc from 4.5.13 to 4.5.14 (#3657)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -713,8 +713,8 @@ dependencies {
     }
     integrationTestImplementation 'com.unboundid:unboundid-ldapsdk:4.0.14'
     integrationTestImplementation "org.apache.httpcomponents:httpclient-cache:4.5.14"
-    integrationTestImplementation "org.apache.httpcomponents:httpclient:4.5.13"
-    integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.13"
+    integrationTestImplementation "org.apache.httpcomponents:httpclient:4.5.14"
+    integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.16"
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3657 to `2.x`