### PR TITLE
Re-enable disabled PIT integration tests

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
@@ -20,7 +20,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.CreatePitRequest;
@@ -33,7 +32,6 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.common.unit.TimeValue;
-import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.builder.PointInTimeBuilder;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
@@ -136,17 +134,7 @@ public class PointInTimeOperationTest {
     @Before
     public void cleanUpPits() throws IOException {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            GetAllPitNodesResponse existingPitsResponse = restHighLevelClient.getAllPits(DEFAULT);
-            if (!existingPitsResponse.getPitInfos().isEmpty()) {
-                try {
-                    restHighLevelClient.deleteAllPits(DEFAULT);
-                } catch (OpenSearchStatusException ex) {
-                    if (ex.status() != RestStatus.NOT_FOUND) {
-                        throw ex;
-                    }
-                    // tried to remove pits but no pit exists
-                }
-            }
+            restHighLevelClient.deleteAllPits(DEFAULT);
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
@@ -17,7 +17,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 


### PR DESCRIPTION
### Description

Re-enables 2 PIT integration tests that were previously disabled. This adds a @Before method to clean up all PITs created from previous test cases to ensure each test case runs pristinely.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Issues Resolved

- https://github.com/opensearch-project/security/issues/3424

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
