### PR TITLE
Renames initialAdminPassword to OPENSEARCH_INITIAL_ADMIN_PASSWORD to be compliant with opensearch naming convention

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -71,9 +71,9 @@ runs:
         'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
       shell: pwsh
 
-    - name: Write password to initialAdminPassword location
+    - name: Write password to opensearch_initial_admin_password txt
       run:
-        echo ${{ inputs.admin-password }} >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/initialAdminPassword.txt
+        echo ${{ inputs.admin-password }} >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
       shell: bash
 
     # Run any configuration scripts

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -334,6 +334,10 @@ public class ConfigConstants {
     public static final boolean EXTENSIONS_BWC_PLUGIN_MODE_DEFAULT = false;
     // CS-ENFORCE-SINGLE
 
+    // Variables for initial admin password support
+    public static final String OPENSEARCH_INITIAL_ADMIN_PASSWORD = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
+    public static final String OPENSEARCH_INITIAL_ADMIN_PASSWORD_TXT = "opensearch_initial_admin_password.txt";
+
     public static Set<String> getSettingAsSet(
         final Settings settings,
         final String key,

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -94,8 +94,8 @@ public class SecuritySettingsConfigurer {
      * Replaces the admin password in internal_users.yml with the custom or generated password
      */
     void updateAdminPassword() {
-        String initialAdminPassword = System.getenv().get("initialAdminPassword");
-        String ADMIN_PASSWORD_FILE_PATH = installer.OPENSEARCH_CONF_DIR + "initialAdminPassword.txt";
+        String initialAdminPassword = System.getenv().get("OPENSEARCH_INITIAL_ADMIN_PASSWORD");
+        String ADMIN_PASSWORD_FILE_PATH = installer.OPENSEARCH_CONF_DIR + "opensearch_initial_admin_password.txt";
         String INTERNAL_USERS_FILE_PATH = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         boolean shouldValidatePassword = installer.environment.equals(ExecutionEnvironment.DEMO);
         try {
@@ -115,7 +115,7 @@ public class SecuritySettingsConfigurer {
                     try (BufferedReader br = new BufferedReader(new FileReader(ADMIN_PASSWORD_FILE_PATH, StandardCharsets.UTF_8))) {
                         ADMIN_PASSWORD = br.readLine();
                     } catch (IOException e) {
-                        System.out.println("Error reading admin password from initialAdminPassword.txt.");
+                        System.out.println("Error reading admin password from opensearch_initial_admin_password.txt.");
                         System.exit(-1);
                     }
                 }

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -31,6 +31,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
+import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.tools.Hasher;
 
 import org.yaml.snakeyaml.DumperOptions;
@@ -94,8 +95,8 @@ public class SecuritySettingsConfigurer {
      * Replaces the admin password in internal_users.yml with the custom or generated password
      */
     void updateAdminPassword() {
-        String initialAdminPassword = System.getenv().get("OPENSEARCH_INITIAL_ADMIN_PASSWORD");
-        String ADMIN_PASSWORD_FILE_PATH = installer.OPENSEARCH_CONF_DIR + "opensearch_initial_admin_password.txt";
+        String initialAdminPassword = System.getenv().get(ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD);
+        String ADMIN_PASSWORD_FILE_PATH = installer.OPENSEARCH_CONF_DIR + ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD_TXT;
         String INTERNAL_USERS_FILE_PATH = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         boolean shouldValidatePassword = installer.environment.equals(ExecutionEnvironment.DEMO);
         try {
@@ -115,7 +116,9 @@ public class SecuritySettingsConfigurer {
                     try (BufferedReader br = new BufferedReader(new FileReader(ADMIN_PASSWORD_FILE_PATH, StandardCharsets.UTF_8))) {
                         ADMIN_PASSWORD = br.readLine();
                     } catch (IOException e) {
-                        System.out.println("Error reading admin password from opensearch_initial_admin_password.txt.");
+                        System.out.println(
+                            "Error reading admin password from " + ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD_TXT + "."
+                        );
                         System.exit(-1);
                     }
                 }

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.tools.democonfig.util.NoExitSecurityManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,7 +56,7 @@ public class SecuritySettingsConfigurerTests {
     private final PrintStream originalErr = System.err;
     private final InputStream originalIn = System.in;
 
-    private final String adminPasswordKey = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
+    private final String adminPasswordKey = ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD;
 
     private static SecuritySettingsConfigurer securitySettingsConfigurer;
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -55,7 +55,7 @@ public class SecuritySettingsConfigurerTests {
     private final PrintStream originalErr = System.err;
     private final InputStream originalIn = System.in;
 
-    private final String adminPasswordKey = "initialAdminPassword";
+    private final String adminPasswordKey = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
 
     private static SecuritySettingsConfigurer securitySettingsConfigurer;
 


### PR DESCRIPTION
### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/3842



### Testing

- automated tests

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
