### PR TITLE
Update json-path to address CVE-2023-51074

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     }
     implementation 'commons-lang:commons-lang:2.4'
     implementation 'commons-collections:commons-collections:3.2.2'
-    implementation 'com.jayway.jsonpath:json-path:2.4.0'
+    implementation 'com.jayway.jsonpath:json-path:2.9.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'


### PR DESCRIPTION
### Description
* Category (Maintenance)
* Updates the json-path library to address [CVE-2023-51074](https://www.cve.org/CVERecord?id=CVE-2023-51074)

### Issues Resolved
https://www.cve.org/CVERecord?id=CVE-2023-51074

### Testing
Manually built and ran the security plugin according to the [developer guide](https://github.com/opensearch-project/security/blob/1.3/DEVELOPER_GUIDE.md#building).

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
