### PR TITLE
[Backport 2.11] Add release notes for 2.11.1

### DIFF
--- a/release-notes/opensearch-security.release-notes-2.11.1.0.md
+++ b/release-notes/opensearch-security.release-notes-2.11.1.0.md
@@ -1,0 +1,7 @@
+## 2023-11-21 Version 2.11.1.0
+
+Compatible with OpenSearch 2.11.1
+
+### Bug Fixes
+* Fix regression on concurrent gzipped requests ([#3599](https://github.com/opensearch-project/security/pull/3599))
+* Fix issue with response content-types changed in 2.11 ([#3721](https://github.com/opensearch-project/security/pull/3721))


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/security/pull/3749 to 2.11