### PR TITLE
Improve code coverage for SSLNettyTransport class

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.ExceptionsHelper;
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.network.NetworkService;
@@ -104,7 +105,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
     }
 
     // This allows for testing log messages
-    public Logger getLogger() {
+     Logger getLogger() {
         return logger;
     }
 
@@ -120,6 +121,9 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
         errorHandler.logError(cause, false);
         getLogger().error("Exception during establishing a SSL connection: " + cause, cause);
 
+        if (channel == null || !channel.isOpen()) {
+            throw new OpenSearchSecurityException("The provided TCP channel is invalid.", e);
+        }
         super.onException(channel, e);
     }
 

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
@@ -103,6 +103,11 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
         this.SSLConfig = SSLConfig;
     }
 
+    // This allows for testing log messages
+    public Logger getLogger() {
+        return logger;
+    }
+
     @Override
     public void onException(TcpChannel channel, Exception e) {
 
@@ -113,7 +118,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
         }
 
         errorHandler.logError(cause, false);
-        logger.error("Exception during establishing a SSL connection: " + cause, cause);
+        getLogger().error("Exception during establishing a SSL connection: " + cause, cause);
 
         super.onException(channel, e);
     }
@@ -156,7 +161,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
             }
 
             errorHandler.logError(cause, false);
-            logger.error("Exception during establishing a SSL connection: " + cause, cause);
+            getLogger().error("Exception during establishing a SSL connection: " + cause, cause);
 
             super.exceptionCaught(ctx, cause);
         }
@@ -291,7 +296,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
             }
 
             errorHandler.logError(cause, false);
-            logger.error("Exception during establishing a SSL connection: " + cause, cause);
+            getLogger().error("Exception during establishing a SSL connection: " + cause, cause);
 
             super.exceptionCaught(ctx, cause);
         }

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransport.java
@@ -105,7 +105,7 @@ public class SecuritySSLNettyTransport extends Netty4Transport {
     }
 
     // This allows for testing log messages
-     Logger getLogger() {
+    Logger getLogger() {
         return logger;
     }
 

--- a/src/test/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransportTests.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransportTests.java
@@ -18,6 +18,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.common.network.NetworkService;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;

--- a/src/test/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransportTests.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/SecuritySSLNettyTransportTests.java
@@ -11,21 +11,13 @@
 
 package org.opensearch.security.ssl.transport;
 
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.DecoderException;
 import java.util.Collections;
-import net.bytebuddy.implementation.bytecode.Throw;
-import org.junit.Assert;
+
+import org.apache.logging.log4j.Logger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.junit.MockitoRule;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.Version;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -38,32 +30,29 @@ import org.opensearch.security.ssl.SecurityKeyStore;
 import org.opensearch.security.ssl.SslExceptionHandler;
 import org.opensearch.security.ssl.transport.SecuritySSLNettyTransport.SSLClientChannelInitializer;
 import org.opensearch.security.ssl.transport.SecuritySSLNettyTransport.SSLServerChannelInitializer;
-import org.opensearch.security.transport.SecurityInterceptorTests;
 import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.FakeTcpChannel;
 import org.opensearch.transport.SharedGroupFactory;
-
-import org.apache.logging.log4j.Logger;
-import io.netty.channel.ChannelHandler;
-import org.mockito.Mock;
 import org.opensearch.transport.TcpChannel;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.DecoderException;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.common.inject.matcher.Matchers.any;
-
 
 public class SecuritySSLNettyTransportTests {
 
@@ -106,7 +95,8 @@ public class SecuritySSLNettyTransportTests {
         sslConfig = new SSLConfig(Settings.EMPTY);
         mockLogger = mock(Logger.class);
 
-        securitySSLNettyTransport = spy(new SecuritySSLNettyTransport(
+        securitySSLNettyTransport = spy(
+            new SecuritySSLNettyTransport(
                 Settings.EMPTY,
                 version,
                 threadPool,
@@ -119,7 +109,8 @@ public class SecuritySSLNettyTransportTests {
                 sharedGroupFactory,
                 sslConfig,
                 trace
-        ));
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description
[Describe what this change achieves]
This change increases code coverage for the SecuritySSLNettyTransport class. In the middle of 12/23, a few unit tests were added to give coverage to different parts of the class. This change builds on these existing changes. 

### Issues Resolved
Box three of https://github.com/opensearch-project/security/issues/3137

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
