### PR TITLE
Refactor SSL handler retrieval to use HttpChannel / TranportChannel APIs instead of typecasting

### DIFF
--- a/src/main/java/org/opensearch/security/filter/NettyAttribute.java
+++ b/src/main/java/org/opensearch/security/filter/NettyAttribute.java
@@ -12,7 +12,7 @@ package org.opensearch.security.filter;
 
 import java.util.Optional;
 
-import org.opensearch.http.netty4.Netty4HttpChannel;
+import org.opensearch.http.HttpChannel;
 import org.opensearch.rest.RestRequest;
 
 import io.netty.channel.Channel;
@@ -25,11 +25,12 @@ public class NettyAttribute {
      * Gets an attribute value from the request context and clears it from that context
      */
     public static <T> Optional<T> popFrom(final RestRequest request, final AttributeKey<T> attribute) {
-        if (request.getHttpChannel() instanceof Netty4HttpChannel) {
-            Channel nettyChannel = ((Netty4HttpChannel) request.getHttpChannel()).getNettyChannel();
-            return Optional.ofNullable(nettyChannel.attr(attribute).getAndSet(null));
+        final HttpChannel httpChannel = request.getHttpChannel();
+        if (httpChannel != null) {
+            return httpChannel.get("channel", Channel.class).map(channel -> channel.attr(attribute).getAndSet(null));
+        } else {
+            return Optional.empty();
         }
-        return Optional.empty();
     }
 
     /**
@@ -50,9 +51,9 @@ public class NettyAttribute {
      * Clears an attribute value from the channel handler context
      */
     public static <T> void clearAttribute(final RestRequest request, final AttributeKey<T> attribute) {
-        if (request.getHttpChannel() instanceof Netty4HttpChannel) {
-            Channel nettyChannel = ((Netty4HttpChannel) request.getHttpChannel()).getNettyChannel();
-            nettyChannel.attr(attribute).set(null);
+        final HttpChannel httpChannel = request.getHttpChannel();
+        if (httpChannel != null) {
+            httpChannel.get("channel", Channel.class).ifPresent(channel -> channel.attr(attribute).set(null));
         }
     }
 

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -36,13 +36,9 @@ import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.TaskTransportChannel;
-import org.opensearch.transport.TcpChannel;
-import org.opensearch.transport.TcpTransportChannel;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
-import org.opensearch.transport.netty4.Netty4TcpChannel;
 
 import io.netty.handler.ssl.SslHandler;
 
@@ -111,21 +107,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
         }
 
         try {
-
-            Netty4TcpChannel nettyChannel = null;
-
-            if (channel instanceof TaskTransportChannel) {
-                final TransportChannel inner = ((TaskTransportChannel) channel).getChannel();
-                nettyChannel = (Netty4TcpChannel) ((TcpTransportChannel) inner).getChannel();
-            } else if (channel instanceof TcpTransportChannel) {
-                final TcpChannel inner = ((TcpTransportChannel) channel).getChannel();
-                nettyChannel = (Netty4TcpChannel) inner;
-            } else {
-                throw new Exception("Invalid channel of type " + channel.getClass() + " (" + channel.getChannelType() + ")");
-            }
-
-            final SslHandler sslhandler = (SslHandler) nettyChannel.getNettyChannel().pipeline().get("ssl_server");
-
+            final SslHandler sslhandler = channel.get("ssl_server", SslHandler.class).orElse(null);
             if (sslhandler == null) {
                 if (SSLConfig.isDualModeEnabled()) {
                     log.info("Communication in dual mode. Skipping SSL handler check");


### PR DESCRIPTION
### Description
This is cherry-pick from https://github.com/opensearch-project/security/pull/3514 to use the channel properties instead of type-casting

### Issues Resolved
Closes  https://github.com/opensearch-project/security/issues/3911

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
The change is covered by existing test suites

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
