### PR TITLE
Fix cluster default initialization #1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -618,6 +618,7 @@ dependencies {
 
     //OpenSAML
     implementation 'net.shibboleth.utilities:java-support:8.4.1'
+    runtimeOnly "io.dropwizard.metrics:metrics-core:4.2.15"
     implementation "com.onelogin:java-saml:${one_login_java_saml}"
     implementation "com.onelogin:java-saml-core:${one_login_java_saml}"
     implementation "org.opensaml:opensaml-core:${open_saml_version}"
@@ -643,7 +644,6 @@ dependencies {
     runtimeOnly 'com.google.j2objc:j2objc-annotations:2.8'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
     runtimeOnly 'org.lz4:lz4-java:1.8.0'
-    runtimeOnly 'io.dropwizard.metrics:metrics-core:4.2.25'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.5'
@@ -704,12 +704,12 @@ dependencies {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.13'
-    testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
     testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.2') {
         exclude(group:'ch.qos.logback', module: 'logback-classic' )
         exclude(group:'ch.qos.logback', module: 'logback-core' )
     }
+    testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+public class DefaultConfigurationMultiNodeClusterTests extends AbstractDefaultConfigurationTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.allow_default_init_securityindex",
+                true,
+                "plugins.security.restapi.roles_enabled",
+                List.of("user_admin__all_access")
+            )
+        )
+        .defaultConfigurationInitDirectory(configurationFolder.toString())
+        .loadConfigurationIntoIndex(false)
+        .build();
+
+    public DefaultConfigurationMultiNodeClusterTests() {
+        super(cluster);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterUseClusterStateTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterUseClusterStateTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+public class DefaultConfigurationMultiNodeClusterUseClusterStateTests extends AbstractDefaultConfigurationTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.allow_default_init_securityindex",
+                true,
+                "plugins.security.allow_default_init_securityindex.use_cluster_state",
+                true,
+                "plugins.security.restapi.roles_enabled",
+                List.of("user_admin__all_access")
+            )
+        )
+        .defaultConfigurationInitDirectory(configurationFolder.toString())
+        .loadConfigurationIntoIndex(false)
+        .build();
+
+    public DefaultConfigurationMultiNodeClusterUseClusterStateTests() {
+        super(cluster);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterTests.java
@@ -1,0 +1,44 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class DefaultConfigurationSingleNodeClusterTests extends AbstractDefaultConfigurationTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.allow_default_init_securityindex",
+                true,
+                "plugins.security.restapi.roles_enabled",
+                List.of("user_admin__all_access")
+            )
+        )
+        .defaultConfigurationInitDirectory(configurationFolder.toString())
+        .loadConfigurationIntoIndex(false)
+        .build();
+
+    public DefaultConfigurationSingleNodeClusterTests() {
+        super(cluster);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterUseClusterStateTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterUseClusterStateTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+public class DefaultConfigurationSingleNodeClusterUseClusterStateTests extends AbstractDefaultConfigurationTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .nodeSettings(
+            Map.of(
+                "plugins.security.allow_default_init_securityindex",
+                true,
+                "plugins.security.allow_default_init_securityindex.use_cluster_state",
+                true,
+                "plugins.security.restapi.roles_enabled",
+                List.of("user_admin__all_access")
+            )
+        )
+        .defaultConfigurationInitDirectory(configurationFolder.toString())
+        .loadConfigurationIntoIndex(false)
+        .build();
+
+    public DefaultConfigurationSingleNodeClusterUseClusterStateTests() {
+        super(cluster);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityConfigurationBootstrapTests.java
@@ -124,6 +124,7 @@ public class SecurityConfigurationBootstrapTests {
                     .put("action_groups.yml", CType.ACTIONGROUPS)
                     .put("config.yml", CType.CONFIG)
                     .put("roles.yml", CType.ROLES)
+                    .put("roles_mapping.yml", CType.ROLESMAPPING)
                     .put("tenants.yml", CType.TENANTS)
                     .build();
 
@@ -146,7 +147,7 @@ public class SecurityConfigurationBootstrapTests {
                     // After the configuration has been loaded, the rest clients should be able to connect successfully
                     cluster.triggerConfigurationReloadForCTypes(
                         internalNodeClient,
-                        List.of(CType.ACTIONGROUPS, CType.CONFIG, CType.ROLES, CType.TENANTS),
+                        List.of(CType.ACTIONGROUPS, CType.CONFIG, CType.ROLES, CType.ROLESMAPPING, CType.TENANTS),
                         true
                     );
                     try (final TestRestClient freshClient = cluster.getRestClient(USER_ADMIN)) {

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -72,6 +72,8 @@ import org.opensearch.action.search.PitService;
 import org.opensearch.action.search.SearchScrollAction;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.NamedDiff;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -173,6 +175,7 @@ import org.opensearch.security.ssl.http.netty.ValidatingDispatcher;
 import org.opensearch.security.ssl.transport.DefaultPrincipalExtractor;
 import org.opensearch.security.ssl.transport.SecuritySSLNettyTransport;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.security.state.SecurityMetadata;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.GuardedSearchOperationWrapper;
 import org.opensearch.security.support.HeaderHelper;
@@ -204,6 +207,8 @@ import org.opensearch.watcher.ResourceWatcherService;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
 import static org.opensearch.security.setting.DeprecatedSettings.checkForDeprecatedSetting;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION;
 // CS-ENFORCE-SINGLE
 
@@ -282,6 +287,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
     private static boolean isDisabled(final Settings settings) {
         return settings.getAsBoolean(ConfigConstants.SECURITY_DISABLED, false);
+    }
+
+    private static boolean useClusterStateToInitSecurityConfig(final Settings settings) {
+        return settings.getAsBoolean(SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE, false);
     }
 
     /**
@@ -1166,9 +1175,21 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         components.add(si);
         components.add(dcf);
         components.add(userService);
-
+        final var allowDefaultInit = settings.getAsBoolean(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false);
+        final var useClusterState = useClusterStateToInitSecurityConfig(settings);
+        if (!SSLConfig.isSslOnlyMode() && !isDisabled(settings) && allowDefaultInit && useClusterState) {
+            clusterService.addListener(cr);
+        }
         return components;
 
+    }
+
+    @Override
+    public List<NamedWriteableRegistry.Entry> getNamedWriteables() {
+        return List.of(
+            new NamedWriteableRegistry.Entry(ClusterState.Custom.class, SecurityMetadata.TYPE, SecurityMetadata::new),
+            new NamedWriteableRegistry.Entry(NamedDiff.class, SecurityMetadata.TYPE, SecurityMetadata::readDiffFrom)
+        );
     }
 
     @Override
@@ -1311,9 +1332,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             settings.add(
                 Setting.boolSetting(ConfigConstants.SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES, false, Property.NodeScope, Property.Filtered)
             );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false, Property.NodeScope, Property.Filtered)
-            );
+            settings.add(Setting.boolSetting(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false, Property.NodeScope, Property.Filtered));
+            settings.add(Setting.boolSetting(SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE, false, Property.NodeScope, Property.Filtered));
             settings.add(
                 Setting.boolSetting(
                     ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST,
@@ -1909,11 +1929,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
     @Override
     public void onNodeStarted(DiscoveryNode localNode) {
-        log.info("Node started");
-        if (!SSLConfig.isSslOnlyMode() && !client && !disabled) {
+        this.localNode.set(localNode);
+        if (!SSLConfig.isSslOnlyMode() && !client && !disabled && !useClusterStateToInitSecurityConfig(settings)) {
             cr.initOnNodeStart();
         }
-        this.localNode.set(localNode);
         final Set<ModuleInfo> securityModules = ReflectionHelper.getModulesLoaded();
         log.info("{} OpenSearch Security modules loaded so far: {}", securityModules.size(), securityModules);
     }

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -38,12 +39,16 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -58,13 +63,19 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.client.Client;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.ClusterStateListener;
+import org.opensearch.cluster.ClusterStateUpdateTask;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.common.util.concurrent.ThreadContext.StoredContext;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
@@ -75,12 +86,16 @@ import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.ssl.util.ExceptionUtils;
+import org.opensearch.security.state.SecurityMetadata;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.ConfigHelper;
+import org.opensearch.security.support.SecurityIndexHandler;
 import org.opensearch.security.support.SecurityUtils;
 import org.opensearch.threadpool.ThreadPool;
 
-public class ConfigurationRepository {
+import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE;
+
+public class ConfigurationRepository implements ClusterStateListener {
     private static final Logger LOGGER = LogManager.getLogger(ConfigurationRepository.class);
 
     private final String securityIndex;
@@ -96,20 +111,27 @@ public class ConfigurationRepository {
     private DynamicConfigFactory dynamicConfigFactory;
     public static final int DEFAULT_CONFIG_VERSION = 2;
     private final CompletableFuture<Void> initalizeConfigTask = new CompletableFuture<>();
+
     private final boolean acceptInvalid;
 
-    private ConfigurationRepository(
-        Settings settings,
+    private final AtomicBoolean auditHotReloadingEnabled = new AtomicBoolean(false);
+
+    private final AtomicBoolean initializationInProcess = new AtomicBoolean(false);
+
+    private final SecurityIndexHandler securityIndexHandler;
+
+    // visible for testing
+    protected ConfigurationRepository(
+        final String securityIndex,
+        final Settings settings,
         final Path configPath,
-        ThreadPool threadPool,
-        Client client,
-        ClusterService clusterService,
-        AuditLog auditLog
+        final ThreadPool threadPool,
+        final Client client,
+        final ClusterService clusterService,
+        final AuditLog auditLog,
+        final SecurityIndexHandler securityIndexHandler
     ) {
-        this.securityIndex = settings.get(
-            ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
-            ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
-        );
+        this.securityIndex = securityIndex;
         this.settings = settings;
         this.configPath = configPath;
         this.client = client;
@@ -119,8 +141,38 @@ public class ConfigurationRepository {
         this.configurationChangedListener = new ArrayList<>();
         this.acceptInvalid = settings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_ACCEPT_INVALID_CONFIG, false);
         cl = new ConfigurationLoaderSecurity7(client, threadPool, settings, clusterService);
-
         configCache = CacheBuilder.newBuilder().build();
+        this.securityIndexHandler = securityIndexHandler;
+    }
+
+    private Path resolveConfigDir() {
+        return Optional.ofNullable(System.getProperty("security.default_init.dir"))
+            .map(Path::of)
+            .orElseGet(() -> new Environment(settings, configPath).configDir().resolve("opensearch-security/"));
+    }
+
+    @Override
+    public void clusterChanged(final ClusterChangedEvent event) {
+        final SecurityMetadata securityMetadata = event.state().custom(SecurityMetadata.TYPE);
+        // init and upload sec index on the manager node only as soon as
+        // creation of index and upload config are done a new cluster state will be created.
+        // in case of failures it repeats attempt after restart
+        if (nodeSelectedAsManager(event)) {
+            if (securityMetadata == null) {
+                initSecurityIndex(event);
+            }
+        }
+        // executes reload of cache on each node on the cluster,
+        // since sec initialization has been finished
+        if (securityMetadata != null) {
+            executeConfigurationInitialization(securityMetadata);
+        }
+    }
+
+    private boolean nodeSelectedAsManager(final ClusterChangedEvent event) {
+        boolean wasClusterManager = event.previousState().nodes().isLocalNodeElectedClusterManager();
+        boolean isClusterManager = event.localNodeClusterManager();
+        return !wasClusterManager && isClusterManager;
     }
 
     public String getConfigDirectory() {
@@ -236,7 +288,7 @@ public class ConfigurationRepository {
                 } catch (Exception e) {
                     LOGGER.debug("Unable to load configuration due to {}", String.valueOf(ExceptionUtils.getRootCause(e)));
                     try {
-                        Thread.sleep(3000);
+                        TimeUnit.MILLISECONDS.sleep(3000);
                     } catch (InterruptedException e1) {
                         Thread.currentThread().interrupt();
                         LOGGER.debug("Thread was interrupted so we cancel initialization");
@@ -244,31 +296,32 @@ public class ConfigurationRepository {
                     }
                 }
             }
-
-            final Set<String> deprecatedAuditKeysInSettings = AuditConfig.getDeprecatedKeys(settings);
-            if (!deprecatedAuditKeysInSettings.isEmpty()) {
-                LOGGER.warn(
-                    "Following keys {} are deprecated in opensearch settings. They will be removed in plugin v2.0.0.0",
-                    deprecatedAuditKeysInSettings
-                );
-            }
-            final boolean isAuditConfigDocPresentInIndex = cl.isAuditConfigDocPresentInIndex();
-            if (isAuditConfigDocPresentInIndex) {
-                if (!deprecatedAuditKeysInSettings.isEmpty()) {
-                    LOGGER.warn("Audit configuration settings found in both index and opensearch settings (deprecated)");
-                }
-                LOGGER.info("Hot-reloading of audit configuration is enabled");
-            } else {
-                LOGGER.info(
-                    "Hot-reloading of audit configuration is disabled. Using configuration with defaults from opensearch settings.  Populate the configuration in index using audit.yml or securityadmin to enable it."
-                );
-                auditLog.setConfig(AuditConfig.from(settings));
-            }
-
+            setupAuditConfigurationIfAny(cl.isAuditConfigDocPresentInIndex());
             LOGGER.info("Node '{}' initialized", clusterService.localNode().getName());
 
         } catch (Exception e) {
             LOGGER.error("Unexpected exception while initializing node " + e, e);
+        }
+    }
+
+    private void setupAuditConfigurationIfAny(final boolean auditConfigDocPresent) {
+        final Set<String> deprecatedAuditKeysInSettings = AuditConfig.getDeprecatedKeys(settings);
+        if (!deprecatedAuditKeysInSettings.isEmpty()) {
+            LOGGER.warn(
+                "Following keys {} are deprecated in opensearch settings. They will be removed in plugin v2.0.0.0",
+                deprecatedAuditKeysInSettings
+            );
+        }
+        if (auditConfigDocPresent) {
+            if (!deprecatedAuditKeysInSettings.isEmpty()) {
+                LOGGER.warn("Audit configuration settings found in both index and opensearch settings (deprecated)");
+            }
+            LOGGER.info("Hot-reloading of audit configuration is enabled");
+        } else {
+            LOGGER.info(
+                "Hot-reloading of audit configuration is disabled. Using configuration with defaults from opensearch settings.  Populate the configuration in index using audit.yml or securityadmin to enable it."
+            );
+            auditLog.setConfig(AuditConfig.from(settings));
         }
     }
 
@@ -304,7 +357,7 @@ public class ConfigurationRepository {
                 response == null ? "no response" : (response.isTimedOut() ? "timeout" : "other, maybe red cluster")
             );
             try {
-                Thread.sleep(500);
+                TimeUnit.MILLISECONDS.sleep(500);
             } catch (InterruptedException e) {
                 // ignore
                 Thread.currentThread().interrupt();
@@ -317,6 +370,69 @@ public class ConfigurationRepository {
         }
     }
 
+    void initSecurityIndex(final ClusterChangedEvent event) {
+        if (!event.state().metadata().hasIndex(securityIndex)) {
+            securityIndexHandler.createIndex(
+                ActionListener.wrap(r -> uploadDefaultConfiguration0(), e -> LOGGER.error("Couldn't create index {}", securityIndex, e))
+            );
+        } else {
+            // in case index was created and cluster state has not been changed (e.g. restart of the node or something)
+            // just upload default configuration
+            uploadDefaultConfiguration0();
+        }
+    }
+
+    private void uploadDefaultConfiguration0() {
+        securityIndexHandler.uploadDefaultConfiguration(
+            resolveConfigDir(),
+            ActionListener.wrap(
+                configuration -> clusterService.submitStateUpdateTask(
+                    "init-security-configuration",
+                    new ClusterStateUpdateTask(Priority.IMMEDIATE) {
+                        @Override
+                        public ClusterState execute(ClusterState clusterState) throws Exception {
+                            return ClusterState.builder(clusterState)
+                                .putCustom(SecurityMetadata.TYPE, new SecurityMetadata(Instant.now(), configuration))
+                                .build();
+                        }
+
+                        @Override
+                        public void onFailure(String s, Exception e) {
+                            LOGGER.error(s, e);
+                        }
+                    }
+                ),
+                e -> LOGGER.error("Couldn't upload default configuration", e)
+            )
+        );
+    }
+
+    Future<Void> executeConfigurationInitialization(final SecurityMetadata securityMetadata) {
+        if (!initalizeConfigTask.isDone()) {
+            if (initializationInProcess.compareAndSet(false, true)) {
+                return threadPool.generic().submit(() -> {
+                    securityIndexHandler.loadConfiguration(securityMetadata.configuration(), ActionListener.wrap(cTypeConfigs -> {
+                        notifyConfigurationListeners(cTypeConfigs);
+                        final var auditConfigDocPresent = cTypeConfigs.containsKey(CType.AUDIT) && cTypeConfigs.get(CType.AUDIT).notEmpty();
+                        setupAuditConfigurationIfAny(auditConfigDocPresent);
+                        auditHotReloadingEnabled.getAndSet(auditConfigDocPresent);
+                        initalizeConfigTask.complete(null);
+                        LOGGER.info(
+                            "Security configuration initialized. Applied hashes: {}",
+                            securityMetadata.configuration()
+                                .stream()
+                                .map(c -> String.format("%s:%s", c.type().toLCString(), c.hash()))
+                                .collect(Collectors.toList())
+                        );
+                    }, e -> LOGGER.error("Couldn't reload security configuration", e)));
+                    return null;
+                });
+            }
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Deprecated
     public CompletableFuture<Boolean> initOnNodeStart() {
         final boolean installDefaultConfig = settings.getAsBoolean(ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, false);
 
@@ -333,13 +449,15 @@ public class ConfigurationRepository {
                 return startInitialization.get();
             } else if (settings.getAsBoolean(ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, true)) {
                 LOGGER.info(
-                    "Will not attempt to create index {} and default configs if they are absent. Use securityadmin to initialize cluster",
+                    "Will not attempt to create index {} and default configs if they are absent."
+                        + " Use securityadmin to initialize cluster",
                     securityIndex
                 );
                 return startInitialization.get();
             } else {
                 LOGGER.info(
-                    "Will not attempt to create index {} and default configs if they are absent. Will not perform background initialization",
+                    "Will not attempt to create index {} and default configs if they are absent. "
+                        + "Will not perform background initialization",
                     securityIndex
                 );
                 initalizeConfigTask.complete(null);
@@ -352,7 +470,11 @@ public class ConfigurationRepository {
     }
 
     public boolean isAuditHotReloadingEnabled() {
-        return cl.isAuditConfigDocPresentInIndex();
+        if (settings.getAsBoolean(SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE, false)) {
+            return auditHotReloadingEnabled.get();
+        } else {
+            return cl.isAuditConfigDocPresentInIndex();
+        }
     }
 
     public static ConfigurationRepository create(
@@ -363,15 +485,20 @@ public class ConfigurationRepository {
         ClusterService clusterService,
         AuditLog auditLog
     ) {
-        final ConfigurationRepository repository = new ConfigurationRepository(
+        final var securityIndex = settings.get(
+            ConfigConstants.SECURITY_CONFIG_INDEX_NAME,
+            ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX
+        );
+        return new ConfigurationRepository(
+            securityIndex,
             settings,
             configPath,
             threadPool,
             client,
             clusterService,
-            auditLog
+            auditLog,
+            new SecurityIndexHandler(securityIndex, settings, client)
         );
-        return repository;
     }
 
     public void setDynamicConfigFactory(DynamicConfigFactory dynamicConfigFactory) {
@@ -403,6 +530,10 @@ public class ConfigurationRepository {
             LOGGER.warn("Unable to reload configuration, initalization thread has not yet completed.");
             return false;
         }
+        return loadConfigurationWithLock(configTypes);
+    }
+
+    private boolean loadConfigurationWithLock(Collection<CType> configTypes) {
         try {
             if (LOCK.tryLock(60, TimeUnit.SECONDS)) {
                 try {
@@ -422,8 +553,12 @@ public class ConfigurationRepository {
 
     private void reloadConfiguration0(Collection<CType> configTypes, boolean acceptInvalid) {
         final Map<CType, SecurityDynamicConfiguration<?>> loaded = getConfigurationsFromIndex(configTypes, false, acceptInvalid);
-        configCache.putAll(loaded);
-        notifyAboutChanges(loaded);
+        notifyConfigurationListeners(loaded);
+    }
+
+    private void notifyConfigurationListeners(final Map<CType, SecurityDynamicConfiguration<?>> configuration) {
+        configCache.putAll(configuration);
+        notifyAboutChanges(configuration);
     }
 
     public synchronized void subscribeOnChange(ConfigurationChangeListener listener) {

--- a/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -68,6 +68,11 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
         return new SecurityDynamicConfiguration<T>();
     }
 
+    @JsonIgnore
+    public boolean notEmpty() {
+        return !centries.isEmpty();
+    }
+
     public static <T> SecurityDynamicConfiguration<T> fromJson(String json, CType ctype, int version, long seqNo, long primaryTerm)
         throws IOException {
         return fromJson(json, ctype, version, seqNo, primaryTerm, false);

--- a/src/main/java/org/opensearch/security/state/SecurityConfig.java
+++ b/src/main/java/org/opensearch/security/state/SecurityConfig.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.state;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.security.securityconf.impl.CType;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+public class SecurityConfig implements Writeable, ToXContent {
+
+    private final CType type;
+
+    private final Instant lastModified;
+
+    private final String hash;
+
+    public SecurityConfig(final CType type, final String hash, final Instant lastModified) {
+        this.type = type;
+        this.hash = hash;
+        this.lastModified = lastModified;
+    }
+
+    public SecurityConfig(final StreamInput in) throws IOException {
+        this.type = in.readEnum(CType.class);
+        this.hash = in.readString();
+        this.lastModified = in.readOptionalInstant();
+    }
+
+    public Optional<Instant> lastModified() {
+        return Optional.ofNullable(lastModified);
+    }
+
+    public CType type() {
+        return type;
+    }
+
+    public String hash() {
+        return hash;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeEnum(type);
+        out.writeString(hash);
+        out.writeOptionalInstant(lastModified);
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder xContentBuilder, final Params params) throws IOException {
+        xContentBuilder.startObject(type.toLCString()).field("hash", hash);
+        if (lastModified != null) {
+            xContentBuilder.field("last_modified", ISO_INSTANT.format(lastModified));
+        } else {
+            xContentBuilder.nullField("last_modified");
+        }
+        return xContentBuilder.endObject();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SecurityConfig that = (SecurityConfig) o;
+        return type == that.type && Objects.equals(lastModified, that.lastModified) && Objects.equals(hash, that.hash);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, lastModified, hash);
+    }
+
+    public final static class Builder {
+
+        private final CType type;
+
+        private Instant lastModified;
+
+        private String hash;
+
+        Builder(final SecurityConfig securityConfig) {
+            this.type = securityConfig.type;
+            this.lastModified = securityConfig.lastModified;
+            this.hash = securityConfig.hash;
+        }
+
+        public Builder withHash(final String hash) {
+            this.hash = hash;
+            return this;
+        }
+
+        public Builder withLastModified(final Instant lastModified) {
+            this.lastModified = lastModified;
+            return this;
+        }
+
+        public SecurityConfig build() {
+            return new SecurityConfig(type, hash, lastModified);
+        }
+
+    }
+
+    public static SecurityConfig.Builder from(final SecurityConfig securityConfig) {
+        return new SecurityConfig.Builder(securityConfig);
+    }
+
+}

--- a/src/main/java/org/opensearch/security/state/SecurityMetadata.java
+++ b/src/main/java/org/opensearch/security/state/SecurityMetadata.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.state;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.AbstractNamedDiffable;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.NamedDiff;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import static java.time.format.DateTimeFormatter.ISO_INSTANT;
+
+public final class SecurityMetadata extends AbstractNamedDiffable<ClusterState.Custom> implements ClusterState.Custom {
+
+    public final static String TYPE = "security";
+
+    private final Instant created;
+
+    private final Set<SecurityConfig> configuration;
+
+    public SecurityMetadata(final Instant created, final Set<SecurityConfig> configuration) {
+        this.created = created;
+        this.configuration = configuration;
+    }
+
+    public SecurityMetadata(StreamInput in) throws IOException {
+        this.created = in.readInstant();
+        this.configuration = in.readSet(SecurityConfig::new);
+    }
+
+    public Instant created() {
+        return created;
+    }
+
+    public Set<SecurityConfig> configuration() {
+        return configuration;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.CURRENT.minimumCompatibilityVersion();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeInstant(created);
+        out.writeCollection(configuration);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder xContentBuilder, Params params) throws IOException {
+        xContentBuilder.field("created", ISO_INSTANT.format(created));
+        xContentBuilder.startObject("configuration");
+        for (final var securityConfig : configuration) {
+            securityConfig.toXContent(xContentBuilder, EMPTY_PARAMS);
+        }
+        return xContentBuilder.endObject();
+    }
+
+    public static NamedDiff<ClusterState.Custom> readDiffFrom(StreamInput in) throws IOException {
+        return readDiffFrom(ClusterState.Custom.class, TYPE, in);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SecurityMetadata that = (SecurityMetadata) o;
+        return Objects.equals(created, that.created) && Objects.equals(configuration, that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(created, configuration);
+    }
+
+    public final static class Builder {
+
+        private final Instant created;
+
+        private final ImmutableSet.Builder<SecurityConfig> configuration = new ImmutableSortedSet.Builder<>(
+            Comparator.comparing(SecurityConfig::type)
+        );
+
+        Builder(SecurityMetadata oldMetadata) {
+            this.created = oldMetadata.created;
+            this.configuration.addAll(oldMetadata.configuration);
+        }
+
+        public Builder withSecurityConfig(final SecurityConfig securityConfig) {
+            this.configuration.add(securityConfig);
+            return this;
+        }
+
+        public SecurityMetadata build() {
+            return new SecurityMetadata(created, configuration.build());
+        }
+
+    }
+
+    public static SecurityMetadata.Builder from(final SecurityMetadata securityMetadata) {
+        return new SecurityMetadata.Builder(securityMetadata);
+    }
+
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -220,9 +220,14 @@ public class ConfigConstants {
     public static final String SECURITY_NODES_DN = "plugins.security.nodes_dn";
     public static final String SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED = "plugins.security.nodes_dn_dynamic_config_enabled";
     public static final String SECURITY_DISABLED = "plugins.security.disabled";
+
     public static final String SECURITY_CACHE_TTL_MINUTES = "plugins.security.cache.ttl_minutes";
     public static final String SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES = "plugins.security.allow_unsafe_democertificates";
     public static final String SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX = "plugins.security.allow_default_init_securityindex";
+
+    public static final String SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE =
+        "plugins.security.allow_default_init_securityindex.use_cluster_state";
+
     public static final String SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST =
         "plugins.security.background_init_if_securityindex_not_exist";
 

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -57,6 +57,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
+@Deprecated
 public class ConfigHelper {
 
     private static final Logger LOGGER = LogManager.getLogger(ConfigHelper.class);

--- a/src/main/java/org/opensearch/security/support/SecurityIndexHandler.java
+++ b/src/main/java/org/opensearch/security/support/SecurityIndexHandler.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.hash.Hashing;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.get.MultiGetRequest;
+import org.opensearch.action.get.MultiGetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest;
+import org.opensearch.client.Client;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.state.SecurityConfig;
+
+import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
+import static org.opensearch.security.support.YamlConfigReader.emptyJsonConfigFor;
+import static org.opensearch.security.support.YamlConfigReader.yamlContentFor;
+
+public class SecurityIndexHandler {
+
+    private final static int MINIMUM_HASH_BITS = 128;
+
+    private static final Logger LOGGER = LogManager.getLogger(SecurityIndexHandler.class);
+
+    private final Settings settings;
+
+    private final Client client;
+
+    private final String indexName;
+
+    public SecurityIndexHandler(final String indexName, final Settings settings, final Client client) {
+        this.indexName = indexName;
+        this.settings = settings;
+        this.client = client;
+    }
+
+    public final static Map<String, Object> INDEX_SETTINGS = Map.of("index.number_of_shards", 1, "index.auto_expand_replicas", "0-all");
+
+    public void createIndex(ActionListener<Boolean> listener) {
+        try (final ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+            client.admin()
+                .indices()
+                .create(
+                    new CreateIndexRequest(indexName).settings(INDEX_SETTINGS).waitForActiveShards(1),
+                    ActionListener.runBefore(ActionListener.wrap(r -> {
+                        if (r.isAcknowledged()) {
+                            listener.onResponse(true);
+                        } else listener.onFailure(new SecurityException("Couldn't create security index " + indexName));
+                    }, listener::onFailure), threadContext::restore)
+                );
+        }
+    }
+
+    public void uploadDefaultConfiguration(final Path configDir, final ActionListener<Set<SecurityConfig>> listener) {
+        try (final ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                try {
+                    LOGGER.info("Uploading default security configuration from {}", configDir.toAbsolutePath());
+                    final var bulkRequest = new BulkRequest().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                    final var configuration = new ImmutableSortedSet.Builder<>(Comparator.comparing(SecurityConfig::type));
+                    for (final var cType : CType.values()) {
+                        final var fileExists = Files.exists(cType.configFile(configDir));
+                        // Audit config is not packaged by default and while list is deprecated
+                        if ((cType == CType.AUDIT || cType == CType.WHITELIST) && !fileExists) continue;
+                        if (cType == CType.WHITELIST) {
+                            LOGGER.warn(
+                                "WHITELIST configuration type is deprecated and will be replaced with ALLOWLIST in the next major version"
+                            );
+                        }
+                        final var yamlContent = yamlContentFor(cType, configDir);
+                        final var hash = Hashing.goodFastHash(MINIMUM_HASH_BITS).hashBytes(yamlContent.toBytesRef().bytes);
+                        configuration.add(new SecurityConfig(cType, hash.toString(), null));
+                        bulkRequest.add(
+                            new IndexRequest(indexName).id(cType.toLCString())
+                                .opType(DocWriteRequest.OpType.INDEX)
+                                .source(cType.toLCString(), yamlContent)
+                        );
+                    }
+                    client.bulk(bulkRequest, ActionListener.runBefore(ActionListener.wrap(r -> {
+                        if (r.hasFailures()) {
+                            listener.onFailure(new SecurityException(r.buildFailureMessage()));
+                            return;
+                        }
+                        listener.onResponse(configuration.build());
+                    }, listener::onFailure), threadContext::restore));
+                } catch (final IOException ioe) {
+                    listener.onFailure(new SecurityException(ioe));
+                }
+                return null;
+            });
+        }
+    }
+
+    public void loadConfiguration(
+        final Set<SecurityConfig> configuration,
+        final ActionListener<Map<CType, SecurityDynamicConfiguration<?>>> listener
+    ) {
+        try (final ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
+            client.threadPool().getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER, "true");
+            final var configurationTypes = configuration.stream().map(SecurityConfig::type).collect(Collectors.toUnmodifiableList());
+            client.multiGet(newMultiGetRequest(configurationTypes), ActionListener.runBefore(ActionListener.wrap(r -> {
+                final var cTypeConfigsBuilder = ImmutableMap.<CType, SecurityDynamicConfiguration<?>>builderWithExpectedSize(
+                    configuration.size()
+                );
+                var hasFailures = false;
+                for (final var item : r.getResponses()) {
+                    if (item.isFailed()) {
+                        listener.onFailure(new SecurityException(multiGetFailureMessage(item.getId(), item.getFailure())));
+                        hasFailures = true;
+                        break;
+                    }
+                    final var cType = CType.fromString(item.getId());
+                    final var cTypeResponse = item.getResponse();
+                    if (cTypeResponse.isExists() && !cTypeResponse.isSourceEmpty()) {
+                        final var config = buildDynamicConfiguration(
+                            cType,
+                            cTypeResponse.getSourceAsBytesRef(),
+                            cTypeResponse.getSeqNo(),
+                            cTypeResponse.getPrimaryTerm()
+                        );
+                        if (config.getVersion() != DEFAULT_CONFIG_VERSION) {
+                            listener.onFailure(
+                                new SecurityException("Version " + config.getVersion() + " is not supported for " + cType.name())
+                            );
+                            hasFailures = true;
+                            break;
+                        }
+                        cTypeConfigsBuilder.put(cType, config);
+                    } else {
+                        if (!cType.emptyIfMissing()) {
+                            listener.onFailure(new SecurityException("Missing required configuration for type: " + cType));
+                            hasFailures = true;
+                            break;
+                        }
+                        cTypeConfigsBuilder.put(
+                            cType,
+                            SecurityDynamicConfiguration.fromJson(
+                                emptyJsonConfigFor(cType),
+                                cType,
+                                DEFAULT_CONFIG_VERSION,
+                                cTypeResponse.getSeqNo(),
+                                cTypeResponse.getPrimaryTerm()
+                            )
+                        );
+                    }
+                }
+                if (!hasFailures) {
+                    listener.onResponse(cTypeConfigsBuilder.build());
+                }
+            }, listener::onFailure), threadContext::restore));
+        }
+    }
+
+    private MultiGetRequest newMultiGetRequest(final List<CType> configurationTypes) {
+        final var request = new MultiGetRequest().realtime(true).refresh(true);
+        for (final var cType : configurationTypes) {
+            request.add(indexName, cType.toLCString());
+        }
+        return request;
+    }
+
+    private SecurityDynamicConfiguration<?> buildDynamicConfiguration(
+        final CType cType,
+        final BytesReference bytesRef,
+        final long seqNo,
+        final long primaryTerm
+    ) {
+        try {
+            final var source = SecurityUtils.replaceEnvVars(configTypeSource(bytesRef.streamInput()), settings);
+            final var jsonNode = DefaultObjectMapper.readTree(source);
+            var version = 1;
+            if (jsonNode.has("_meta")) {
+                if (jsonNode.get("_meta").has("config_version")) {
+                    version = jsonNode.get("_meta").get("config_version").asInt();
+                }
+            }
+            return SecurityDynamicConfiguration.fromJson(source, cType, version, seqNo, primaryTerm);
+        } catch (IOException e) {
+            throw new SecurityException("Couldn't parse content for " + cType, e);
+        }
+    }
+
+    private String configTypeSource(final InputStream inputStream) throws IOException {
+        final var jsonContent = XContentType.JSON.xContent();
+        try (final var parser = jsonContent.createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, inputStream)) {
+            parser.nextToken();
+            parser.nextToken();
+            parser.nextToken();
+            return new String(parser.binaryValue(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private String multiGetFailureMessage(final String cTypeId, final MultiGetResponse.Failure failure) {
+        return String.format("Failure %s retrieving configuration for %s (index=%s)", failure, cTypeId, indexName);
+    }
+
+}

--- a/src/main/java/org/opensearch/security/support/YamlConfigReader.java
+++ b/src/main/java/org/opensearch/security/support/YamlConfigReader.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.support;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.Meta;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+
+import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
+
+/**
+ * Read YAML security config files
+ */
+public final class YamlConfigReader {
+
+    private static final Logger LOGGER = LogManager.getLogger(YamlConfigReader.class);
+
+    public static BytesReference yamlContentFor(final CType cType, final Path configDir) throws IOException {
+        final var yamlXContent = XContentType.YAML.xContent();
+        try (
+            final var r = newReader(cType, configDir);
+            final var parser = yamlXContent.createParser(NamedXContentRegistry.EMPTY, THROW_UNSUPPORTED_OPERATION, r)
+        ) {
+            parser.nextToken();
+            try (final var xContentBuilder = XContentFactory.jsonBuilder()) {
+                xContentBuilder.copyCurrentStructure(parser);
+                final var bytesRef = BytesReference.bytes(xContentBuilder);
+                validateYamlContent(cType, bytesRef.streamInput());
+                return bytesRef;
+            }
+        }
+    }
+
+    public static Reader newReader(final CType cType, final Path configDir) throws IOException {
+        final var cTypeFile = cType.configFile(configDir);
+        final var fileExists = Files.exists(cTypeFile);
+        if (!fileExists && !cType.emptyIfMissing()) {
+            throw new IOException("Couldn't find configuration file " + cTypeFile.getFileName());
+        }
+        if (fileExists) {
+            LOGGER.info("Reading {} configuration from {}", cType, cTypeFile.getFileName());
+            return new FileReader(cTypeFile.toFile(), StandardCharsets.UTF_8);
+        } else {
+            LOGGER.info("Reading empty {} configuration", cType);
+            return new StringReader(emptyYamlConfigFor(cType));
+        }
+    }
+
+    private static SecurityDynamicConfiguration<?> emptyConfigFor(final CType cType) {
+        final var emptyConfiguration = SecurityDynamicConfiguration.empty();
+        emptyConfiguration.setCType(cType);
+        emptyConfiguration.set_meta(new Meta());
+        emptyConfiguration.get_meta().setConfig_version(DEFAULT_CONFIG_VERSION);
+        emptyConfiguration.get_meta().setType(cType.toLCString());
+        return emptyConfiguration;
+    }
+
+    public static String emptyJsonConfigFor(final CType cType) throws IOException {
+        return DefaultObjectMapper.writeValueAsString(emptyConfigFor(cType), false);
+    }
+
+    public static String emptyYamlConfigFor(final CType cType) throws IOException {
+        return DefaultObjectMapper.YAML_MAPPER.writeValueAsString(emptyConfigFor(cType));
+    }
+
+    private static void validateYamlContent(final CType cType, final InputStream in) throws IOException {
+        SecurityDynamicConfiguration.fromNode(DefaultObjectMapper.YAML_MAPPER.readTree(in), cType, DEFAULT_CONFIG_VERSION, -1, -1);
+    }
+
+}

--- a/src/test/java/org/opensearch/security/state/SecurityMetadataSerializationTestCase.java
+++ b/src/test/java/org/opensearch/security/state/SecurityMetadataSerializationTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.state;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.google.common.collect.ImmutableSortedSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.common.io.stream.BytesStreamOutput;
+import org.opensearch.core.common.io.stream.NamedWriteableAwareStreamInput;
+import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.test.DiffableTestUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+@RunWith(RandomizedRunner.class)
+public class SecurityMetadataSerializationTestCase extends RandomizedTest {
+
+    protected ClusterState.Custom createTestInstance() {
+        final var configuration = new ImmutableSortedSet.Builder<>(Comparator.comparing(SecurityConfig::type));
+        for (final var c : CType.values()) {
+            configuration.add(new SecurityConfig(c, randomAsciiAlphanumOfLength(128), null));
+        }
+        return new SecurityMetadata(randomInstant(), configuration.build());
+    }
+
+    protected ClusterState.Custom makeTestChanges(ClusterState.Custom custom) {
+        final var securityMetadata = (SecurityMetadata) custom;
+
+        if (randomBoolean()) {
+            final var configuration = securityMetadata.configuration();
+            int leaveElements = randomIntBetween(0, configuration.size() - 1);
+            final var randomConfigs = randomSubsetOf(leaveElements, configuration);
+            final var securityMetadataBuilder = SecurityMetadata.from(securityMetadata);
+            for (final var config : randomConfigs) {
+                securityMetadataBuilder.withSecurityConfig(
+                    SecurityConfig.from(config).withLastModified(randomInstant()).withHash(randomAsciiAlphanumOfLength(128)).build()
+                );
+            }
+            return securityMetadataBuilder.build();
+        }
+
+        return securityMetadata;
+    }
+
+    public static <T> List<T> randomSubsetOf(int size, Collection<T> collection) {
+        if (size > collection.size()) {
+            throw new IllegalArgumentException(
+                "Can't pick " + size + " random objects from a collection of " + collection.size() + " objects"
+            );
+        }
+        List<T> tempList = new ArrayList<>(collection);
+        Collections.shuffle(tempList, RandomizedContext.current().getRandom());
+        return tempList.subList(0, size);
+    }
+
+    protected Instant randomInstant() {
+        return Instant.ofEpochSecond(randomLongBetween(0L, 3000000000L), randomLongBetween(0L, 999999999L));
+    }
+
+    @Test
+    public void testSerialization() throws IOException {
+        for (int runs = 0; runs < 20; runs++) {
+            ClusterState.Custom testInstance = createTestInstance();
+            assertSerialization(testInstance);
+        }
+    }
+
+    void assertSerialization(ClusterState.Custom testInstance) throws IOException {
+        assertSerialization(testInstance, Version.CURRENT);
+    }
+
+    void assertSerialization(ClusterState.Custom testInstance, Version version) throws IOException {
+        ClusterState.Custom deserializedInstance = copyInstance(testInstance, version);
+        assertEqualInstances(testInstance, deserializedInstance);
+    }
+
+    void assertEqualInstances(ClusterState.Custom expectedInstance, ClusterState.Custom newInstance) {
+        assertNotSame(newInstance, expectedInstance);
+        assertEquals(expectedInstance, newInstance);
+        assertEquals(expectedInstance.hashCode(), newInstance.hashCode());
+    }
+
+    @Test
+    public void testDiffableSerialization() throws IOException {
+        DiffableTestUtils.testDiffableSerialization(
+            this::createTestInstance,
+            this::makeTestChanges,
+            getNamedWriteableRegistry(),
+            SecurityMetadata::new,
+            SecurityMetadata::readDiffFrom
+        );
+    }
+
+    protected NamedWriteableRegistry getNamedWriteableRegistry() {
+        return new NamedWriteableRegistry(Collections.emptyList());
+    }
+
+    protected final ClusterState.Custom copyInstance(ClusterState.Custom instance, Version version) throws IOException {
+        return copyWriteable(instance, getNamedWriteableRegistry(), SecurityMetadata::new, version);
+    }
+
+    public static <T extends Writeable> T copyWriteable(
+        T original,
+        NamedWriteableRegistry namedWriteableRegistry,
+        Writeable.Reader<T> reader,
+        Version version
+    ) throws IOException {
+        return copyInstance(original, namedWriteableRegistry, (out, value) -> value.writeTo(out), reader, version);
+    }
+
+    protected static <T> T copyInstance(
+        T original,
+        NamedWriteableRegistry namedWriteableRegistry,
+        Writeable.Writer<T> writer,
+        Writeable.Reader<T> reader,
+        Version version
+    ) throws IOException {
+        try (BytesStreamOutput output = new BytesStreamOutput()) {
+            output.setVersion(version);
+            writer.write(output, original);
+            try (StreamInput in = new NamedWriteableAwareStreamInput(output.bytes().streamInput(), namedWriteableRegistry)) {
+                in.setVersion(version);
+                return reader.read(in);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
+++ b/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.support;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.securityconf.impl.CType;
+
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class ConfigReaderTest {
+
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    private static File configDir;
+
+    @BeforeClass
+    public static void createConfigFile() throws IOException {
+        configDir = folder.newFolder("config");
+    }
+
+    @Test
+    public void testThrowsIOExceptionForMandatoryCTypes() {
+        for (final var cType : CType.REQUIRED_CONFIG_FILES) {
+            assertThrows(IOException.class, () -> YamlConfigReader.newReader(cType, configDir.toPath()));
+        }
+    }
+
+    @Test
+    public void testCreateReaderForNonMandatoryCTypes() throws IOException {
+        final var yamlMapper = DefaultObjectMapper.YAML_MAPPER;
+        for (final var cType : CType.NOT_REQUIRED_CONFIG_FILES) {
+            try (final var reader = new BufferedReader(YamlConfigReader.newReader(cType, configDir.toPath()))) {
+                final var emptyYaml = yamlMapper.readTree(reader);
+                assertTrue(emptyYaml.has("_meta"));
+
+                final var meta = emptyYaml.get("_meta");
+                assertEquals(cType.toLCString(), meta.get("type").asText());
+                assertEquals(DEFAULT_CONFIG_VERSION, meta.get("config_version").asInt());
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
+++ b/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
@@ -1,0 +1,510 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.support;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.get.MultiGetItemResponse;
+import org.opensearch.action.get.MultiGetRequest;
+import org.opensearch.action.get.MultiGetResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActiveShardCount;
+import org.opensearch.client.AdminClient;
+import org.opensearch.client.Client;
+import org.opensearch.client.IndicesAdminClient;
+import org.opensearch.common.CheckedSupplier;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.index.get.GetResult;
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.state.SecurityConfig;
+import org.opensearch.threadpool.ThreadPool;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
+import static org.opensearch.security.support.YamlConfigReader.emptyYamlConfigFor;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecurityIndexHandlerTest {
+
+    final static String INDEX_NAME = "some_index";
+
+    final static String CONFIG_YAML = "_meta: \n"
+        + "  type: \"config\"\n"
+        + "  config_version: 2\n"
+        + "config:\n"
+        + "  dynamic:\n"
+        + "    http:\n"
+        + "      anonymous_auth_enabled: false\n";
+
+    final static String USERS_YAML = "_meta:\n"
+        + "  type: \"internalusers\"\n"
+        + "  config_version: 2\n"
+        + "admin:\n"
+        + "  hash: \"$2y$12$erlkZeSv7eRMa1vs3UgDl.xoqu1P9GY94Toj1BwdvJiq7eKTOjQjS\"\n"
+        + "  reserved: true\n"
+        + "  backend_roles:\n"
+        + "  - \"admin\"\n"
+        + "  description: \"Some admin user\"\n";
+
+    final static String ROLES_YAML = "_meta:\n" + "  type: \"roles\"\n" + "  config_version: 2\n" + "some_role:\n" + "  reserved: true\n";
+
+    final static String ROLES_MAPPING_YAML = "_meta:\n"
+        + " type: \"rolesmapping\"\n"
+        + " config_version: 2\n"
+        + "all_access: \n"
+        + " reserved: false\n";
+
+    static final Map<CType, CheckedSupplier<String, IOException>> YAML = Map.of(
+        CType.ACTIONGROUPS,
+        () -> emptyYamlConfigFor(CType.ACTIONGROUPS),
+        CType.ALLOWLIST,
+        () -> emptyYamlConfigFor(CType.ALLOWLIST),
+        CType.AUDIT,
+        () -> emptyYamlConfigFor(CType.AUDIT),
+        CType.CONFIG,
+        () -> CONFIG_YAML,
+        CType.INTERNALUSERS,
+        () -> USERS_YAML,
+        CType.NODESDN,
+        () -> emptyYamlConfigFor(CType.NODESDN),
+        CType.ROLES,
+        () -> ROLES_YAML,
+        CType.ROLESMAPPING,
+        () -> ROLES_MAPPING_YAML,
+        CType.TENANTS,
+        () -> emptyYamlConfigFor(CType.TENANTS),
+        CType.WHITELIST,
+        () -> emptyYamlConfigFor(CType.WHITELIST)
+    );
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private Client client;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+
+    private Path configFolder;
+
+    private ThreadContext threadContext;
+
+    private SecurityIndexHandler securityIndexHandler;
+
+    @Before
+    public void setupClient() throws IOException {
+        when(client.admin()).thenReturn(mock(AdminClient.class));
+        when(client.admin().indices()).thenReturn(indicesAdminClient);
+        when(client.threadPool()).thenReturn(threadPool);
+        threadContext = new ThreadContext(Settings.EMPTY);
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        configFolder = temporaryFolder.newFolder("config").toPath();
+        securityIndexHandler = new SecurityIndexHandler(INDEX_NAME, Settings.EMPTY, client);
+    }
+
+    @Test
+    public void testCreateIndex_shouldCreateIndex() {
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new CreateIndexResponse(true, true, "some_index"));
+            return null;
+        }).when(indicesAdminClient).create(any(), any());
+
+        securityIndexHandler.createIndex(ActionListener.wrap(Assert::assertTrue, Assert::assertNull));
+
+        final var requestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
+
+        verify(indicesAdminClient).create(requestCaptor.capture(), any());
+
+        final var createRequest = requestCaptor.getValue();
+        assertEquals(INDEX_NAME, createRequest.index());
+        for (final var setting : SecurityIndexHandler.INDEX_SETTINGS.entrySet())
+            assertEquals(setting.getValue().toString(), createRequest.settings().get(setting.getKey()));
+
+        assertEquals(ActiveShardCount.ONE, createRequest.waitForActiveShards());
+    }
+
+    @Test
+    public void testCreateIndex_shouldReturnSecurityExceptionIfItCanNotCreateIndex() {
+
+        final var listener = spy(ActionListener.<Boolean>wrap(r -> fail("Unexpected behave"), e -> {
+            assertEquals(SecurityException.class, e.getClass());
+            assertEquals("Couldn't create security index " + INDEX_NAME, e.getMessage());
+        }));
+
+        doAnswer(invocation -> {
+            ActionListener<CreateIndexResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new CreateIndexResponse(false, false, "some_index"));
+            return null;
+        }).when(indicesAdminClient).create(any(), any());
+
+        securityIndexHandler.createIndex(listener);
+
+        verify(indicesAdminClient).create(isA(CreateIndexRequest.class), any());
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testUploadDefaultConfiguration_shouldFailIfRequiredConfigFilesAreMissing() {
+        final var listener = spy(ActionListener.<Set<SecurityConfig>>wrap(r -> fail("Unexpected behave"), e -> {
+            assertEquals(SecurityException.class, e.getClass());
+            assertThat(e.getMessage(), containsString("Couldn't find configuration file"));
+        }));
+        securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
+
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testUploadDefaultConfiguration_shouldFailIfBulkHasFailures() throws IOException {
+        final var failedBulkResponse = new BulkResponse(
+            new BulkItemResponse[] {
+                new BulkItemResponse(1, DocWriteRequest.OpType.CREATE, new BulkItemResponse.Failure("a", "b", new Exception())) },
+            100L
+        );
+        final var listener = spy(ActionListener.<Set<SecurityConfig>>wrap(r -> fail("Unexpected behave"), e -> {
+            assertEquals(SecurityException.class, e.getClass());
+            assertEquals(e.getMessage(), failedBulkResponse.buildFailureMessage());
+        }));
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(failedBulkResponse);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), any());
+        for (final var c : CType.REQUIRED_CONFIG_FILES) {
+            try (final var io = Files.newBufferedWriter(c.configFile(configFolder))) {
+                io.write(YAML.get(c).get());
+                io.flush();
+            }
+        }
+        securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testUploadDefaultConfiguration_shouldCreateSetOfSecurityConfigs() throws IOException {
+
+        final var listener = spy(ActionListener.<Set<SecurityConfig>>wrap(configuration -> {
+            for (final var sc : configuration) {
+                assertTrue(sc.lastModified().isEmpty());
+                assertNotNull(sc.hash());
+            }
+        }, e -> fail("Unexpected behave")));
+
+        for (final var c : CType.REQUIRED_CONFIG_FILES) {
+            try (final var io = Files.newBufferedWriter(c.configFile(configFolder))) {
+                final var source = YAML.get(c).get();
+                io.write(source);
+                io.flush();
+            }
+        }
+
+        final var bulkRequestCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> actionListener = invocation.getArgument(1);
+            final var r = mock(BulkResponse.class);
+            when(r.hasFailures()).thenReturn(false);
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).bulk(bulkRequestCaptor.capture(), any());
+        securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
+
+        final var bulkRequest = bulkRequestCaptor.getValue();
+        for (final var r : bulkRequest.requests()) {
+            final var indexRequest = (IndexRequest) r;
+            assertEquals(INDEX_NAME, r.index());
+            assertEquals(DocWriteRequest.OpType.INDEX, indexRequest.opType());
+        }
+        verify(listener).onResponse(any());
+    }
+
+    @Test
+    public void testUploadDefaultConfiguration_shouldSkipAudit() throws IOException {
+        final var listener = spy(
+            ActionListener.<Set<SecurityConfig>>wrap(
+                configuration -> assertFalse(configuration.stream().anyMatch(sc -> sc.type() == CType.AUDIT)),
+                e -> fail("Unexpected behave")
+            )
+        );
+
+        for (final var c : CType.REQUIRED_CONFIG_FILES) {
+            if (c == CType.AUDIT) continue;
+            try (final var io = Files.newBufferedWriter(c.configFile(configFolder))) {
+                final var source = YAML.get(c).get();
+                io.write(source);
+                io.flush();
+            }
+        }
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> actionListener = invocation.getArgument(1);
+            final var r = mock(BulkResponse.class);
+            when(r.hasFailures()).thenReturn(false);
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), any());
+
+        securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
+        verify(listener).onResponse(any());
+    }
+
+    @Test
+    public void testUploadDefaultConfiguration_shouldSkipWhitelist() throws IOException {
+        final var listener = spy(
+            ActionListener.<Set<SecurityConfig>>wrap(
+                configuration -> assertFalse(configuration.stream().anyMatch(sc -> sc.type() == CType.WHITELIST)),
+                e -> fail("Unexpected behave")
+            )
+        );
+
+        for (final var c : CType.REQUIRED_CONFIG_FILES) {
+            if (c == CType.WHITELIST) continue;
+            try (final var io = Files.newBufferedWriter(c.configFile(configFolder))) {
+                final var source = YAML.get(c).get();
+                io.write(source);
+                io.flush();
+            }
+        }
+        doAnswer(invocation -> {
+            ActionListener<BulkResponse> actionListener = invocation.getArgument(1);
+            final var r = mock(BulkResponse.class);
+            when(r.hasFailures()).thenReturn(false);
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).bulk(any(BulkRequest.class), any());
+
+        securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
+        verify(listener).onResponse(any());
+    }
+
+    @Test
+    public void testLoadConfiguration_shouldFailIfResponseHasFailures() {
+        final var listener = spy(
+            ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
+                r -> fail("Unexpected behave"),
+                e -> assertEquals(SecurityException.class, e.getClass())
+            )
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
+            final var r = mock(MultiGetResponse.class);
+            final var mr = mock(MultiGetItemResponse.class);
+            when(mr.isFailed()).thenReturn(true);
+            when(mr.getFailure()).thenReturn(new MultiGetResponse.Failure("a", "id", new Exception()));
+            when(r.getResponses()).thenReturn(new MultiGetItemResponse[] { mr });
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).multiGet(any(MultiGetRequest.class), any());
+
+        securityIndexHandler.loadConfiguration(configuration(), listener);
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testLoadConfiguration_shouldFailIfNoRequiredConfigInResponse() {
+        final var listener = spy(
+            ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
+                r -> fail("Unexpected behave"),
+                e -> assertEquals("Missing required configuration for type: CONFIG", e.getMessage())
+            )
+        );
+        doAnswer(invocation -> {
+            ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
+            final var getResult = mock(GetResult.class);
+            final var r = new MultiGetResponse(new MultiGetItemResponse[] { new MultiGetItemResponse(new GetResponse(getResult), null) });
+            when(getResult.getId()).thenReturn(CType.CONFIG.toLCString());
+            when(getResult.isExists()).thenReturn(false);
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).multiGet(any(MultiGetRequest.class), any());
+
+        securityIndexHandler.loadConfiguration(configuration(), listener);
+
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testLoadConfiguration_shouldFailForUnsupportedVersion() {
+        final var listener = spy(
+            ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
+                r -> fail("Unexpected behave"),
+                e -> assertEquals("Version 1 is not supported for CONFIG", e.getMessage())
+            )
+        );
+        doAnswer(invocation -> {
+
+            final var objectMapper = DefaultObjectMapper.objectMapper;
+
+            ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
+            final var getResult = mock(GetResult.class);
+            final var r = new MultiGetResponse(new MultiGetItemResponse[] { new MultiGetItemResponse(new GetResponse(getResult), null) });
+            when(getResult.getId()).thenReturn(CType.CONFIG.toLCString());
+            when(getResult.isExists()).thenReturn(true);
+
+            final var oldVersionJson = objectMapper.createObjectNode()
+                .set("opendistro_security", objectMapper.createObjectNode().set("dynamic", objectMapper.createObjectNode()))
+                .toString()
+                .getBytes(StandardCharsets.UTF_8);
+            final var configResponse = objectMapper.createObjectNode().put(CType.CONFIG.toLCString(), oldVersionJson);
+            final var source = objectMapper.writeValueAsBytes(configResponse);
+            when(getResult.sourceRef()).thenReturn(new BytesArray(source, 0, source.length));
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).multiGet(any(MultiGetRequest.class), any());
+        securityIndexHandler.loadConfiguration(configuration(), listener);
+
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testLoadConfiguration_shouldFailForUnparseableConfig() {
+        final var listener = spy(
+            ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
+                r -> fail("Unexpected behave"),
+                e -> assertEquals("Couldn't parse content for CONFIG", e.getMessage())
+            )
+        );
+        doAnswer(invocation -> {
+
+            final var objectMapper = DefaultObjectMapper.objectMapper;
+
+            ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
+            final var getResult = mock(GetResult.class);
+            final var r = new MultiGetResponse(new MultiGetItemResponse[] { new MultiGetItemResponse(new GetResponse(getResult), null) });
+            when(getResult.getId()).thenReturn(CType.CONFIG.toLCString());
+            when(getResult.isExists()).thenReturn(true);
+
+            final var configResponse = objectMapper.createObjectNode()
+                .put(
+                    CType.CONFIG.toLCString(),
+                    objectMapper.createObjectNode()
+                        .set("_meta", objectMapper.createObjectNode().put("type", CType.CONFIG.toLCString()))
+                        .toString()
+                        .getBytes(StandardCharsets.UTF_8)
+                );
+            final var source = objectMapper.writeValueAsBytes(configResponse);
+            when(getResult.sourceRef()).thenReturn(new BytesArray(source, 0, source.length));
+            actionListener.onResponse(r);
+            return null;
+        }).when(client).multiGet(any(MultiGetRequest.class), any());
+        securityIndexHandler.loadConfiguration(configuration(), listener);
+
+        verify(listener).onFailure(any());
+    }
+
+    @Test
+    public void testLoadConfiguration_shouldBuildSecurityConfig() {
+        final var listener = spy(ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(config -> {
+            assertEquals(CType.values().length, config.keySet().size());
+            for (final var c : CType.values()) {
+                assertTrue(c.toLCString(), config.containsKey(c));
+            }
+        }, e -> fail("Unexpected behave")));
+        doAnswer(invocation -> {
+            final var objectMapper = DefaultObjectMapper.objectMapper;
+            ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
+
+            final var responses = new MultiGetItemResponse[CType.values().length];
+            var counter = 0;
+            for (final var c : CType.values()) {
+                final var getResult = mock(GetResult.class);
+                if (!c.emptyIfMissing()) {
+                    when(getResult.getId()).thenReturn(c.toLCString());
+                    when(getResult.isExists()).thenReturn(true);
+
+                    final var minimumRequiredConfig = minimumRequiredConfig(c);
+                    if (c == CType.CONFIG) minimumRequiredConfig.set(
+                        "config",
+                        objectMapper.createObjectNode().set("dynamic", objectMapper.createObjectNode())
+                    );
+
+                    final var source = objectMapper.writeValueAsBytes(
+                        objectMapper.createObjectNode()
+                            .put(c.toLCString(), minimumRequiredConfig.toString().getBytes(StandardCharsets.UTF_8))
+                    );
+
+                    when(getResult.sourceRef()).thenReturn(new BytesArray(source, 0, source.length));
+
+                    responses[counter] = new MultiGetItemResponse(new GetResponse(getResult), null);
+                } else {
+                    when(getResult.getId()).thenReturn(c.toLCString());
+                    when(getResult.isExists()).thenReturn(false);
+                    responses[counter] = new MultiGetItemResponse(new GetResponse(getResult), null);
+                }
+                counter++;
+            }
+            actionListener.onResponse(new MultiGetResponse(responses));
+            return null;
+        }).when(client).multiGet(any(MultiGetRequest.class), any());
+        securityIndexHandler.loadConfiguration(configuration(), listener);
+
+        verify(listener).onResponse(any());
+    }
+
+    private ObjectNode minimumRequiredConfig(final CType cType) {
+        final var objectMapper = DefaultObjectMapper.objectMapper;
+        return objectMapper.createObjectNode()
+            .set("_meta", objectMapper.createObjectNode().put("type", cType.toLCString()).put("config_version", DEFAULT_CONFIG_VERSION));
+    }
+
+    private Set<SecurityConfig> configuration() {
+        return Set.of(new SecurityConfig(CType.CONFIG, "aaa", null), new SecurityConfig(CType.AUDIT, "bbb", null));
+    }
+
+}


### PR DESCRIPTION
### Description
Change the way how the security plugin initialize its configuration. 
The current solution uses poll to upload the default security configuration from each node in the cluster. As result it could lead to the races during initialization of the security index. 

To solve the problem with possible races the new solution uses cluster state and initializes the default configuration only on the management node and after that sends updated cluster state on all other nodes to load the configuration from the index.   

Initialization using cluster state makes things much more simpler and security admin shell script can be removed in the future.

the cluster state for the security plugin is this:
```json
"security": {
    "created": "2024-02-27T15:44:44.194028751Z",
    "configuration": {
      "actiongroups": {
        "hash": "219b41179866fc2419b736aff874a23f",
        "last_modified": null
      },
      "allowlist": {
        "hash": "522ce41bf5755eeb591d0161844830c0",
        "last_modified": null
      },
      "config": {
        "hash": "d97d664526b42ffa583dbb492742d3cc",
        "last_modified": null
      },
      "internalusers": {
        "hash": "f15fbfe131e0beb466313906d207f00b",
        "last_modified": null
      },
      "nodesdn": {
        "hash": "38e29064f142bfdf8632bc1a66cf8d00",
        "last_modified": null
      },
      "roles": {
        "hash": "db58ba06f214bfb53eee783378f5500c",
        "last_modified": null
      },
      "rolesmapping": {
        "hash": "f2b1cbdf73fa861f1321983cb0241964",
        "last_modified": null
      },
      "tenants": {
        "hash": "7942de6dc0f3bade63d8fc4b49d727d2",
        "last_modified": null
      },
      "whitelist": {
        "hash": "b73aadf21bca6a0de199121d982da460",
        "last_modified": null
      }
    }
  }
```

Next steps as a separate PRs:
  - Security configuration update on the manager node only and wait for confirmation from other nodes that configuration successfully updated on them.
  - Add migration from old version to new version with the cluster state support     
  -  Change existing documentation to reflect changes here: https://github.com/opensearch-project/security/blob/main/ARCHITECTURE.md#security-configuration
     

### Issues Resolved
- Resolves #3972 
- Partially resolve #3275

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
