### PR TITLE
[1.3] Resolve zookeeper, databind, xmlsec to address CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ configurations.all {
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
+        force "org.apache.zookeeper:zookeeper:3.9.1"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
 configurations.all {
     resolutionStrategy {
         force 'commons-codec:commons-codec:1.14'
-        force 'org.apache.santuario:xmlsec:2.2.3'
+        force 'org.apache.santuario:xmlsec:2.2.4'
         force 'org.cryptacular:cryptacular:1.2.4'
         force 'net.minidev:json-smart:2.4.10'
         force 'commons-cli:commons-cli:1.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -169,7 +169,7 @@ dependencies {
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.75'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
     implementation 'io.jsonwebtoken:jjwt-api:0.10.8'
@@ -222,7 +222,7 @@ dependencies {
     integrationTestImplementation "org.opensearch.plugin:aggs-matrix-stats-client:${opensearch_version}"
     integrationTestImplementation "com.google.guava:guava:32.1.1-jre"
     integrationTestImplementation "org.apache.commons:commons-lang3:3.4"
-    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    integrationTestImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     integrationTestImplementation 'io.jsonwebtoken:jjwt-api:0.10.8'
     integrationTestImplementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     integrationTestImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,6 @@ configurations.all {
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
         force "org.apache.zookeeper:zookeeper:3.9.1"
-        force "ch.qos.logback:logback-classic:1.3.12"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ configurations.all {
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
         force "org.apache.zookeeper:zookeeper:3.9.1"
+        force "ch.qos.logback:logback-classic:1.3.12"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ ext {
 configurations.all {
     resolutionStrategy {
         force 'commons-codec:commons-codec:1.14'
-        force 'org.apache.santuario:xmlsec:2.2.4'
+        force 'org.apache.santuario:xmlsec:2.3.4'
         force 'org.cryptacular:cryptacular:1.2.4'
         force 'net.minidev:json-smart:2.4.10'
         force 'commons-cli:commons-cli:1.3.1'


### PR DESCRIPTION
### Description
Bumps zookeeper to 3.9.1 to resolve: CVE-2023-44981
Bumps xmlsec to 2.3.4 to resolve: CVE-2023-44483
Bumps jackson-databind to match core: https://github.com/opensearch-project/OpenSearch/blob/1.3/buildSrc/version.properties#L11

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
