### PR TITLE
Add deprecation check for `jwt_header` setting

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.Strings;
@@ -48,6 +49,7 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 
 public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator {
     private final static Logger log = LogManager.getLogger(AbstractHTTPJwtAuthenticator.class);
+    private final static DeprecationLogger deprecationLog = DeprecationLogger.getLogger(AbstractHTTPJwtAuthenticator.class);
 
     private static final String BEARER = "bearer ";
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
@@ -74,6 +76,10 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
         requiredAudience = settings.get("required_audience");
         requiredIssuer = settings.get("required_issuer");
+
+        if (!jwtHeaderName.equals(AUTHORIZATION)) {
+            deprecationLog.deprecate("jwt_header", "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details.");
+        }
 
         try {
             this.keyProvider = this.initKeyProvider(settings, configPath);

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -78,7 +78,10 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         requiredIssuer = settings.get("required_issuer");
 
         if (!jwtHeaderName.equals(AUTHORIZATION)) {
-            deprecationLog.deprecate("jwt_header", "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details.");
+            deprecationLog.deprecate(
+                "jwt_header",
+                "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details."
+            );
         }
 
         try {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -26,11 +26,13 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
+import org.opensearch.security.setting.DeprecatedSettings;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.KeyUtils;
 
@@ -44,6 +46,8 @@ import static org.apache.http.HttpHeaders.AUTHORIZATION;
 public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
+    protected final DeprecationLogger deprecationLog = DeprecationLogger.getLogger(this.getClass());
+
 
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";
@@ -68,6 +72,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         subjectKey = settings.get("subject_key");
         requireAudience = settings.get("required_audience");
         requireIssuer = settings.get("required_issuer");
+
+        if (!jwtHeaderName.equals(AUTHORIZATION)) {
+            deprecationLog.deprecate("jwt_header", "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details.");
+        }
 
         final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);
         if (jwtParserBuilder == null) {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -32,7 +32,6 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
-import org.opensearch.security.setting.DeprecatedSettings;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.KeyUtils;
 
@@ -47,7 +46,6 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final DeprecationLogger deprecationLog = DeprecationLogger.getLogger(this.getClass());
-
 
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";
@@ -74,7 +72,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         requireIssuer = settings.get("required_issuer");
 
         if (!jwtHeaderName.equals(AUTHORIZATION)) {
-            deprecationLog.deprecate("jwt_header", "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details.");
+            deprecationLog.deprecate(
+                "jwt_header",
+                "The 'jwt_header' setting will be removed in the next major version of OpenSearch.  Consult https://github.com/opensearch-project/security/issues/3886 for more details."
+            );
         }
 
         final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);


### PR DESCRIPTION
### Description
Add deprecation check for `jwt_header` setting

### Issues Resolved
- Related https://github.com/opensearch-project/security/issues/3886

### Check List
- [ ] ~New functionality includes testing~
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
