### PR TITLE
[Backport] [2.x] Bump com.nimbusds:nimbus-jose-jwt from 9.37.1 to 9.37.2 (#3785)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -569,7 +569,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.6.0'
     implementation "org.bouncycastle:bcprov-jdk15to18:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.37.2'
 
     //JWT
     implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3785 to `2.x`