### PR TITLE
[Enhancement-3191] `transport_enabled` setting on an auth domain and authorizer may be unnecessary after transport client removal 

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,9 +14,8 @@
 # After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
 # the roles from a given backend for the authenticated user.
 #
-# Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
+# Both, authc and auth can be enabled/disabled separately for REST layer. Default is true for both.
 #        http_enabled: true
-#        transport_enabled: true
 #
 # For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
 # find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
@@ -86,7 +85,6 @@ config:
     authc:
       kerberos_auth_domain:
         http_enabled: false
-        transport_enabled: false
         order: 6
         http_authenticator:
           type: kerberos
@@ -101,7 +99,6 @@ config:
       basic_internal_auth_domain:
         description: "Authenticate via HTTP Basic against internal users database"
         http_enabled: true
-        transport_enabled: true
         order: 4
         http_authenticator:
           type: basic
@@ -111,7 +108,6 @@ config:
       proxy_auth_domain:
         description: "Authenticate via proxy"
         http_enabled: false
-        transport_enabled: false
         order: 3
         http_authenticator:
           type: proxy
@@ -124,7 +120,6 @@ config:
       jwt_auth_domain:
         description: "Authenticate via Json Web Token"
         http_enabled: false
-        transport_enabled: false
         order: 0
         http_authenticator:
           type: jwt
@@ -141,7 +136,6 @@ config:
       clientcert_auth_domain:
         description: "Authenticate via SSL client certificates"
         http_enabled: false
-        transport_enabled: false
         order: 2
         http_authenticator:
           type: clientcert
@@ -153,7 +147,6 @@ config:
       ldap:
         description: "Authenticate via LDAP or Active Directory"
         http_enabled: false
-        transport_enabled: false
         order: 5
         http_authenticator:
           type: basic
@@ -184,7 +177,6 @@ config:
       roles_from_myldap:
         description: "Authorize via LDAP or Active Directory"
         http_enabled: false
-        transport_enabled: false
         authorization_backend:
           # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
           type: ldap
@@ -228,7 +220,6 @@ config:
       roles_from_another_ldap:
         description: "Authorize via another Active Directory"
         http_enabled: false
-        transport_enabled: false
         authorization_backend:
           type: ldap
           #config goes here ...

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
@@ -68,8 +68,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
     private final Path configPath;
     private SortedSet<AuthDomain> restAuthDomains;
     private Set<AuthorizationBackend> restAuthorizers;
-    private SortedSet<AuthDomain> transportAuthDomains;
-    private Set<AuthorizationBackend> transportAuthorizers;
     private List<Destroyable> destroyableComponents;
     private final InternalAuthenticationBackend iab;
 
@@ -216,8 +214,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
 
         final SortedSet<AuthDomain> restAuthDomains0 = new TreeSet<>();
         final Set<AuthorizationBackend> restAuthorizers0 = new HashSet<>();
-        final SortedSet<AuthDomain> transportAuthDomains0 = new TreeSet<>();
-        final Set<AuthorizationBackend> transportAuthorizers0 = new HashSet<>();
         final List<Destroyable> destroyableComponents0 = new LinkedList<>();
         final List<AuthFailureListener> ipAuthFailureListeners0 = new ArrayList<>();
         final Multimap<String, AuthFailureListener> authBackendFailureListeners0 = ArrayListMultimap.create();
@@ -229,9 +225,8 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         for (final Entry<String, AuthzDomain> ad : authzDyn.getDomains().entrySet()) {
             final boolean enabled = ad.getValue().enabled;
             final boolean httpEnabled = enabled && ad.getValue().http_enabled;
-            final boolean transportEnabled = enabled && ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
 
                     final String authzBackendClazz = ad.getValue().authorization_backend.type;
@@ -262,10 +257,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
 
                     if (httpEnabled) {
                         restAuthorizers0.add(authorizationBackend);
-                    }
-
-                    if (transportEnabled) {
-                        transportAuthorizers0.add(authorizationBackend);
                     }
 
                     if (authorizationBackend instanceof Destroyable) {
@@ -343,10 +334,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
                         restAuthDomains0.add(_ad);
                     }
 
-                    if (transportEnabled) {
-                        transportAuthDomains0.add(_ad);
-                    }
-
                     if (httpAuthenticator instanceof Destroyable) {
                         destroyableComponents0.add((Destroyable) httpAuthenticator);
                     }
@@ -365,9 +352,7 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
-        transportAuthDomains = Collections.unmodifiableSortedSet(transportAuthDomains0);
         restAuthorizers = Collections.unmodifiableSet(restAuthorizers0);
-        transportAuthorizers = Collections.unmodifiableSet(transportAuthorizers0);
 
         destroyableComponents = Collections.unmodifiableList(destroyableComponents0);
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -76,8 +76,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
     private final Path configPath;
     private SortedSet<AuthDomain> restAuthDomains;
     private Set<AuthorizationBackend> restAuthorizers;
-    private SortedSet<AuthDomain> transportAuthDomains;
-    private Set<AuthorizationBackend> transportAuthorizers;
     private List<Destroyable> destroyableComponents;
     private final InternalAuthenticationBackend iab;
 
@@ -234,8 +232,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
         final SortedSet<AuthDomain> restAuthDomains0 = new TreeSet<>();
         final Set<AuthorizationBackend> restAuthorizers0 = new HashSet<>();
-        final SortedSet<AuthDomain> transportAuthDomains0 = new TreeSet<>();
-        final Set<AuthorizationBackend> transportAuthorizers0 = new HashSet<>();
         final List<Destroyable> destroyableComponents0 = new LinkedList<>();
         final List<AuthFailureListener> ipAuthFailureListeners0 = new ArrayList<>();
         final Multimap<String, AuthFailureListener> authBackendFailureListeners0 = ArrayListMultimap.create();
@@ -246,9 +242,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
         for (final Entry<String, AuthzDomain> ad : authzDyn.getDomains().entrySet()) {
             final boolean httpEnabled = ad.getValue().http_enabled;
-            final boolean transportEnabled = ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
 
                     final String authzBackendClazz = ad.getValue().authorization_backend.type;
@@ -279,10 +274,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
                     if (httpEnabled) {
                         restAuthorizers0.add(authorizationBackend);
-                    }
-
-                    if (transportEnabled) {
-                        transportAuthorizers0.add(authorizationBackend);
                     }
 
                     if (authorizationBackend instanceof Destroyable) {
@@ -359,10 +350,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
                         restAuthDomains0.add(_ad);
                     }
 
-                    if (transportEnabled) {
-                        transportAuthDomains0.add(_ad);
-                    }
-
                     if (httpAuthenticator instanceof Destroyable) {
                         destroyableComponents0.add((Destroyable) httpAuthenticator);
                     }
@@ -398,9 +385,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
-        transportAuthDomains = Collections.unmodifiableSortedSet(transportAuthDomains0);
         restAuthorizers = Collections.unmodifiableSet(restAuthorizers0);
-        transportAuthorizers = Collections.unmodifiableSet(transportAuthorizers0);
 
         destroyableComponents = Collections.unmodifiableList(destroyableComponents0);
 


### PR DESCRIPTION
### Description
Remove the transport_enabled setting in config.yml and its related code in DynamicConfigModel.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
#3191 states that since the transport client has been removed, there is no need for the transport_enabled config and its related code to exist in the codebase, so this ticket removes that unnecessary code.

* What is the old behavior before changes and new behavior after changes?
Nothing.

### Issues Resolved
#3191 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
No tests were made, all tests should run since the behavior should not change.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
