### PR TITLE
[BUG-3791] Adds missing permissions in logstash static role

### DIFF
--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -132,6 +132,7 @@ logstash:
   index_permissions:
     - index_patterns:
         - "logstash-*"
+        - "ecs-logstash-*"
       allowed_actions:
         - "create_index"
         - "crud"


### PR DESCRIPTION
### Description
* Category: Bug fix

### Issues Resolved
- https://github.com/opensearch-project/security/issues/3791

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
