### PR TITLE
Upgrade logback-classic to address CVE CVE-2023-6378

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -497,6 +497,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore:4.4.16"
             force "com.google.errorprone:error_prone_annotations:2.23.0"
             force "org.checkerframework:checker-qual:3.40.0"
+            force "ch.qos.logback:logback-classic:1.3.12"
         }
     }
 


### PR DESCRIPTION
### Description
Force resolve logback-classic to 1.3.12 to address https://github.com/advisories/GHSA-vmq6-5m68-f53m

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
