### PR TITLE
[DRAFT Backport 2.11] Minor comments follow up for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -398,8 +398,6 @@ tasks.withType(JavaCompile) {
 }
 
 tasks.test.finalizedBy(jacocoTestReport)  // report is always generated after tests run
-tasks.jacocoTestReport.dependsOn(test) // tests are required to run before generating the report
-
 
 allprojects {
     tasks.withType(Javadoc).all { enabled = false }
@@ -435,7 +433,7 @@ configurations {
             force "org.xerial.snappy:snappy-java:1.1.10.5"
             force "com.google.guava:guava:${guava_version}"
 
-            // TODO: Seems like this should be removable
+            // For integrationTest
             force "org.apache.httpcomponents:httpclient-cache:4.5.13"
             force "org.apache.httpcomponents:httpclient:4.5.13"
             force "org.apache.httpcomponents:fluent-hc:4.5.13"
@@ -457,7 +455,6 @@ sourceSets {
             srcDir file ('src/integrationTest/java')
             compileClasspath += sourceSets.main.output
             runtimeClasspath += sourceSets.main.output
-
         }
         resources {
             srcDir file('src/integrationTest/resources')
@@ -472,9 +469,7 @@ sourceSets {
 task integrationTest(type: Test) {
     doFirst {
         // Only run resources tests on resource-test CI environments or locally
-        if (System.getenv('CI_ENVIRONMENT') == 'resource-test' || System.getenv('CI_ENVIRONMENT') == null) {
-            include '**/ResourceFocusedTests.class'
-        } else {
+        if (System.getenv('CI_ENVIRONMENT') != 'resource-test' && System.getenv('CI_ENVIRONMENT') != null) {
             exclude '**/ResourceFocusedTests.class'
         }
         // Only run with retries while in CI systems

--- a/release-notes/opensearch-security.release-notes-2.11.1.0.md
+++ b/release-notes/opensearch-security.release-notes-2.11.1.0.md
@@ -1,0 +1,7 @@
+## 2023-11-21 Version 2.11.1.0
+
+Compatible with OpenSearch 2.11.1
+
+### Bug Fixes
+* Fix regression on concurrent gzipped requests ([#3599](https://github.com/opensearch-project/security/pull/3599))
+* Fix issue with response content-types changed in 2.11 ([#3721](https://github.com/opensearch-project/security/pull/3721))


### PR DESCRIPTION
There have been issues with long-running CI on the 2.11 branch. I am opening a Draft PR to backport https://github.com/opensearch-project/security/pull/3427 to determine if the reason for longer running CI is because this PR was backported to 2.x, but is not in 2.11.