### PR TITLE
Add logging for test LdapServer actions

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
@@ -23,9 +23,12 @@ import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
 
 import com.google.common.io.CharStreams;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -153,9 +156,8 @@ final class LdapServer {
         config.setEnforceAttributeSyntaxCompliance(false);
         config.setEnforceSingleStructuralObjectClass(false);
 
-        // config.setLDAPDebugLogHandler(DEBUG_HANDLER);
-        // config.setAccessLogHandler(DEBUG_HANDLER);
-        // config.addAdditionalBindCredentials(configuration.getBindDn(), configuration.getPassword());
+        config.setLDAPDebugLogHandler(new DebugHandler());
+        config.setAccessLogHandler(new DebugHandler());
 
         server = new InMemoryDirectoryServer(config);
 
@@ -214,25 +216,33 @@ final class LdapServer {
         return ldifLoadCount;
     }
 
-    /* private static class DebugHandler extends Handler {
-        private final static Logger LOG = LogManager.getLogger(DebugHandler.class);
+    private static class DebugHandler extends Handler {
+        final Logger logger = LogManager.getLogger(DebugHandler.class);
 
         @Override
-        public void publish(LogRecord logRecord) {
-           //LOG.debug(ToStringBuilder.reflectionToString(logRecord, ToStringStyle.MULTI_LINE_STYLE));
+        public void publish(final LogRecord logRecord) {
+            logger.log(toLog4jLevel(logRecord.getLevel()), logRecord.getMessage(), logRecord.getThrown());
         }
 
         @Override
-        public void flush() {
-
-        }
+        public void flush() {}
 
         @Override
-        public void close() throws SecurityException {
+        public void close() throws SecurityException {}
 
+        private Level toLog4jLevel(java.util.logging.Level javaLevel) {
+            switch (javaLevel.getName()) {
+                case "SEVERE":
+                    return Level.ERROR;
+                case "WARNING":
+                    return Level.WARN;
+                case "INFO":
+                    return Level.INFO;
+                case "CONFIG":
+                    return Level.DEBUG;
+                default:
+                    return Level.TRACE;
+            }
         }
     }
-
-    private static final DebugHandler DEBUG_HANDLER = new DebugHandler();
-    */
 }

--- a/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/srv/LdapServer.java
@@ -156,8 +156,8 @@ final class LdapServer {
         config.setEnforceAttributeSyntaxCompliance(false);
         config.setEnforceSingleStructuralObjectClass(false);
 
-        config.setLDAPDebugLogHandler(new DebugHandler());
-        config.setAccessLogHandler(new DebugHandler());
+        config.setLDAPDebugLogHandler(new ServerLogger());
+        config.setAccessLogHandler(new ServerLogger());
 
         server = new InMemoryDirectoryServer(config);
 
@@ -216,8 +216,8 @@ final class LdapServer {
         return ldifLoadCount;
     }
 
-    private static class DebugHandler extends Handler {
-        final Logger logger = LogManager.getLogger(DebugHandler.class);
+    private static class ServerLogger extends Handler {
+        final Logger logger = LogManager.getLogger(ServerLogger.class);
 
         @Override
         public void publish(final LogRecord logRecord) {

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -17,8 +17,11 @@ rootLogger.level = warn
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.file.ref = LOGFILE
 
-logger.resolver.name = com.amazon.dlic.auth.ldap.srv.LdapServer
-logger.resolver.level = info
+# For troubleshooting com.amazon.dlic.auth.ldap.* test cases
+logger.ldapServerLogger.name = com.amazon.dlic.auth.ldap.srv.LdapServer.ServerLogger
+logger.ldapServerLogger.level = info
+logger.ldapAuthBackend.name = com.amazon.dlic.auth.ldap.backend.LDAPAuthorizationBackend
+logger.ldapAuthBackend.level = debug
 
 #logger.resolver.name = org.opensearch.security.resolver
 #logger.resolver.level = trace

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -17,6 +17,9 @@ rootLogger.level = warn
 rootLogger.appenderRef.console.ref = console
 rootLogger.appenderRef.file.ref = LOGFILE
 
+logger.resolver.name = com.amazon.dlic.auth.ldap.srv.LdapServer
+logger.resolver.level = info
+
 #logger.resolver.name = org.opensearch.security.resolver
 #logger.resolver.level = trace
 


### PR DESCRIPTION
### Description
Add logging for test LdapServer actions.  Looks like the failure was a one time network issue, but this logging should provide answers if anything happens again.

### Issues Resolved
- Resolves https://github.com/opensearch-project/security/issues/3731

### Testing
Ran locally, get messages like:
```
[2024-01-09T22:28:04,941][DEBUG][com.amazon.dlic.auth.ldap.backend.LDAPAuthorizationBackend] Opened a connection, total count is now 1
[2024-01-09T22:28:04,941][INFO ][com.amazon.dlic.auth.ldap.srv.LdapServer.ServerLogger] CONNECT conn=11 from="127.0.0.1:53892" to="127.0.0.1:14388"

[2024-01-09T22:28:04,941][DEBUG][com.amazon.dlic.auth.ldap.backend.LDAPAuthorizationBackend] DBGTRACE (5): authenticatedUser=spock -> [115, 112, 111, 99, 107]
[2024-01-09T22:28:04,942][INFO ][com.amazon.dlic.auth.ldap.srv.LdapServer.ServerLogger] conn=11 from="127.0.0.1:53892" to="127.0.0.1:14388"
LDAP Message:
     Message ID:  1
     Search Request Protocol Op:
          Base DN:  ou=people,o=TEST
          Scope:  SUB
          Dereference Policy:  ALWAYS
          Size Limit:  0
          Time Limit:  0
          Types Only:  false
          Filter:  (uid=spock)
          Requested Attributes:
               *
               +

[2024-01-09T22:28:04,942][INFO ][com.amazon.dlic.auth.ldap.srv.LdapServer.ServerLogger] [09/Jan/2024:22:28:04 +0000] SEARCH REQUEST conn=11 op=0 msgID=1 base="ou=people,o=TEST" scope=2 filter="(uid=spock)" attrs="*,+"
[2024-01-09T22:28:04,943][INFO ][com.amazon.dlic.auth.ldap.srv.LdapServer.ServerLogger] conn=11 from="127.0.0.1:53892" to="127.0.0.1:14388"
LDAP Message:
     Message ID:  1
     Search Result Entry Protocol Op:
          dn: cn=Captain Spock,ou=people,o=TEST
          objectClass: inetOrgPerson
          objectClass: organizationalPerson
          objectClass: person
          objectClass: top
          cn: Captain Spock
          sn: spock
          uid: spock
          userpassword: spocksecret
          mail: spock@example.com
          description: cn=dummyempty,ou=groups,o=TEST
          description: cn=rolemo4,ou=groups,o=TEST
          ou: Human Resources
          entryDN: cn=captain spock,ou=people,o=test
          entryUUID: 3d0655e7-99e4-4929-a706-a9ca0ead1863
          subschemaSubentry: cn=schema
          creatorsName: cn=Internal Root User
          createTimestamp: 20240109222804.475Z
          modifiersName: cn=Internal Root User
          modifyTimestamp: 20240109222804.475Z
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
