### PR TITLE
[2.11] Revert PRs added to 2.11 that are not part of 2.11.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -665,6 +665,9 @@ dependencies {
     integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.13"
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
 
+    //Checkstyle
+    checkstyle 'com.puppycrawl.tools:checkstyle:10.12.1'
+
     //spotless
     implementation('com.google.googlejavaformat:google-java-format:1.17.0') {
         exclude group: 'com.google.guava'

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/AbstractRestHandler.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/AbstractRestHandler.java
@@ -1,12 +1,12 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- */
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
 package org.opensearch.test.framework.testplugins;
 
 import org.opensearch.ExceptionsHelper;

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/EndpointValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/EndpointValidator.java
@@ -1,12 +1,12 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- */
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
 package org.opensearch.security.dlic.rest.validation;
 
 import org.opensearch.core.rest.RestStatus;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- */
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
 package org.opensearch.security.dlic.rest.api;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiActionValidationTest.java
@@ -1,12 +1,12 @@
 /*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
- *
- */
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
 package org.opensearch.security.dlic.rest.api;
 
 import org.junit.Before;


### PR DESCRIPTION
### Description

Reverts 2 PRs added after the 2.11.0 release that should not be in the 2.11.1 release:

- https://github.com/opensearch-project/security/pull/3486
- https://github.com/opensearch-project/security/pull/3480

### Issues Resolved

https://github.com/opensearch-project/security/issues/3650

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
