### PR TITLE
Remove duplicate permissions

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -34,6 +34,8 @@ grant {
   permission javax.security.auth.AuthPermission "modifyPrivateCredentials";
   permission javax.security.auth.AuthPermission "doAs";
   permission javax.security.auth.kerberos.ServicePermission "*","accept";
+
+  //SAML and internal plugin policy
   permission java.util.PropertyPermission "*","read,write";
 
   //Enable when we switch to UnboundID LDAP SDK
@@ -74,8 +76,6 @@ grant {
   //Enable this permission to debug unauthorized de-serialization attempt
   //permission java.io.SerializablePermission "enableSubstitution";
 
-  //SAML policy
-  permission java.util.PropertyPermission "*", "read,write";
 };
 
 grant codeBase "${codebase.netty-common}" {


### PR DESCRIPTION
### Description
Permission: `permission java.util.PropertyPermission "*", "read,write";` was declared twice 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
