### PR TITLE
Support URL for external end points

### DIFF
--- a/src/test/java/org/opensearch/security/httpclient/HttpClientTest.java
+++ b/src/test/java/org/opensearch/security/httpclient/HttpClientTest.java
@@ -30,7 +30,10 @@ public class HttpClientTest extends SingleClusterTest {
     @Test
     public void testPlainConnection() throws Exception {
 
-        final Settings settings = Settings.builder().put("plugins.security.ssl.http.enabled", false).build();
+        final Settings settings = Settings.builder()
+            .put("plugins.security.ssl.http.enabled", false)
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
+            .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
 
@@ -84,6 +87,7 @@ public class HttpClientTest extends SingleClusterTest {
             .put(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_ALIAS, "node-0")
             .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks"))
             .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks"))
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
             .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
@@ -123,6 +127,7 @@ public class HttpClientTest extends SingleClusterTest {
             .put(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_ALIAS, "node-0")
             .put("plugins.security.ssl.http.keystore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/node-0-keystore.jks"))
             .put("plugins.security.ssl.http.truststore_filepath", FileHelper.getAbsoluteFilePathFromClassPath("auditlog/truststore.jks"))
+            .loadFromPath(FileHelper.getAbsoluteFilePathFromClassPath("auditlog/endpoints/routing/configuration_valid.yml"))
             .build();
 
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);

--- a/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
+++ b/src/test/resources/auditlog/endpoints/routing/configuration_valid.yml
@@ -15,7 +15,23 @@ plugins.security:
       endpoint2:
         type: external_opensearch
         config:
-          http_endpoints: ['localhost:9200','localhost:9201','localhost:9202']
+          http_endpoints: [
+            'localhost',
+            'localhost:9200',
+            'localhost:9201',
+            'localhost:9202',
+            'localhost:9202/opensearch',
+            '127.0.0.1',
+            '127.0.0.1:9200',
+            '127.0.0.1:9200/opensearch',
+            'my-opensearch-cluster.company.com:9200',
+            'my-opensearch-cluster.company.com:9200/opensearch',
+            'http://my-opensearch-cluster.company.com',
+            'https://my-opensearch-cluster.company.com:9200',
+            'https://my-opensearch-cluster.company.com:9200/opensearch',
+            '[::1]:9200',
+            '[::1]:9200/opensearch',
+          ]
           index: auditlog
           username: auditloguser
           password: auditlogpassword


### PR DESCRIPTION
### Description
Allow adding URLs to the OpenSearch cluster with support for both http:// and https:// for external logs.

### Issues Resolved
Backport #3574

### Testing
Tested using **HttpClientTest.java** and **RouterTest.java**.

### Check List
- [] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
