### PR TITLE
[1.3] Remove json-smart and json-path dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,6 @@ configurations.all {
         force 'commons-codec:commons-codec:1.14'
         force 'org.apache.santuario:xmlsec:2.3.4'
         force 'org.cryptacular:cryptacular:1.2.4'
-        force 'net.minidev:json-smart:2.4.10'
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
@@ -186,7 +185,6 @@ dependencies {
     }
     implementation 'commons-lang:commons-lang:2.4'
     implementation 'commons-collections:commons-collections:3.2.2'
-    implementation 'com.jayway.jsonpath:json-path:2.4.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.10.8'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.10.8'

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/RolesValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/RolesValidator.java
@@ -55,8 +55,10 @@ public class RolesValidator extends AbstractConfigurationValidator {
 
             ArrayNode indexPermissions = getContentAsNode().withArray("index_permissions");
             Set<String> maskedFields = new HashSet<>();
-            for (JsonNode ip : indexPermissions) {
-                ip.withArray("masked_fields").forEach((n) -> maskedFields.add(n.asText()));
+            if (indexPermissions != null) {
+                for (JsonNode ip : indexPermissions) {
+                    ip.withArray("masked_fields").forEach((n) -> maskedFields.add(n.asText()));
+                }
             }
 
             for (String mf : maskedFields) {

--- a/src/test/java/org/opensearch/security/ssl/SecuritySSLCertsInfoActionTests.java
+++ b/src/test/java/org/opensearch/security/ssl/SecuritySSLCertsInfoActionTests.java
@@ -15,6 +15,10 @@
 
 package org.opensearch.security.ssl;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.SingleClusterTest;
@@ -22,7 +26,6 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import net.minidev.json.JSONObject;
 import org.opensearch.common.settings.Settings;
 import org.junit.Assert;
 import org.junit.Test;
@@ -52,11 +55,11 @@ public class SecuritySSLCertsInfoActionTests extends SingleClusterTest {
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
 
-        final RestHelper.HttpResponse transportInfoRestResponse = rh.executeGetRequest(ENDPOINT);
-        JSONObject expectedJsonResponse = new JSONObject();
-        expectedJsonResponse.appendField("http_certificates_list", NODE_CERT_DETAILS);
-        expectedJsonResponse.appendField("transport_certificates_list", NODE_CERT_DETAILS);
-        Assert.assertEquals(expectedJsonResponse.toString(), transportInfoRestResponse.getBody());
+        final String certInfoRestResponse = rh.executeSimpleRequest(ENDPOINT);
+        final ObjectNode expectedJsonResponse = DefaultObjectMapper.objectMapper.createObjectNode();
+        expectedJsonResponse.set("http_certificates_list", SecuritySSLReloadCertsActionTests.buildCertsInfoNode(NODE_CERT_DETAILS));
+        expectedJsonResponse.set("transport_certificates_list", SecuritySSLReloadCertsActionTests.buildCertsInfoNode(NODE_CERT_DETAILS));
+        Assert.assertEquals(expectedJsonResponse, DefaultObjectMapper.readTree(certInfoRestResponse));
     }
 
     @Test


### PR DESCRIPTION
### Description

Selective manual backport of https://github.com/opensearch-project/security/pull/3262. The original PR cannot be backported as is because of the changes to how the AbstractAPI is written between the 2.x and 1.x line. 

This PR resolves the build error seen on https://github.com/opensearch-project/security/pull/3979.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
