### PR TITLE
Improve messaging on how to set initial admin password

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -149,7 +149,9 @@ public class SecuritySettingsConfigurer {
 
             // if ADMIN_PASSWORD is still an empty string, it implies no custom password was provided. We exit the setup.
             if (Strings.isNullOrEmpty(ADMIN_PASSWORD)) {
-                System.out.println("No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.");
+                System.out.println(
+                    "No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD."
+                );
                 System.exit(-1);
             }
 

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -150,7 +150,10 @@ public class SecuritySettingsConfigurer {
             // if ADMIN_PASSWORD is still an empty string, it implies no custom password was provided. We exit the setup.
             if (Strings.isNullOrEmpty(ADMIN_PASSWORD)) {
                 System.out.println(
-                    "No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD."
+                    String.format(
+                        "No custom admin password found. Please provide a password via the environment variable %s.",
+                        ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD
+                    )
                 );
                 System.exit(-1);
             }

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -149,7 +149,7 @@ public class SecuritySettingsConfigurer {
 
             // if ADMIN_PASSWORD is still an empty string, it implies no custom password was provided. We exit the setup.
             if (Strings.isNullOrEmpty(ADMIN_PASSWORD)) {
-                System.out.println("No custom admin password found. Please provide a password.");
+                System.out.println("No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.");
                 System.exit(-1);
             }
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -104,7 +104,9 @@ public class SecuritySettingsConfigurerTests {
             System.setSecurityManager(null);
         }
 
-        verifyStdOutContainsString("No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.");
+        verifyStdOutContainsString(
+            "No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD."
+        );
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -104,7 +104,7 @@ public class SecuritySettingsConfigurerTests {
             System.setSecurityManager(null);
         }
 
-        verifyStdOutContainsString("No custom admin password found. Please provide a password.");
+        verifyStdOutContainsString("No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD.");
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -105,7 +105,10 @@ public class SecuritySettingsConfigurerTests {
         }
 
         verifyStdOutContainsString(
-            "No custom admin password found. Please provide a password via the environment variable OPENSEARCH_INITIAL_ADMIN_PASSWORD."
+            String.format(
+                "No custom admin password found. Please provide a password via the environment variable %s.",
+                ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD
+            )
         );
     }
 


### PR DESCRIPTION
### Description
When the demo configuration script fails when no initial admin password is set, it does not provide helpful output telling the user how to set the initial admin password. This PR provides some helpful output indicating what variable the user should modify in order for the setup to succeed.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
Changed test asserting output 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
