### PR TITLE
Fix the CI / report-coverage check by switching to corresponding actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         arguments: |
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
-    - uses: alehechka/upload-tartifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-${{ matrix.gradle_task }}-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,7 @@ jobs:
           ./build/reports/
 
   report-coverage:
-    needs:
-      - "test"
-      - "integration-tests"
+    needs: ["test", "integration-tests"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,17 +80,6 @@ jobs:
         run: ls -R
         working-directory: downloaded-artifacts
 
-      - name: Extract downloaded artifacts
-        run: |
-          for archive in ./*/artifact.tar; do
-            (cd "$(dirname "$archive")" && tar -xvf artifact.tar)
-          done
-        working-directory: downloaded-artifacts
-
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: downloaded-artifacts
-
       - name: Upload Coverage with retry
         uses: Wandalen/wretry.action@v1.3.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: downloaded-artifacts
 


### PR DESCRIPTION
### Description

This PR fixes the CI / report-coverage check by using the corresponding upload artifact package. I verified this change by creating a PR on my local fork and checked that the artifacts are uploaded to the CI summary after the build is complete.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

- https://github.com/opensearch-project/security/issues/3878

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
