### PR TITLE
[Backport] [2.x] Add Java 11/17/21 matrix for plugin install, test and integration test checks (#3641)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
         platform: [windows-latest, ubuntu-latest]
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -87,7 +87,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
         platform: [ubuntu-latest] # Removing windows temporarily
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
         test-run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        jdk: [11, 17]
+        jdk: [11, 17, 21]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3641 to `2.x`