### PR TITLE
Add flow framework system indices and roles

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -373,3 +373,26 @@ security_analytics_ack_alerts:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opensearch/securityanalytics/alerts/*'
+
+# Allows users to use all Flow Framework functionality
+flow_framework_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/flow_framework/*'
+    - 'cluster_monitor'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mappings/get'
+        - 'indices_monitor'
+
+# Allow users to read flow framework's workflows and their state
+flow_framework_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/flow_framework/workflow/get'
+    - 'cluster:admin/opensearch/flow_framework/workflow/search'
+    - 'cluster:admin/opensearch/flow_framework/workflow_state/get'
+    - 'cluster:admin/opensearch/flow_framework/workflow_state/search'

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -68,7 +68,10 @@ public class SecuritySettingsConfigurer {
         ".opendistro-asynchronous-search-response*",
         ".replication-metadata-store",
         ".opensearch-knn-models",
-        ".geospatial-ip2geo-data*"
+        ".geospatial-ip2geo-data*",
+        ".plugins-flow-framework-config",
+        ".plugins-flow-framework-templates",
+        ".plugins-flow-framework-state"
     );
     static String ADMIN_PASSWORD = "";
     static String ADMIN_USERNAME = "admin";


### PR DESCRIPTION
### Description
Adds 2 flow-framework related roles to the plugin: read only and fully access.
Adds flow-framework system indices to demo scripts as well.

### Issues Resolved

### Testing
manual testing of roles

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
