### PR TITLE
[Backport 2.x] Fix the CI / report-coverage check by switching to corresponding actions/upload-artifact@v4 (#3893)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
+        name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-${{ matrix.gradle_task }}-reports
         path: |
           ./build/reports/
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,27 +60,36 @@ jobs:
         arguments: |
           ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
-    - name: Coverage
-      uses: Wandalen/wretry.action@v1.3.0
-      with:
-        attempt_limit: 3
-        attempt_delay: 2000
-        action: codecov/codecov-action@v3
-        with: |
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          files: ./build/reports/jacoco/test/jacocoTestReport.xml
-
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports
         path: |
           ./build/reports/
 
-    - name: check archive for debugging
-      if: always()
-      run: echo "Check the artifact ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports for detailed test results"
+  report-coverage:
+    needs: ["test", "integration-tests"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: downloaded-artifacts
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: downloaded-artifacts
+
+      - name: Upload Coverage with retry
+        uses: Wandalen/wretry.action@v1.3.0
+        with:
+          attempt_limit: 5
+          attempt_delay: 2000
+          action: codecov/codecov-action@v3
+          with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
+            fail_ci_if_error: true
+            verbose: true
 
   integration-tests:
     name: integration-tests


### PR DESCRIPTION
Backport #3893 to 2.x