### PR TITLE
[Enhancement-3139] Make FLS, DLS and Field Masking Unit Tests more extensive by testing more document retrieval APIs

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -554,7 +554,7 @@ public class DlsIntegrationTests {
     }
 
     @Test
-    public void testGetDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
+    public void testGetDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
         GetRequest findExistingDoc = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
         GetRequest findNonExistingDoc = new GetRequest(FIRST_INDEX_NAME, "RANDOM_INDEX");
 
@@ -578,7 +578,7 @@ public class DlsIntegrationTests {
     }
 
     @Test
-    public void testMultiGetDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
+    public void testMultiGetDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
@@ -605,7 +605,7 @@ public class DlsIntegrationTests {
     }
 
     @Test
-    public void testSearchDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
+    public void testSearchDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
         SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_ARTIST_BOOL_QUERY)) {

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -19,7 +19,6 @@ import java.util.stream.Collectors;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.cxf.common.i18n.Exception;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -175,7 +174,7 @@ public class DlsIntegrationTests {
     /**
      * User with a role with DLS restrictions containing a bool query.
      */
-    static final TestSecurityConfig.User BOOL_USER = new TestSecurityConfig.User("bool_user").roles(
+    static final TestSecurityConfig.User USER_WITH_BOOL_DLS_RESTRICTIONS = new TestSecurityConfig.User("bool_user").roles(
         new TestSecurityConfig.Role("test_role_bool").clusterPermissions("cluster_composite_ops_ro")
             .indexPermissions("read")
             .dls(String.format("{\"match\":{\"%s\":\"%s\"}}", FIELD_ARTIST, ARTIST_FIRST))

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -197,8 +197,9 @@ public class DlsIntegrationTests {
      * User with two roles: a role with DLS restrictions containing a bool query in which the artist field needs to match ARTIST_FIRST, and a role with DLS restrictions containing a term query in which the stars field needs to match 1.
      */
 
-    static final TestSecurityConfig.User USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY = new TestSecurityConfig.User("bool_term_user")
-        .roles(ROLE_MATCH_ARTIST_BOOL_QUERY, ROLE_MATCH_STARS_TERM_QUERY);
+    static final TestSecurityConfig.User USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY = new TestSecurityConfig.User(
+        "bool_term_user"
+    ).roles(ROLE_MATCH_ARTIST_BOOL_QUERY, ROLE_MATCH_STARS_TERM_QUERY);
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)

--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -248,10 +248,8 @@ public class FlsAndFieldMaskingTests {
     /**
      * Example user with fls filter in which the user can only see the {@link Song#FIELD_TITLE} field and can see every field but the {@link Song#FIELD_TITLE} field- should default to showing no fields.
      */
-    static final TestSecurityConfig.User USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS = new TestSecurityConfig.User("inclusive_exclusive_fls_user").roles(
-        ROLE_ONLY_FIELD_TITLE_FLS,
-        ROLE_NO_FIELD_TITLE_FLS
-    );
+    static final TestSecurityConfig.User USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS = new TestSecurityConfig.User("inclusive_exclusive_fls_user")
+        .roles(ROLE_ONLY_FIELD_TITLE_FLS, ROLE_NO_FIELD_TITLE_FLS);
 
     /**
      * Example user with fls filter in which the user can only see the {@link Song#FIELD_TITLE} field and in which {@link Song#FIELD_TITLE} field is masked.
@@ -263,8 +261,9 @@ public class FlsAndFieldMaskingTests {
     /**
      *  Example user with fls filter in which the user can see every field but the {@link Song#FIELD_TITLE} field and in which {@link Song#FIELD_TITLE} field is masked- {@link Song#FIELD_TITLE} field should not be visible.
      */
-    static final TestSecurityConfig.User USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED = new TestSecurityConfig.User("exclusive_masked_user")
-        .roles(ROLE_NO_FIELD_TITLE_FLS, ROLE_ONLY_FIELD_TITLE_MASKED);
+    static final TestSecurityConfig.User USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED = new TestSecurityConfig.User(
+        "exclusive_masked_user"
+    ).roles(ROLE_NO_FIELD_TITLE_FLS, ROLE_ONLY_FIELD_TITLE_MASKED);
 
     /**
      * Example user with fls filter in which the user can only see the {@link Song#FIELD_TITLE} field and can see every field but the {@link Song#FIELD_TITLE} field and in which {@link Song#FIELD_TITLE} field is masked- should default to showing no fields.
@@ -1554,7 +1553,11 @@ public class FlsAndFieldMaskingTests {
     public void testGetDocumentWithTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
         GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
+            )
+        ) {
             assertProperGetResponsesForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, getRequest);
         }
     }
@@ -1580,7 +1583,11 @@ public class FlsAndFieldMaskingTests {
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
+            )
+        ) {
             assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
                 restHighLevelClient,
                 multiGetRequest
@@ -1646,7 +1653,11 @@ public class FlsAndFieldMaskingTests {
     public void testSearchDocumentWithTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
         SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+        try (
+            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
+            )
+        ) {
             assertProperSearchResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
                 restHighLevelClient,
                 searchRequest

--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -849,19 +849,19 @@ public class FlsAndFieldMaskingTests {
     }
 
     @Test
-    public void testGetDocumentWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
+    public void testGetDocumentWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
         GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertProperGetResponsesForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, getRequest, true);
+            assertProperGetResponsesForCorrespondingFLSRestrictions(restHighLevelClient, getRequest, true);
         }
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertProperGetResponsesForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, getRequest, false);
+            assertProperGetResponsesForCorrespondingFLSRestrictions(restHighLevelClient, getRequest, false);
         }
     }
 
-    private void assertProperGetResponsesForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
+    private void assertProperGetResponsesForCorrespondingFLSRestrictions(
         RestHighLevelClient restHighLevelClient,
         GetRequest getRequest,
         boolean getOne
@@ -901,21 +901,21 @@ public class FlsAndFieldMaskingTests {
     }
 
     @Test
-    public void testMultiGetDocumentWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
+    public void testMultiGetDocumentWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
         MultiGetRequest multiGetRequest = new MultiGetRequest();
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertProperMultiGetResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, multiGetRequest, true);
+            assertProperMultiGetResponseForCorrespondingFLSRestrictions(restHighLevelClient, multiGetRequest, true);
         }
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertProperMultiGetResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, multiGetRequest, false);
+            assertProperMultiGetResponseForCorrespondingFLSRestrictions(restHighLevelClient, multiGetRequest, false);
         }
     }
 
-    private void assertProperMultiGetResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
+    private void assertProperMultiGetResponseForCorrespondingFLSRestrictions(
         RestHighLevelClient restHighLevelClient,
         MultiGetRequest multiGetRequest,
         boolean getOne
@@ -984,19 +984,19 @@ public class FlsAndFieldMaskingTests {
     }
 
     @Test
-    public void testSearchDocumentWithWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
+    public void testSearchDocumentWithWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
         SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertProperSearchResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, searchRequest, true);
+            assertProperSearchResponseForCorrespondingFLSRestrictions(restHighLevelClient, searchRequest, true);
         }
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertProperSearchResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, searchRequest, false);
+            assertProperSearchResponseForCorrespondingFLSRestrictions(restHighLevelClient, searchRequest, false);
         }
     }
 
-    private void assertProperSearchResponseForNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
+    private void assertProperSearchResponseForCorrespondingFLSRestrictions(
         RestHighLevelClient restHighLevelClient,
         SearchRequest searchRequest,
         boolean getOne

--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -21,7 +21,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import org.apache.cxf.common.i18n.Exception;
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;


### PR DESCRIPTION
### Description
Add new cases to DlsIntegrationTests.java, and FlsAndFieldMaskingTests.java to account for all permutations of cases.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
Previously these tests weren't comprehensive, therefore leading to uncatched bugs in deployment.


* What is the old behavior before changes and new behavior after changes?
Tests are more comprehensive.

### Issues Resolved
#3139 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Added new test cases.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
