### PR TITLE
Bump spotless (6.24.0 -> 6.25.0) to bump eclipse resources (3.18 -> 3.19) 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ plugins {
     id 'idea'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.24.0'
+    id 'com.diffplug.spotless' version '6.25.0'
     id 'checkstyle'
     id 'com.netflix.nebula.ospackage' version "11.6.0"
     id "org.gradle.test-retry" version "1.5.8"


### PR DESCRIPTION
### Description
This PR bumps spotless to bump the transient dependency on org.eclipse.platform:org.eclipse.core.resources@3.18.100 -> org.eclipse.platform:org.eclipse.core.resources@3.19.100. In turn this should stop scanners from reporting the project as vulnerable to: https://nvd.nist.gov/vuln/detail/CVE-2023-4218. 

I was not able to easily move just the Eclipse dependency because it seems that the package causing the flagging org.eclipse.platform:org.eclipse.core.resources@3.18.100 does not have a straight path forward to the recommended versions listed on the CVE. However, https://security.snyk.io/package/maven/org.eclipse.platform:org.eclipse.core.resources/3.19.100 reports that this version should remove the issue while https://security.snyk.io/package/maven/org.eclipse.platform:org.eclipse.core.resources/3.18.100 will cause the flag. 

One note: We should not actually be concerned about this issue as it is related to Eclipse IDE behavior and nothing to do with the type of dependency on the Eclipse packages like we have. 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
