### PR TITLE
Add codecov token as secret inline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v4-beta
+        env:
+          token: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,16 +80,12 @@ jobs:
         run: ls -R
         working-directory: downloaded-artifacts
 
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v1.3.0
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@v3
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            fail_ci_if_error: true
-            verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
 
   integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         working-directory: downloaded-artifacts
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4-beta
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,5 @@
+codecov: 
+  token: secret:v2::vYxLY5VXLm3g4IhSqxkJyji99Izk93bpX+JxfCbndlcWC1j7XkNaO1Pt+Us+TOIYYiHJ491QqD5INZGEVRpoYxJTr33ySpDnxpLFkcI5n1A=
 coverage:
   status:
     project:


### PR DESCRIPTION
### Description
Add codecov token as secret inline

This secret is repository specific and is not usable outside of opensearch-project/security Generated from https://app.codecov.io/gh/opensearch-project/security/settings/yaml

### Issues Resolved
- Resolves #2649

Seeing a number of codecov jobs fail this morning along with a log message indicating the token is not making it into the uploader executable.

```
  Codecov report uploader 0.7.1
[2024-01-08T13:46:12.908Z] ['info'] => Project root located at: /home/runner/work/security/security
[2024-01-08T13:46:12.912Z] ['info'] -> No token specified or token is empty
```
- Issue seen https://github.com/opensearch-project/security/pull/3929
- Issue seen https://github.com/opensearch-project/security/pull/3930

### Testing
Will be validating the coverage job associated with this PR

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
