### PR TITLE
Disable custom serialization

### DIFF
--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -184,7 +184,7 @@ public class SecurityFilter implements ActionFilter {
             }
 
             if (threadContext.getTransient(ConfigConstants.USE_JDK_SERIALIZATION) == null) {
-                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, false);
+                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, true);
             }
 
             final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -46,6 +46,8 @@ import org.opensearch.transport.netty4.Netty4TcpChannel;
 
 import io.netty.handler.ssl.SslHandler;
 
+import static org.opensearch.security.support.Base64Helper.shouldUseJDKSerialization;
+
 public class SecuritySSLRequestHandler<T extends TransportRequest> implements TransportRequestHandler<T> {
 
     private final String action;
@@ -94,10 +96,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
             channel = getInnerChannel(channel);
         }
 
-        threadContext.putTransient(
-            ConfigConstants.USE_JDK_SERIALIZATION,
-            channel.getVersion().before(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION)
-        );
+        threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, shouldUseJDKSerialization(channel.getVersion()));
 
         if (SSLRequestHelper.containsBadHeader(threadContext, "_opendistro_security_ssl_")) {
             final Exception exception = ExceptionUtils.createBadHeaderException();

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -28,6 +28,8 @@ package org.opensearch.security.support;
 
 import java.io.Serializable;
 
+import org.opensearch.Version;
+
 public class Base64Helper {
 
     public static String serializeObject(final Serializable object, final boolean useJDKSerialization) {
@@ -35,11 +37,11 @@ public class Base64Helper {
     }
 
     public static String serializeObject(final Serializable object) {
-        return serializeObject(object, false);
+        return serializeObject(object, true);
     }
 
     public static Serializable deserializeObject(final String string) {
-        return deserializeObject(string, false);
+        return deserializeObject(string, true);
     }
 
     public static Serializable deserializeObject(final String string, final boolean useJDKDeserialization) {
@@ -68,5 +70,33 @@ public class Base64Helper {
         }
         // If we see an exception now, we want the caller to see it -
         return Base64Helper.serializeObject(serializable, true);
+    }
+
+    /**
+     * Ensures that the returned string is custom serialized.
+     *
+     * If the supplied string is a JDK serialized representation, will deserialize it and further serialize using
+     * custom, otherwise returns the string as is.
+     *
+     * @param string original string, can be JDK or custom serialized
+     * @return custom serialized string
+     */
+    public static String ensureCustomSerialized(final String string) {
+        Serializable serializable;
+        try {
+            serializable = Base64Helper.deserializeObject(string, true);
+        } catch (Exception e) {
+            // We received an exception when de-serializing the given string. It is probably custom serialized.
+            // Try to deserialize using custom
+            Base64Helper.deserializeObject(string, false);
+            // Since we could deserialize the object using custom, the string is already custom serialized, return as is
+            return string;
+        }
+        // If we see an exception now, we want the caller to see it -
+        return Base64Helper.serializeObject(serializable, false);
+    }
+
+    public static boolean shouldUseJDKSerialization(Version remoteVersion) {
+        return !remoteVersion.equals(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION);
     }
 }

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -38,6 +38,11 @@ public class Base64HelperTest {
         String test = "string";
         Assert.assertEquals(test, ds(test));
         Assert.assertEquals(test, dsJDK(test));
+
+        // verify that default methods use JDK serialization
+        Assert.assertEquals(serializeObject(test), serializeObject(test, true));
+        String serialized = serializeObject(test);
+        Assert.assertEquals(deserializeObject(serialized), deserializeObject(serialized, true));
     }
 
     @Test
@@ -47,5 +52,14 @@ public class Base64HelperTest {
         String customSerialized = Base64Helper.serializeObject(test, false);
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(jdkSerialized));
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(customSerialized));
+    }
+
+    @Test
+    public void testEnsureCustomSerialized() {
+        String test = "string";
+        String jdkSerialized = Base64Helper.serializeObject(test, true);
+        String customSerialized = Base64Helper.serializeObject(test, false);
+        Assert.assertEquals(customSerialized, Base64Helper.ensureCustomSerialized(jdkSerialized));
+        Assert.assertEquals(customSerialized, Base64Helper.ensureCustomSerialized(customSerialized));
     }
 }

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -21,6 +21,7 @@ import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.extensions.ExtensionsManager;
@@ -108,8 +109,7 @@ public class SecurityInterceptorTests {
         );
     }
 
-    private void testSendRequestDecorate(Version remoteNodeVersion) {
-        boolean useJDKSerialization = remoteNodeVersion.before(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION);
+    private void testSendRequestDecorate(DiscoveryNode localNode, DiscoveryNode otherNode, boolean shouldUseJDKSerialization) {
         ClusterName clusterName = ClusterName.DEFAULT;
         when(clusterService.getClusterName()).thenReturn(clusterName);
 
@@ -143,17 +143,7 @@ public class SecurityInterceptorTests {
         @SuppressWarnings("unchecked")
         TransportResponseHandler<TransportResponse> handler = mock(TransportResponseHandler.class);
 
-        InetAddress localAddress = null;
-        try {
-            localAddress = InetAddress.getByName("0.0.0.0");
-        } catch (final UnknownHostException uhe) {
-            throw new RuntimeException(uhe);
-        }
-
-        DiscoveryNode localNode = new DiscoveryNode("local-node", new TransportAddress(localAddress, 1234), Version.CURRENT);
         Connection connection1 = transportService.getConnection(localNode);
-
-        DiscoveryNode otherNode = new DiscoveryNode("remote-node", new TransportAddress(localAddress, 4321), remoteNodeVersion);
         Connection connection2 = transportService.getConnection(otherNode);
 
         // from thread context inside sendRequestDecorate
@@ -189,7 +179,7 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 String serializedUserHeader = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
-                assertEquals(serializedUserHeader, Base64Helper.serializeObject(user, useJDKSerialization));
+                assertEquals(serializedUserHeader, Base64Helper.serializeObject(user, shouldUseJDKSerialization));
             }
         };
         // isSameNodeRequest = false
@@ -201,17 +191,49 @@ public class SecurityInterceptorTests {
         assertEquals(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER), null);
     }
 
+    /**
+     * Tests the scenario when remote node is on same OS version
+     */
     @Test
     public void testSendRequestDecorate() {
-        testSendRequestDecorate(Version.CURRENT);
+        DiscoveryNode localNode = new DiscoveryNode("local-node", new TransportAddress(getLocalAddress(), 1234), Version.CURRENT);
+        DiscoveryNode otherNode = new DiscoveryNode("other-node", new TransportAddress(getLocalAddress(), 3456), Version.CURRENT);
+        testSendRequestDecorate(localNode, otherNode, true);
     }
 
     /**
-     * Tests the scenario when remote node does not implement custom serialization protocol and uses JDK serialization
+     * Tests the scenarios for mixed node versions
      */
     @Test
-    public void testSendRequestDecorateWhenRemoteNodeUsesJDKSerde() {
-        testSendRequestDecorate(Version.V_2_0_0);
+    public void testSendRequestDecorateWithMixedNodeVersions() {
+
+        // local on latest version, remote on 2.11.0 - should use custom
+
+        try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
+            DiscoveryNode localNode = new DiscoveryNode("local-node", new TransportAddress(getLocalAddress(), 1234), Version.CURRENT);
+            DiscoveryNode otherNode = new DiscoveryNode(
+                "other-node",
+                new TransportAddress(getLocalAddress(), 3456),
+                ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION
+            );
+            testSendRequestDecorate(localNode, otherNode, false);
+        }
+
+        // remote node is on a version > 2.11.1 while local node is on version 2.11.1 - should use JDK
+        try (ThreadContext.StoredContext ignore = threadPool.getThreadContext().stashContext()) {
+            DiscoveryNode localNode = new DiscoveryNode("local-node", new TransportAddress(getLocalAddress(), 1234), Version.CURRENT);
+            DiscoveryNode otherNode = new DiscoveryNode("other-node", new TransportAddress(getLocalAddress(), 3456), Version.V_2_11_1);
+            testSendRequestDecorate(localNode, otherNode, true);
+        }
+
+    }
+
+    private static InetAddress getLocalAddress() {
+        try {
+            return InetAddress.getByName("0.0.0.0");
+        } catch (final UnknownHostException uhe) {
+            throw new RuntimeException(uhe);
+        }
     }
 
 }

--- a/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
@@ -89,14 +89,15 @@ public class SecuritySSLRequestHandlerTests {
         Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_2_11_0);
+        when(transportChannel.getVersion()).thenReturn(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        when(transportChannel.getVersion()).thenReturn(Version.CURRENT);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
-        Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
     }
 
     @Test
@@ -113,14 +114,14 @@ public class SecuritySSLRequestHandlerTests {
         Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_2_11_0);
+        when(transportChannel.getVersion()).thenReturn(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, wrappedChannel, task));
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        when(transportChannel.getVersion()).thenReturn(Version.CURRENT);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, wrappedChannel, task));
-        Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
     }
 
     @Test


### PR DESCRIPTION
### Description
Disables custom serialization for the `2.11.1` patch release.

Needs to be backported to `2.x`.

Below is the approach. 

* For **requests sent** from the `2.11.1` nodes to -
    * Case 1 : a node running OS version < `2.11`
        * always use JDK to serialize the headers [this check was already present]
    * Case 2: a node running *OS* `2.11.0`
        * serialize via custom serialization
    * Case 3:  a node running *OS >=* `2.11.1`  
        * serialize via JDK serialization
* For **requests received** on the `2.11.1` nodes from -
    * Case 1 : a node running OS version < `2.11`
        * always use JDK to deserialize the headers [this check was already present]
    * Case 2: a node running OS  *`2.11.0`*
        * deserialize via custom serialization
    * Case 3: a node running OS >=  `2.11.1` 
        *  deserialize via JDK serialization

### Related Issues
- Related #3776 


### Testing 
BWCs should cover most of the scenarios, while still carry out a manual cluster upgrade test.
