### PR TITLE
[Backport 2.x] Bump com.google.errorprone:error_prone_annotations from 2.23.0 to 2.24.0 (#3897)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -507,7 +507,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
             force 'org.checkerframework:checker-qual:3.40.0'
-            force "com.google.errorprone:error_prone_annotations:2.23.0"
+            force "com.google.errorprone:error_prone_annotations:2.24.0"
             force "org.checkerframework:checker-qual:3.42.0"
             force "ch.qos.logback:logback-classic:1.2.13"
         }
@@ -602,7 +602,7 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.16.0'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.6'
-    compileOnly 'com.google.errorprone:error_prone_annotations:2.23.0'
+    compileOnly 'com.google.errorprone:error_prone_annotations:2.24.0'
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.1'
     runtimeOnly 'org.ow2.asm:asm:9.6'


### PR DESCRIPTION
Backport of #3897 to 2.x