### PR TITLE
Adds missing default security config lines when updating opensearch.yml

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/Certificates.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Certificates.java
@@ -1,3 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 package org.opensearch.security.tools.democonfig;
 
 /**

--- a/src/main/java/org/opensearch/security/tools/democonfig/ExecutionEnvironment.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/ExecutionEnvironment.java
@@ -1,3 +1,14 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
 package org.opensearch.security.tools.democonfig;
 
 /**

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -217,9 +217,8 @@ public class SecuritySettingsConfigurer extends Installer {
         securityConfigLines.append("plugins.security.check_snapshot_restore_write_privileges:  true\n");
         securityConfigLines.append("plugins.security.restapi.roles_enabled:  [\"all_access\", \"security_rest_api_access\"]\n");
 
-        securityConfigLines.append("plugins.security.system_indices.enabled: true\n" + "plugins.security.system_indices.indices: [")
-            .append(SYSTEM_INDICES)
-            .append("]\n");
+        securityConfigLines.append("plugins.security.system_indices.enabled: true\n");
+        securityConfigLines.append("plugins.security.system_indices.indices: [").append(SYSTEM_INDICES).append("]\n");
 
         if (!isNetworkHostAlreadyPresent(OPENSEARCH_CONF_FILE)) {
             if (cluster_mode) {

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -212,6 +212,11 @@ public class SecuritySettingsConfigurer extends Installer {
 
         securityConfigLines.append("plugins.security.authcz.admin_dn:\n  - CN=kirk,OU=client,O=client,L=test, C=de\n\n");
 
+        securityConfigLines.append("plugins.security.audit.type:  internal_opensearch\n");
+        securityConfigLines.append("plugins.security.enable_snapshot_restore_privilege:  true\n");
+        securityConfigLines.append("plugins.security.check_snapshot_restore_write_privileges:  true\n");
+        securityConfigLines.append("plugins.security.restapi.roles_enabled:  [\"all_access\", \"security_rest_api_access\"]\n");
+
         securityConfigLines.append("plugins.security.system_indices.enabled: true\n" + "plugins.security.system_indices.indices: [")
             .append(SYSTEM_INDICES)
             .append("]\n");


### PR DESCRIPTION
Adds 4 config lines that were missed in the original PR: https://github.com/opensearch-project/security/blob/deff84265cd22badf9cca02a3240aeb000acb439/tools/install_demo_configuration.sh#L384C1-L388C1

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
