### PR TITLE
Add spring_version variable to have single instance of spring version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ buildscript {
         jjwt_version = '0.12.3'
         guava_version = '32.1.3-jre'
         jaxb_version = '2.3.9'
+        spring_version = '5.3.31'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -685,7 +686,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     testImplementation 'commons-validator:commons-validator:1.7'
     testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
-    testImplementation 'org.springframework:spring-beans:5.3.31'
+    testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
@@ -697,7 +698,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.4'
-    testRuntimeOnly ('org.springframework:spring-core:5.3.31') {
+    testRuntimeOnly ("org.springframework:spring-core:{$spring_version}") {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.12'

--- a/build.gradle
+++ b/build.gradle
@@ -698,7 +698,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.4'
-    testRuntimeOnly ("org.springframework:spring-core:{$spring_version}") {
+    testRuntimeOnly ("org.springframework:spring-core:${spring_version}") {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.12'


### PR DESCRIPTION
### Description

Extracts `spring_version` to a variable so it can be re-used. This will cut down slightly on maintenance where dependabot can make multiple PRs to update this version.

Recent examples:

- https://github.com/opensearch-project/security/pull/3744
- https://github.com/opensearch-project/security/pull/3743

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
