### PR TITLE
[Backport 2.x] Allow TransportConfigUpdateAction when security config initialization has completed (#3810)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
+++ b/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
@@ -31,12 +31,13 @@ class ConfigurationFiles {
             String[] configurationFiles = {
                 "config.yml",
                 "action_groups.yml",
-                "config.yml",
                 "internal_users.yml",
+                "nodes_dn.yml",
                 "roles.yml",
                 "roles_mapping.yml",
                 "security_tenants.yml",
-                "tenants.yml" };
+                "tenants.yml",
+                "whitelist.yml" };
             for (String fileName : configurationFiles) {
                 Path configFileDestination = tempDirectory.resolve(fileName);
                 copyResourceToFile(fileName, configFileDestination.toFile());

--- a/src/integrationTest/java/org/opensearch/security/SecurityAdminLauncher.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityAdminLauncher.java
@@ -10,6 +10,7 @@
 package org.opensearch.security;
 
 import java.io.File;
+import java.nio.file.Path;
 
 import org.opensearch.security.tools.SecurityAdmin;
 import org.opensearch.test.framework.certificate.TestCertificates;
@@ -41,6 +42,23 @@ class SecurityAdminLauncher {
             roleMappingsConfigurationFile.getAbsolutePath(),
             "-t",
             "rolesmapping" };
+
+        return SecurityAdmin.execute(commandLineArguments);
+    }
+
+    public int runSecurityAdmin(Path configurationFolder) throws Exception {
+        String[] commandLineArguments = {
+            "-cacert",
+            certificates.getRootCertificate().getAbsolutePath(),
+            "-cert",
+            certificates.getAdminCertificate().getAbsolutePath(),
+            "-key",
+            certificates.getAdminKey(null).getAbsolutePath(),
+            "-nhnv",
+            "-p",
+            String.valueOf(port),
+            "-cd",
+            configurationFolder.toString() };
 
         return SecurityAdmin.execute(commandLineArguments);
     }

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.support.ConfigHelper;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.ContextHeaderDecoratorClient;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
+import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class SecurityConfigurationBootstrapTests {
+
+    private final static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
+    private static final User USER_ADMIN = new User("admin").roles(ALL_ACCESS);
+
+    private static LocalCluster createCluster(final Map<String, Object> nodeSettings) {
+        var cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+            .loadConfigurationIntoIndex(false)
+            .defaultConfigurationInitDirectory(configurationFolder.toString())
+            .nodeSettings(
+                ImmutableMap.<String, Object>builder()
+                    .put(SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_" + USER_ADMIN.getName() + "__" + ALL_ACCESS.getName()))
+                    .putAll(nodeSettings)
+                    .build()
+            )
+            .build();
+
+        cluster.before(); // normally invoked by JUnit rules when run as a class rule - this starts the cluster
+        return cluster;
+    }
+
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
+
+    @Test
+    public void testInitializeWithSecurityAdminWhenNoBackgroundInitialization() throws Exception {
+        final var nodeSettings = ImmutableMap.<String, Object>builder()
+            .put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false)
+            .put(SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, false)
+            .build();
+        try (final LocalCluster cluster = createCluster(nodeSettings)) {
+            try (final TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                final var rolesMapsResponse = client.get("_plugins/_security/api/rolesmapping/readall");
+                assertThat(rolesMapsResponse.getStatusCode(), equalTo(SC_SERVICE_UNAVAILABLE));
+                assertThat(rolesMapsResponse.getBody(), containsString("OpenSearch Security not initialized"));
+            }
+
+            final var securityAdminLauncher = new SecurityAdminLauncher(cluster.getHttpPort(), cluster.getTestCertificates());
+            final int exitCode = securityAdminLauncher.runSecurityAdmin(configurationFolder);
+            assertThat(exitCode, equalTo(0));
+
+            try (final TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                Awaitility.await()
+                    .alias("Waiting for rolemapping 'readall' availability.")
+                    .until(() -> client.get("_plugins/_security/api/rolesmapping/readall").getStatusCode(), equalTo(200));
+            }
+        }
+    }
+
+    @Test
+    public void shouldStillLoadSecurityConfigDuringBootstrapAndActiveConfigUpdateRequests() throws Exception {
+        final var nodeSettings = ImmutableMap.<String, Object>builder()
+            .put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
+            .put(SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS, 5)
+            .build();
+        try (final LocalCluster cluster = createCluster(nodeSettings)) {
+            try (final TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                cluster.getInternalNodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest(OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX).waitForGreenStatus())
+                    .actionGet();
+
+                // Make sure the cluster is unavalaible to authenticate with the security plugin even though it is green
+                final var authResponseWhenUnconfigured = client.getAuthInfo();
+                authResponseWhenUnconfigured.assertStatusCode(503);
+
+                final var internalNodeClient = new ContextHeaderDecoratorClient(
+                    cluster.getInternalNodeClient(),
+                    Map.of(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true")
+                );
+                final var filesToUpload = ImmutableMap.<String, CType>builder()
+                    .put("action_groups.yml", CType.ACTIONGROUPS)
+                    .put("config.yml", CType.CONFIG)
+                    .put("roles.yml", CType.ROLES)
+                    .put("tenants.yml", CType.TENANTS)
+                    .build();
+
+                final String defaultInitDirectory = System.getProperty("security.default_init.dir") + "/";
+                filesToUpload.forEach((fileName, ctype) -> {
+                    try {
+                        ConfigHelper.uploadFile(
+                            internalNodeClient,
+                            defaultInitDirectory + fileName,
+                            OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX,
+                            ctype,
+                            DEFAULT_CONFIG_VERSION
+                        );
+                    } catch (final Exception ex) {
+                        throw new RuntimeException(ex);
+                    }
+                });
+
+                Awaitility.await().alias("Load default configuration").pollInterval(Duration.ofMillis(100)).until(() -> {
+                    // After the configuration has been loaded, the rest clients should be able to connect successfully
+                    cluster.triggerConfigurationReloadForCTypes(
+                        internalNodeClient,
+                        List.of(CType.ACTIONGROUPS, CType.CONFIG, CType.ROLES, CType.TENANTS),
+                        true
+                    );
+                    try (final TestRestClient freshClient = cluster.getRestClient(USER_ADMIN)) {
+                        return client.getAuthInfo().getStatusCode();
+                    }
+                }, equalTo(200));
+            }
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationTests.java
@@ -70,7 +70,7 @@ public class SecurityConfigurationTests {
                 SECURITY_RESTAPI_ROLES_ENABLED,
                 List.of("user_" + USER_ADMIN.getName() + "__" + ALL_ACCESS.getName()),
                 SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST,
-                true
+                false
             )
         )
         .build();

--- a/src/integrationTest/java/org/opensearch/security/api/CreateResetPasswordTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/CreateResetPasswordTest.java
@@ -63,7 +63,7 @@ public class CreateResetPasswordTest {
                 SECURITY_RESTAPI_ROLES_ENABLED,
                 List.of("user_" + USER_ADMIN.getName() + "__" + ALL_ACCESS.getName()),
                 SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST,
-                true,
+                false,
                 ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX,
                 CUSTOM_PASSWORD_REGEX,
                 ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
@@ -126,8 +126,8 @@ public class OnBehalfOfJwtAuthenticationTest {
         .users(ADMIN_USER, OBO_USER, OBO_USER_NO_PERM, HOST_MAPPING_OBO_USER)
         .nodeSettings(
             Map.of(
-                SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX,
-                true,
+                SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST,
+                false,
                 SECURITY_RESTAPI_ROLES_ENABLED,
                 ADMIN_USER.getRoleNames(),
                 SECURITY_RESTAPI_ADMIN_ENABLED,

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -133,7 +133,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
     }
 
     @Override
-    public void before() throws Throwable {
+    public void before() {
         if (localOpenSearchCluster == null) {
             for (LocalCluster dependency : clusterDependencies) {
                 if (!dependency.isStarted()) {
@@ -155,12 +155,12 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
 
     @Override
     protected void after() {
-        System.clearProperty(INIT_CONFIGURATION_DIR);
         close();
     }
 
     @Override
     public void close() {
+        System.clearProperty(INIT_CONFIGURATION_DIR);
         if (localOpenSearchCluster != null && localOpenSearchCluster.isStarted()) {
             try {
                 localOpenSearchCluster.destroy();
@@ -293,6 +293,16 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
             new ConfigUpdateRequest(CType.lcStringValues().toArray(new String[0]))
         ).actionGet();
         if (configUpdateResponse.hasFailures()) {
+            throw new RuntimeException("ConfigUpdateResponse produced failures: " + configUpdateResponse.failures());
+        }
+    }
+
+    public void triggerConfigurationReloadForCTypes(Client client, List<CType> cTypes, boolean ignoreFailures) {
+        ConfigUpdateResponse configUpdateResponse = client.execute(
+            ConfigUpdateAction.INSTANCE,
+            new ConfigUpdateRequest(cTypes.stream().map(CType::toLCString).toArray(String[]::new))
+        ).actionGet();
+        if (!ignoreFailures && configUpdateResponse.hasFailures()) {
             throw new RuntimeException("ConfigUpdateResponse produced failures: " + configUpdateResponse.failures());
         }
     }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1791,6 +1791,14 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     Property.Filtered
                 )
             );
+            settings.add(
+                Setting.intSetting(
+                    ConfigConstants.SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS,
+                    0,
+                    Property.NodeScope,
+                    Property.Filtered
+                )
+            );
 
             // system integration
             settings.add(

--- a/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/TransportConfigUpdateAction.java
@@ -125,8 +125,10 @@ public class TransportConfigUpdateAction extends TransportNodesAction<
 
     @Override
     protected ConfigUpdateNodeResponse nodeOperation(final NodeConfigUpdateRequest request) {
-        configurationRepository.reloadConfiguration(CType.fromStringValues((request.request.getConfigTypes())));
-        backendRegistry.get().invalidateCache();
+        boolean didReload = configurationRepository.reloadConfiguration(CType.fromStringValues((request.request.getConfigTypes())));
+        if (didReload) {
+            backendRegistry.get().invalidateCache();
+        }
         return new ConfigUpdateNodeResponse(clusterService.localNode(), request.request.getConfigTypes(), null);
     }
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -28,6 +28,8 @@ package org.opensearch.security.configuration;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,10 +39,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -86,13 +89,13 @@ public class ConfigurationRepository {
     private final List<ConfigurationChangeListener> configurationChangedListener;
     private final ConfigurationLoaderSecurity7 cl;
     private final Settings settings;
+    private final Path configPath;
     private final ClusterService clusterService;
     private final AuditLog auditLog;
     private final ThreadPool threadPool;
     private DynamicConfigFactory dynamicConfigFactory;
-    private static final int DEFAULT_CONFIG_VERSION = 2;
-    private final Thread bgThread;
-    private final AtomicBoolean installDefaultConfig = new AtomicBoolean();
+    public static final int DEFAULT_CONFIG_VERSION = 2;
+    private final CompletableFuture<Void> initalizeConfigTask = new CompletableFuture<>();
     private final boolean acceptInvalid;
 
     private ConfigurationRepository(
@@ -108,6 +111,7 @@ public class ConfigurationRepository {
             ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
         );
         this.settings = settings;
+        this.configPath = configPath;
         this.client = client;
         this.threadPool = threadPool;
         this.clusterService = clusterService;
@@ -117,148 +121,150 @@ public class ConfigurationRepository {
         cl = new ConfigurationLoaderSecurity7(client, threadPool, settings, clusterService);
 
         configCache = CacheBuilder.newBuilder().build();
+    }
 
-        bgThread = new Thread(() -> {
-            try {
-                LOGGER.info("Background init thread started. Install default config?: " + installDefaultConfig.get());
-                // wait for the cluster here until it will finish managed node election
-                while (clusterService.state().blocks().hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)) {
-                    LOGGER.info("Wait for cluster to be available ...");
-                    TimeUnit.SECONDS.sleep(1);
-                }
-
-                if (installDefaultConfig.get()) {
-
-                    try {
-                        String lookupDir = System.getProperty("security.default_init.dir");
-                        final String cd = lookupDir != null
-                            ? (lookupDir + "/")
-                            : new Environment(settings, configPath).configFile().toAbsolutePath().toString() + "/opensearch-security/";
-                        File confFile = new File(cd + "config.yml");
-                        if (confFile.exists()) {
-                            final ThreadContext threadContext = threadPool.getThreadContext();
-                            try (StoredContext ctx = threadContext.stashContext()) {
-                                threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
-
-                                createSecurityIndexIfAbsent();
-                                waitForSecurityIndexToBeAtLeastYellow();
-
-                                ConfigHelper.uploadFile(client, cd + "config.yml", securityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
-                                ConfigHelper.uploadFile(client, cd + "roles.yml", securityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "roles_mapping.yml",
-                                    securityIndex,
-                                    CType.ROLESMAPPING,
-                                    DEFAULT_CONFIG_VERSION
-                                );
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "internal_users.yml",
-                                    securityIndex,
-                                    CType.INTERNALUSERS,
-                                    DEFAULT_CONFIG_VERSION
-                                );
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "action_groups.yml",
-                                    securityIndex,
-                                    CType.ACTIONGROUPS,
-                                    DEFAULT_CONFIG_VERSION
-                                );
-                                if (DEFAULT_CONFIG_VERSION == 2) {
-                                    ConfigHelper.uploadFile(
-                                        client,
-                                        cd + "tenants.yml",
-                                        securityIndex,
-                                        CType.TENANTS,
-                                        DEFAULT_CONFIG_VERSION
-                                    );
-                                }
-                                final boolean populateEmptyIfFileMissing = true;
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "nodes_dn.yml",
-                                    securityIndex,
-                                    CType.NODESDN,
-                                    DEFAULT_CONFIG_VERSION,
-                                    populateEmptyIfFileMissing
-                                );
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "whitelist.yml",
-                                    securityIndex,
-                                    CType.WHITELIST,
-                                    DEFAULT_CONFIG_VERSION,
-                                    populateEmptyIfFileMissing
-                                );
-                                ConfigHelper.uploadFile(
-                                    client,
-                                    cd + "allowlist.yml",
-                                    securityIndex,
-                                    CType.ALLOWLIST,
-                                    DEFAULT_CONFIG_VERSION,
-                                    populateEmptyIfFileMissing
-                                );
-
-                                // audit.yml is not packaged by default
-                                final String auditConfigPath = cd + "audit.yml";
-                                if (new File(auditConfigPath).exists()) {
-                                    ConfigHelper.uploadFile(client, auditConfigPath, securityIndex, CType.AUDIT, DEFAULT_CONFIG_VERSION);
-                                }
-                            }
-                        } else {
-                            LOGGER.error("{} does not exist", confFile.getAbsolutePath());
-                        }
-                    } catch (Exception e) {
-                        LOGGER.error("Cannot apply default config (this is maybe not an error!)", e);
-                    }
-                }
-
-                while (!dynamicConfigFactory.isInitialized()) {
-                    try {
-                        LOGGER.debug("Try to load config ...");
-                        reloadConfiguration(Arrays.asList(CType.values()));
-                        break;
-                    } catch (Exception e) {
-                        LOGGER.debug("Unable to load configuration due to {}", String.valueOf(ExceptionUtils.getRootCause(e)));
-                        try {
-                            Thread.sleep(3000);
-                        } catch (InterruptedException e1) {
-                            Thread.currentThread().interrupt();
-                            LOGGER.debug("Thread was interrupted so we cancel initialization");
-                            break;
-                        }
-                    }
-                }
-
-                final Set<String> deprecatedAuditKeysInSettings = AuditConfig.getDeprecatedKeys(settings);
-                if (!deprecatedAuditKeysInSettings.isEmpty()) {
-                    LOGGER.warn(
-                        "Following keys {} are deprecated in opensearch settings. They will be removed in plugin v2.0.0.0",
-                        deprecatedAuditKeysInSettings
-                    );
-                }
-                final boolean isAuditConfigDocPresentInIndex = cl.isAuditConfigDocPresentInIndex();
-                if (isAuditConfigDocPresentInIndex) {
-                    if (!deprecatedAuditKeysInSettings.isEmpty()) {
-                        LOGGER.warn("Audit configuration settings found in both index and opensearch settings (deprecated)");
-                    }
-                    LOGGER.info("Hot-reloading of audit configuration is enabled");
-                } else {
-                    LOGGER.info(
-                        "Hot-reloading of audit configuration is disabled. Using configuration with defaults from opensearch settings.  Populate the configuration in index using audit.yml or securityadmin to enable it."
-                    );
-                    auditLog.setConfig(AuditConfig.from(settings));
-                }
-
-                LOGGER.info("Node '{}' initialized", clusterService.localNode().getName());
-
-            } catch (Exception e) {
-                LOGGER.error("Unexpected exception while initializing node " + e, e);
+    private void initalizeClusterConfiguration(final boolean installDefaultConfig) {
+        try {
+            LOGGER.info("Background init thread started. Install default config?: " + installDefaultConfig);
+            // wait for the cluster here until it will finish managed node election
+            while (clusterService.state().blocks().hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)) {
+                LOGGER.info("Wait for cluster to be available ...");
+                TimeUnit.SECONDS.sleep(1);
             }
-        });
 
+            if (installDefaultConfig) {
+
+                try {
+                    String lookupDir = System.getProperty("security.default_init.dir");
+                    final String cd = lookupDir != null
+                        ? (lookupDir + "/")
+                        : new Environment(settings, configPath).configDir().toAbsolutePath().toString() + "/opensearch-security/";
+                    File confFile = new File(cd + "config.yml");
+                    if (confFile.exists()) {
+                        final ThreadContext threadContext = threadPool.getThreadContext();
+                        try (StoredContext ctx = threadContext.stashContext()) {
+                            threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
+
+                            createSecurityIndexIfAbsent();
+                            waitForSecurityIndexToBeAtLeastYellow();
+
+                            final int initializationDelaySeconds = settings.getAsInt(
+                                ConfigConstants.SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS,
+                                0
+                            );
+                            if (initializationDelaySeconds > 0) {
+                                LOGGER.error("Test setting loaded to delay initialization for {} seconds", initializationDelaySeconds);
+                                TimeUnit.SECONDS.sleep(initializationDelaySeconds);
+                            }
+
+                            ConfigHelper.uploadFile(client, cd + "config.yml", securityIndex, CType.CONFIG, DEFAULT_CONFIG_VERSION);
+                            ConfigHelper.uploadFile(client, cd + "roles.yml", securityIndex, CType.ROLES, DEFAULT_CONFIG_VERSION);
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "roles_mapping.yml",
+                                securityIndex,
+                                CType.ROLESMAPPING,
+                                DEFAULT_CONFIG_VERSION
+                            );
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "internal_users.yml",
+                                securityIndex,
+                                CType.INTERNALUSERS,
+                                DEFAULT_CONFIG_VERSION
+                            );
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "action_groups.yml",
+                                securityIndex,
+                                CType.ACTIONGROUPS,
+                                DEFAULT_CONFIG_VERSION
+                            );
+                            if (DEFAULT_CONFIG_VERSION == 2) {
+                                ConfigHelper.uploadFile(client, cd + "tenants.yml", securityIndex, CType.TENANTS, DEFAULT_CONFIG_VERSION);
+                            }
+                            final boolean populateEmptyIfFileMissing = true;
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "nodes_dn.yml",
+                                securityIndex,
+                                CType.NODESDN,
+                                DEFAULT_CONFIG_VERSION,
+                                populateEmptyIfFileMissing
+                            );
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "whitelist.yml",
+                                securityIndex,
+                                CType.WHITELIST,
+                                DEFAULT_CONFIG_VERSION,
+                                populateEmptyIfFileMissing
+                            );
+                            ConfigHelper.uploadFile(
+                                client,
+                                cd + "allowlist.yml",
+                                securityIndex,
+                                CType.ALLOWLIST,
+                                DEFAULT_CONFIG_VERSION,
+                                populateEmptyIfFileMissing
+                            );
+
+                            // audit.yml is not packaged by default
+                            final String auditConfigPath = cd + "audit.yml";
+                            if (new File(auditConfigPath).exists()) {
+                                ConfigHelper.uploadFile(client, auditConfigPath, securityIndex, CType.AUDIT, DEFAULT_CONFIG_VERSION);
+                            }
+                        }
+                    } else {
+                        LOGGER.error("{} does not exist", confFile.getAbsolutePath());
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Cannot apply default config (this is maybe not an error!)", e);
+                }
+            }
+
+            while (!dynamicConfigFactory.isInitialized()) {
+                try {
+                    LOGGER.debug("Try to load config ...");
+                    reloadConfiguration(Arrays.asList(CType.values()), true);
+                    break;
+                } catch (Exception e) {
+                    LOGGER.debug("Unable to load configuration due to {}", String.valueOf(ExceptionUtils.getRootCause(e)));
+                    try {
+                        Thread.sleep(3000);
+                    } catch (InterruptedException e1) {
+                        Thread.currentThread().interrupt();
+                        LOGGER.debug("Thread was interrupted so we cancel initialization");
+                        break;
+                    }
+                }
+            }
+
+            final Set<String> deprecatedAuditKeysInSettings = AuditConfig.getDeprecatedKeys(settings);
+            if (!deprecatedAuditKeysInSettings.isEmpty()) {
+                LOGGER.warn(
+                    "Following keys {} are deprecated in opensearch settings. They will be removed in plugin v2.0.0.0",
+                    deprecatedAuditKeysInSettings
+                );
+            }
+            final boolean isAuditConfigDocPresentInIndex = cl.isAuditConfigDocPresentInIndex();
+            if (isAuditConfigDocPresentInIndex) {
+                if (!deprecatedAuditKeysInSettings.isEmpty()) {
+                    LOGGER.warn("Audit configuration settings found in both index and opensearch settings (deprecated)");
+                }
+                LOGGER.info("Hot-reloading of audit configuration is enabled");
+            } else {
+                LOGGER.info(
+                    "Hot-reloading of audit configuration is disabled. Using configuration with defaults from opensearch settings.  Populate the configuration in index using audit.yml or securityadmin to enable it."
+                );
+                auditLog.setConfig(AuditConfig.from(settings));
+            }
+
+            LOGGER.info("Node '{}' initialized", clusterService.localNode().getName());
+
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception while initializing node " + e, e);
+        }
     }
 
     private boolean createSecurityIndexIfAbsent() {
@@ -306,27 +312,37 @@ public class ConfigurationRepository {
         }
     }
 
-    public void initOnNodeStart() {
+    public CompletableFuture<Boolean> initOnNodeStart() {
+        final boolean installDefaultConfig = settings.getAsBoolean(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false);
+
+        final Supplier<CompletableFuture<Boolean>> startInitialization = () -> {
+            new Thread(() -> {
+                initalizeClusterConfiguration(installDefaultConfig);
+                initalizeConfigTask.complete(null);
+            }).start();
+            return initalizeConfigTask.thenApply(result -> installDefaultConfig);
+        };
         try {
-            if (settings.getAsBoolean(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false)) {
+            if (installDefaultConfig) {
                 LOGGER.info("Will attempt to create index {} and default configs if they are absent", securityIndex);
-                installDefaultConfig.set(true);
-                bgThread.start();
+                return startInitialization.get();
             } else if (settings.getAsBoolean(ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, true)) {
                 LOGGER.info(
                     "Will not attempt to create index {} and default configs if they are absent. Use securityadmin to initialize cluster",
                     securityIndex
                 );
-                bgThread.start();
+                return startInitialization.get();
             } else {
                 LOGGER.info(
                     "Will not attempt to create index {} and default configs if they are absent. Will not perform background initialization",
                     securityIndex
                 );
+                initalizeConfigTask.complete(null);
+                return initalizeConfigTask.thenApply(result -> installDefaultConfig);
             }
         } catch (Throwable e2) {
             LOGGER.error("Error during node initialization: {}", e2, e2);
-            bgThread.start();
+            return startInitialization.get();
         }
     }
 
@@ -372,16 +388,26 @@ public class ConfigurationRepository {
 
     private final Lock LOCK = new ReentrantLock();
 
-    public void reloadConfiguration(Collection<CType> configTypes) throws ConfigUpdateAlreadyInProgressException {
+    public boolean reloadConfiguration(final Collection<CType> configTypes) throws ConfigUpdateAlreadyInProgressException {
+        return reloadConfiguration(configTypes, false);
+    }
+
+    private boolean reloadConfiguration(final Collection<CType> configTypes, final boolean fromBackgroundThread)
+        throws ConfigUpdateAlreadyInProgressException {
+        if (!fromBackgroundThread && !initalizeConfigTask.isDone()) {
+            LOGGER.warn("Unable to reload configuration, initalization thread has not yet completed.");
+            return false;
+        }
         try {
             if (LOCK.tryLock(60, TimeUnit.SECONDS)) {
                 try {
                     reloadConfiguration0(configTypes, this.acceptInvalid);
+                    return true;
                 } finally {
                     LOCK.unlock();
                 }
             } else {
-                throw new ConfigUpdateAlreadyInProgressException("A config update is already imn progress");
+                throw new ConfigUpdateAlreadyInProgressException("A config update is already in progress");
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
@@ -488,4 +514,27 @@ public class ConfigurationRepository {
     public static int getDefaultConfigVersion() {
         return ConfigurationRepository.DEFAULT_CONFIG_VERSION;
     }
+<<<<<<< HEAD
+=======
+
+    private class AccessControllerWrappedThread extends Thread {
+        private final Thread innerThread;
+
+        public AccessControllerWrappedThread(Thread innerThread) {
+            this.innerThread = innerThread;
+        }
+
+        @Override
+        public void run() {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+
+                @Override
+                public Void run() {
+                    innerThread.run();
+                    return null;
+                }
+            });
+        }
+    }
+>>>>>>> 045d4ef8a (Allow TransportConfigUpdateAction when security config initialization has completed (#3810))
 }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -28,8 +28,6 @@ package org.opensearch.security.configuration;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -138,7 +138,7 @@ public class ConfigurationRepository {
                     String lookupDir = System.getProperty("security.default_init.dir");
                     final String cd = lookupDir != null
                         ? (lookupDir + "/")
-                        : new Environment(settings, configPath).configDir().toAbsolutePath().toString() + "/opensearch-security/";
+                        : new Environment(settings, configPath).configFile().toAbsolutePath().toString() + "/opensearch-security/";
                     File confFile = new File(cd + "config.yml");
                     if (confFile.exists()) {
                         final ThreadContext threadContext = threadPool.getThreadContext();
@@ -514,27 +514,4 @@ public class ConfigurationRepository {
     public static int getDefaultConfigVersion() {
         return ConfigurationRepository.DEFAULT_CONFIG_VERSION;
     }
-<<<<<<< HEAD
-=======
-
-    private class AccessControllerWrappedThread extends Thread {
-        private final Thread innerThread;
-
-        public AccessControllerWrappedThread(Thread innerThread) {
-            this.innerThread = innerThread;
-        }
-
-        @Override
-        public void run() {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-
-                @Override
-                public Void run() {
-                    innerThread.run();
-                    return null;
-                }
-            });
-        }
-    }
->>>>>>> 045d4ef8a (Allow TransportConfigUpdateAction when security config initialization has completed (#3810))
 }

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -324,7 +324,6 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         }
 
         initialized.set(true);
-
     }
 
     private static ConfigV6 getConfigV6(SecurityDynamicConfiguration<?> sdc) {

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -279,6 +279,8 @@ public class ConfigConstants {
 
     public static final String SECURITY_UNSUPPORTED_DISABLE_REST_AUTH_INITIALLY =
         "plugins.security.unsupported.disable_rest_auth_initially";
+    public static final String SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS =
+        "plugins.security.unsupported.delay_initialization_seconds";
     public static final String SECURITY_UNSUPPORTED_DISABLE_INTERTRANSPORT_AUTH_INITIALLY =
         "plugins.security.unsupported.disable_intertransport_auth_initially";
     public static final String SECURITY_UNSUPPORTED_PASSIVE_INTERTRANSPORT_AUTH_INITIALLY =

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -264,12 +264,6 @@ public class InitializationIntegrationTests extends SingleClusterTest {
                 HttpStatus.SC_SERVICE_UNAVAILABLE,
                 rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode()
             );
-
-            ClusterHelper.updateDefaultDirectory(defaultInitDirectory);
-            restart(Settings.EMPTY, null, settings, false);
-            rh = nonSslRestHelper();
-            Thread.sleep(10000);
-            Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
         } finally {
             ClusterHelper.resetSystemProperties();
         }

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.configuration;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.client.Client;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.transport.SecurityInterceptorTests;
+import org.opensearch.threadpool.ThreadPool;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ConfigurationRepositoryTest {
+
+    @Mock
+    private Client localClient;
+    @Mock
+    private AuditLog auditLog;
+    @Mock
+    private Path path;
+    @Mock
+    private ClusterService clusterService;
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+
+        Settings settings = Settings.builder()
+            .put("node.name", SecurityInterceptorTests.class.getSimpleName())
+            .put("request.headers.default", "1")
+            .build();
+
+        threadPool = new ThreadPool(settings);
+    }
+
+    private ConfigurationRepository createConfigurationRepository(Settings settings) {
+
+        return ConfigurationRepository.create(settings, path, threadPool, localClient, clusterService, auditLog);
+    }
+
+    @Test
+    public void create_shouldReturnConfigurationRepository() {
+        ConfigurationRepository configRepository = createConfigurationRepository(Settings.EMPTY);
+
+        assertThat(configRepository, is(notNullValue()));
+        assertThat(configRepository, instanceOf(ConfigurationRepository.class));
+    }
+
+    @Test
+    public void initOnNodeStart_withSecurityIndexCreationEnabledShouldSetInstallDefaultConfigTrue() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true).build();
+
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+
+        final var result = configRepository.initOnNodeStart();
+
+        assertThat(result.join(), is(true));
+    }
+
+    @Test
+    public void initOnNodeStart_withSecurityIndexNotCreatedShouldNotSetInstallDefaultConfig() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, false).build();
+
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+
+        final var result = configRepository.initOnNodeStart();
+
+        assertThat(result.join(), is(false));
+    }
+
+    @Test
+    public void getConfiguration_withInvalidConfigurationShouldReturnNewEmptyConfigurationObject() throws IOException {
+        ConfigurationRepository configRepository = createConfigurationRepository(Settings.EMPTY);
+
+        SecurityDynamicConfiguration<?> config = configRepository.getConfiguration(CType.CONFIG);
+        SecurityDynamicConfiguration<?> emptyConfig = SecurityDynamicConfiguration.empty();
+
+        assertThat(config, is(instanceOf(SecurityDynamicConfiguration.class)));
+        assertThat(config.getCEntries().size(), is(equalTo(0)));
+        assertThat(config.getVersion(), is(equalTo(emptyConfig.getVersion())));
+        assertThat(config.getCType(), is(equalTo(emptyConfig.getCType())));
+        assertThat(config.getSeqNo(), is(equalTo(emptyConfig.getSeqNo())));
+        assertThat(config, is(not(equalTo(emptyConfig))));
+    }
+}

--- a/src/test/java/org/opensearch/security/test/SingleClusterTest.java
+++ b/src/test/java/org/opensearch/security/test/SingleClusterTest.java
@@ -83,18 +83,6 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
         setup(initTransportClientSettings, dynamicSecuritySettings, nodeOverride, initSecurityIndex, ClusterConfiguration.DEFAULT);
     }
 
-    protected void restart(
-        Settings initTransportClientSettings,
-        DynamicSecurityConfig dynamicSecuritySettings,
-        Settings nodeOverride,
-        boolean initOpendistroSecurityIndex
-    ) throws Exception {
-        clusterInfo = clusterHelper.startCluster(minimumSecuritySettings(ccs(nodeOverride)), ClusterConfiguration.DEFAULT);
-        if (initOpendistroSecurityIndex && dynamicSecuritySettings != null) {
-            initialize(clusterHelper, clusterInfo, dynamicSecuritySettings);
-        }
-    }
-
     private Settings ccs(Settings nodeOverride) throws Exception {
         if (remoteClusterHelper != null) {
             Assert.assertNull("No remote clusters", remoteClusterInfo);


### PR DESCRIPTION
### Description
- Backport of #3810 from 045d4ef8a5d9bb8470e03c1b4d7cc68847b986cb

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
