### PR TITLE
[Backport] [2.x] Bump org.gradle.test-retry from 1.5.6 to 1.5.7 (#3787)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.22.0'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.5.0"
-    id "org.gradle.test-retry" version "1.5.5"
+    id "org.gradle.test-retry" version "1.5.7"
     id 'eclipse'
     id "com.github.spotbugs" version "5.2.5"
     id "com.google.osdetector" version "1.7.3"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3787 to `2.x`