### PR TITLE
Ensures that jacoco test report is produced after integration test task completes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -558,6 +558,8 @@ task integrationTest(type: Test) {
     }
 }
 
+tasks.integrationTest.finalizedBy(jacocoTestReport) // report is always generated after integration tests run
+
 //run the integrationTest task before the check task
 check.dependsOn integrationTest
 


### PR DESCRIPTION
### Description
While trying to run tests locally, I observed that all tests under src/test folder produce jacocoTestReport.xml while the integration tests under src/integrationTest do not produce this artifact.

This change will now produced jacocoTestReport.xml after integration test run.



### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
