### PR TITLE
Add test coverage for ComplianceConfig

### DIFF
--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -214,6 +214,7 @@ public class AuditConfigSerializeTest {
             false,
             Collections.singletonList("test-write-watch-index"),
             Collections.singleton("test-user-2"),
+            null,
             Settings.EMPTY
         );
         final AuditConfig auditConfig = new AuditConfig(true, audit, compliance);


### PR DESCRIPTION
### Description
There are some cases that use datetime that were causing code coverage fluctuations depending on when the tests are run, fixed this by adding a date provider and new unit tests.

### Issues Resolved
- Related #3137
- New Issue #3950

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
