### PR TITLE
Add flush cache for individual user

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -584,7 +584,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                         Objects.requireNonNull(auditLog),
                         sks,
                         Objects.requireNonNull(userService),
-                        sslCertReloadEnabled
+                        sslCertReloadEnabled,
+                        backendRegistry
                     )
                 );
                 log.debug("Added {} rest handler(s)", handlers.size());

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -166,6 +166,29 @@ public class BackendRegistry {
         restRoleCache.invalidateAll();
     }
 
+    public void invalidateUserCache(String username) {
+        if (username == null || username.isEmpty()) {
+            log.debug("No username given, not invalidating user cache.");
+            return;
+        }
+    
+        // Invalidate entries in the userCache by iterating over the keys and matching the username.
+        userCache.asMap().keySet().stream()
+            .filter(authCreds -> username.equals(authCreds.getUsername()))
+            .forEach(userCache::invalidate);
+    
+        // Invalidate entries in the restImpersonationCache directly since it uses the username as the key.
+        restImpersonationCache.invalidate(username);
+    
+        // Invalidate entries in the restRoleCache by iterating over the keys and matching the username.
+        restRoleCache.asMap().keySet().stream()
+            .filter(user -> username.equals(user.getName()))
+            .forEach(restRoleCache::invalidate);
+    
+        // If the user isn't found it still says this, which could be bad
+        log.debug("Invalidated cache for user {}", username);
+    }
+
     @Subscribe
     public void onDynamicConfigModelChanged(DynamicConfigModel dcm) {
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
@@ -41,7 +42,8 @@ public class FlushCacheApiAction extends AbstractApiAction {
             new Route(Method.DELETE, "/cache"),
             new Route(Method.GET, "/cache"),
             new Route(Method.PUT, "/cache"),
-            new Route(Method.POST, "/cache")
+            new Route(Method.POST, "/cache"),
+            new Route(Method.DELETE, "/cache/user/{username}")
         )
     );
 
@@ -64,34 +66,55 @@ public class FlushCacheApiAction extends AbstractApiAction {
         requestHandlersBuilder.allMethodsNotImplemented()
             .override(
                 Method.DELETE,
-                (channel, request, client) -> client.execute(
-                    ConfigUpdateAction.INSTANCE,
-                    new ConfigUpdateRequest(CType.lcStringValues().toArray(new String[0])),
-                    new ActionListener<>() {
-
-                        @Override
-                        public void onResponse(ConfigUpdateResponse configUpdateResponse) {
-                            if (configUpdateResponse.hasFailures()) {
-                                LOGGER.error("Cannot flush cache due to", configUpdateResponse.failures().get(0));
-                                internalSeverError(
-                                    channel,
-                                    "Cannot flush cache due to " + configUpdateResponse.failures().get(0).getMessage() + "."
-                                );
-                                return;
-                            }
-                            LOGGER.debug("cache flushed successfully");
-                            ok(channel, "Cache flushed successfully.");
-                        }
-
-                        @Override
-                        public void onFailure(final Exception e) {
-                            LOGGER.error("Cannot flush cache due to", e);
-                            internalSeverError(channel, "Cannot flush cache due to " + e.getMessage() + ".");
-                        }
-
+                (channel, request, client) -> {
+                    if (request.path().contains("/user/")) {
+                        // Extract the username from the request
+                        final String username = request.param("username");
+                        // Validate and handle user-specific cache invalidation
+                        handleUserCacheInvalidation(channel, username);
                     }
-                )
+                    else
+                    {
+                        client.execute(
+                            ConfigUpdateAction.INSTANCE,
+                            new ConfigUpdateRequest(CType.lcStringValues().toArray(new String[0])),
+                            new ActionListener<>() {
+
+                                @Override
+                                public void onResponse(ConfigUpdateResponse configUpdateResponse) {
+                                    if (configUpdateResponse.hasFailures()) {
+                                        LOGGER.error("Cannot flush cache due to", configUpdateResponse.failures().get(0));
+                                        internalSeverError(
+                                            channel,
+                                            "Cannot flush cache due to " + configUpdateResponse.failures().get(0).getMessage() + "."
+                                        );
+                                        return;
+                                    }
+                                    LOGGER.debug("cache flushed successfully");
+                                    ok(channel, "Cache flushed successfully.");
+                                }
+
+                                @Override
+                                public void onFailure(final Exception e) {
+                                    LOGGER.error("Cannot flush cache due to", e);
+                                    internalSeverError(channel, "Cannot flush cache due to " + e.getMessage() + ".");
+                                }
+
+                            }
+                        );
+                    }
+                }
             );
+    }
+
+    private void handleUserCacheInvalidation(RestChannel channel, String username) {
+        if (username == null || username.isEmpty()) {
+            internalSeverError(channel, "No username provided for cache invalidation.");
+            return;
+        }
+        // Use BackendRegistry's method to invalidate cache for the specific user
+        securityApiDependencies.backendRegistry().invalidateUserCache(username);
+        ok(channel, "Cache invalidated for user: " + username);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityApiDependencies.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityApiDependencies.java
@@ -13,6 +13,7 @@ package org.opensearch.security.dlic.rest.api;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.auth.BackendRegistry;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -23,6 +24,7 @@ public class SecurityApiDependencies {
     private final ConfigurationRepository configurationRepository;
     private final RestApiPrivilegesEvaluator restApiPrivilegesEvaluator;
     private final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator;
+    private final BackendRegistry backendRegistry;
     private final AuditLog auditLog;
     private final Settings settings;
 
@@ -35,7 +37,8 @@ public class SecurityApiDependencies {
         final RestApiPrivilegesEvaluator restApiPrivilegesEvaluator,
         final RestApiAdminPrivilegesEvaluator restApiAdminPrivilegesEvaluator,
         final AuditLog auditLog,
-        final Settings settings
+        final Settings settings,
+        final BackendRegistry backendRegistry
     ) {
         this.adminDNs = adminDNs;
         this.configurationRepository = configurationRepository;
@@ -44,6 +47,7 @@ public class SecurityApiDependencies {
         this.restApiAdminPrivilegesEvaluator = restApiAdminPrivilegesEvaluator;
         this.auditLog = auditLog;
         this.settings = settings;
+        this.backendRegistry = backendRegistry;
     }
 
     public AdminDNs adminDNs() {
@@ -72,6 +76,10 @@ public class SecurityApiDependencies {
 
     public Settings settings() {
         return settings;
+    }
+
+    public BackendRegistry backendRegistry() {
+        return backendRegistry;
     }
 
     public String securityIndexName() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -21,6 +21,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.auth.BackendRegistry;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -47,7 +48,8 @@ public class SecurityRestApiActions {
         final AuditLog auditLog,
         final SecurityKeyStore securityKeyStore,
         final UserService userService,
-        final boolean certificatesReloadEnabled
+        final boolean certificatesReloadEnabled,
+        final BackendRegistry backendRegistry
     ) {
         final var securityApiDependencies = new SecurityApiDependencies(
             adminDns,
@@ -61,7 +63,8 @@ public class SecurityRestApiActions {
                 settings.getAsBoolean(SECURITY_RESTAPI_ADMIN_ENABLED, false)
             ),
             auditLog,
-            settings
+            settings,
+            backendRegistry
         );
         return List.of(
             new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies),

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
@@ -71,7 +71,8 @@ public abstract class AbstractApiActionValidationTest {
             null,
             restApiAdminPrivilegesEvaluator,
             null,
-            Settings.EMPTY
+            Settings.EMPTY,
+            null
         );
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/FlushCacheApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/FlushCacheApiTest.java
@@ -42,6 +42,9 @@ public class FlushCacheApiTest extends AbstractRestApiUnitTest {
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendAdminCertificate = true;
 
+        // Username to test cache invalidation
+        String username = "testuser";
+
         // GET
         HttpResponse response = rh.executeGetRequest(ENDPOINT);
         Assert.assertEquals(HttpStatus.SC_NOT_IMPLEMENTED, response.getStatusCode());
@@ -65,6 +68,13 @@ public class FlushCacheApiTest extends AbstractRestApiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(settings.get("message"), "Cache flushed successfully.");
+
+        // DELETE request for a specific user's cache
+        String userEndpoint = ENDPOINT + "/user/" + username;
+        response = rh.executeDeleteRequest(userEndpoint, new Header[0]);
+        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
+        Assert.assertEquals(settings.get("message"), "Cache invalidated for user: " + username);
 
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiActionValidationTest.java
@@ -30,7 +30,7 @@ public class SecurityConfigApiActionValidationTest extends AbstractApiActionVali
         final var securityConfigApiAction = new SecurityConfigApiAction(
             clusterService,
             threadPool,
-            new SecurityApiDependencies(null, configurationRepository, null, null, restApiAdminPrivilegesEvaluator, null, Settings.EMPTY)
+            new SecurityApiDependencies(null, configurationRepository, null, null, restApiAdminPrivilegesEvaluator, null, Settings.EMPTY, null)
         );
         assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
         assertFalse(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()));
@@ -49,7 +49,8 @@ public class SecurityConfigApiActionValidationTest extends AbstractApiActionVali
                 null,
                 restApiAdminPrivilegesEvaluator,
                 null,
-                Settings.builder().put(SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build()
+                Settings.builder().put(SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true).build(),
+                null
             )
         );
         assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));
@@ -70,7 +71,8 @@ public class SecurityConfigApiActionValidationTest extends AbstractApiActionVali
                         null,
                         restApiAdminPrivilegesEvaluator,
                         null,
-                        Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build()
+                        Settings.builder().put(SECURITY_RESTAPI_ADMIN_ENABLED, true).build(),
+                        null
                 )
         );
         assertTrue(securityConfigApiAction.accessHandler(FakeRestRequest.builder().withMethod(RestRequest.Method.GET).build()));


### PR DESCRIPTION
### Description
Currently, our system only allows for the invalidation of the entire user authentication cache, which can lead to numerous cache misses and inefficiencies. This change is required to allow for more precise cache management, specifically targeting stale cache entries at the individual user level without disrupting the cache state of other users

* Category: New feature
* Why these changes are required?
Currently, our system only allows for the invalidation of the entire user authentication cache. This change is required to allow for more precise cache management, specifically targeting stale cache entries at the individual user level without disrupting the cache state of other users.
* What is the old behavior before changes and new behavior after changes?
Previously, invalidating a user's cache required clearing the entire cache, affecting all users. The new behavior introduces an endpoint that allows for the invalidation of cache entries on a per-user basis, thereby maintaining cache integrity for other users and reducing unnecessary cache misses.
### Issues Resolved
#2829

### Testing
Unit testing was written in FlushCacheApiTest.java

### Check List
- [X ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff
