### PR TITLE
Fix flaky test SlowIntegrationTests.testDelayInSecurityIndexInitialization

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -232,11 +232,30 @@ curl -XGET https://localhost:9200/_plugins/_security/authinfo -u 'admin:admin' -
 
 Launch IntelliJ IDEA, choose **Project from Existing Sources**, and select directory with Gradle build script (`build.gradle`).
 
-## Running integration tests
+## Running tests
 
 Locally these can be run with `./gradlew test` with detailed results being available at `${project-root}/build/reports/tests/test/index.html`. You can also run tests through an IDEs JUnit test runner.
 
-Integration tests are automatically run on all pull requests for all supported versions of the JDK. These must pass for change(s) to be merged. Detailed logs of these test results are available by going to the GitHub Actions workflow summary view and downloading the workflow run of the tests. If you see multiple tests listed with different JDK versions, you can download the version with whichever JDK you are interested in. After extracting the test file on your local machine, integration tests results can be found at `./tests/tests/index.html`.
+Tests are automatically run on all pull requests for all supported versions of the JDK. These must pass for change(s) to be merged. Detailed logs of these test results are available by going to the GitHub Actions workflow summary view and downloading the workflow run of the tests. If you see multiple tests listed with different JDK versions, you can download the version with whichever JDK you are interested in. After extracting the test file on your local machine, integration tests results can be found at `./tests/tests/index.html`.
+
+### Running an individual test multiple times
+
+This repo has a `@Repeat` annotation which you can import to annotate a test to run many times repeatedly. To use the annotation, add the following code to your test suite.
+
+```
+@Rule
+public RepeatRule repeatRule = new RepeatRule();
+
+@Test
+@Repeat(10)
+public void testMethod() {
+    ...
+}
+```
+
+## Tests in the integrationTest package
+
+Tests in the integrationTest package can be run with `./gradlew integrationTest`.
 
 ### Bulk test runs
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -253,7 +253,7 @@ public void testMethod() {
 }
 ```
 
-## Tests in the integrationTest package
+## Running tests in the integrationTest package
 
 Tests in the integrationTest package can be run with `./gradlew integrationTest`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -683,6 +683,9 @@ dependencies {
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
+    testImplementation('org.awaitility:awaitility:4.2.0') {
+        exclude(group: 'org.hamcrest', module: 'hamcrest')
+    }
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
         testImplementation "io.netty:netty-tcnative-classes:2.0.61.Final"

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -29,7 +29,6 @@ package org.opensearch.security;
 import java.io.IOException;
 
 import com.google.common.collect.Lists;
-import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,6 +52,7 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThrows;
 
 public class SlowIntegrationTests extends SingleClusterTest {
 
@@ -227,7 +227,7 @@ public class SlowIntegrationTests extends SingleClusterTest {
             .put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
             .put("cluster.routing.allocation.exclude._ip", "127.0.0.1")
             .build();
-        try {
+        assertThrows(IOException.class, () -> {
             setup(Settings.EMPTY, null, settings, false);
             clusterHelper.nodeClient()
                 .admin()
@@ -235,24 +235,26 @@ public class SlowIntegrationTests extends SingleClusterTest {
                 .create(new CreateIndexRequest("test-index").timeout(TimeValue.timeValueSeconds(10)))
                 .actionGet();
             clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(5), ClusterConfiguration.DEFAULT.getNodes());
-            Assert.fail("Expected IOException here due to red cluster state");
-        } catch (IOException e) {
-            // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
-            // IP address
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .updateSettings(
-                    new ClusterUpdateSettingsRequest().transientSettings(
-                        Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
-                    )
-                );
-            this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
-        }
+        });
+        // Ideally, we would want to remove this cluster setting, but default settings cannot be removed. So overriding with a reserved
+        // IP address
+        clusterHelper.nodeClient()
+            .admin()
+            .cluster()
+            .updateSettings(
+                new ClusterUpdateSettingsRequest().transientSettings(
+                    Settings.builder().put("cluster.routing.allocation.exclude._ip", "192.0.2.0").build()
+                )
+            );
+        this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
         RestHelper rh = nonSslRestHelper();
         Awaitility.await()
             .alias("Wait until Security is initialized")
-            .until(() -> rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode(), equalTo(HttpStatus.SC_OK));
+            .until(
+                () -> rh.executeGetRequest("/_plugins/_security/health", encodeBasicHeader("admin", "admin"))
+                    .getTextFromJsonBody("/status"),
+                equalTo("UP")
+            );
     }
 
 }

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import com.google.common.collect.Lists;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -50,14 +49,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
-import org.opensearch.security.util.Repeat;
-import org.opensearch.security.util.RepeatRule;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 public class SlowIntegrationTests extends SingleClusterTest {
-
-    @Rule
-    public RepeatRule repeatRule = new RepeatRule();
 
     @Test
     public void testCustomInterclusterRequestEvaluator() throws Exception {

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -225,7 +225,6 @@ public class SlowIntegrationTests extends SingleClusterTest {
     }
 
     @Test
-    @Repeat(10)
     public void testDelayInSecurityIndexInitialization() throws Exception {
         final Settings settings = Settings.builder()
             .put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 
 import com.google.common.collect.Lists;
 import org.apache.http.HttpStatus;
+import org.awaitility.Awaitility;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,6 +51,8 @@ import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.transport.Netty4ModulePlugin;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class SlowIntegrationTests extends SingleClusterTest {
 
@@ -247,8 +250,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
             this.clusterInfo = clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), 3);
         }
         RestHelper rh = nonSslRestHelper();
-        Thread.sleep(10000);
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
+        Awaitility.await()
+            .alias("Wait until Security is initialized")
+            .until(() -> rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode(), equalTo(HttpStatus.SC_OK));
     }
 
 }

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import com.google.common.collect.Lists;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
@@ -49,9 +50,14 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+import org.opensearch.security.util.Repeat;
+import org.opensearch.security.util.RepeatRule;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 public class SlowIntegrationTests extends SingleClusterTest {
+
+    @Rule
+    public RepeatRule repeatRule = new RepeatRule();
 
     @Test
     public void testCustomInterclusterRequestEvaluator() throws Exception {
@@ -219,6 +225,7 @@ public class SlowIntegrationTests extends SingleClusterTest {
     }
 
     @Test
+    @Repeat(10)
     public void testDelayInSecurityIndexInitialization() throws Exception {
         final Settings settings = Settings.builder()
             .put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -26,7 +26,10 @@
 
 package org.opensearch.security;
 
+import java.io.IOException;
+
 import com.google.common.collect.Lists;
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,6 +39,7 @@ import org.opensearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
@@ -44,6 +48,7 @@ import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
+import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.transport.Netty4ModulePlugin;
 
 public class SlowIntegrationTests extends SingleClusterTest {

--- a/src/test/java/org/opensearch/security/util/Repeat.java
+++ b/src/test/java/org/opensearch/security/util/Repeat.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.METHOD;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ METHOD, ANNOTATION_TYPE })
+public @interface Repeat {
+    int value() default 1;
+}

--- a/src/test/java/org/opensearch/security/util/RepeatRule.java
+++ b/src/test/java/org/opensearch/security/util/RepeatRule.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RepeatRule implements TestRule {
+
+    private static class RepeatStatement extends Statement {
+        private final Statement statement;
+        private final int repeat;
+
+        public RepeatStatement(Statement statement, int repeat) {
+            this.statement = statement;
+            this.repeat = repeat;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            for (int i = 0; i < repeat; i++) {
+                statement.evaluate();
+            }
+        }
+
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        Statement result = statement;
+        Repeat repeat = description.getAnnotation(Repeat.class);
+        if (repeat != null) {
+            int times = repeat.value();
+            result = new RepeatStatement(statement, times);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
### Description

Explicitly adds a command after setup to create an index and wait for cluster green which produces the expected IOException.

The pseudo code of this test is:

1. Setup a cluster, but forbid allocating any shards so cluster is red
2. If cluster is red as expected, then remove the restriction on shard allocation and wait for cluster to turn green
3. Wait another 10s to ensure that the security index is initialized.

I believe this test is not succeeding, because the cluster is coming up as green initially since there is no data (and hence no shards) in the cluster. By adding an explicit command to create an index, the test ensures that the shards are not being allocated and cluster is indeed red.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test Fix

### Issues Resolved

- Resolves https://github.com/opensearch-project/security/issues/2230

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
