### PR TITLE
[Backport] [2.x] Bump com.diffplug.spotless from 6.23.0 to 6.23.3 (#3786)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.22.0'
+    id 'com.diffplug.spotless' version '6.23.3'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.5.0"
     id "org.gradle.test-retry" version "1.5.5"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3786 to `2.x`