### PR TITLE
[Enhancement-3191] `transport_enabled` setting on an auth domain and authorizer may be unnecessary after transport client removal 

### DIFF
--- a/config/config.yml
+++ b/config/config.yml
@@ -14,8 +14,9 @@
 # After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
 # the roles from a given backend for the authenticated user.
 #
-# Both, authc and auth can be enabled/disabled separately for REST layer. Default is true for both.
+# Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
 #        http_enabled: true
+#        transport_enabled: true
 #
 # For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
 # find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
@@ -85,6 +86,7 @@ config:
     authc:
       kerberos_auth_domain:
         http_enabled: false
+        transport_enabled: false
         order: 6
         http_authenticator:
           type: kerberos
@@ -99,6 +101,7 @@ config:
       basic_internal_auth_domain:
         description: "Authenticate via HTTP Basic against internal users database"
         http_enabled: true
+        transport_enabled: true
         order: 4
         http_authenticator:
           type: basic
@@ -108,6 +111,7 @@ config:
       proxy_auth_domain:
         description: "Authenticate via proxy"
         http_enabled: false
+        transport_enabled: false
         order: 3
         http_authenticator:
           type: proxy
@@ -120,6 +124,7 @@ config:
       jwt_auth_domain:
         description: "Authenticate via Json Web Token"
         http_enabled: false
+        transport_enabled: false
         order: 0
         http_authenticator:
           type: jwt
@@ -136,6 +141,7 @@ config:
       clientcert_auth_domain:
         description: "Authenticate via SSL client certificates"
         http_enabled: false
+        transport_enabled: false
         order: 2
         http_authenticator:
           type: clientcert
@@ -147,6 +153,7 @@ config:
       ldap:
         description: "Authenticate via LDAP or Active Directory"
         http_enabled: false
+        transport_enabled: false
         order: 5
         http_authenticator:
           type: basic
@@ -177,6 +184,7 @@ config:
       roles_from_myldap:
         description: "Authorize via LDAP or Active Directory"
         http_enabled: false
+        transport_enabled: false
         authorization_backend:
           # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
           type: ldap
@@ -220,6 +228,7 @@ config:
       roles_from_another_ldap:
         description: "Authorize via another Active Directory"
         http_enabled: false
+        transport_enabled: false
         authorization_backend:
           type: ldap
           #config goes here ...

--- a/config/config.yml
+++ b/config/config.yml
@@ -14,9 +14,8 @@
 # After authentication authorization (authz) will be applied. There can be zero or more authorizers which collect
 # the roles from a given backend for the authenticated user.
 #
-# Both, authc and auth can be enabled/disabled separately for REST and TRANSPORT layer. Default is true for both.
+# Both, authc and auth can be enabled/disabled separately for REST layer. Default is true for both.
 #        http_enabled: true
-#        transport_enabled: true
 #
 # For HTTP it is possible to allow anonymous authentication. If that is the case then the HTTP authenticators try to
 # find user credentials in the HTTP request. If credentials are found then the user gets regularly authenticated.
@@ -86,7 +85,6 @@ config:
     authc:
       kerberos_auth_domain:
         http_enabled: false
-        transport_enabled: false
         order: 6
         http_authenticator:
           type: kerberos
@@ -101,7 +99,6 @@ config:
       basic_internal_auth_domain:
         description: "Authenticate via HTTP Basic against internal users database"
         http_enabled: true
-        transport_enabled: true
         order: 4
         http_authenticator:
           type: basic
@@ -111,7 +108,6 @@ config:
       proxy_auth_domain:
         description: "Authenticate via proxy"
         http_enabled: false
-        transport_enabled: false
         order: 3
         http_authenticator:
           type: proxy
@@ -124,7 +120,6 @@ config:
       jwt_auth_domain:
         description: "Authenticate via Json Web Token"
         http_enabled: false
-        transport_enabled: false
         order: 0
         http_authenticator:
           type: jwt
@@ -141,7 +136,6 @@ config:
       clientcert_auth_domain:
         description: "Authenticate via SSL client certificates"
         http_enabled: false
-        transport_enabled: false
         order: 2
         http_authenticator:
           type: clientcert
@@ -153,7 +147,6 @@ config:
       ldap:
         description: "Authenticate via LDAP or Active Directory"
         http_enabled: false
-        transport_enabled: false
         order: 5
         http_authenticator:
           type: basic
@@ -184,7 +177,6 @@ config:
       roles_from_myldap:
         description: "Authorize via LDAP or Active Directory"
         http_enabled: false
-        transport_enabled: false
         authorization_backend:
           # LDAP authorization backend (gather roles from a LDAP or Active Directory, you have to configure the above LDAP authentication backend settings too)
           type: ldap
@@ -228,7 +220,6 @@ config:
       roles_from_another_ldap:
         description: "Authorize via another Active Directory"
         http_enabled: false
-        transport_enabled: false
         authorization_backend:
           type: ldap
           #config goes here ...

--- a/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapAuthenticationTest.java
@@ -109,7 +109,6 @@ public class LdapAuthenticationTest {
         .rolesMapping(new RolesMapping(ALL_ACCESS).backendRoles(CN_GROUP_ADMIN))
         .authz(
             new AuthzDomain("ldap_roles").httpEnabled(true)
-                .transportEnabled(true)
                 .authorizationBackend(
                     new AuthorizationBackend("ldap").config(
                         () -> new LdapAuthorizationConfigBuilder().hosts(List.of("localhost:" + embeddedLDAPServer.getLdapNonTlsPort()))

--- a/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
@@ -156,7 +156,6 @@ public class LdapTlsAuthenticationTest {
         )
         .authz(
             new AuthzDomain("ldap_roles").httpEnabled(true)
-                .transportEnabled(true)
                 .authorizationBackend(
                     new AuthorizationBackend("ldap").config(
                         () -> new LdapAuthorizationConfigBuilder().hosts(List.of("localhost:" + embeddedLDAPServer.getLdapTlsPort()))

--- a/src/integrationTest/java/org/opensearch/test/framework/AuthzDomain.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AuthzDomain.java
@@ -62,7 +62,6 @@ public class AuthzDomain implements ToXContentObject {
         xContentBuilder.startObject();
         xContentBuilder.field("description", description);
         xContentBuilder.field("http_enabled", httpEnabled);
-        xContentBuilder.field("transport_enabled", transportEnabled);
         xContentBuilder.field("authorization_backend", authorizationBackend);
         xContentBuilder.endObject();
         return xContentBuilder;

--- a/src/integrationTest/java/org/opensearch/test/framework/AuthzDomain.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AuthzDomain.java
@@ -25,8 +25,6 @@ public class AuthzDomain implements ToXContentObject {
 
     private boolean httpEnabled;
 
-    private boolean transportEnabled;
-
     private AuthorizationBackend authorizationBackend;
 
     public AuthzDomain(String id) {
@@ -49,11 +47,6 @@ public class AuthzDomain implements ToXContentObject {
 
     public AuthzDomain authorizationBackend(AuthorizationBackend authorizationBackend) {
         this.authorizationBackend = authorizationBackend;
-        return this;
-    }
-
-    public AuthzDomain transportEnabled(boolean transportEnabled) {
-        this.transportEnabled = transportEnabled;
         return this;
     }
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
@@ -273,9 +273,8 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         for (final Entry<String, AuthcDomain> ad : authcDyn.getDomains().entrySet()) {
             final boolean enabled = ad.getValue().enabled;
             final boolean httpEnabled = enabled && ad.getValue().http_enabled;
-            final boolean transportEnabled = enabled && ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
                     AuthenticationBackend authenticationBackend;
                     final String authBackendClazz = ad.getValue().authentication_backend.type;

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV6.java
@@ -68,8 +68,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
     private final Path configPath;
     private SortedSet<AuthDomain> restAuthDomains;
     private Set<AuthorizationBackend> restAuthorizers;
-    private SortedSet<AuthDomain> transportAuthDomains;
-    private Set<AuthorizationBackend> transportAuthorizers;
     private List<Destroyable> destroyableComponents;
     private final InternalAuthenticationBackend iab;
 
@@ -216,8 +214,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
 
         final SortedSet<AuthDomain> restAuthDomains0 = new TreeSet<>();
         final Set<AuthorizationBackend> restAuthorizers0 = new HashSet<>();
-        final SortedSet<AuthDomain> transportAuthDomains0 = new TreeSet<>();
-        final Set<AuthorizationBackend> transportAuthorizers0 = new HashSet<>();
         final List<Destroyable> destroyableComponents0 = new LinkedList<>();
         final List<AuthFailureListener> ipAuthFailureListeners0 = new ArrayList<>();
         final Multimap<String, AuthFailureListener> authBackendFailureListeners0 = ArrayListMultimap.create();
@@ -229,9 +225,8 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         for (final Entry<String, AuthzDomain> ad : authzDyn.getDomains().entrySet()) {
             final boolean enabled = ad.getValue().enabled;
             final boolean httpEnabled = enabled && ad.getValue().http_enabled;
-            final boolean transportEnabled = enabled && ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
 
                     final String authzBackendClazz = ad.getValue().authorization_backend.type;
@@ -262,10 +257,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
 
                     if (httpEnabled) {
                         restAuthorizers0.add(authorizationBackend);
-                    }
-
-                    if (transportEnabled) {
-                        transportAuthorizers0.add(authorizationBackend);
                     }
 
                     if (authorizationBackend instanceof Destroyable) {
@@ -343,10 +334,6 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
                         restAuthDomains0.add(_ad);
                     }
 
-                    if (transportEnabled) {
-                        transportAuthDomains0.add(_ad);
-                    }
-
                     if (httpAuthenticator instanceof Destroyable) {
                         destroyableComponents0.add((Destroyable) httpAuthenticator);
                     }
@@ -365,9 +352,7 @@ public class DynamicConfigModelV6 extends DynamicConfigModel {
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
-        transportAuthDomains = Collections.unmodifiableSortedSet(transportAuthDomains0);
         restAuthorizers = Collections.unmodifiableSet(restAuthorizers0);
-        transportAuthorizers = Collections.unmodifiableSet(transportAuthorizers0);
 
         destroyableComponents = Collections.unmodifiableList(destroyableComponents0);
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -76,8 +76,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
     private final Path configPath;
     private SortedSet<AuthDomain> restAuthDomains;
     private Set<AuthorizationBackend> restAuthorizers;
-    private SortedSet<AuthDomain> transportAuthDomains;
-    private Set<AuthorizationBackend> transportAuthorizers;
     private List<Destroyable> destroyableComponents;
     private final InternalAuthenticationBackend iab;
 
@@ -234,8 +232,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
         final SortedSet<AuthDomain> restAuthDomains0 = new TreeSet<>();
         final Set<AuthorizationBackend> restAuthorizers0 = new HashSet<>();
-        final SortedSet<AuthDomain> transportAuthDomains0 = new TreeSet<>();
-        final Set<AuthorizationBackend> transportAuthorizers0 = new HashSet<>();
         final List<Destroyable> destroyableComponents0 = new LinkedList<>();
         final List<AuthFailureListener> ipAuthFailureListeners0 = new ArrayList<>();
         final Multimap<String, AuthFailureListener> authBackendFailureListeners0 = ArrayListMultimap.create();
@@ -246,9 +242,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
         for (final Entry<String, AuthzDomain> ad : authzDyn.getDomains().entrySet()) {
             final boolean httpEnabled = ad.getValue().http_enabled;
-            final boolean transportEnabled = ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
 
                     final String authzBackendClazz = ad.getValue().authorization_backend.type;
@@ -279,10 +274,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
                     if (httpEnabled) {
                         restAuthorizers0.add(authorizationBackend);
-                    }
-
-                    if (transportEnabled) {
-                        transportAuthorizers0.add(authorizationBackend);
                     }
 
                     if (authorizationBackend instanceof Destroyable) {
@@ -359,10 +350,6 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
                         restAuthDomains0.add(_ad);
                     }
 
-                    if (transportEnabled) {
-                        transportAuthDomains0.add(_ad);
-                    }
-
                     if (httpAuthenticator instanceof Destroyable) {
                         destroyableComponents0.add((Destroyable) httpAuthenticator);
                     }
@@ -398,9 +385,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         List<Destroyable> originalDestroyableComponents = destroyableComponents;
 
         restAuthDomains = Collections.unmodifiableSortedSet(restAuthDomains0);
-        transportAuthDomains = Collections.unmodifiableSortedSet(transportAuthDomains0);
         restAuthorizers = Collections.unmodifiableSet(restAuthorizers0);
-        transportAuthorizers = Collections.unmodifiableSet(transportAuthorizers0);
 
         destroyableComponents = Collections.unmodifiableList(destroyableComponents0);
 

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -289,9 +289,8 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
 
         for (final Entry<String, AuthcDomain> ad : authcDyn.getDomains().entrySet()) {
             final boolean httpEnabled = ad.getValue().http_enabled;
-            final boolean transportEnabled = ad.getValue().transport_enabled;
 
-            if (httpEnabled || transportEnabled) {
+            if (httpEnabled) {
                 try {
                     AuthenticationBackend authenticationBackend;
                     final String authBackendClazz = ad.getValue().authentication_backend.type;

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -38,11 +38,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
 
 public class ConfigV6 {
+
+    private static final Logger LOGGER = LogManager.getLogger(ConfigV6.class);
 
     public Dynamic dynamic;
 
@@ -244,6 +248,18 @@ public class ConfigV6 {
                 + "]";
         }
 
+        @JsonAnySetter
+        public void unknownPropertiesHandler(String name, Object value) {
+            if (name.equals("transport_enabled")) {
+                LOGGER.info(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+                System.out.println(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+            }
+        }
+
     }
 
     public static class HttpAuthenticator {
@@ -345,6 +361,18 @@ public class ConfigV6 {
                 + ", authorization_backend="
                 + authorization_backend
                 + "]";
+        }
+
+        @JsonAnySetter
+        public void unknownPropertiesHandler(String name, Object value) {
+            if (name.equals("transport_enabled")) {
+                LOGGER.info(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+                System.out.println(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+            }
         }
 
     }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -38,15 +38,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
+import org.opensearch.security.setting.DeprecatedSettings;
 
 public class ConfigV6 {
-
-    private static final Logger LOGGER = LogManager.getLogger(ConfigV6.class);
 
     public Dynamic dynamic;
 
@@ -249,11 +248,27 @@ public class ConfigV6 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) {
-            if (name.equals("transport_enabled")) {
-                LOGGER.warn(
-                    "Detected transport_enabled setting in config.yml file under an AuthcDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
+        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+            switch (name) {
+                case "transport_enabled":
+                    DeprecatedSettings.logCustomDeprecationMessage(
+                        String.format(
+                            "In AuthcDomain, using http_authenticator=%s, authentication_backend=%s",
+                            http_authenticator,
+                            authentication_backend
+                        ),
+                        name
+                    );
+                    break;
+                default:
+                    throw new UnrecognizedPropertyException(
+                        null,
+                        "Unrecognized field " + name + " present in the input data for AuthcDomain config",
+                        null,
+                        AuthcDomain.class,
+                        name,
+                        null
+                    );
             }
         }
 
@@ -361,11 +376,23 @@ public class ConfigV6 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) {
-            if (name.equals("transport_enabled")) {
-                LOGGER.warn(
-                    "Detected transport_enabled setting in config.yml file under an AuthzDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
+        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+            switch (name) {
+                case "transport_enabled":
+                    DeprecatedSettings.logCustomDeprecationMessage(
+                        String.format("In AuthzDomain, using authorization_backend=%s", authorization_backend),
+                        name
+                    );
+                    break;
+                default:
+                    throw new UnrecognizedPropertyException(
+                        null,
+                        "Unrecognized field " + name + " present in the input data for AuthzDomain config",
+                        null,
+                        AuthzDomain.class,
+                        name,
+                        null
+                    );
             }
         }
 

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -251,8 +251,8 @@ public class ConfigV6 {
         @JsonAnySetter
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
-                LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                LOGGER.warn(
+                    "Detected transport_enabled setting in config.yml file under an AuthcDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }
         }
@@ -363,8 +363,8 @@ public class ConfigV6 {
         @JsonAnySetter
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
-                LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                LOGGER.warn(
+                    "Detected transport_enabled setting in config.yml file under an AuthzDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }
         }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -254,9 +254,6 @@ public class ConfigV6 {
                 LOGGER.info(
                     "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
-                System.out.println(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
             }
         }
 
@@ -367,9 +364,6 @@ public class ConfigV6 {
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
                 LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
-                System.out.println(
                     "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v6/ConfigV6.java
@@ -224,8 +224,6 @@ public class ConfigV6 {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean http_enabled = true;
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        public boolean transport_enabled = true;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean enabled = true;
         public int order = 0;
         public HttpAuthenticator http_authenticator = new HttpAuthenticator();
@@ -235,8 +233,6 @@ public class ConfigV6 {
         public String toString() {
             return "AuthcDomain [http_enabled="
                 + http_enabled
-                + ", transport_enabled="
-                + transport_enabled
                 + ", enabled="
                 + enabled
                 + ", order="
@@ -337,8 +333,6 @@ public class ConfigV6 {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean http_enabled = true;
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        public boolean transport_enabled = true;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean enabled = true;
         public AuthzBackend authorization_backend = new AuthzBackend();
 
@@ -346,8 +340,6 @@ public class ConfigV6 {
         public String toString() {
             return "AuthzDomain [http_enabled="
                 + http_enabled
-                + ", transport_enabled="
-                + transport_enabled
                 + ", enabled="
                 + enabled
                 + ", authorization_backend="

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -293,7 +293,6 @@ public class ConfigV7 {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean http_enabled = true;
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        public boolean transport_enabled = true;
         // public boolean enabled= true;
         public int order = 0;
         public HttpAuthenticator http_authenticator = new HttpAuthenticator();
@@ -307,10 +306,8 @@ public class ConfigV7 {
         public AuthcDomain(ConfigV6.AuthcDomain v6) {
             super();
             http_enabled = v6.http_enabled && v6.enabled;
-            transport_enabled = v6.transport_enabled && v6.enabled;
             // if(v6.enabled)vv {
             // http_enabled = true;
-            // transport_enabled = true;
             // }
             order = v6.order;
             http_authenticator = new HttpAuthenticator(v6.http_authenticator);
@@ -322,8 +319,6 @@ public class ConfigV7 {
         public String toString() {
             return "AuthcDomain [http_enabled="
                 + http_enabled
-                + ", transport_enabled="
-                + transport_enabled
                 + ", order="
                 + order
                 + ", http_authenticator="
@@ -451,8 +446,6 @@ public class ConfigV7 {
     public static class AuthzDomain {
         @JsonInclude(JsonInclude.Include.NON_NULL)
         public boolean http_enabled = true;
-        @JsonInclude(JsonInclude.Include.NON_NULL)
-        public boolean transport_enabled = true;
         public AuthzBackend authorization_backend = new AuthzBackend();
         public String description;
 
@@ -462,7 +455,6 @@ public class ConfigV7 {
 
         public AuthzDomain(ConfigV6.AuthzDomain v6) {
             http_enabled = v6.http_enabled && v6.enabled;
-            transport_enabled = v6.transport_enabled && v6.enabled;
             authorization_backend = new AuthzBackend(v6.authorization_backend);
             description = "Migrated from v6";
         }
@@ -471,8 +463,6 @@ public class ConfigV7 {
         public String toString() {
             return "AuthzDomain [http_enabled="
                 + http_enabled
-                + ", transport_enabled="
-                + transport_enabled
                 + ", authorization_backend="
                 + authorization_backend
                 + ", description="

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -337,8 +337,8 @@ public class ConfigV7 {
         @JsonAnySetter
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
-                LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                LOGGER.warn(
+                    "Detected transport_enabled setting in config.yml file under an AuthcDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }
         }
@@ -486,8 +486,8 @@ public class ConfigV7 {
         @JsonAnySetter
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
-                LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                LOGGER.warn(
+                    "Detected transport_enabled setting in config.yml file under an AuthzDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }
         }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -340,9 +340,6 @@ public class ConfigV7 {
                 LOGGER.info(
                     "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
-                System.out.println(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
             }
         }
 
@@ -490,9 +487,6 @@ public class ConfigV7 {
         public void unknownPropertiesHandler(String name, Object value) {
             if (name.equals("transport_enabled")) {
                 LOGGER.info(
-                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
-                System.out.println(
                     "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
                 );
             }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -39,16 +39,15 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
 import org.opensearch.security.securityconf.impl.v6.ConfigV6;
+import org.opensearch.security.setting.DeprecatedSettings;
 
 public class ConfigV7 {
-
-    private static final Logger LOGGER = LogManager.getLogger(ConfigV7.class);
 
     public Dynamic dynamic;
 
@@ -335,11 +334,27 @@ public class ConfigV7 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) {
-            if (name.equals("transport_enabled")) {
-                LOGGER.warn(
-                    "Detected transport_enabled setting in config.yml file under an AuthcDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
+        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+            switch (name) {
+                case "transport_enabled":
+                    DeprecatedSettings.logCustomDeprecationMessage(
+                        String.format(
+                            "In AuthcDomain, using http_authenticator=%s, authentication_backend=%s",
+                            http_authenticator,
+                            authentication_backend
+                        ),
+                        name
+                    );
+                    break;
+                default:
+                    throw new UnrecognizedPropertyException(
+                        null,
+                        "Unrecognized field " + name + " present in the input data for AuthcDomain config",
+                        null,
+                        AuthcDomain.class,
+                        name,
+                        null
+                    );
             }
         }
 
@@ -484,11 +499,23 @@ public class ConfigV7 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) {
-            if (name.equals("transport_enabled")) {
-                LOGGER.warn(
-                    "Detected transport_enabled setting in config.yml file under an AuthzDomain. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
-                );
+        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+            switch (name) {
+                case "transport_enabled":
+                    DeprecatedSettings.logCustomDeprecationMessage(
+                        String.format("In AuthzDomain, using authorization_backend=%s", authorization_backend),
+                        name
+                    );
+                    break;
+                default:
+                    throw new UnrecognizedPropertyException(
+                        null,
+                        "Unrecognized field " + name + " present in the input data for AuthzDomain config",
+                        null,
+                        AuthzDomain.class,
+                        name,
+                        null
+                    );
             }
         }
     }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -39,12 +39,16 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
 import org.opensearch.security.securityconf.impl.v6.ConfigV6;
 
 public class ConfigV7 {
+
+    private static final Logger LOGGER = LogManager.getLogger(ConfigV7.class);
 
     public Dynamic dynamic;
 
@@ -330,6 +334,18 @@ public class ConfigV7 {
                 + "]";
         }
 
+        @JsonAnySetter
+        public void unknownPropertiesHandler(String name, Object value) {
+            if (name.equals("transport_enabled")) {
+                LOGGER.info(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+                System.out.println(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+            }
+        }
+
     }
 
     public static class HttpAuthenticator {
@@ -470,6 +486,17 @@ public class ConfigV7 {
                 + "]";
         }
 
+        @JsonAnySetter
+        public void unknownPropertiesHandler(String name, Object value) {
+            if (name.equals("transport_enabled")) {
+                LOGGER.info(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+                System.out.println(
+                    "Detected transport_enabled setting in config.yml file. Since the transport client has been removed, this setting is now unnecessary/unsupported and therefore can be safely removed."
+                );
+            }
+        }
     }
 
     public static class OnBehalfOfSettings {

--- a/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
+++ b/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
@@ -36,7 +36,9 @@ public class DeprecatedSettings {
     public static void logCustomDeprecationMessage(final String deprecationLocationInformation, final String deprecatedSettingKey) {
         DEPRECATION_LOGGER.deprecate(
             deprecatedSettingKey,
-            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: "
+            "In OpenSearch "
+                + Version.CURRENT
+                + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: "
                 + deprecationLocationInformation,
             deprecatedSettingKey
         );

--- a/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
+++ b/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
@@ -28,4 +28,16 @@ public class DeprecatedSettings {
             );
         }
     }
+
+    /**
+     * Logs that a specific setting is deprecated, including a specific supplemental message parameter containing information that details where this setting can be removed from. Should be used in cases where a setting is not supported by the codebase and processing it would introduce errors on setup.
+     */
+    public static void logCustomDeprecationMessage(final String deprecationLocationInformation, final String deprecatedSettingKey) {
+        DEPRECATION_LOGGER.deprecate(
+            deprecatedSettingKey,
+            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: "
+                + deprecationLocationInformation,
+            deprecatedSettingKey
+        );
+    }
 }

--- a/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
+++ b/src/main/java/org/opensearch/security/setting/DeprecatedSettings.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.security.setting;
 
+import org.opensearch.Version;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 
@@ -35,7 +36,7 @@ public class DeprecatedSettings {
     public static void logCustomDeprecationMessage(final String deprecationLocationInformation, final String deprecatedSettingKey) {
         DEPRECATION_LOGGER.deprecate(
             deprecatedSettingKey,
-            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: "
+            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: "
                 + deprecationLocationInformation,
             deprecatedSettingKey
         );

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -5,6 +5,7 @@
 
 package org.opensearch.security.setting;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,8 +15,6 @@ import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigHelper;
-
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -118,37 +117,37 @@ public class DeprecatedSettingsTest {
     public void testForExceptionOnUnknownAuthcAuthzSettingsOnYamlLoad() throws Exception {
         try {
             ConfigHelper.fromYamlString(
-            "---\n"
-                + "_meta:\n"
-                + "  type: \"config\"\n"
-                + "  config_version: 2\n"
-                + "config:\n"
-                + "  dynamic:\n"
-                + "    authc:\n"
-                + "      authentication_domain_kerb:\n"
-                + "        http_enabled: false\n"
-                + "        unknown_property: false\n"
-                + "        order: 3\n"
-                + "        http_authenticator:\n"
-                + "          challenge: true\n"
-                + "          type: \"kerberos\"\n"
-                + "          config: {}\n"
-                + "        authentication_backend:\n"
-                + "          type: \"noop\"\n"
-                + "          config: {}\n"
-                + "        description: \"Migrated from v6\"\n"
-                + "    authz:\n"
-                + "      roles_from_xxx:\n"
-                + "        http_enabled: false\n"
-                + "        unknown_property: false\n"
-                + "        authorization_backend:\n"
-                + "          type: \"xxx\"\n"
-                + "          config: {}\n"
-                + "        description: \"Migrated from v6\"",
-            CType.CONFIG,
-            DEFAULT_CONFIG_VERSION,
-            0,
-            0
+                "---\n"
+                    + "_meta:\n"
+                    + "  type: \"config\"\n"
+                    + "  config_version: 2\n"
+                    + "config:\n"
+                    + "  dynamic:\n"
+                    + "    authc:\n"
+                    + "      authentication_domain_kerb:\n"
+                    + "        http_enabled: false\n"
+                    + "        unknown_property: false\n"
+                    + "        order: 3\n"
+                    + "        http_authenticator:\n"
+                    + "          challenge: true\n"
+                    + "          type: \"kerberos\"\n"
+                    + "          config: {}\n"
+                    + "        authentication_backend:\n"
+                    + "          type: \"noop\"\n"
+                    + "          config: {}\n"
+                    + "        description: \"Migrated from v6\"\n"
+                    + "    authz:\n"
+                    + "      roles_from_xxx:\n"
+                    + "        http_enabled: false\n"
+                    + "        unknown_property: false\n"
+                    + "        authorization_backend:\n"
+                    + "          type: \"xxx\"\n"
+                    + "          config: {}\n"
+                    + "        description: \"Migrated from v6\"",
+                CType.CONFIG,
+                DEFAULT_CONFIG_VERSION,
+                0,
+                0
             );
         } catch (JsonMappingException e) {
             verifyNoInteractions(logger);

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -10,6 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.opensearch.Version;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
@@ -103,12 +104,16 @@ public class DeprecatedSettingsTest {
         );
         verify(logger).deprecate(
             "transport_enabled",
-            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthcDomain, using http_authenticator=HttpAuthenticator [challenge=true, type=null, config={}], authentication_backend=AuthcBackend [type=org.opensearch.security.auth.internal.InternalAuthenticationBackend, config={}]",
+            "In OpenSearch "
+                + Version.CURRENT
+                + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthcDomain, using http_authenticator=HttpAuthenticator [challenge=true, type=null, config={}], authentication_backend=AuthcBackend [type=org.opensearch.security.auth.internal.InternalAuthenticationBackend, config={}]",
             "transport_enabled"
         );
         verify(logger).deprecate(
             "transport_enabled",
-            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthzDomain, using authorization_backend=AuthzBackend [type=noop, config={}]",
+            "In OpenSearch "
+                + Version.CURRENT
+                + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthzDomain, using authorization_backend=AuthzBackend [type=noop, config={}]",
             "transport_enabled"
         );
     }

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -12,10 +12,15 @@ import org.junit.runner.RunWith;
 
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.support.ConfigHelper;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
 import static org.opensearch.security.setting.DeprecatedSettings.checkForDeprecatedSetting;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -60,5 +65,93 @@ public class DeprecatedSettingsTest {
         checkForDeprecatedSetting(settings, "legacyKey", "properKey");
 
         verify(logger).deprecate(eq("legacyKey"), anyString(), any(), any());
+    }
+
+    @Test
+    public void testForTransportEnabledDeprecationMessageOnYamlLoad() throws Exception {
+        ConfigHelper.fromYamlString(
+            "---\n"
+                + "_meta:\n"
+                + "  type: \"config\"\n"
+                + "  config_version: 2\n"
+                + "config:\n"
+                + "  dynamic:\n"
+                + "    authc:\n"
+                + "      authentication_domain_kerb:\n"
+                + "        http_enabled: false\n"
+                + "        transport_enabled: false\n"
+                + "        order: 3\n"
+                + "        http_authenticator:\n"
+                + "          challenge: true\n"
+                + "          type: \"kerberos\"\n"
+                + "          config: {}\n"
+                + "        authentication_backend:\n"
+                + "          type: \"noop\"\n"
+                + "          config: {}\n"
+                + "        description: \"Migrated from v6\"\n"
+                + "    authz:\n"
+                + "      roles_from_xxx:\n"
+                + "        http_enabled: false\n"
+                + "        transport_enabled: false\n"
+                + "        authorization_backend:\n"
+                + "          type: \"xxx\"\n"
+                + "          config: {}\n"
+                + "        description: \"Migrated from v6\"",
+            CType.CONFIG,
+            DEFAULT_CONFIG_VERSION,
+            0,
+            0
+        );
+        verify(logger).deprecate(
+            "transport_enabled",
+            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthcDomain, using http_authenticator=HttpAuthenticator [challenge=true, type=null, config={}], authentication_backend=AuthcBackend [type=org.opensearch.security.auth.internal.InternalAuthenticationBackend, config={}]",
+            "transport_enabled"
+        );
+        verify(logger).deprecate(
+            "transport_enabled",
+            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthzDomain, using authorization_backend=AuthzBackend [type=noop, config={}]",
+            "transport_enabled"
+        );
+    }
+
+    @Test
+    public void testForExceptionOnUnknownAuthcAuthzSettingsOnYamlLoad() throws Exception {
+        try {
+            ConfigHelper.fromYamlString(
+            "---\n"
+                + "_meta:\n"
+                + "  type: \"config\"\n"
+                + "  config_version: 2\n"
+                + "config:\n"
+                + "  dynamic:\n"
+                + "    authc:\n"
+                + "      authentication_domain_kerb:\n"
+                + "        http_enabled: false\n"
+                + "        unknown_property: false\n"
+                + "        order: 3\n"
+                + "        http_authenticator:\n"
+                + "          challenge: true\n"
+                + "          type: \"kerberos\"\n"
+                + "          config: {}\n"
+                + "        authentication_backend:\n"
+                + "          type: \"noop\"\n"
+                + "          config: {}\n"
+                + "        description: \"Migrated from v6\"\n"
+                + "    authz:\n"
+                + "      roles_from_xxx:\n"
+                + "        http_enabled: false\n"
+                + "        unknown_property: false\n"
+                + "        authorization_backend:\n"
+                + "          type: \"xxx\"\n"
+                + "          config: {}\n"
+                + "        description: \"Migrated from v6\"",
+            CType.CONFIG,
+            DEFAULT_CONFIG_VERSION,
+            0,
+            0
+            );
+        } catch (JsonMappingException e) {
+            verifyNoInteractions(logger);
+        }
     }
 }

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -10,7 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
+import org.opensearch.Version;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.securityconf.impl.CType;
@@ -103,12 +103,12 @@ public class DeprecatedSettingsTest {
         );
         verify(logger).deprecate(
             "transport_enabled",
-            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthcDomain, using http_authenticator=HttpAuthenticator [challenge=true, type=null, config={}], authentication_backend=AuthcBackend [type=org.opensearch.security.auth.internal.InternalAuthenticationBackend, config={}]",
+            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthcDomain, using http_authenticator=HttpAuthenticator [challenge=true, type=null, config={}], authentication_backend=AuthcBackend [type=org.opensearch.security.auth.internal.InternalAuthenticationBackend, config={}]",
             "transport_enabled"
         );
         verify(logger).deprecate(
             "transport_enabled",
-            "In OpenSearch v2.0.0+ the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthzDomain, using authorization_backend=AuthzBackend [type=noop, config={}]",
+            "In OpenSearch " + Version.CURRENT + " the setting '{}' is deprecated, it should be removed from the relevant config file using the following location information: In AuthzDomain, using authorization_backend=AuthzBackend [type=noop, config={}]",
             "transport_enabled"
         );
     }

--- a/src/test/resources/restapi/invalid_config.json
+++ b/src/test/resources/restapi/invalid_config.json
@@ -23,7 +23,6 @@
     "authc":{
       "authentication_domain_kerb":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":3,
         "http_authenticator":{
           "challenge":true,
@@ -42,7 +41,6 @@
       },
       "authentication_domain_clientcert":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":1,
         "http_authenticator":{
           "challenge":true,
@@ -61,7 +59,6 @@
       },
       "authentication_domain_proxy":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":2,
         "http_authenticator":{
           "challenge":true,
@@ -81,7 +78,6 @@
       },
       "authentication_domain_basic_internal":{
         "http_enabled":true,
-        "transport_enabled":true,
         "order":0,
         "http_authenticator":{
           "challenge":true,
@@ -102,7 +98,6 @@
     "authz":{
       "roles_from_xxx":{
         "http_enabled":false,
-        "transport_enabled":false,
         "authorization_backend":{
           "type":"xxx",
           "config":{
@@ -113,7 +108,6 @@
       },
       "roles_from_myldap":{
         "http_enabled":false,
-        "transport_enabled":false,
         "authorization_backend":{
           "type":"ldap",
           "config":{

--- a/src/test/resources/restapi/security_config.json
+++ b/src/test/resources/restapi/security_config.json
@@ -23,7 +23,6 @@
           "authc":{
              "authentication_domain_kerb":{
                 "http_enabled":false,
-                "transport_enabled":false,
                 "order":3,
                 "http_authenticator":{
                    "challenge":true,
@@ -42,7 +41,6 @@
              },
              "authentication_domain_clientcert":{
                 "http_enabled":false,
-                "transport_enabled":false,
                 "order":1,
                 "http_authenticator":{
                    "challenge":true,
@@ -61,7 +59,6 @@
              },
              "authentication_domain_proxy":{
                 "http_enabled":false,
-                "transport_enabled":false,
                 "order":2,
                 "http_authenticator":{
                    "challenge":true,
@@ -81,7 +78,6 @@
              },
              "authentication_domain_basic_internal":{
                 "http_enabled":true,
-                "transport_enabled":true,
                 "order":0,
                 "http_authenticator":{
                    "challenge":true,
@@ -102,7 +98,6 @@
           "authz":{
              "roles_from_xxx":{
                 "http_enabled":false,
-                "transport_enabled":false,
                 "authorization_backend":{
                    "type":"xxx",
                    "config":{
@@ -113,7 +108,6 @@
              },
              "roles_from_myldap":{
                 "http_enabled":false,
-                "transport_enabled":false,
                 "authorization_backend":{
                    "type":"ldap",
                    "config":{

--- a/src/test/resources/restapi/securityconfig.json
+++ b/src/test/resources/restapi/securityconfig.json
@@ -23,7 +23,6 @@
     "authc":{
       "authentication_domain_saml": {
         "http_enabled" : true,
-        "transport_enabled" : false,
         "order" : 5,
         "http_authenticator" : {
           "challenge" : true,
@@ -44,7 +43,6 @@
       },
       "authentication_domain_kerb":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":3,
         "http_authenticator":{
           "challenge":true,
@@ -63,7 +61,6 @@
       },
       "authentication_domain_clientcert":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":1,
         "http_authenticator":{
           "challenge":true,
@@ -82,7 +79,6 @@
       },
       "authentication_domain_proxy":{
         "http_enabled":false,
-        "transport_enabled":false,
         "order":2,
         "http_authenticator":{
           "challenge":true,
@@ -102,7 +98,6 @@
       },
       "authentication_domain_basic_internal":{
         "http_enabled":true,
-        "transport_enabled":true,
         "order":0,
         "http_authenticator":{
           "challenge":true,
@@ -123,7 +118,6 @@
     "authz":{
       "roles_from_xxx":{
         "http_enabled":false,
-        "transport_enabled":false,
         "authorization_backend":{
           "type":"xxx",
           "config":{
@@ -134,7 +128,6 @@
       },
       "roles_from_myldap":{
         "http_enabled":false,
-        "transport_enabled":false,
         "authorization_backend":{
           "type":"ldap",
           "config":{

--- a/src/test/resources/restapi/securityconfig_nondefault.json
+++ b/src/test/resources/restapi/securityconfig_nondefault.json
@@ -22,7 +22,6 @@
     "authc" : {
       "jwt_auth_domain" : {
         "http_enabled" : true,
-        "transport_enabled" : true,
         "order" : 0,
         "http_authenticator" : {
           "challenge" : false,
@@ -40,7 +39,6 @@
       },
       "ldap" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "order" : 5,
         "http_authenticator" : {
           "challenge" : false,
@@ -65,7 +63,6 @@
       },
       "basic_internal_auth_domain" : {
         "http_enabled" : true,
-        "transport_enabled" : true,
         "order" : 4,
         "http_authenticator" : {
           "challenge" : true,
@@ -80,7 +77,6 @@
       },
       "proxy_auth_domain" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "order" : 3,
         "http_authenticator" : {
           "challenge" : false,
@@ -98,7 +94,6 @@
       },
       "clientcert_auth_domain" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "order" : 2,
         "http_authenticator" : {
           "challenge" : false,
@@ -115,7 +110,6 @@
       },
       "kerberos_auth_domain" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "order" : 6,
         "http_authenticator" : {
           "challenge" : true,
@@ -134,7 +128,6 @@
     "authz" : {
       "roles_from_another_ldap" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "authorization_backend" : {
           "type" : "ldap",
           "config" : { }
@@ -143,7 +136,6 @@
       },
       "roles_from_myldap" : {
         "http_enabled" : false,
-        "transport_enabled" : false,
         "authorization_backend" : {
           "type" : "ldap",
           "config" : {


### PR DESCRIPTION
### Description
Remove the transport_enabled setting in config.yml and its related code in DynamicConfigModelV6/7, ConfigV6/7, associated tests. Additionally add handlers in Config files to handle when transport_enabled is still used within the config.yml file while alerting the user with a message in startup that this setting can be safely removed from the config.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
#3191 states that since the transport client has been removed, there is no need for the transport_enabled config and its related code to exist in the codebase, so this ticket removes that unnecessary code.

* What is the old behavior before changes and new behavior after changes?
Nothing.

### Issues Resolved
#3191 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
No tests were made, all tests should run since the behavior should not change.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
