### PR TITLE
Better support wrapping of TransportChannel

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -86,6 +86,11 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
 
         ThreadContext threadContext = getThreadContext();
 
+        String channelType = channel.getChannelType();
+        if (!channelType.equals("direct") && !channelType.equals("transport")) {
+            channel = getInnerChannel(channel);
+        }
+
         threadContext.putTransient(
             ConfigConstants.USE_JDK_SERIALIZATION,
             channel.getVersion().before(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION)
@@ -95,11 +100,6 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
             final Exception exception = ExceptionUtils.createBadHeaderException();
             channel.sendResponse(exception);
             throw exception;
-        }
-
-        String channelType = channel.getChannelType();
-        if (!channelType.equals("direct") && !channelType.equals("transport")) {
-            channel = getInnerChannel(channel);
         }
 
         if (!"transport".equals(channel.getChannelType())) { // netty4

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Method;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Set;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import org.apache.logging.log4j.LogManager;
@@ -55,6 +56,8 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
     private final SslExceptionHandler errorHandler;
     private final SSLConfig SSLConfig;
 
+    private static final Set<String> DEFAULT_CHANNEL_TYPES = Set.of("direct", "transport");
+
     public SecuritySSLRequestHandler(
         String action,
         TransportRequestHandler<T> actualHandler,
@@ -87,7 +90,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
         ThreadContext threadContext = getThreadContext();
 
         String channelType = channel.getChannelType();
-        if (!channelType.equals("direct") && !channelType.equals("transport")) {
+        if (!DEFAULT_CHANNEL_TYPES.contains(channelType)) {
             channel = getInnerChannel(channel);
         }
 


### PR DESCRIPTION
### Description

Performance Analyzer (PA) sets up a transport interceptor that [wraps a TransportChannel](https://github.com/opensearch-project/performance-analyzer/blob/main/src/main/java/org/opensearch/performanceanalyzer/transport/PerformanceAnalyzerTransportChannel.java#L147-L151). The security plugin has logic to [extract the inner channel](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java#L100-L103) so that the rest of SecuritySSLRequestHandler uses the original channel. There is logic before the inner channel extraction to determine whether to use JDK Serialization if the incoming message was received from a [node running OS <= 2.10](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java#L89-L92). That code relies on `channel.getVersion()` to get the version of the node that transmitted the transport request, but when the channel is wrapped its not delegating to the original channel in PA. This PR moves the logic after the extraction of the inner channel to ensure that `channel.getVersion()` correctly returns the version from the transmitting node.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

- Resolved https://github.com/opensearch-project/security/issues/3771

### Testing

Will update with testing steps

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
