### PR TITLE
Removing flaky test case testAutoInit

### DIFF
--- a/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -126,31 +126,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
     }
 
     @Test
-    public void testAutoInit() throws Exception {
-
-        Settings additionalSettings = Settings.builder()
-            .put("plugins.security.audit.type", TestAuditlogImpl.class.getName())
-            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
-            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
-            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_BULK_REQUESTS, false)
-            .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, true)
-            .put(ConfigConstants.SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, true)
-            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .build();
-
-        setup(additionalSettings);
-
-        Thread.sleep(1500);
-
-        Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_INTERNAL_CONFIG_WRITE"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("COMPLIANCE_EXTERNAL_CONFIG"));
-        validateMsgs(TestAuditlogImpl.messages);
-    }
-
-    @Test
     public void testRestApiNewUser() throws Exception {
 
         Settings additionalSettings = Settings.builder()


### PR DESCRIPTION
### Description
Considering what is tested - the auto log events that are creating when a test cluster starts up.  This isn't a useful test case, removing.

### Issues Resolved
- Resolves #3730

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
