### PR TITLE
Update security analytics roles to include custom log type cluster permissions

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -346,6 +346,7 @@ security_analytics_read_access:
     - 'cluster:admin/opensearch/securityanalytics/detector/get'
     - 'cluster:admin/opensearch/securityanalytics/detector/search'
     - 'cluster:admin/opensearch/securityanalytics/findings/get'
+    - 'cluster:admin/opensearch/securityanalytics/logtype/search'
     - 'cluster:admin/opensearch/securityanalytics/mapping/get'
     - 'cluster:admin/opensearch/securityanalytics/mapping/view/get'
     - 'cluster:admin/opensearch/securityanalytics/rule/get'
@@ -359,6 +360,7 @@ security_analytics_full_access:
     - 'cluster:admin/opensearch/securityanalytics/correlations/*'
     - 'cluster:admin/opensearch/securityanalytics/detector/*'
     - 'cluster:admin/opensearch/securityanalytics/findings/*'
+    - 'cluster:admin/opensearch/securityanalytics/logtype/*'
     - 'cluster:admin/opensearch/securityanalytics/mapping/*'
     - 'cluster:admin/opensearch/securityanalytics/rule/*'
   index_permissions:


### PR DESCRIPTION
### Description
update security analytics roles with custom log type cluster permissions

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Security Analytics Role enhancement

* Why these changes are required?

Custom Log Types were introduced in `2.10` but they were only available for `admin` users. This pr allows `non-admin` users to access custom log types.
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
