### PR TITLE
Force newer version of Eclipse core transitive dependency (resolves CVE-2023-4218)

### DIFF
--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 17
 
       - uses: gradle/gradle-build-action@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -488,6 +488,9 @@ configurations {
             // for spotbugs dependency conflict
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
 
+            // for spotless transitive dependency CVE
+            force "org.eclipse.platform:org.eclipse.core.runtime:3.29.0"
+
             // For integrationTest
             force "org.apache.httpcomponents:httpclient:4.5.14"
             force "org.apache.httpcomponents:httpcore:4.4.16"


### PR DESCRIPTION
### Description

The Spotless Gradle Plugin brings in a transitive dependency on Eclipse Core Runtime 3.26.100.  That version is impacted by a CVE.

This forces the newest version, currently 3.29.0.  Note that newer versions than 3.26 require JDK17+ to run spotless.

### Issues Resolved

Fixes #3688 

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
