### PR TITLE
[BUG-2556] Add new DLS filtering test

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -10,6 +10,7 @@
 package org.opensearch.security;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -205,7 +206,10 @@ public class DlsIntegrationTests {
             READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING,
             READ_WHERE_STARS_LESS_THAN_THREE,
             READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE,
-            READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
+            READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST,
+            TEST_ROLE_ONE_USER,
+            TEST_ROLE_TWO_USER,
+            TEST_ROLE_USER
         )
         .build();
 
@@ -248,6 +252,21 @@ public class DlsIntegrationTests {
             put(SECOND_INDEX_ID_SONG_2, SONGS[2]); // (ARTIST_TWINS, TITLE_NEXT_SONG, LYRICS_3, 3, GENRE_JAZZ),
             put(SECOND_INDEX_ID_SONG_3, SONGS[1]); // (ARTIST_STRING, TITLE_SONG_1_PLUS_1, LYRICS_2, 2, GENRE_BLUES),
             put(SECOND_INDEX_ID_SONG_4, SONGS[0]); // (ARTIST_FIRST, TITLE_MAGNUM_OPUS ,LYRICS_1, 1, GENRE_ROCK)
+        }
+    };
+
+    static final TreeMap<String, Map<String, Serializable>> UNION_ROLE_TEST_DATA = new TreeMap<>() {
+        {
+            put("1", Map.of("genre", "History", "date", "01-01-2020", "sensitive", true));
+            put("2", Map.of("genre", "History", "date", "01-01-2020", "sensitive", true));
+            put("3", Map.of("genre", "History", "date", "01-01-2020", "sensitive", true));
+            put("4", Map.of("genre", "History", "date", "01-01-2020", "sensitive", true));
+            put("5", Map.of("genre", "History", "date", "01-01-2020", "sensitive", true));
+            put("6", Map.of("genre", "Math", "date", "01-01-2020", "sensitive", false));
+            put("7", Map.of("genre", "Math", "date", "01-01-2020", "sensitive", false));
+            put("8", Map.of("genre", "Math", "date", "01-01-2020", "sensitive", false));
+            put("9", Map.of("genre", "Math", "date", "01-01-2020", "sensitive", false));
+            put("10", Map.of("genre", "Math", "date", "01-01-2020", "sensitive", false));
         }
     };
 
@@ -308,6 +327,10 @@ public class DlsIntegrationTests {
                     )
                 )
                 .actionGet();
+            
+            UNION_ROLE_TEST_DATA.forEach((index, document) -> {
+                client.prepareIndex(UNION_TEST_INDEX_NAME).setId(index).setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            });
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -188,7 +188,9 @@ public class DlsIntegrationTests {
     /**
      * User with DLS permission to only be able to access documents with false sensitive property.
      */
-    static final TestSecurityConfig.User USER_NON_SENSITIVE_ONLY = new TestSecurityConfig.User("test_role_1_user").roles(ROLE_NON_SENSITIVE_ONLY);
+    static final TestSecurityConfig.User USER_NON_SENSITIVE_ONLY = new TestSecurityConfig.User("test_role_1_user").roles(
+        ROLE_NON_SENSITIVE_ONLY
+    );
 
     /**
      * User with DLS permission to access all documents.
@@ -198,7 +200,9 @@ public class DlsIntegrationTests {
     /**
      * User with DLS permission to access documents with genre property matching History.
      */
-    static final TestSecurityConfig.User USER_MATCH_HISTORY_GENRE_ONLY = new TestSecurityConfig.User("test_role_3_user").roles(ROLE_MATCH_HISTORY_GENRE_ONLY);
+    static final TestSecurityConfig.User USER_MATCH_HISTORY_GENRE_ONLY = new TestSecurityConfig.User("test_role_3_user").roles(
+        ROLE_MATCH_HISTORY_GENRE_ONLY
+    );
 
     /**
      * User with overlapping DLS permissions to access documents with false sensitive property and access all documents- should yield accessing all documents.
@@ -210,9 +214,11 @@ public class DlsIntegrationTests {
     /**
      * User with non-overlapping DLS permissions to access documents with false sensitive property and genre property matching History.
      */
-    static final TestSecurityConfig.User USER_UNION_OF_NONOVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_HISTORY_GENRE_ONLY = new TestSecurityConfig.User(
-        "test_union_of_non_overlapping_roles_user"
-    ).roles(ROLE_NON_SENSITIVE_ONLY, ROLE_MATCH_HISTORY_GENRE_ONLY);
+    static final TestSecurityConfig.User USER_UNION_OF_NONOVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_HISTORY_GENRE_ONLY =
+        new TestSecurityConfig.User("test_union_of_non_overlapping_roles_user").roles(
+            ROLE_NON_SENSITIVE_ONLY,
+            ROLE_MATCH_HISTORY_GENRE_ONLY
+        );
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
@@ -625,7 +631,11 @@ public class DlsIntegrationTests {
             assertSearchResponseHitsEqualTo(searchResponse, 10);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_UNION_OF_OVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_ALLOW_ALL)) {
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_UNION_OF_OVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_ALLOW_ALL
+            )
+        ) {
             SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
             SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
@@ -680,7 +690,11 @@ public class DlsIntegrationTests {
             );
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_UNION_OF_NONOVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_HISTORY_GENRE_ONLY)) {
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_UNION_OF_NONOVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_HISTORY_GENRE_ONLY
+            )
+        ) {
             SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
             SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
 
@@ -705,5 +719,5 @@ public class DlsIntegrationTests {
     private void assertSearchResponseHitsEqualTo(SearchResponse searchResponse, int hits) throws Exception {
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(hits));
-}
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.BiFunction;
+import java.util.stream.IntStream;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.junit.BeforeClass;
@@ -27,6 +28,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.client.Client;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHits;
 import org.opensearch.search.aggregations.Aggregation;
 import org.opensearch.search.aggregations.metrics.ParsedAvg;
 import org.opensearch.test.framework.TestSecurityConfig;
@@ -34,6 +36,7 @@ import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
@@ -82,6 +85,7 @@ public class DlsIntegrationTests {
     static final String FIRST_INDEX_ALIAS_FILTERED_BY_TWINS_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-twins-artist");
     static final String FIRST_INDEX_ALIAS_FILTERED_BY_FIRST_ARTIST = FIRST_INDEX_NAME.concat("-filtered-by-first-artist");
     static final String ALL_INDICES_ALIAS = "_all";
+    static final String UNION_TEST_INDEX_NAME = "my_index1";
 
     static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 


### PR DESCRIPTION
### Description
This PR adds a new DLS filtering test that checks for the union of different dls settings related to different roles attached to the same user.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
These tests were previously not included, which makes testing bugs including the one in #2556 difficult. Adding this test makes it easy to recreate these bugs if they appear in the future. Additionally the data in these test cases matches the examples provided in the bug case so these tests were also used to determine if the bug in the ticket is actually happening. Since these two tests pass, I personally don't think this bug is reproducible.

* What is the old behavior before changes and new behavior after changes?
A new test should increase code coverage.

### Issues Resolved
#2556 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Added new test

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
