### PR TITLE
Hot-reload support in SSL only mode

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -310,7 +310,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         }
 
         if (SSLConfig.isSslOnlyMode()) {
-            this.sslCertReloadEnabled = false;
             log.warn("OpenSearch Security plugin run in ssl only mode. No authentication or authorization is performed");
             return;
         }
@@ -588,6 +587,25 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     )
                 );
                 log.debug("Added {} rest handler(s)", handlers.size());
+            } else {
+                handlers.addAll(
+                    SecurityRestApiActions.getHandler(
+                        settings,
+                        configPath,
+                        restController,
+                        localClient,
+                        adminDns,
+                        cr,
+                        cs,
+                        principalExtractor,
+                        evaluator,
+                        threadPool,
+                        auditLog,
+                        userService,
+                        sks,
+                        sslCertReloadEnabled
+                    )
+                );
             }
         }
 
@@ -962,6 +980,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     ) {
 
         SSLConfig.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
+        this.threadPool = threadPool;
         if (SSLConfig.isSslOnlyMode()) {
             return super.createComponents(
                 localClient,
@@ -1160,6 +1179,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         settings.addAll(super.getSettings());
 
         settings.add(Setting.boolSetting(ConfigConstants.SECURITY_SSL_ONLY, false, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(ConfigConstants.SECURITY_SSL_CERT_RELOAD_ENABLED, false, Property.NodeScope, Property.Filtered));
 
         // currently dual mode is supported only when ssl_only is enabled, but this stance would change in future
         settings.add(SecuritySettings.SSL_DUAL_MODE_SETTING);
@@ -1818,9 +1838,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             );
             settings.add(
                 Setting.boolSetting(ConfigConstants.SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES, true, Property.NodeScope, Property.Filtered)
-            );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.SECURITY_SSL_CERT_RELOAD_ENABLED, false, Property.NodeScope, Property.Filtered)
             );
             settings.add(
                 Setting.boolSetting(

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -601,8 +601,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                         evaluator,
                         threadPool,
                         auditLog,
-                        userService,
                         sks,
+                        userService,
                         sslCertReloadEnabled
                     )
                 );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -26,6 +26,7 @@ import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.SecurityKeyStore;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
+import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.UserService;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -63,6 +64,17 @@ public class SecurityRestApiActions {
             auditLog,
             settings
         );
+        if (settings.getAsBoolean(ConfigConstants.SECURITY_SSL_ONLY, false)) {
+            return List.of(
+                new SecuritySSLCertsApiAction(
+                    clusterService,
+                    threadPool,
+                    securityKeyStore,
+                    certificatesReloadEnabled,
+                    securityApiDependencies
+                )
+            );
+        }
         return List.of(
             new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies),
             new RolesMappingApiAction(clusterService, threadPool, securityApiDependencies),

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
@@ -121,9 +121,11 @@ public class SecuritySSLCertsApiAction extends AbstractApiAction {
 
     boolean accessHandler(final RestRequest request) {
         if (request.method() == Method.GET) {
-            return securityApiDependencies.restApiAdminPrivilegesEvaluator().isCurrentUserAdminFor(endpoint, CERTS_INFO_ACTION);
+            return isClusterInSSLOnlyMode()
+                || securityApiDependencies.restApiAdminPrivilegesEvaluator().isCurrentUserAdminFor(endpoint, CERTS_INFO_ACTION);
         } else if (request.method() == Method.PUT) {
-            return securityApiDependencies.restApiAdminPrivilegesEvaluator().isCurrentUserAdminFor(endpoint, RELOAD_CERTS_ACTION);
+            return isClusterInSSLOnlyMode()
+                || securityApiDependencies.restApiAdminPrivilegesEvaluator().isCurrentUserAdminFor(endpoint, RELOAD_CERTS_ACTION);
         } else {
             return false;
         }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -33,6 +33,7 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_SSL_ONLY;
 
 public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 
@@ -95,6 +96,24 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         rh.keystore = "restapi/kirk-keystore.jks";
 
         AuditTestUtils.updateAuditConfig(rh, nodeOverride != null ? nodeOverride : Settings.EMPTY);
+    }
+
+    protected final void setupWithSSLOnlyMode() throws Exception {
+        setupWithSSLOnlyMode(null);
+    }
+
+    protected final void setupWithSSLOnlyMode(Settings nodeOverride) throws Exception {
+        Settings.Builder builder = Settings.builder();
+        builder.put(SECURITY_SSL_ONLY, true)
+            .put("plugins.security.ssl.http.enabled", true)
+            .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("restapi/node-0-keystore.jks"))
+            .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("restapi/truststore.jks"));
+        if (null != nodeOverride) {
+            builder.put(nodeOverride);
+        }
+        setupSslOnlyMode(builder.build());
+        rh = restHelper();
+        rh.keystore = "restapi/kirk-keystore.jks";
     }
 
     protected Settings rolesSettings() {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
@@ -193,7 +193,6 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
     public void testReloadCertsSSLModeOnlyWithReloadEnable() throws Exception {
         setupWithSSLOnlyMode(reloadEnabled());
         HttpResponse response = rh.executePutRequest(certsReloadEndpoint("transport"), "{}");
-        System.out.println(response);
         Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SslCertsApiTest.java
@@ -134,6 +134,14 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
     }
 
     @Test
+    public void testCertsInfoSSLModeOnly() throws Exception {
+        setupWithSSLOnlyMode();
+        HttpResponse response = rh.executeGetRequest(certsInfoEndpoint());
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
+        Assert.assertEquals(EXPECTED_CERTIFICATES_BY_TYPE, response.getBody());
+    }
+
+    @Test
     public void testReloadCertsNotAvailableByDefault() throws Exception {
         setupWithRestRoles();
 
@@ -165,6 +173,28 @@ public class SslCertsApiTest extends AbstractRestApiUnitTest {
         response = rh.executePutRequest(certsReloadEndpoint("cccc"), "{}", restApiReloadCertsAdminHeader);
         Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
 
+    }
+
+    @Test
+    public void testReloadCertsWrongUriSSLModeOnly() throws Exception {
+        setupWithSSLOnlyMode(reloadEnabled());
+        HttpResponse response = rh.executePutRequest(certsReloadEndpoint("aaaaa"), "{}");
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    public void testReloadCertsSSLModeOnlyWithoutReloadEnable() throws Exception {
+        setupWithSSLOnlyMode();
+        HttpResponse response = rh.executePutRequest(certsReloadEndpoint("transport"), "{}");
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    public void testReloadCertsSSLModeOnlyWithReloadEnable() throws Exception {
+        setupWithSSLOnlyMode(reloadEnabled());
+        HttpResponse response = rh.executePutRequest(certsReloadEndpoint("transport"), "{}");
+        System.out.println(response);
+        Assert.assertEquals(response.getBody(), HttpStatus.SC_OK, response.getStatusCode());
     }
 
     private void sendAdminCert() {


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement)
* Why these changes are required?
Currently hot-reload feature was not supported with SSL only mode.
* What is the old behavior before changes and new behavior after changes?
Old behaviour:- SSL certificate renewal was not supported in SSL only mode. To update certificate we need to bring cluster down to pick latest certificate. 

New behaviour:- Added certificate renewal for SSL only mode. Now certificate will be reloaded by using `reloadcerts` api.

### Issues Resolved
https://github.com/opensearch-project/security/issues/3466

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
unit testing
##### Manual testing

```
opensearch curl https://localhost:9200/_plugins/_security/api/ssl/certs\?pretty -k
{
  "http_certificates_list" : [
    {
      "issuer_dn" : "CN=Example Com Inc. Root CA,OU=Example Com Inc. Root CA,O=Example Com Inc.,DC=example,DC=com",
      "subject_dn" : "CN=node-0.example.com,OU=node,O=node,L=test,C=de",
      "san" : "[[8, 1.2.3.4.5.5], [2, node-0.example.com], [2, localhost], [7, 0:0:0:0:0:0:0:1], [7, 127.0.0.1]]",
      "not_before" : "2023-08-29T04:23:12Z",
      "not_after" : "2033-08-26T04:23:12Z"
    }
  ],
  "transport_certificates_list" : [
    {
      "issuer_dn" : "CN=Example Com Inc. Root CA,OU=Example Com Inc. Root CA,O=Example Com Inc.,DC=example,DC=com",
      "subject_dn" : "CN=node-0.example.com,OU=node,O=node,L=test,C=de",
      "san" : "[[8, 1.2.3.4.5.5], [2, node-0.example.com], [2, localhost], [7, 0:0:0:0:0:0:0:1], [7, 127.0.0.1]]",
      "not_before" : "2023-08-29T04:23:12Z",
      "not_after" : "2033-08-26T04:23:12Z"
    }
  ]
}
```
```
opensearch curl -sX PUT https://localhost:9200/_plugins/_security/api/ssl/transport/reloadcerts -k
{"message":"updated transport certs"}%

```

### Check List
- [ X ] New functionality includes testing
- [ ] New functionality has been documented
- [ X ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
