### PR TITLE
[Backport] [2.x] Bump commons-io:commons-io from 2.15.0 to 2.15.1 (#3784)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -707,7 +707,7 @@ dependencies {
     integrationTestImplementation 'junit:junit:4.13.2'
     integrationTestImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     integrationTestImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
-    integrationTestImplementation 'commons-io:commons-io:2.14.0'
+    integrationTestImplementation 'commons-io:commons-io:2.15.1'
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3784 to `2.x`