### PR TITLE
Serialize user connected with admin certificate into the Thread Context

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/rest/UserSerializationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/UserSerializationTests.java
@@ -1,0 +1,60 @@
+package org.opensearch.security.rest;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.testplugins.userserialization.UserSerializationPlugin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class UserSerializationTests {
+    public static final String BASE_ENDPOINT = "_plugins/_userserialization";
+    public static final String GET_SERIALIZED_USER_API = BASE_ENDPOINT + "/get_serialized_user";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER)
+        .nodeSettings(
+            Map.of("plugins.security.restapi.roles_enabled", List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()))
+        )
+        .plugin(UserSerializationPlugin.class)
+        .build();
+
+    @Test
+    public void testReturnAdminSerialized() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            String expectedResponse = "{\"serialized_user\":\"admin||user_admin__all_access\"}";
+            TestRestClient.HttpResponse res = client.get(GET_SERIALIZED_USER_API);
+            assertThat(res.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            assertThat(res.getBody(), equalTo(expectedResponse));
+        }
+    }
+
+    @Test
+    public void testReturnSuperAdminSerialized() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            String expectedResponse = "{\"serialized_user\":\"CN=kirk,OU=client,O=client,L=test,C=de||\"}";
+            TestRestClient.HttpResponse res = client.get(GET_SERIALIZED_USER_API);
+            assertThat(res.getStatusCode(), equalTo(HttpStatus.SC_OK));
+            assertThat(res.getBody(), equalTo(expectedResponse));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/GetSerializedUserRestHandler.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/GetSerializedUserRestHandler.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.testplugins.userserialization;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestStatusToXContentListener;
+import org.opensearch.test.framework.testplugins.AbstractRestHandler;
+import org.opensearch.test.framework.testplugins.userserialization.actions.GetSerializedUserAction;
+import org.opensearch.test.framework.testplugins.userserialization.actions.GetSerializedUserRequest;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
+public class GetSerializedUserRestHandler extends AbstractRestHandler {
+
+    private static final List<Route> routes = addRoutesPrefix(
+        ImmutableList.of(new Route(GET, "/get_serialized_user")),
+        "/_plugins/_userserialization"
+    );
+
+    public GetSerializedUserRestHandler() {
+        super();
+    }
+
+    @Override
+    public List<Route> routes() {
+        return routes;
+    }
+
+    @Override
+    public String getName() {
+        return "Get Serialized User Rest Action";
+    }
+
+    @Override
+    public void handleGet(RestChannel channel, RestRequest request, NodeClient client) {
+        client.execute(GetSerializedUserAction.INSTANCE, new GetSerializedUserRequest(), new RestStatusToXContentListener<>(channel));
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/UserSerializationPlugin.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/UserSerializationPlugin.java
@@ -1,0 +1,79 @@
+package org.opensearch.test.framework.testplugins.userserialization;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.client.Client;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.env.Environment;
+import org.opensearch.env.NodeEnvironment;
+import org.opensearch.plugins.ActionPlugin;
+import org.opensearch.plugins.Plugin;
+import org.opensearch.repositories.RepositoriesService;
+import org.opensearch.rest.RestController;
+import org.opensearch.rest.RestHandler;
+import org.opensearch.script.ScriptService;
+import org.opensearch.test.framework.testplugins.userserialization.actions.GetSerializedUserAction;
+import org.opensearch.test.framework.testplugins.userserialization.actions.TransportGetSerializedUserAction;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.watcher.ResourceWatcherService;
+
+/**
+ * Registers a plugin with one REST Handler that returns the user that was serialized into the thread context
+ */
+public class UserSerializationPlugin extends Plugin implements ActionPlugin {
+    private ThreadContext threadContext;
+
+    @Override
+    public Collection<Object> createComponents(
+        Client client,
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        ResourceWatcherService resourceWatcherService,
+        ScriptService scriptService,
+        NamedXContentRegistry xContentRegistry,
+        Environment environment,
+        NodeEnvironment nodeEnvironment,
+        NamedWriteableRegistry namedWriteableRegistry,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<RepositoriesService> repositoriesServiceSupplier
+    ) {
+        this.threadContext = threadPool.getThreadContext();
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<RestHandler> getRestHandlers(
+        Settings settings,
+        RestController restController,
+        ClusterSettings clusterSettings,
+        IndexScopedSettings indexScopedSettings,
+        SettingsFilter settingsFilter,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        Supplier<DiscoveryNodes> nodesInCluster
+    ) {
+        final List<RestHandler> handlers = new ArrayList<RestHandler>(1);
+        handlers.add(new GetSerializedUserRestHandler());
+        return handlers;
+    }
+
+    @Override
+    public List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
+        List<ActionPlugin.ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(1);
+        actions.add(new ActionPlugin.ActionHandler<>(GetSerializedUserAction.INSTANCE, TransportGetSerializedUserAction.class));
+        return actions;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserAction.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserAction.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.testplugins.userserialization.actions;
+
+import org.opensearch.action.ActionType;
+
+public class GetSerializedUserAction extends ActionType<GetSerializedUserResponse> {
+
+    public static final GetSerializedUserAction INSTANCE = new GetSerializedUserAction();
+    public static final String NAME = "cluster:admin/userserialization/get_serialized_user";
+
+    protected GetSerializedUserAction() {
+        super(NAME, GetSerializedUserResponse::new);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserRequest.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserRequest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.testplugins.userserialization.actions;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class GetSerializedUserRequest extends ActionRequest implements ToXContent {
+
+    public GetSerializedUserRequest(final StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public GetSerializedUserRequest() {}
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        return xContentBuilder;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserResponse.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/GetSerializedUserResponse.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.testplugins.userserialization.actions;
+
+import java.io.IOException;
+
+import org.opensearch.common.xcontent.StatusToXContentObject;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class GetSerializedUserResponse extends ActionResponse implements StatusToXContentObject {
+    private final String serializedUser;
+
+    public GetSerializedUserResponse(String serializedUser) {
+        this.serializedUser = serializedUser;
+    }
+
+    public GetSerializedUserResponse(StreamInput in) throws IOException {
+        super(in);
+        serializedUser = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(serializedUser);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("serialized_user", serializedUser);
+        builder.endObject();
+        return builder;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.toString(MediaTypeRegistry.JSON, this, true, true);
+    }
+
+    @Override
+    public RestStatus status() {
+        return RestStatus.OK;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/TransportGetSerializedUserAction.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/testplugins/userserialization/actions/TransportGetSerializedUserAction.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.testplugins.userserialization.actions;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+
+import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
+
+public class TransportGetSerializedUserAction extends HandledTransportAction<GetSerializedUserRequest, GetSerializedUserResponse> {
+
+    private final ThreadPool threadPool;
+
+    @Inject
+    public TransportGetSerializedUserAction(
+        final TransportService transportService,
+        final ActionFilters actionFilters,
+        final ThreadPool threadPool
+    ) {
+        super(GetSerializedUserAction.NAME, transportService, actionFilters, GetSerializedUserRequest::new);
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    protected void doExecute(Task task, GetSerializedUserRequest request, ActionListener<GetSerializedUserResponse> listener) {
+        String serializedUser = threadPool.getThreadContext().getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
+        listener.onResponse(new GetSerializedUserResponse(serializedUser));
+    }
+}

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -289,6 +289,7 @@ public class SecurityFilter implements ActionFilter {
                 if (userIsAdmin && !confRequest && !internalRequest && !passThroughRequest) {
                     auditLog.logGrantedPrivileges(action, request, task);
                     auditLog.logIndexEvent(action, request, task);
+                    evalp.setUserInfoInThreadContext(user);
                 }
 
                 chain.proceed(task, action, request, listener);

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -210,7 +210,7 @@ public class PrivilegesEvaluator {
         return configModel != null && configModel.getSecurityRoles() != null && dcm != null;
     }
 
-    private void setUserInfoInThreadContext(User user) {
+    public void setUserInfoInThreadContext(User user) {
         if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
             StringJoiner joiner = new StringJoiner("|");
             joiner.add(user.getName());


### PR DESCRIPTION
### Description

This PR is to ensure that any time there is an authenticated user, that the user is serialized into the thread context for downstream consumption by plugins. Some plugins rely on user info being serialized into the Thread Context to read the currently authenticated user (via common-utils) and potentially use info from the user to perform plugin operations (i.e. ABAC using backend roles in AD and ml-commons) or to save into a scheduled job definition to perform roles injection at job execution time.

User serialization is done during privilege evaluation and the serialization is currently skipped for a user connecting with the admin certificate as the "superadmin" bypasses privilege evaluation. This will serialize the superadmin user into the ThreadContext in that bypass for the superadmin.

ML-Commons has a use case where they need to distinguish a superadmin vs a regular user and is currently using a [workaround](https://github.com/opensearch-project/ml-commons/blob/feature/agent_framework_dev/plugin/src/main/java/org/opensearch/ml/utils/RestActionUtils.java#L215-L231) to get the username of the user with the admin cert (using the SSL principal). After this PR, ML-commons can reliably get the username from the `_opendistro_security_user_info` threadcontext header which is the designated header meant for consumption by plugins. 

tldr; Whenever a user is authenticated, plugins should be able to reliably trust that the `_opendistro_security_user_info` threadcontext header is populated. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug Fix

### Issues Resolved
[List any issues this PR will resolve]

Will add momentarily

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
