### PR TITLE
Add SAML authenticator setting to allow repeat attribute names

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -140,7 +140,7 @@ class AuthTokenProcessorHandler {
         String samlRequestId,
         String acsEndpoint,
         Saml2Settings saml2Settings
-    ) {
+    ) throws Exception {
         if (token_log.isDebugEnabled()) {
             try {
                 token_log.debug(
@@ -172,10 +172,10 @@ class AuthTokenProcessorHandler {
             return responseBody;
         } catch (ValidationError e) {
             log.warn("Error while validating SAML response", e);
-            return null;
+            throw e;
         } catch (Exception e) {
             log.error("Error while converting SAML to JWT", e);
-            return null;
+            throw e;
         }
     }
 
@@ -236,6 +236,12 @@ class AuthTokenProcessorHandler {
         } catch (JsonProcessingException e) {
             log.warn("Error while parsing JSON for /_opendistro/_security/api/authtoken", e);
             return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, "JSON could not be parsed"));
+        } catch (ValidationError e) {
+            log.warn("Error while validating SAML response", e);
+            return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, "Error while validating SAML response"));
+        } catch (Exception e) {
+            log.warn("Error while converting SAML to JWT", e);
+            return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, "Error while converting SAML to JWT"));
         }
     }
 

--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -75,6 +75,7 @@ class AuthTokenProcessorHandler {
     private String jwtRolesKey;
     private String samlSubjectKey;
     private String samlRolesKey;
+    private boolean allowRepeatAttributeName;
     private String kibanaRootUrl;
 
     private long expiryOffset = 0;
@@ -88,6 +89,7 @@ class AuthTokenProcessorHandler {
 
         this.jwtRolesKey = jwtSettings.get("roles_key", "roles");
         this.jwtSubjectKey = jwtSettings.get("subject_key", "sub");
+        this.allowRepeatAttributeName = settings.getAsBoolean("allow_repeat_attribute_names", false);
 
         this.samlRolesKey = settings.get("roles_key");
         this.samlSubjectKey = settings.get("subject_key");
@@ -149,6 +151,10 @@ class AuthTokenProcessorHandler {
             } catch (Exception e) {
                 token_log.warn("SAMLResponse for {} cannot be decoded from base64\n{}", samlRequestId, samlResponseBase64, e);
             }
+        }
+
+        if (allowRepeatAttributeName) {
+            saml2Settings.setAllowRepeatAttributeName(allowRepeatAttributeName);
         }
 
         try {

--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -185,7 +185,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
             final String suffix = matcher.matches() ? matcher.group(2) : null;
 
             if (API_AUTHTOKEN_SUFFIX.equals(suffix)) {
-                // Verficiation of SAML ASC endpoint only works with RestRequests
+                // Verification of SAML ASC endpoint only works with RestRequests
                 if (!(request instanceof OpenSearchRequest)) {
                     throw new SecurityRequestChannelUnsupported(
                         API_AUTHTOKEN_SUFFIX + " not supported for request of type " + request.getClass().getName()
@@ -208,8 +208,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
             if (e instanceof SecurityRequestChannelUnsupported) {
                 throw (SecurityRequestChannelUnsupported) e;
             }
-            log.error("Error in reRequestAuthentication()", e);
-            return Optional.empty();
+            return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, e.getMessage()));
         }
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/saml/MockSamlIdpServer.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/MockSamlIdpServer.java
@@ -172,7 +172,7 @@ class MockSamlIdpServer implements Closeable {
     private Credential signingCredential;
     private String authenticateUser;
     private List<String> authenticateUserRoles;
-    private boolean allowRepeatAttributes = false;
+    private List<String> authenticateUserRolesAsRepeatedAttributeName;
     private int baseId = 1;
     private boolean signResponses = true;
     private X509Certificate spSignatureCertificate;
@@ -466,31 +466,31 @@ class MockSamlIdpServer implements Closeable {
             conditions.setNotOnOrAfter(Instant.now().plus(1, ChronoUnit.MINUTES));
 
             if (authenticateUserRoles != null) {
-                if (!allowRepeatAttributes) {
+                AttributeStatement attributeStatement = createSamlElement(AttributeStatement.class);
+                assertion.getAttributeStatements().add(attributeStatement);
+
+                Attribute attribute = createSamlElement(Attribute.class);
+                attributeStatement.getAttributes().add(attribute);
+
+                attribute.setName("roles");
+                attribute.setNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:basic");
+
+                for (String role : authenticateUserRoles) {
+                    attribute.getAttributeValues().add(createXSAny(AttributeValue.DEFAULT_ELEMENT_NAME, role));
+                }
+            }
+
+            if (authenticateUserRolesAsRepeatedAttributeName != null) {
+                for (String role : authenticateUserRolesAsRepeatedAttributeName) {
                     AttributeStatement attributeStatement = createSamlElement(AttributeStatement.class);
                     assertion.getAttributeStatements().add(attributeStatement);
 
                     Attribute attribute = createSamlElement(Attribute.class);
                     attributeStatement.getAttributes().add(attribute);
 
-                    attribute.setName("roles");
+                    attribute.setName("role");
                     attribute.setNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:basic");
-
-                    for (String role : authenticateUserRoles) {
-                        attribute.getAttributeValues().add(createXSAny(AttributeValue.DEFAULT_ELEMENT_NAME, role));
-                    }
-                } else {
-                    for (String role : authenticateUserRoles) {
-                        AttributeStatement attributeStatement = createSamlElement(AttributeStatement.class);
-                        assertion.getAttributeStatements().add(attributeStatement);
-
-                        Attribute attribute = createSamlElement(Attribute.class);
-                        attributeStatement.getAttributes().add(attribute);
-
-                        attribute.setName("role");
-                        attribute.setNameFormat("urn:oasis:names:tc:SAML:2.0:attrname-format:basic");
-                        attribute.getAttributeValues().add(createXSAny(AttributeValue.DEFAULT_ELEMENT_NAME, role));
-                    }
+                    attribute.getAttributeValues().add(createXSAny(AttributeValue.DEFAULT_ELEMENT_NAME, role));
                 }
             }
 
@@ -1127,8 +1127,12 @@ class MockSamlIdpServer implements Closeable {
         this.authenticateUserRoles = authenticateUserRoles;
     }
 
-    public void setAllowRepeatAttributeNames(boolean allowRepeatAttributes) {
-        this.allowRepeatAttributes = allowRepeatAttributes;
+    public List<String> getAuthenticateUserRolesAsRepeatedAttributeName() {
+        return authenticateUserRolesAsRepeatedAttributeName;
+    }
+
+    public void setAuthenticateUserRolesAsRepeatedAttributeName(List<String> authenticateUserRolesAsRepeatedAttributeName) {
+        this.authenticateUserRolesAsRepeatedAttributeName = authenticateUserRolesAsRepeatedAttributeName;
     }
 
     public boolean isSignResponses() {


### PR DESCRIPTION
### Description

Adds a new setting for SAML authentication to `allow_repeat_attribute_names`. Currently, the security plugin uses the [Saml2Settings default of false](https://github.com/SAML-Toolkits/java-saml/blob/master/core/src/main/java/com/onelogin/saml2/settings/Saml2Settings.java#L82) which prevents repeat attributes with the same name in the SAML assertion.

Example of SAML Response where an attribute appears at most once per attribute name:

<details>
  <summary>No repeat attribute names</summary>
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<saml2p:Response
	xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="MOCKSAML_1" InResponseTo="ONELOGIN_e0d57268-3160-48ab-978f-7a7cae05398b" IssueInstant="2024-02-09T17:16:57.340Z" Version="2.0">
	<saml2p:Status>
		<saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
	</saml2p:Status>
	<saml2:Assertion
		xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="MOCKSAML_2" IssueInstant="2024-02-09T17:16:57.340Z" Version="2.0">
		<saml2:Issuer>http://test.entity</saml2:Issuer>
		<ds:Signature
			xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
			<ds:SignedInfo>
				<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
				<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
				<ds:Reference URI="#MOCKSAML_2">
					<ds:Transforms>
						<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
						<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
					</ds:Transforms>
					<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
					<ds:DigestValue>neQI779y5e173nAgsI/3mnBkEV0gssO3zRRCZ/+xd2g=</ds:DigestValue>
				</ds:Reference>
			</ds:SignedInfo>
			<ds:SignatureValue>
				flsOEajENFQc1qQpx8DGZmQySAUQi5juDztIOuTvwkuY2MMRkVp9MeG72PsIStgg5wbcEn/47O+T&#13;
				NwS8Wey60F0oGErrhz1j56j27qwklPIRl5Q0sYPC3UIiyY5HYnvZDosrIdRWk5zotaD7l8kbXwJ0&#13;
				3umoQzUQhTB7LGzGM3vbgsClhidKi4X3okXcQBS/DKeL+hE+Ry2scIVlM4jnAJlYXcedyl7JyRr/&#13;
				TxWK6jXofc6CrJsqE2d0GkLBLbe5G7+xiQYywJC0gdNL7Vpk//78FvhWEQ8FLgT+TCwS/FeNl4cn&#13;
				Z7etIXrcLwe0Wk2MSw8g8EtLsrRqytD/zkjgeg==
			</ds:SignatureValue>
		</ds:Signature>
		<saml2:Subject>
			<saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">horst</saml2:NameID>
			<saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
				<saml2:SubjectConfirmationData InResponseTo="ONELOGIN_e0d57268-3160-48ab-978f-7a7cae05398b" NotOnOrAfter="2024-02-09T17:17:57.341Z" Recipient="http://wherever/_opendistro/_security/saml/acs"/>
			</saml2:SubjectConfirmation>
		</saml2:Subject>
		<saml2:Conditions NotBefore="2024-02-09T17:16:57.342Z" NotOnOrAfter="2024-02-09T17:17:57.342Z"/>
		<saml2:AuthnStatement AuthnInstant="2024-02-09T17:16:57.340Z" SessionIndex="MOCKSAML_3">
			<saml2:AuthnContext>
				<saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
			</saml2:AuthnContext>
		</saml2:AuthnStatement>
		<saml2:AttributeStatement>
			<saml2:Attribute Name="roles" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
				<saml2:AttributeValue>Admin</saml2:AttributeValue>
				<saml2:AttributeValue>Developer</saml2:AttributeValue>
			</saml2:Attribute>
		</saml2:AttributeStatement>
	</saml2:Assertion>
</saml2p:Response>
</details>

Example with repeat attribute name (in this example `role` is the repeat attribute name):

<details>
  <summary>With repeat attribute names</summary>
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<saml2p:Response
	xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" ID="MOCKSAML_1" InResponseTo="ONELOGIN_9f2f961b-7771-47e4-9472-f89c08e580e9" IssueInstant="2024-02-09T17:05:35.409Z" Version="2.0">
	<saml2p:Status>
		<saml2p:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
	</saml2p:Status>
	<saml2:Assertion
		xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion" ID="MOCKSAML_2" IssueInstant="2024-02-09T17:05:35.409Z" Version="2.0">
		<saml2:Issuer>http://test.entity</saml2:Issuer>
		<ds:Signature
			xmlns:ds="http://www.w3.org/2000/09/xmldsig#">
			<ds:SignedInfo>
				<ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
				<ds:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
				<ds:Reference URI="#MOCKSAML_2">
					<ds:Transforms>
						<ds:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
						<ds:Transform Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
					</ds:Transforms>
					<ds:DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
					<ds:DigestValue>EYXZTcsxuHz/kfn9Y4CU2FuOAOOYr0KznMc77+knl4w=</ds:DigestValue>
				</ds:Reference>
			</ds:SignedInfo>
			<ds:SignatureValue>
				OwfhibGkbGa5r5/GkMXrBRhaowuvMeSl36E+VSLZqIktakvEFE/QJDupLOZR1Rk+G1Ru8/1PdyRK&#13;
				dd1dQ6DYUkJzlq/qMWEnkqqXdUb5Qk0YQtIFpwCv0X/aYn7T08sprVyQJx+/NICFWRiNDQKYPyBO&#13;
				68vOpIK+qoM15DD1UCFzHWxqqKZ5YwIgJP/SKiFec5RIY940FK7xxwrBrQSGW+BWaexz2hLyAu2n&#13;
				ZqkQfA0LXDSCd4MXUrTOZYTNwhhYdFpOZzDoa4OrztjtpT8yusbOh5FqgOJOk9IFH5qQvKYMZgaD&#13;
				9V5xgHQi9PpuZiuIKf0lijO7qVKvJiGYGH+M3A==
			</ds:SignatureValue>
		</ds:Signature>
		<saml2:Subject>
			<saml2:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified">horst</saml2:NameID>
			<saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
				<saml2:SubjectConfirmationData InResponseTo="ONELOGIN_9f2f961b-7771-47e4-9472-f89c08e580e9" NotOnOrAfter="2024-02-09T17:06:35.411Z" Recipient="http://wherever/_opendistro/_security/saml/acs"/>
			</saml2:SubjectConfirmation>
		</saml2:Subject>
		<saml2:Conditions NotBefore="2024-02-09T17:05:35.412Z" NotOnOrAfter="2024-02-09T17:06:35.412Z"/>
		<saml2:AuthnStatement AuthnInstant="2024-02-09T17:05:35.410Z" SessionIndex="MOCKSAML_3">
			<saml2:AuthnContext>
				<saml2:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified</saml2:AuthnContextClassRef>
			</saml2:AuthnContext>
		</saml2:AuthnStatement>
		<saml2:AttributeStatement>
			<saml2:Attribute Name="role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
				<saml2:AttributeValue>Admin</saml2:AttributeValue>
			</saml2:Attribute>
		</saml2:AttributeStatement>
		<saml2:AttributeStatement>
			<saml2:Attribute Name="role" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
				<saml2:AttributeValue>Developer</saml2:AttributeValue>
			</saml2:Attribute>
		</saml2:AttributeStatement>
	</saml2:Assertion>
</saml2p:Response>
</details>

Currently, when there is a repeat attribute name the security plugin will produce the following error:

```
  1> com.onelogin.saml2.exception.ValidationError: Found an Attribute element with duplicated Name
  1>    at com.onelogin.saml2.authn.SamlResponse.getAttributes(SamlResponse.java:598) ~[java-saml-core-2.9.0.jar:?]
  1>    at com.amazon.dlic.auth.http.saml.AuthTokenProcessorHandler.extractRoles(AuthTokenProcessorHandler.java:383) ~[main/:?]
  1>    at com.amazon.dlic.auth.http.saml.AuthTokenProcessorHandler.createJwt(AuthTokenProcessorHandler.java:289) ~[main/:?]
  1>    at com.amazon.dlic.auth.http.saml.AuthTokenProcessorHandler.handleImpl(AuthTokenProcessorHandler.java:164) ~[main/:?]
  1>    at com.amazon.dlic.auth.http.saml.AuthTokenProcessorHandler.handleLowLevel(AuthTokenProcessorHandler.java:221) ~[main/:?]
  1>    at com.amazon.dlic.auth.http.saml.AuthTokenProcessorHandler.lambda$handle$0(AuthTokenProcessorHandler.java:126) ~[main/:?]
  1>    at java.base/java.security.AccessController.doPrivileged(AccessController.java:569) [?:?]
```

* Category

Enhancement

### Issues Resolved

- Will add one shortly

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
