### PR TITLE
[Backport] [2.x] Bump github/codeql-action from 2 to 3 (#3859)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,11 +187,11 @@ jobs:
       with:
         distribution: temurin # Temurin is a distribution of adoptium
         java-version: 11
-    - uses: github/codeql-action/init@v2
+    - uses: github/codeql-action/init@v3
       with:
         languages: java
     - run: ./gradlew clean assemble -Dbuild.snapshot=false
-    - uses: github/codeql-action/analyze@v2
+    - uses: github/codeql-action/analyze@v3
 
   build-artifact-names:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/3859 to `2.x`