### PR TITLE
Validate content type of responses

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -65,6 +65,7 @@ import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -76,7 +77,9 @@ import org.opensearch.security.DefaultObjectMapper;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 /**
@@ -284,7 +287,29 @@ public class TestRestClient implements AutoCloseable {
             this.header = inner.getHeaders();
             this.statusCode = inner.getCode();
             this.statusReason = inner.getReasonPhrase();
+
             inner.close();
+
+            if (this.body.length() != 0) {
+                verifyContentType();
+            }
+        }
+
+        private void verifyContentType() {
+            final String contentType = this.getHeader(HttpHeaders.CONTENT_TYPE).getValue();
+            if (contentType.equals("application/json")) {
+                assertThat("Response body should not have been empty", body, emptyOrNullString());
+                assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));
+            } else {
+                if (body.length() != 0) {
+                    assertThat(
+                        "Response body format was json, whereas content-type was " + contentType + ", body: " + body,
+                        body.charAt(0),
+                        not(equalTo("{"))
+                    );
+                }
+            }
+
         }
 
         public String getContentType() {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -77,7 +77,6 @@ import org.opensearch.security.DefaultObjectMapper;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -298,13 +297,13 @@ public class TestRestClient implements AutoCloseable {
         private void verifyContentType() {
             final String contentType = this.getHeader(HttpHeaders.CONTENT_TYPE).getValue();
             if (contentType.equals("application/json")) {
-                assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));
+                assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo('{'));
             } else {
                 if (body.length() != 0) {
                     assertThat(
                         "Response body format was json, whereas content-type was " + contentType + ", body: " + body,
                         body.charAt(0),
-                        not(equalTo("{"))
+                        not(equalTo('{'))
                     );
                 }
             }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -298,7 +298,6 @@ public class TestRestClient implements AutoCloseable {
         private void verifyContentType() {
             final String contentType = this.getHeader(HttpHeaders.CONTENT_TYPE).getValue();
             if (contentType.equals("application/json")) {
-                assertThat("Response body should not have been empty", body, emptyOrNullString());
                 assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));
             } else {
                 if (body.length() != 0) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -296,16 +296,14 @@ public class TestRestClient implements AutoCloseable {
 
         private void verifyContentType() {
             final String contentType = this.getHeader(HttpHeaders.CONTENT_TYPE).getValue();
-            if (contentType.equals("application/json")) {
+            if (contentType.contains("application/json")) {
                 assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo('{'));
             } else {
-                if (body.length() != 0) {
-                    assertThat(
-                        "Response body format was json, whereas content-type was " + contentType + ", body: " + body,
-                        body.charAt(0),
-                        not(equalTo('{'))
-                    );
-                }
+                assertThat(
+                    "Response body format was json, whereas content-type was " + contentType + ", body: " + body,
+                    body.charAt(0),
+                    not(equalTo('{'))
+                );
             }
 
         }

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -416,10 +416,10 @@ public class RestHelper {
         private void verifyBodyContentType() {
             final String contentType = this.getHeaders()
                 .stream()
-                .filter(h -> h.getName() == HttpHeaders.CONTENT_TYPE)
+                .filter(h -> HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(h.getName()))
                 .map(Header::getValue)
                 .findFirst()
-                .orElseThrow(() -> new RuntimeException("No content type found"));
+                .orElseThrow(() -> new RuntimeException("No content type found. Headers:\n" + getHeaders() + "\n\nBody:\n" + body));
 
             if (contentType.equals("application/json")) {
                 assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -422,7 +422,6 @@ public class RestHelper {
                 .orElseThrow(() -> new RuntimeException("No content type found"));
 
             if (contentType.equals("application/json")) {
-                assertThat("Response body should not have been empty", body, emptyOrNullString());
                 assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));
             } else {
                 assertThat(

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -91,7 +91,6 @@ import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.file.FileHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 
@@ -422,12 +421,12 @@ public class RestHelper {
                 .orElseThrow(() -> new RuntimeException("No content type found. Headers:\n" + getHeaders() + "\n\nBody:\n" + body));
 
             if (contentType.equals("application/json")) {
-                assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo("{"));
+                assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo('{'));
             } else {
                 assertThat(
                     "Response body format was json, whereas content-type was " + contentType + ", body: " + body,
                     body.charAt(0),
-                    not(equalTo("{"))
+                    not(equalTo('{'))
                 );
             }
         }

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -420,7 +420,7 @@ public class RestHelper {
                 .findFirst()
                 .orElseThrow(() -> new RuntimeException("No content type found. Headers:\n" + getHeaders() + "\n\nBody:\n" + body));
 
-            if (contentType.equals("application/json")) {
+            if (contentType.contains("application/json")) {
                 assertThat("Response body format was not json, body: " + body, body.charAt(0), equalTo('{'));
             } else {
                 assertThat(


### PR DESCRIPTION
### Description
Makes sure that for response with a body they are returning the expected content type

### Issues Resolved
- Related to https://github.com/opensearch-project/security/issues/3718

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
