### PR TITLE
Fix issue when scroll is created with LDAP user

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
@@ -10,8 +10,10 @@
 package org.opensearch.security.http;
 
 import java.util.List;
+import java.util.Map;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.ClassRule;
@@ -20,7 +22,12 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.runner.RunWith;
 
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.AuthorizationBackend;
+import org.opensearch.test.framework.AuthzDomain;
 import org.opensearch.test.framework.LdapAuthenticationConfigBuilder;
+import org.opensearch.test.framework.LdapAuthorizationConfigBuilder;
+import org.opensearch.test.framework.RolesMapping;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
 import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AuthenticationBackend;
@@ -32,13 +39,20 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.ldap.EmbeddedLDAPServer;
 import org.opensearch.test.framework.log.LogsRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.opensearch.security.http.CertificateAuthenticationTest.POINTER_BACKEND_ROLES;
+import static org.opensearch.security.http.DirectoryInformationTrees.CN_GROUP_ADMIN;
 import static org.opensearch.security.http.DirectoryInformationTrees.DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG;
+import static org.opensearch.security.http.DirectoryInformationTrees.DN_GROUPS_TEST_ORG;
 import static org.opensearch.security.http.DirectoryInformationTrees.DN_OPEN_SEARCH_PEOPLE_TEST_ORG;
 import static org.opensearch.security.http.DirectoryInformationTrees.DN_PEOPLE_TEST_ORG;
 import static org.opensearch.security.http.DirectoryInformationTrees.LDIF_DATA;
+import static org.opensearch.security.http.DirectoryInformationTrees.PASSWORD_KIRK;
 import static org.opensearch.security.http.DirectoryInformationTrees.PASSWORD_OPEN_SEARCH;
 import static org.opensearch.security.http.DirectoryInformationTrees.PASSWORD_SPOCK;
 import static org.opensearch.security.http.DirectoryInformationTrees.USERNAME_ATTRIBUTE;
+import static org.opensearch.security.http.DirectoryInformationTrees.USER_KIRK;
 import static org.opensearch.security.http.DirectoryInformationTrees.USER_SEARCH;
 import static org.opensearch.security.http.DirectoryInformationTrees.USER_SPOCK;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
@@ -54,6 +68,8 @@ public class LdapAuthenticationTest {
 
     private static final Logger log = LogManager.getLogger(LdapAuthenticationTest.class);
 
+    private static final String HEADER_NAME_IMPERSONATE = "opendistro_security_impersonate_as";
+
     private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
     private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
@@ -67,6 +83,7 @@ public class LdapAuthenticationTest {
     public static LocalCluster cluster = new LocalCluster.Builder().testCertificates(TEST_CERTIFICATES)
         .clusterManager(ClusterManager.SINGLENODE)
         .anonymousAuth(false)
+        .nodeSettings(Map.of(ConfigConstants.SECURITY_AUTHCZ_REST_IMPERSONATION_USERS + "." + ADMIN_USER.getName(), List.of(USER_KIRK)))
         .authc(
             new AuthcDomain("ldap", BASIC_AUTH_DOMAIN_ORDER + 1, true).httpAuthenticator(new HttpAuthenticator("basic").challenge(false))
                 .backend(
@@ -89,6 +106,29 @@ public class LdapAuthenticationTest {
         )
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .users(ADMIN_USER)
+        .rolesMapping(new RolesMapping(ALL_ACCESS).backendRoles(CN_GROUP_ADMIN))
+        .authz(
+            new AuthzDomain("ldap_roles").httpEnabled(true)
+                .transportEnabled(true)
+                .authorizationBackend(
+                    new AuthorizationBackend("ldap").config(
+                        () -> new LdapAuthorizationConfigBuilder().hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))
+                            .enableSsl(false)
+                            .bindDn(DN_OPEN_SEARCH_PEOPLE_TEST_ORG)
+                            .password(PASSWORD_OPEN_SEARCH)
+                            .userBase(DN_PEOPLE_TEST_ORG)
+                            .userSearch(USER_SEARCH)
+                            .usernameAttribute(USERNAME_ATTRIBUTE)
+                            .roleBase(DN_GROUPS_TEST_ORG)
+                            .roleSearch("(uniqueMember={0})")
+                            .userRoleAttribute(null)
+                            .userRoleName("disabled")
+                            .roleName("cn")
+                            .resolveNestedRoles(true)
+                            .build()
+                    )
+                )
+        )
         .build();
 
     @ClassRule
@@ -115,6 +155,40 @@ public class LdapAuthenticationTest {
             String expectedStackTraceFragment = "Unable to bind as user '".concat(DN_CAPTAIN_SPOCK_PEOPLE_TEST_ORG)
                 .concat("' because the provided password was incorrect.");
             logsRule.assertThatStackTraceContain(expectedStackTraceFragment);
+        }
+    }
+
+    @Test
+    public void testShouldCreateScrollWithLdapUserAndImpersonateWithAdmin() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            TestRestClient.HttpResponse response = client.put("movies");
+
+            response.assertStatusCode(200);
+        }
+
+        String scrollId;
+
+        try (TestRestClient client = cluster.getRestClient(USER_KIRK, PASSWORD_KIRK)) {
+            TestRestClient.HttpResponse authinfo = client.getAuthInfo();
+
+            List<String> backendRoles = authinfo.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, contains(CN_GROUP_ADMIN));
+
+            TestRestClient.HttpResponse response = client.getWithJsonBody("movies/_search?scroll=10m", "{\"size\": 1}");
+
+            response.assertStatusCode(200);
+
+            scrollId = response.getTextFromJsonBody("/_scroll_id");
+        }
+
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            TestRestClient.HttpResponse scrollResponse = client.getWithJsonBody(
+                "_search/scroll",
+                "{\"scroll\": \"10m\", \"scroll_id\": \"" + scrollId + "\"}",
+                new BasicHeader(HEADER_NAME_IMPERSONATE, USER_KIRK)
+            );
+
+            scrollResponse.assertStatusCode(200);
         }
     }
 }

--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -229,7 +229,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         if (obj == null) {
             return false;
         }
-        if (!(User.class.isAssignableFrom(getClass()) && User.class.isAssignableFrom(obj.getClass()))) {
+        if (!(obj instanceof User)) {
             return false;
         }
         final User other = (User) obj;

--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -229,7 +229,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         if (obj == null) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
+        if (!(User.class.isAssignableFrom(getClass()) && User.class.isAssignableFrom(obj.getClass()))) {
             return false;
         }
         final User other = (User) obj;


### PR DESCRIPTION
### Description

Fixes an issue when a scroll context is created by an LDAP User. There is a subclass in the system for [LDAP Users](https://github.com/opensearch-project/security/blob/main/src/main/java/com/amazon/dlic/auth/ldap/LdapUser.java) that in some circumstances can lead to issues with the scroll query. The issue is always reproducible when using rest impersonation to impersonate the LDAP User when authenticating as an internal user. 

See steps to reproduce the issue here: https://github.com/opensearch-project/security/issues/3582#issuecomment-1843560293

This PR includes a test that will fail if the fix within User.java is reverted. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security/issues/3582

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
