### PR TITLE
Protect config object from concurrent modification issues

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -56,6 +57,8 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
 
     @JsonIgnore
     private final Map<String, T> centries = new HashMap<>();
+    @JsonIgnore
+    private final Object modificationLock = new Object();
     private long seqNo = -1;
     private long primaryTerm = -1;
     private CType ctype;
@@ -158,23 +161,33 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
 
     @JsonAnyGetter
     public Map<String, T> getCEntries() {
-        return centries;
+        synchronized (modificationLock) {
+            return new HashMap<>(centries);
+        }
     }
 
     @JsonIgnore
     public void removeHidden() {
-        for (Entry<String, T> entry : new HashMap<String, T>(centries).entrySet()) {
-            if (entry.getValue() instanceof Hideable && ((Hideable) entry.getValue()).isHidden()) {
-                centries.remove(entry.getKey());
+        synchronized (modificationLock) {
+            final Iterator<Entry<String, T>> iterator = centries.entrySet().iterator();
+            while (iterator.hasNext()) {
+                final var entry = iterator.next();
+                if (entry.getValue() instanceof Hideable && ((Hideable) entry.getValue()).isHidden()) {
+                    iterator.remove();
+                }
             }
         }
     }
 
     @JsonIgnore
     public void removeStatic() {
-        for (Entry<String, T> entry : new HashMap<String, T>(centries).entrySet()) {
-            if (entry.getValue() instanceof StaticDefinable && ((StaticDefinable) entry.getValue()).isStatic()) {
-                centries.remove(entry.getKey());
+        synchronized (modificationLock) {
+            final Iterator<Entry<String, T>> iterator = centries.entrySet().iterator();
+            while (iterator.hasNext()) {
+                final var entry = iterator.next();
+                if (entry.getValue() instanceof StaticDefinable && ((StaticDefinable) entry.getValue()).isStatic()) {
+                    iterator.remove();
+                }
             }
         }
     }
@@ -189,20 +202,26 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
     }
 
     public void removeOthers(String key) {
-        T tmp = this.centries.get(key);
-        this.centries.clear();
-        this.centries.put(key, tmp);
+        synchronized (modificationLock) {
+            T tmp = this.centries.get(key);
+            this.centries.clear();
+            this.centries.put(key, tmp);
+        }
     }
 
     @JsonIgnore
     public T putCEntry(String key, T value) {
-        return centries.put(key, value);
+        synchronized (modificationLock) {
+            return centries.put(key, value);
+        }
     }
 
     @JsonIgnore
     @SuppressWarnings("unchecked")
     public void putCObject(String key, Object value) {
-        centries.put(key, (T) value);
+        synchronized (modificationLock) {
+            centries.put(key, (T) value);
+        }
     }
 
     @JsonIgnore
@@ -286,36 +305,42 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
 
     @JsonIgnore
     public void remove(String key) {
-        centries.remove(key);
+        synchronized (modificationLock) {
+            centries.remove(key);
+        }
     }
 
     @JsonIgnore
     public void remove(List<String> keySet) {
-        keySet.stream().forEach(this::remove);
+        synchronized (modificationLock) {
+            keySet.stream().forEach(centries::remove);
+        }
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public boolean add(SecurityDynamicConfiguration other) {
-        if (other.ctype == null || !other.ctype.equals(this.ctype)) {
-            return false;
-        }
+        synchronized (modificationLock) {
+            if (other.ctype == null || !other.ctype.equals(this.ctype)) {
+                return false;
+            }
 
-        if (other.getImplementingClass() == null || !other.getImplementingClass().equals(this.getImplementingClass())) {
-            return false;
-        }
+            if (other.getImplementingClass() == null || !other.getImplementingClass().equals(this.getImplementingClass())) {
+                return false;
+            }
 
-        if (other.version != this.version) {
-            return false;
-        }
+            if (other.version != this.version) {
+                return false;
+            }
 
-        this.centries.putAll(other.centries);
-        return true;
+            this.centries.putAll(other.centries);
+            return true;
+        }
     }
 
     @JsonIgnore
     @SuppressWarnings({ "rawtypes" })
     public boolean containsAny(SecurityDynamicConfiguration other) {
-        return !Collections.disjoint(this.centries.keySet(), other.centries.keySet());
+        return !Collections.disjoint(this.getCEntries().keySet(), other.getCEntries().keySet());
     }
 
     public boolean isHidden(String resourceName) {

--- a/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -30,8 +30,8 @@ package org.opensearch.security.securityconf.impl;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 


### PR DESCRIPTION
### Description
Protect config object from concurrent modification issues

We've had rare reports of modification exceptions from customers around the config objects.  Using a lock object to protect the internal collection from modification on other threads and changing the behavoir of the getter to pass a copy of the collection instead of direct collection references.

### Issues Resolved
- Resolves #3404

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
