### PR TITLE
[Maintenance-2930] Review use of JSON Flattener

### DIFF
--- a/src/main/java/org/opensearch/security/compliance/FieldReadCallback.java
+++ b/src/main/java/org/opensearch/security/compliance/FieldReadCallback.java
@@ -35,8 +35,7 @@ import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.support.SourceFieldsContext;
 import org.opensearch.security.support.WildcardMatcher;
-
-import com.github.wnameless.json.flattener.JsonFlattener;
+import org.opensearch.security.support.JsonFlattener;
 
 //TODO  We need to deal with caching!!
 //Currently we disable caching (and realtime requests) when FLS or DLS is applied

--- a/src/main/java/org/opensearch/security/support/JsonFlattener.java
+++ b/src/main/java/org/opensearch/security/support/JsonFlattener.java
@@ -1,0 +1,55 @@
+package org.opensearch.security.support;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.opensearch.core.common.Strings;
+import org.opensearch.security.DefaultObjectMapper;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class JsonFlattener {
+
+    public static Map<String, Object> flattenAsMap(String jsonString) {
+        try {
+            final byte[] bytes = jsonString.getBytes("utf-8");
+            final TypeReference<Map<String, Object>> typeReference = new TypeReference<>() {
+            };
+            final Map<String, Object> jsonMap = DefaultObjectMapper.objectMapper.readValue(bytes, typeReference);
+            final Map<String, Object> flattenMap = new LinkedHashMap<>();
+            flattenEntries("", jsonMap.entrySet(), flattenMap);
+            return flattenMap;
+        } catch (final IOException ioe) {
+            throw new IllegalArgumentException("Unparseable json", ioe);
+        }
+    }
+
+    private static void flattenEntries(String prefix, final Iterable<Map.Entry<String, Object>> entries, final Map<String, Object> result) {
+        if (!Strings.isNullOrEmpty(prefix)) {
+            prefix += ".";
+        }
+
+        for (final Map.Entry<String, Object> e : entries) {
+            flattenElement(prefix.concat(e.getKey()), e.getValue(), result);
+        }
+    }
+
+    private static void flattenElement(String prefix, final Object source, final Map<String, Object> result) {
+        if (source instanceof Iterable) {
+            flattenCollection(prefix, (Iterable<Object>) source, result);
+        }
+        if (source instanceof Map) {
+            flattenEntries(prefix, ((Map<String, Object>) source).entrySet(), result);
+        }
+        result.put(prefix, source);
+    }
+
+    private static void flattenCollection(String prefix, final Iterable<Object> objects, final Map<String, Object> result) {
+        int counter = 0;
+        for (final Object o : objects) {
+            flattenElement(prefix + "[" + counter + "]", o, result);
+            counter++;
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

Implement JsonFlattener helper class as written in #2926 to deprecate the use of the unnecessary JsonFlattener third party module.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

* Why these changes are required?

The JsonFlattener module was being utilized in only one place for one specific purpose, so these functions can be implemented as part of the OpenSearch codebase instead of importing an unnecessary third party module.

* What is the old behavior before changes and new behavior after changes?

Hopefully nothing.

### Issues Resolved
#2930 

Is this a backport? If so, please add backport PR # and/or commits #

No

### Testing
Tests checked to make sure functions are not broken.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
