### PR TITLE
Fix: remove unnecessary trailing slashes in APIs.

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -46,16 +46,16 @@ public class ActionGroupsApiAction extends AbstractApiAction {
             // legacy mapping for backwards compatibility
             // TODO: remove in next version
             new Route(Method.GET, "/actiongroup/{name}"),
-            new Route(Method.GET, "/actiongroup/"),
+            new Route(Method.GET, "/actiongroup"),
             new Route(Method.DELETE, "/actiongroup/{name}"),
             new Route(Method.PUT, "/actiongroup/{name}"),
 
             // corrected mapping, introduced in OpenSearch Security
             new Route(Method.GET, "/actiongroups/{name}"),
-            new Route(Method.GET, "/actiongroups/"),
+            new Route(Method.GET, "/actiongroups"),
             new Route(Method.DELETE, "/actiongroups/{name}"),
             new Route(Method.PUT, "/actiongroups/{name}"),
-            new Route(Method.PATCH, "/actiongroups/"),
+            new Route(Method.PATCH, "/actiongroups"),
             new Route(Method.PATCH, "/actiongroups/{name}")
 
         )

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -123,9 +123,9 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 public class AuditApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
-            new Route(RestRequest.Method.GET, "/audit/"),
+            new Route(RestRequest.Method.GET, "/audit"),
             new Route(RestRequest.Method.PUT, "/audit/config"),
-            new Route(RestRequest.Method.PATCH, "/audit/")
+            new Route(RestRequest.Method.PATCH, "/audit")
         )
     );
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -64,18 +64,18 @@ public class InternalUsersApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
             new Route(Method.GET, "/user/{name}"),
-            new Route(Method.GET, "/user/"),
+            new Route(Method.GET, "/user"),
             new Route(Method.POST, "/user/{name}/authtoken"),
             new Route(Method.DELETE, "/user/{name}"),
             new Route(Method.PUT, "/user/{name}"),
 
             // corrected mapping, introduced in OpenSearch Security
             new Route(Method.GET, "/internalusers/{name}"),
-            new Route(Method.GET, "/internalusers/"),
+            new Route(Method.GET, "/internalusers"),
             new Route(Method.POST, "/internalusers/{name}/authtoken"),
             new Route(Method.DELETE, "/internalusers/{name}"),
             new Route(Method.PUT, "/internalusers/{name}"),
-            new Route(Method.PATCH, "/internalusers/"),
+            new Route(Method.PATCH, "/internalusers"),
             new Route(Method.PATCH, "/internalusers/{name}")
         )
     );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -62,10 +62,10 @@ public class NodesDnApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
             new Route(Method.GET, "/nodesdn/{name}"),
-            new Route(Method.GET, "/nodesdn/"),
+            new Route(Method.GET, "/nodesdn"),
             new Route(Method.DELETE, "/nodesdn/{name}"),
             new Route(Method.PUT, "/nodesdn/{name}"),
-            new Route(Method.PATCH, "/nodesdn/"),
+            new Route(Method.PATCH, "/nodesdn"),
             new Route(Method.PATCH, "/nodesdn/{name}")
         )
     );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -45,11 +45,11 @@ public class RolesApiAction extends AbstractApiAction {
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
-            new Route(Method.GET, "/roles/"),
+            new Route(Method.GET, "/roles"),
             new Route(Method.GET, "/roles/{name}"),
             new Route(Method.DELETE, "/roles/{name}"),
             new Route(Method.PUT, "/roles/{name}"),
-            new Route(Method.PATCH, "/roles/"),
+            new Route(Method.PATCH, "/roles"),
             new Route(Method.PATCH, "/roles/{name}")
         )
     );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -38,11 +38,11 @@ public class RolesMappingApiAction extends AbstractApiAction {
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
-            new Route(Method.GET, "/rolesmapping/"),
+            new Route(Method.GET, "/rolesmapping"),
             new Route(Method.GET, "/rolesmapping/{name}"),
             new Route(Method.DELETE, "/rolesmapping/{name}"),
             new Route(Method.PUT, "/rolesmapping/{name}"),
-            new Route(Method.PATCH, "/rolesmapping/"),
+            new Route(Method.PATCH, "/rolesmapping"),
             new Route(Method.PATCH, "/rolesmapping/{name}")
         )
     );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
@@ -50,7 +50,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  */
 public class SecuritySSLCertsApiAction extends AbstractApiAction {
     private static final List<Route> ROUTES = addRoutesPrefix(
-        ImmutableList.of(new Route(Method.GET, "/ssl/certs"), new Route(Method.PUT, "/ssl/{certType}/reloadcerts/"))
+        ImmutableList.of(new Route(Method.GET, "/ssl/certs"), new Route(Method.PUT, "/ssl/{certType}/reloadcerts"))
     );
 
     private final SecurityKeyStore securityKeyStore;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -50,10 +50,10 @@ public class TenantsApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
             new Route(Method.GET, "/tenants/{name}"),
-            new Route(Method.GET, "/tenants/"),
+            new Route(Method.GET, "/tenants"),
             new Route(Method.DELETE, "/tenants/{name}"),
             new Route(Method.PUT, "/tenants/{name}"),
-            new Route(Method.PATCH, "/tenants/"),
+            new Route(Method.PATCH, "/tenants"),
             new Route(Method.PATCH, "/tenants/{name}")
         )
     );


### PR DESCRIPTION
### Description

Coming from https://github.com/opensearch-project/opensearch-api-specification/pull/179 which flags a couple of false positives because of mismatched trailing slash.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
