### PR TITLE
Add do not fail on forbidden test cases around the stats API

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationTests.java
@@ -69,7 +69,7 @@ public class DefaultConfigurationTests {
         }
         try (TestRestClient client = cluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
             client.confirmCorrectCredentials(ADMIN_USER_NAME);
-            HttpResponse response = client.get("/_plugins/_security/api/internalusers");
+            HttpResponse response = client.get("_plugins/_security/api/internalusers");
             response.assertStatusCode(200);
             Map<String, Object> users = response.getBodyAs(Map.class);
             assertThat(users, allOf(aMapWithSize(3), hasKey(ADMIN_USER_NAME), hasKey(NEW_USER), hasKey(LIMITED_USER)));

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -39,10 +39,14 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
+import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
@@ -51,6 +55,7 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
@@ -127,13 +132,17 @@ public class DoNotFailOnForbiddenTests {
             .on(MARVELOUS_SONGS)
     );
 
+    private static final User STATS_USER = new User("stats_user").roles(
+        new Role("test_role").clusterPermissions("cluster:monitor/*").indexPermissions("read", "indices:monitor/*").on("hi1")
+    );
+
     private static final String BOTH_INDEX_ALIAS = "both-indices";
     private static final String FORBIDDEN_INDEX_ALIAS = "forbidden-index";
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
         .authc(AUTHC_HTTPBASIC_INTERNAL)
-        .users(ADMIN_USER, LIMITED_USER)
+        .users(ADMIN_USER, LIMITED_USER, STATS_USER)
         .anonymousAuth(false)
         .doNotFailOnForbidden(true)
         .build();
@@ -434,4 +443,37 @@ public class DoNotFailOnForbiddenTests {
         }
     }
 
+    @Test
+    public void checkStatsApi() {
+        try (final TestRestClient client = cluster.getRestClient(ADMIN_USER.getName(), ADMIN_USER.getPassword())) {
+            final HttpResponse createDoc1 = client.postJson("hi1/_doc?refresh=true", "{\"hi\":\"Hello1\"}");
+            createDoc1.assertStatusCode(SC_CREATED);
+            final HttpResponse createDoc2 = client.postJson("hi2/_doc?refresh=true", "{\"hi\":\"Hello2\"}");
+            createDoc2.assertStatusCode(SC_CREATED);
+
+            final HttpResponse search = client.postJson("hi*/_search", "{}");
+            assertThat("Unexpected document results in search:" + search.getBody(), search.getBody(), containsString("2"));
+
+            final HttpResponse catIndices = client.get("_cat/indices");
+            assertThat("Expected cat indices: " + catIndices.getBody(), catIndices.getBody(), containsString("hi1"));
+            assertThat("Unexpected cat indices: " + catIndices.getBody(), catIndices.getBody(), containsString("hi2"));
+
+            final HttpResponse stats = client.get("hi*/_stats?filter_path=indices.*.uuid");
+            assertThat("Expected stats indices: " + stats.getBody(), stats.getBody(), containsString("hi1"));
+            assertThat("Unexpected stats indices: " + stats.getBody(), stats.getBody(), containsString("hi2"));
+        }
+
+        try (final TestRestClient client = cluster.getRestClient(STATS_USER.getName(), STATS_USER.getPassword())) {
+            final HttpResponse search = client.postJson("hi*/_search", "{}");
+            assertThat("Unexpected document results in search:" + search.getBody(), search.getBody(), containsString("1"));
+
+            final HttpResponse catIndices = client.get("_cat/indices");
+            assertThat("Expected cat indices: " + catIndices.getBody(), catIndices.getBody(), containsString("hi1"));
+            assertThat("Unexpected cat indices: " + catIndices.getBody(), catIndices.getBody(), not(containsString("hi2")));
+
+            final HttpResponse stats = client.get("hi*/_stats?filter_path=indices.*.uuid");
+            assertThat("Expected stats indices: " + stats.getBody(), stats.getBody(), containsString("hi1"));
+            assertThat("Unexpected stats indices: " + stats.getBody(), stats.getBody(), not(containsString("hi2")));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
@@ -381,7 +381,7 @@ public class PointInTimeOperationTest {
     @Test
     public void listAllPitSegments_positive() {
         try (TestRestClient restClient = cluster.getRestClient(POINT_IN_TIME_USER)) {
-            HttpResponse response = restClient.get("/_cat/pit_segments/_all");
+            HttpResponse response = restClient.get("_cat/pit_segments/_all");
 
             response.assertStatusCode(OK.getStatus());
         }
@@ -390,7 +390,7 @@ public class PointInTimeOperationTest {
     @Test
     public void listAllPitSegments_negative() {
         try (TestRestClient restClient = cluster.getRestClient(LIMITED_POINT_IN_TIME_USER)) {
-            HttpResponse response = restClient.get("/_cat/pit_segments/_all");
+            HttpResponse response = restClient.get("_cat/pit_segments/_all");
 
             response.assertStatusCode(FORBIDDEN.getStatus());
         }

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
@@ -119,7 +119,7 @@ public class SecurityConfigurationTests {
     @Test
     public void shouldAuthenticateAsAdminWithCertificate_positive() {
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
-            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+            HttpResponse httpResponse = client.get("_plugins/_security/whoami");
 
             httpResponse.assertStatusCode(200);
             assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("true"));
@@ -130,7 +130,7 @@ public class SecurityConfigurationTests {
     public void shouldAuthenticateAsAdminWithCertificate_negativeSelfSignedCertificate() {
         TestCertificates testCertificates = cluster.getTestCertificates();
         try (TestRestClient client = cluster.getRestClient(testCertificates.createSelfSignedCertificate("CN=bond"))) {
-            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+            HttpResponse httpResponse = client.get("_plugins/_security/whoami");
 
             httpResponse.assertStatusCode(200);
             assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
@@ -141,7 +141,7 @@ public class SecurityConfigurationTests {
     public void shouldAuthenticateAsAdminWithCertificate_negativeIncorrectDn() {
         TestCertificates testCertificates = cluster.getTestCertificates();
         try (TestRestClient client = cluster.getRestClient(testCertificates.createAdminCertificate("CN=non_admin"))) {
-            HttpResponse httpResponse = client.get("/_plugins/_security/whoami");
+            HttpResponse httpResponse = client.get("_plugins/_security/whoami");
 
             httpResponse.assertStatusCode(200);
             assertThat(httpResponse.getTextFromJsonBody("/is_admin"), equalTo("false"));
@@ -199,7 +199,7 @@ public class SecurityConfigurationTests {
     @Test
     public void shouldAccessIndexWithPlaceholder_positive() {
         try (TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
-            HttpResponse httpResponse = client.get("/" + LIMITED_USER_INDEX + "/_doc/" + ID_1);
+            HttpResponse httpResponse = client.get(LIMITED_USER_INDEX + "/_doc/" + ID_1);
 
             httpResponse.assertStatusCode(200);
         }
@@ -208,7 +208,7 @@ public class SecurityConfigurationTests {
     @Test
     public void shouldAccessIndexWithPlaceholder_negative() {
         try (TestRestClient client = cluster.getRestClient(LIMITED_USER)) {
-            HttpResponse httpResponse = client.get("/" + PROHIBITED_INDEX + "/_doc/" + ID_2);
+            HttpResponse httpResponse = client.get(PROHIBITED_INDEX + "/_doc/" + ID_2);
 
             httpResponse.assertStatusCode(403);
         }

--- a/src/integrationTest/java/org/opensearch/security/SslOnlyTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SslOnlyTests.java
@@ -59,7 +59,7 @@ public class SslOnlyTests {
         try (TestRestClient client = cluster.getRestClient()) {
 
             // request does not contains credential
-            HttpResponse response = client.get("/_cat/indices");
+            HttpResponse response = client.get("_cat/indices");
 
             // successful response is returned because the security plugin in SSL only mode
             // does not perform authentication and authorization

--- a/src/integrationTest/java/org/opensearch/security/http/CommonProxyAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/CommonProxyAuthenticationTests.java
@@ -31,7 +31,7 @@ import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 */
 abstract class CommonProxyAuthenticationTests {
 
-    protected static final String RESOURCE_AUTH_INFO = "/_opendistro/_security/authinfo";
+    protected static final String RESOURCE_AUTH_INFO = "_opendistro/_security/authinfo";
     protected static final TestSecurityConfig.User USER_ADMIN = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
     protected static final String ATTRIBUTE_DEPARTMENT = "department";

--- a/src/integrationTest/java/org/opensearch/security/http/ExtendedProxyAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/ExtendedProxyAuthenticationTest.java
@@ -230,7 +230,7 @@ public class ExtendedProxyAuthenticationTest extends CommonProxyAuthenticationTe
             .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
         try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-            HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_SPOCK + "/_search");
+            HttpResponse response = client.get(PERSONAL_INDEX_NAME_SPOCK + "/_search");
 
             response.assertStatusCode(200);
             assertThat(response.getLongFromJsonBody(POINTER_TOTAL_HITS), equalTo(1L));
@@ -251,7 +251,7 @@ public class ExtendedProxyAuthenticationTest extends CommonProxyAuthenticationTe
             .header(HEADER_DEPARTMENT, DEPARTMENT_BRIDGE);
         try (TestRestClient client = cluster.createGenericClientRestClient(testRestClientConfiguration)) {
 
-            HttpResponse response = client.get("/" + PERSONAL_INDEX_NAME_KIRK + "/_search");
+            HttpResponse response = client.get(PERSONAL_INDEX_NAME_KIRK + "/_search");
 
             response.assertStatusCode(403);
         }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -119,7 +119,7 @@ public class TestRestClient implements AutoCloseable {
     }
 
     public HttpResponse get(String path, Header... headers) {
-        return get(path, Collections.emptyList(), headers);
+        return executeRequest(new HttpGet(getHttpServerUri() + "/" + path), headers);
     }
 
     public HttpResponse getAuthInfo(Header... headers) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -31,8 +31,6 @@ package org.opensearch.test.framework.cluster;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -61,10 +59,8 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.routing.HttpRoutePlanner;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.apache.hc.core5.net.URIBuilder;
 import org.apache.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -107,15 +103,6 @@ public class TestRestClient implements AutoCloseable {
         this.headers.addAll(headers);
         this.sslContext = sslContext;
         this.sourceInetAddress = sourceInetAddress;
-    }
-
-    public HttpResponse get(String path, List<NameValuePair> queryParameters, Header... headers) {
-        try {
-            URI uri = new URIBuilder(getHttpServerUri()).setPath(path).addParameters(queryParameters).build();
-            return executeRequest(new HttpGet(uri), headers);
-        } catch (URISyntaxException ex) {
-            throw new RuntimeException("Incorrect URI syntax", ex);
-        }
     }
 
     public HttpResponse get(String path, Header... headers) {


### PR DESCRIPTION
### Description
There was some question of what permissions around DNFOF applied to scenarios with the stats API, adding in test cases that confirm these APIs are behaving as expected.

### Issues Resolved

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
