### PR TITLE
Removes support for txt file for specifying initial admin password and prevents password from being printed in the logs

### DIFF
--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -85,7 +85,7 @@ runs:
       if: ${{ runner.os == 'Windows' && inputs.setup-script-name != '' }}
       run: |
         echo "running windows setup"
-        $env:OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
+        $env:OPENSEARCH_INITIAL_ADMIN_PASSWORD="${{ inputs.admin-password }}"
         .\${{ inputs.setup-script-name }}.bat
       shell: pwsh
 

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -71,9 +71,9 @@ runs:
         'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
       shell: pwsh
 
-    - name: Write password to opensearch_initial_admin_password txt
+    - name: Export password to OPENSEARCH_INITIAL_ADMIN_PASSWORD variable
       run:
-        echo ${{ inputs.admin-password }} >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
+        export OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
       shell: bash
 
     # Run any configuration scripts

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -71,23 +71,22 @@ runs:
         'y' | .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT\bin\opensearch-plugin.bat install file:$(pwd)\${{ inputs.plugin-name }}.zip
       shell: pwsh
 
-    - name: Export password to OPENSEARCH_INITIAL_ADMIN_PASSWORD variable
-      run:
-        export OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
-      shell: bash
-
     # Run any configuration scripts
     - name: Run Setup Script for Linux
       if: ${{ runner.os == 'Linux' && inputs.setup-script-name != '' }}
       run: |
         echo "running linux setup"
+        export OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
         chmod +x ./${{ inputs.setup-script-name }}.sh
         ./${{ inputs.setup-script-name }}.sh
       shell: bash
 
     - name: Run Setup Script for Windows
       if: ${{ runner.os == 'Windows' && inputs.setup-script-name != '' }}
-      run: .\${{ inputs.setup-script-name }}.bat
+      run: |
+        echo "running windows setup"
+        set OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
+        .\${{ inputs.setup-script-name }}.bat
       shell: pwsh
 
     # Run OpenSearch

--- a/.github/actions/start-opensearch-with-one-plugin/action.yml
+++ b/.github/actions/start-opensearch-with-one-plugin/action.yml
@@ -85,7 +85,7 @@ runs:
       if: ${{ runner.os == 'Windows' && inputs.setup-script-name != '' }}
       run: |
         echo "running windows setup"
-        set OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
+        $env:OPENSEARCH_INITIAL_ADMIN_PASSWORD=${{ inputs.admin-password }}
         .\${{ inputs.setup-script-name }}.bat
       shell: pwsh
 

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -334,9 +334,8 @@ public class ConfigConstants {
     public static final boolean EXTENSIONS_BWC_PLUGIN_MODE_DEFAULT = false;
     // CS-ENFORCE-SINGLE
 
-    // Variables for initial admin password support
+    // Variable for initial admin password support
     public static final String OPENSEARCH_INITIAL_ADMIN_PASSWORD = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
-    public static final String OPENSEARCH_INITIAL_ADMIN_PASSWORD_TXT = "opensearch_initial_admin_password.txt";
 
     public static Set<String> getSettingAsSet(
         final Settings settings,

--- a/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
@@ -428,9 +428,7 @@ public class Installer {
             }
 
             System.out.println(
-                "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/"
-                    + SecuritySettingsConfigurer.ADMIN_PASSWORD
-                    + "."
+                "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/<your-custom-admin-password>."
             );
             System.out.println("### (Ignore the SSL certificate warning because we installed self-signed demo certificates)");
 

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -132,7 +132,7 @@ public class SecuritySettingsConfigurer {
 
             // Read custom password from environment variable
             String initialAdminPassword = System.getenv().get(ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD);
-            if (initialAdminPassword != null && !initialAdminPassword.isEmpty()) {
+            if (!Strings.isNullOrEmpty(initialAdminPassword)) {
                 ADMIN_PASSWORD = initialAdminPassword;
             }
 

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -28,13 +28,13 @@ import java.util.Map;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.Strings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.tools.Hasher;
 
-import joptsimple.internal.Strings;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
@@ -394,9 +394,7 @@ public class InstallerTests {
             + System.lineSeparator()
             + "### After that you can also use the Security Plugin ConfigurationGUI"
             + System.lineSeparator()
-            + "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/"
-            + SecuritySettingsConfigurer.ADMIN_PASSWORD
-            + "."
+            + "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/<your-custom-admin-password>."
             + System.lineSeparator()
             + "### (Ignore the SSL certificate warning because we installed self-signed demo certificates)"
             + System.lineSeparator();
@@ -454,9 +452,7 @@ public class InstallerTests {
             + System.lineSeparator()
             + "### To use the Security Plugin ConfigurationGUI"
             + System.lineSeparator()
-            + "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/"
-            + SecuritySettingsConfigurer.ADMIN_PASSWORD
-            + "."
+            + "### To access your secured cluster open https://<hostname>:<HTTP port> and log in with admin/<your-custom-admin-password>."
             + System.lineSeparator()
             + "### (Ignore the SSL certificate warning because we installed self-signed demo certificates)"
             + System.lineSeparator();

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -88,6 +88,8 @@ public class SecuritySettingsConfigurerTests {
         securitySettingsConfigurer.updateAdminPassword();
 
         assertThat(customPassword, is(equalTo(SecuritySettingsConfigurer.ADMIN_PASSWORD)));
+
+        verifyStdOutContainsString("Admin password set successfully.");
     }
 
     @Test
@@ -128,6 +130,8 @@ public class SecuritySettingsConfigurerTests {
         securitySettingsConfigurer.updateAdminPassword();
 
         assertThat("weakpassword", is(equalTo(SecuritySettingsConfigurer.ADMIN_PASSWORD)));
+
+        verifyStdOutContainsString("Admin password set successfully.");
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -13,11 +13,9 @@ package org.opensearch.security.tools.democonfig;
 
 // CS-SUPPRESS-SINGLE: RegexpSingleline extension key-word is used in file ext variable
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -45,7 +43,6 @@ import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigure
 import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil.createDirectory;
 import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil.createFile;
 import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil.deleteDirectoryRecursive;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
@@ -79,42 +76,23 @@ public class SecuritySettingsConfigurerTests {
         System.setErr(originalErr);
         System.setIn(originalIn);
         deleteDirectoryRecursive(installer.OPENSEARCH_CONF_DIR);
-        unsetEnv(adminPasswordKey);
+        unsetEnvVariables();
         Installer.resetInstance();
     }
 
     @Test
     public void testUpdateAdminPasswordWithCustomPassword() throws NoSuchFieldException, IllegalAccessException {
-        String customPassword = "myStrongPassword123"; // generateStrongPassword();
+        String customPassword = "myStrongPassword123";
         setEnv(adminPasswordKey, customPassword);
 
         securitySettingsConfigurer.updateAdminPassword();
 
         assertThat(customPassword, is(equalTo(SecuritySettingsConfigurer.ADMIN_PASSWORD)));
-
-        verifyStdOutContainsString("ADMIN PASSWORD SET TO: " + customPassword);
-    }
-
-    @Test
-    public void testUpdateAdminPasswordWithFilePassword() throws IOException {
-        String customPassword = "myStrongPassword123";
-        String initialAdminPasswordTxt = installer.OPENSEARCH_CONF_DIR + adminPasswordKey + ".txt";
-        createFile(initialAdminPasswordTxt);
-
-        try (BufferedWriter writer = new BufferedWriter(new FileWriter(initialAdminPasswordTxt, StandardCharsets.UTF_8))) {
-            writer.write(customPassword);
-        } catch (IOException e) {
-            throw new IOException("Unable to update the internal users file with the hashed password.");
-        }
-
-        securitySettingsConfigurer.updateAdminPassword();
-
-        assertEquals(customPassword, SecuritySettingsConfigurer.ADMIN_PASSWORD);
-        verifyStdOutContainsString("ADMIN PASSWORD SET TO: " + customPassword);
     }
 
     @Test
     public void testUpdateAdminPassword_noPasswordSupplied() {
+        SecuritySettingsConfigurer.ADMIN_PASSWORD = ""; // to ensure 0 flaky-ness
         try {
             System.setSecurityManager(new NoExitSecurityManager());
             securitySettingsConfigurer.updateAdminPassword();
@@ -150,7 +128,6 @@ public class SecuritySettingsConfigurerTests {
         securitySettingsConfigurer.updateAdminPassword();
 
         assertThat("weakpassword", is(equalTo(SecuritySettingsConfigurer.ADMIN_PASSWORD)));
-        verifyStdOutContainsString("ADMIN PASSWORD SET TO: weakpassword");
     }
 
     @Test
@@ -298,7 +275,7 @@ public class SecuritySettingsConfigurerTests {
     }
 
     @SuppressWarnings("unchecked")
-    public static void unsetEnv(String key) throws NoSuchFieldException, IllegalAccessException {
+    public static void unsetEnvVariables() throws NoSuchFieldException, IllegalAccessException {
         Class<?>[] classes = Collections.class.getDeclaredClasses();
         Map<String, String> env = System.getenv();
         for (Class<?> cl : classes) {
@@ -307,7 +284,7 @@ public class SecuritySettingsConfigurerTests {
                 field.setAccessible(true);
                 Object obj = field.get(env);
                 Map<String, String> map = (Map<String, String>) obj;
-                map.remove(key);
+                map.clear();
             }
         }
     }

--- a/src/test/java/org/opensearch/security/tools/democonfig/util/NoExitSecurityManager.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/util/NoExitSecurityManager.java
@@ -11,10 +11,13 @@
 
 package org.opensearch.security.tools.democonfig.util;
 
+/**
+ * Helper class to allow capturing and testing exit codes and block test execution from exiting mid-way
+ */
 public class NoExitSecurityManager extends SecurityManager {
     @Override
     public void checkPermission(java.security.Permission perm) {
-        // Allow everything except System.exit code 0 &b -1
+        // Allow everything except System.exit code 0 & -1
         if (perm instanceof java.lang.RuntimePermission && ("exitVM.0".equals(perm.getName()) || "exitVM.-1".equals(perm.getName()))) {
             StringBuilder sb = new StringBuilder();
             sb.append("System.exit(");


### PR DESCRIPTION
### Description
Storing an admin password in a text file that can be available to anyone that has access to config folder at any time could be potentially vulnerable. Although, originally added with the perception to support autonomous process to easily read from the config folder, we now only allow passing the admin password through environment variable as it is session-scoped. Further, we don't print the password to the logs to avoid any traces.

- Related to https://github.com/opensearch-project/security/issues/3847

### Testing
- automated tests

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
