### PR TITLE
.editorconfig and .gitattributes to centralize formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# EditorConfig: http://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+
+[*.gradle]
+indent_size = 2
+
+[*.groovy]
+indent_size = 4
+
+[*.java]
+indent_size = 4
+
+[*.json]
+indent_size = 2
+
+[*.sh]
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_size = 2
+
+[*.{xsd,xml}]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+* text eol=lf
+*.bat binary
+*.zip binary
+*.exe binary
+*.epub binary
+*.pdf binary
+*.vsdx binary
+*.doc binary
+*.bcfks binary
+*.crt binary
+*.p12 binary
+*.txt text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,12 +1,38 @@
-* text eol=lf
-*.bat binary
-*.zip binary
-*.exe binary
-*.epub binary
-*.pdf binary
-*.vsdx binary
-*.doc binary
-*.bcfks binary
-*.crt binary
-*.p12 binary
-*.txt text=auto
+# Java sources
+*.java          text diff=java
+*.kt            text diff=kotlin
+*.groovy        text diff=java
+*.scala         text diff=java
+*.gradle        text diff=java
+*.gradle.kts    text diff=kotlin
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text diff=css
+*.scss          text diff=css
+*.sass          text
+*.df            text
+*.htm           text diff=html
+*.html          text diff=html
+*.js            text
+*.jsp           text
+*.jspf          text
+*.jspx          text
+*.properties    text
+*.tld           text
+*.tag           text
+*.tagx          text
+*.xml           text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.jar           binary
+*.so            binary
+*.war           binary
+*.jks           binary
+
+# Common build-tool wrapper scripts ('.cmd' versions are handled by 'Common.gitattributes')
+mvnw            text eol=lf
+gradlew         text eol=lf


### PR DESCRIPTION
### Description
Added .editorconfig and .gitattributes to centralize formatting and git committing

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
These files are in the main opensearch repository, and it's useful to have these files to have an additional formatting/git commit source of truth

* What is the old behavior before changes and new behavior after changes?
N/A

### Issues Resolved
- #1547 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
