### PR TITLE
Fix the association of code coverage results with source code 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
   report-coverage:
     needs:
       - "test"
-      - "integration-tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,6 @@ jobs:
           with: |
             token: ${{ secrets.CODECOV_TOKEN }}
             fail_ci_if_error: true
-            directory: downloaded-artifacts
             verbose: true
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
-        platform: [windows-latest, ubuntu-latest]
-        jdk: [11, 17, 21]
-        exclude:
-          - platform: windows-lastest
+        # gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
+        # platform: [windows-latest, ubuntu-latest]
+        # jdk: [11, 17, 21]
+        # exclude:
+        #   - platform: windows-lastest
         include:
           - jdk: 17
             gradle_task: ciSecurityIntegrationTest
+            platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -115,10 +116,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17, 21]
-        platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
+        # jdk: [11, 17, 21]
+        # platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
         include:
           - jdk: 17
+            platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,15 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
-        # platform: [windows-latest, ubuntu-latest]
-        # jdk: [11, 17, 21]
-        # exclude:
-        #   - platform: windows-lastest
-        include:
-          - jdk: 17
-            gradle_task: ciSecurityIntegrationTest
-            platform: ubuntu-latest
+        gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
+        platform: [windows-latest, ubuntu-latest]
+        jdk: [11, 17, 21]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -116,11 +110,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # jdk: [11, 17, 21]
-        # platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
-        include:
-          - jdk: 17
-            platform: ubuntu-latest
+        jdk: [11, 17, 21]
+        platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
       - "integration-tests"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
         with:
           path: downloaded-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,11 @@ jobs:
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
         platform: [windows-latest, ubuntu-latest]
         jdk: [11, 17, 21]
+        exclude:
+          - platform: windows-lastest
+        include:
+          - jdk: 17
+            gradle_task: ciSecurityIntegrationTest
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -70,6 +75,7 @@ jobs:
   report-coverage:
     needs:
       - "test"
+      - "integration-tests"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3
@@ -111,6 +117,8 @@ jobs:
       matrix:
         jdk: [11, 17, 21]
         platform: [ubuntu-latest] # Removed windows https://github.com/opensearch-project/security/issues/3423
+        include:
+          - jdk: 17
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
### Description
Fix the association of code coverage results with source code.  You'll have seen how this was broken because we stopped getting the comment on PRs with coverage information.  My apologies for breaking this in the most recent change to centralized the CC runs.

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/2649

### Testing
✅ Inspection CC report on this PR, see [[link]](https://github.com/opensearch-project/security/pull/3668#issuecomment-1802489151).

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
