### PR TITLE
Hide ldap roles

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -964,8 +964,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : nestedReturn) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
-                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
+                    if (filterRole(excludeRoles, role)) {
                         user.addRole(role);
                     } else {
                         log.warn("Role not allowed or empty, attribute: '{}' for entry: {}", roleName, roleLdapName);
@@ -977,8 +976,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
-                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
+                    if (filterRole(excludeRoles, role)) {
                         user.addRole(role);
                     } else {
                         log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);
@@ -1009,6 +1007,14 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
             Utils.unbindAndCloseSilently(connection);
         }
 
+    }
+
+    private static boolean filterRole(String excludeRoles, String role) {
+        //default behavior, no filtering
+        if(Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role)) {
+            return true;
+        }
+        return !Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role);
     }
 
     protected Set<LdapName> resolveNestedRoles(

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
@@ -694,6 +695,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
         String originalUserName;
         LdapEntry entry = null;
         String dn = null;
+        String excludeRoles = settings.get("exclude_roles", null);
 
         final boolean isDebugEnabled = log.isDebugEnabled();
         if (isDebugEnabled) {
@@ -962,10 +964,11 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : nestedReturn) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (!Strings.isNullOrEmpty(role)) {
+                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
+                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
                         user.addRole(role);
                     } else {
-                        log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);
+                        log.warn("Role not allowed or empty, attribute: '{}' for entry: {}", roleName, roleLdapName);
                     }
                 }
 
@@ -974,7 +977,8 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (!Strings.isNullOrEmpty(role)) {
+                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
+                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
                         user.addRole(role);
                     } else {
                         log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -1010,8 +1010,8 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
     }
 
     private static boolean filterRole(String excludeRoles, String role) {
-        //default behavior, no filtering
-        if(Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role)) {
+        // default behavior, no filtering
+        if (Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role)) {
             return true;
         }
         return !Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role);

--- a/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.regex.Pattern;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
@@ -964,7 +963,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : nestedReturn) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (filterRole(excludeRoles, role)) {
+                    if (LdapHelper.allowRole(excludeRoles, role)) {
                         user.addRole(role);
                     } else {
                         log.warn("Role not allowed or empty, attribute: '{}' for entry: {}", roleName, roleLdapName);
@@ -976,7 +975,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (filterRole(excludeRoles, role)) {
+                    if (LdapHelper.allowRole(excludeRoles, role)) {
                         user.addRole(role);
                     } else {
                         log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);
@@ -1007,14 +1006,6 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
             Utils.unbindAndCloseSilently(connection);
         }
 
-    }
-
-    private static boolean filterRole(String excludeRoles, String role) {
-        // default behavior, no filtering
-        if (Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role)) {
-            return true;
-        }
-        return !Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role);
     }
 
     protected Set<LdapName> resolveNestedRoles(

--- a/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap/util/LdapHelper.java
@@ -16,11 +16,13 @@ import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 
 import org.opensearch.SpecialPermission;
+import org.opensearch.core.common.Strings;
 
 import org.ldaptive.Connection;
 import org.ldaptive.DerefAliases;
@@ -122,7 +124,15 @@ public class LdapHelper {
         } else {
             return input;
         }
+    }
 
+    public static boolean allowRole(String excludeRoles, String role) {
+        if (Strings.isNullOrEmpty(role)) {
+            return false;
+        } else if (Strings.isNullOrEmpty(excludeRoles)) {
+            return true;
+        }
+        return !Pattern.matches(excludeRoles, role);
     }
 
 }

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -331,8 +331,10 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                         for (final Iterator<LdapEntry> iterator = rolesResult.iterator(); iterator.hasNext();) {
                             LdapEntry searchResultEntry = iterator.next();
                             LdapName ldapName = new LdapName(searchResultEntry.getDn());
-                            ldapRoles.add(ldapName);
-                            resultRoleSearchBaseKeys.put(ldapName, roleSearchSettingsEntry);
+                            if (LdapHelper.allowRole(excludeRoles, searchResultEntry.getDn())) {
+                                ldapRoles.add(ldapName);
+                                resultRoleSearchBaseKeys.put(ldapName, roleSearchSettingsEntry);
+                            }
                         }
                     }
                 }

--- a/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
+++ b/src/main/java/com/amazon/dlic/auth/ldap2/LDAPAuthorizationBackend2.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import javax.naming.InvalidNameException;
 import javax.naming.ldap.LdapName;
 
@@ -159,6 +160,7 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
         String originalUserName;
         LdapEntry entry = null;
         String dn = null;
+        String excludeRoles = settings.get("exclude_roles", null);
 
         if (user instanceof LdapUser) {
             entry = ((LdapUser) user).getUserEntry();
@@ -376,7 +378,8 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                 for (final LdapName roleLdapName : nestedReturn) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (!Strings.isNullOrEmpty(role)) {
+                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
+                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
                         user.addRole(role);
                     } else {
                         log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);
@@ -388,7 +391,8 @@ public class LDAPAuthorizationBackend2 implements AuthorizationBackend, Destroya
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 
-                    if (!Strings.isNullOrEmpty(role)) {
+                    if ((Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role))
+                        || (!Strings.isNullOrEmpty(excludeRoles) && !Strings.isNullOrEmpty(role) && !Pattern.matches(excludeRoles, role))) {
                         user.addRole(role);
                     } else {
                         log.warn("No or empty attribute '{}' for entry {}", roleName, roleLdapName);

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -39,6 +39,7 @@ import org.ldaptive.LdapEntry;
 import org.ldaptive.ReturnAttributes;
 
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 public class LdapBackendTest {
 
@@ -577,6 +578,62 @@ public class LdapBackendTest {
         Assert.assertEquals("spock", user.getName());
         Assert.assertEquals(4, user.getRoles().size());
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
+    }
+
+    @Test
+    public void testLdapNestedRoleFiltering() {
+
+        final Settings settings = Settings.builder()
+            .putList(ConfigConstants.LDAP_HOSTS, "localhost:" + ldapPort)
+            .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
+            .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,o=TEST")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLEBASE, "ou=groups,o=TEST")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLENAME, "cn")
+            .put(ConfigConstants.LDAP_AUTHZ_RESOLVE_NESTED_ROLES, true)
+            .put(ConfigConstants.LDAP_AUTHZ_ROLESEARCH, "(uniqueMember={0})")
+            .put("exclude_roles", "(nested.)")
+            .build();
+
+        final User user = new User("spock");
+
+        new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
+
+        Assert.assertNotNull(user);
+        Assert.assertEquals("spock", user.getName());
+        Assert.assertEquals(2, user.getRoles().size());
+        // filtered out
+        MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested1")));
+        MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested2")));
+        MatcherAssert.assertThat(user.getRoles(), hasItem("role2"));
+        MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
+    }
+
+    @Test
+    public void testLdapdRoleFiltering() {
+
+        final Settings settings = Settings.builder()
+            .putList(ConfigConstants.LDAP_HOSTS, "localhost:" + ldapPort)
+            .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
+            .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,o=TEST")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLEBASE, "ou=groups,o=TEST")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLENAME, "cn")
+            .put(ConfigConstants.LDAP_AUTHZ_RESOLVE_NESTED_ROLES, true)
+            .put(ConfigConstants.LDAP_AUTHZ_ROLESEARCH, "(uniqueMember={0})")
+            .put("exclude_roles", "(ceo|role1|role2)")
+            .build();
+
+        final User user = new User("spock");
+
+        new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
+
+        Assert.assertNotNull(user);
+        Assert.assertEquals("spock", user.getName());
+        Assert.assertEquals(2, user.getRoles().size());
+        MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
+        MatcherAssert.assertThat(user.getRoles(), hasItem("nested2"));
+        // filtered out
+        MatcherAssert.assertThat(user.getRoles(), not(hasItem("role2")));
+        MatcherAssert.assertThat(user.getRoles(), not(hasItem("ceo")));
     }
 
     @Test


### PR DESCRIPTION
### Description

* Category: Enhancement, New feature
* Why these changes are required?
To allow admin to have more control on what backend roles user sees. 
* What is the old behavior before changes and new behavior after changes?
Old behavior is that all user's roles are fetched from ldap/ad. Even if role is not used in opensearch use can view all assigned roles.
New behavior is that admin can configure what roles will be visible to the user. If flag is not configured cluster will behave the same. With new config admin is able to hide part of roles from users using simple regex.
Example config:
```
    authz:
      ldap_roles:
        description: "Authorize using LDAP"
        http_enabled: true
        transport_enabled: true
        authorization_backend:
          type: ldap
          config:
            enable_ssl: false
            enable_start_tls: false
            enable_ssl_client_auth: false
            verify_hostnames: false
            hosts:
            - 127.0.1.1:390
            bind_dn: cn=readonly,dc=example,dc=org
            password: changethistoo
            userbase: ou=People,dc=example,dc=org
            usersearch: (cn={0})
            username_attribute: cn
            skip_users:
              - admin
              - kibanaserver
            rolebase: ou=Groups,dc=example,dc=org
            rolesearch: (uniqueMember={0})
            userroleattribute: null
            userrolename: disabled
            rolename: cn
            resolve_nested_roles: true
  new ->    exclude_roles: "(this_role_will_be_hidden.*)"

```

### Issues Resolved
https://github.com/opensearch-project/security/issues/2189

### Testing
Unit testing and manual testing performed

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
