### PR TITLE
[Backport 1.3] Bump Logback Classic to 1.2.13 (resolves CVE-2023-6481)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ configurations.all {
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
         force "org.apache.zookeeper:zookeeper:3.9.1"
+        force "ch.qos.logback:logback-classic:1.2.13"
     }
 }
 


### PR DESCRIPTION
### Description
Resolve logback classic to 1.2.13 for https://github.com/advisories/GHSA-gm62-rw4g-vrc4

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
