### PR TITLE
[BUG-2548] LDAP fails when the security.ssl.transport.truststore_filepath is missing

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -82,8 +82,8 @@ import org.ldaptive.ssl.CredentialConfigFactory;
 import org.ldaptive.ssl.SslConfig;
 import org.ldaptive.ssl.ThreadLocalTLSSocketFactory;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
@@ -581,9 +581,9 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
             } else {
                 final KeyStore trustStore = PemKeyReader.loadKeyStore(
-                    PemKeyReader.resolve(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH, settings, configPath, !trustAll),
-                    SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD.getSetting(settings),
-                    settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE)
+                    PemKeyReader.resolve(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, settings, configPath, !trustAll),
+                    SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings),
+                    settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE)
                 );
 
                 final List<String> trustStoreAliases = settings.getAsList(ConfigConstants.LDAPS_JKS_TRUST_ALIAS, null);
@@ -591,15 +591,15 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 // for client authentication
                 final KeyStore keyStore = PemKeyReader.loadKeyStore(
                     PemKeyReader.resolve(
-                        SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH,
+                        SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH,
                         settings,
                         configPath,
                         enableClientAuth
                     ),
-                    SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
-                    settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_TYPE)
+                    SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
+                    settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_TYPE)
                 );
-                final String keyStorePassword = SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(
+                final String keyStorePassword = SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(
                     settings,
                     SSLConfigConstants.DEFAULT_STORE_PASSWORD
                 );

--- a/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfigurator.java
+++ b/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfigurator.java
@@ -47,8 +47,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public class SettingsBasedSSLConfigurator {
     private static final Logger log = LogManager.getLogger(SettingsBasedSSLConfigurator.class);
@@ -324,17 +324,17 @@ public class SettingsBasedSSLConfigurator {
         try {
             trustStore = PemKeyReader.loadKeyStore(
                 PemKeyReader.resolve(
-                    SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
+                    SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH,
                     settings,
                     configPath,
                     !isTrustAllEnabled()
                 ),
-                SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD.getSetting(settings),
-                settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE)
+                SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings),
+                settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE)
             );
         } catch (Exception e) {
             throw new SSLConfigException(
-                "Error loading trust store from " + settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH),
+                "Error loading trust store from " + settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH),
                 e
             );
         }
@@ -346,22 +346,22 @@ public class SettingsBasedSSLConfigurator {
         try {
             keyStore = PemKeyReader.loadKeyStore(
                 PemKeyReader.resolve(
-                    SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH,
+                    SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH,
                     settings,
                     configPath,
                     enableSslClientAuth
                 ),
-                SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
-                settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_TYPE)
+                SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
+                settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_TYPE)
             );
         } catch (Exception e) {
             throw new SSLConfigException(
-                "Error loading key store from " + settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH),
+                "Error loading key store from " + settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH),
                 e
             );
         }
 
-        String keyStorePassword = SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD);
+        String keyStorePassword = SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD);
         effectiveKeyPassword = keyStorePassword == null || keyStorePassword.isEmpty() ? null : keyStorePassword.toCharArray();
         effectiveKeyAlias = getSetting(CERT_ALIAS);
 

--- a/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfiguratorV4.java
+++ b/src/main/java/com/amazon/dlic/util/SettingsBasedSSLConfiguratorV4.java
@@ -48,8 +48,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public class SettingsBasedSSLConfiguratorV4 {
     private static final Logger log = LogManager.getLogger(SettingsBasedSSLConfigurator.class);
@@ -325,17 +325,17 @@ public class SettingsBasedSSLConfiguratorV4 {
         try {
             trustStore = PemKeyReader.loadKeyStore(
                 PemKeyReader.resolve(
-                    SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
+                    SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH,
                     settings,
                     configPath,
                     !isTrustAllEnabled()
                 ),
-                SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD.getSetting(settings),
-                settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE)
+                SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings),
+                settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE)
             );
         } catch (Exception e) {
             throw new SSLConfigException(
-                "Error loading trust store from " + settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH),
+                "Error loading trust store from " + settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH),
                 e
             );
         }
@@ -347,22 +347,22 @@ public class SettingsBasedSSLConfiguratorV4 {
         try {
             keyStore = PemKeyReader.loadKeyStore(
                 PemKeyReader.resolve(
-                    SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH,
+                    SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH,
                     settings,
                     configPath,
                     enableSslClientAuth
                 ),
-                SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
-                settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_TYPE)
+                SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
+                settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_TYPE)
             );
         } catch (Exception e) {
             throw new SSLConfigException(
-                "Error loading key store from " + settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH),
+                "Error loading key store from " + settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH),
                 e
             );
         }
 
-        String keyStorePassword = SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD);
+        String keyStorePassword = SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD);
         effectiveKeyPassword = keyStorePassword == null || keyStorePassword.isEmpty() ? null : keyStorePassword.toCharArray();
         effectiveKeyAlias = getSetting(CERT_ALIAS);
 

--- a/src/main/java/org/opensearch/security/auditlog/sink/ExternalOpenSearchSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/ExternalOpenSearchSink.java
@@ -31,8 +31,8 @@ import org.opensearch.security.support.PemKeyReader;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public final class ExternalOpenSearchSink extends AuditLogSink {
 
@@ -171,23 +171,23 @@ public final class ExternalOpenSearchSink extends AuditLogSink {
 
             } else {
                 final KeyStore trustStore = PemKeyReader.loadKeyStore(
-                    PemKeyReader.resolve(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH, settings, configPath, true),
-                    SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD.getSetting(settings),
-                    settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE)
+                    PemKeyReader.resolve(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, settings, configPath, true),
+                    SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings),
+                    settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE)
                 );
 
                 // for client authentication
                 final KeyStore keyStore = PemKeyReader.loadKeyStore(
                     PemKeyReader.resolve(
-                        SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH,
+                        SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH,
                         settings,
                         configPath,
                         enableSslClientAuth
                     ),
-                    SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
-                    settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_TYPE)
+                    SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(settings, SSLConfigConstants.DEFAULT_STORE_PASSWORD),
+                    settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_TYPE)
                 );
-                final String keyStorePassword = SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD.getSetting(
+                final String keyStorePassword = SECURITY_SSL_HTTP_KEYSTORE_PASSWORD.getSetting(
                     settings,
                     SSLConfigConstants.DEFAULT_STORE_PASSWORD
                 );

--- a/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
@@ -49,7 +49,7 @@ import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public class WebhookSink extends AuditLogSink {
 
@@ -341,13 +341,13 @@ public class WebhookSink extends AuditLogSink {
                     } else {
                         return PemKeyReader.loadKeyStore(
                             PemKeyReader.resolve(
-                                SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH,
+                                SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH,
                                 settings,
                                 configPath,
                                 false
                             ),
-                            SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD.getSetting(settings),
-                            settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE)
+                            SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings),
+                            settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE)
                         );
                     }
                 } catch (Exception ex) {


### PR DESCRIPTION
### Description
Refactored SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH to SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH in LDAP authentication and related functions. The reason for doing so is that according to the documentation: https://opensearch.org/docs/latest/security/authentication-backends/ldap/, TRANSPORT is not used for LDAP, HTTP is. So, whenever SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH is removed from `opensearch.yml`, LDAP authentication fails.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug fix

* Why these changes are required?
SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH not used in LDAP authentication according to docs, causing bug #2548 

* What is the old behavior before changes and new behavior after changes?
LDAP uses HTTP instead of TRANSPORT, so now SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH and related HTTP settings are used in LDAP authentication.

### Issues Resolved
#2548 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
At end of process, all LDAP related tests will also use HTTP instead of TRANSPORT.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
