### PR TITLE
Force eclipse version to resolve CVE-2023-4218 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -470,6 +470,7 @@ configurations {
     all {
         resolutionStrategy {
             force 'commons-codec:commons-codec:1.16.0'
+            force("org.eclipse.platform:org.eclipse.core.runtime:3.29.0") // CVE for 3.26.100
             force 'org.slf4j:slf4j-api:1.7.36'
             force 'org.scala-lang:scala-library:2.13.12'
             force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"


### PR DESCRIPTION
### Description
Follow ai-flow repository's method of fixing CVE-2023-4218 and force the Eclipse version to 3.29.0. 

### Issues Resolved
#3688

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
