### PR TITLE
[Backport 2.12] v2.12 update roles.yml with new API for experimental alerting plugin feature #4027

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -35,6 +35,7 @@ alerting_read_access:
     - 'cluster:admin/opensearch/alerting/findings/get'
     - 'cluster:admin/opensearch/alerting/workflow/get'
     - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
+    - 'cluster:admin/opensearch/alerting/remote/indexes/get'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -33,9 +33,9 @@ alerting_read_access:
     - 'cluster:admin/opendistro/alerting/monitor/get'
     - 'cluster:admin/opendistro/alerting/monitor/search'
     - 'cluster:admin/opensearch/alerting/findings/get'
+    - 'cluster:admin/opensearch/alerting/remote/indexes/get'
     - 'cluster:admin/opensearch/alerting/workflow/get'
     - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
-    - 'cluster:admin/opensearch/alerting/remote/indexes/get'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:


### PR DESCRIPTION
### Description
We added a new API to the alerting plugin to support enhancements to the UI ([link](https://github.com/opensearch-project/alerting/blob/main/alerting/src/main/kotlin/org/opensearch/alerting/action/GetRemoteIndexesAction.kt#L13)). The enhancements allow users to configure per query, and per bucket monitors that can query remote clusters via the UI. Previously, such monitors could only be configured using devtools/API commands.

In addition, we added support for configuring cluster metrics monitors which can execute various API ([link to full list of supported API](https://opensearch.org/docs/latest/observing-your-data/alerting/per-cluster-metrics-monitors/#supported-apis)) against remote clusters. The new API is used by the frontend to also support creating these monitors via the UI.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
  * New experimental feature
  * Enhancement to existing features
* Why these changes are required?
  * To include this API permission in the reserved role that's shipped with the default distribution of OpenSearch.
* What is the old behavior before changes and new behavior after changes?
  * This API was not available before the experimental launch. With the experimental feature enabled, this API can be used to retrieve a list of connect remote clusters, the indexes/aliases on those clusters along with their health statuses, and optionally the mappings for those indexes.

### Issues Resolved
https://github.com/opensearch-project/alerting-dashboards-plugin/issues/796

Is this a backport? If so, please add backport PR # and/or commits #
https://github.com/opensearch-project/security/pull/4027

### Testing
Executed E2E tests with and without the experimental feature enabled to help ensure no regressions.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
