### PR TITLE
Add exlusion for logback-core to resolve CVE-2023-6378

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -707,6 +707,7 @@ dependencies {
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
     testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.1') {
         exclude(group:'ch.qos.logback', module: 'logback-classic' )
+        exclude(group:'ch.qos.logback', module: 'logback-core' )
     }
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"


### PR DESCRIPTION
### Description
[Describe what this change achieves]
This change adds an exclusion for the transitive logback-core dependency that the Security plugin was still using as a test dependency. 

This should resolve the flagging of CVE-2023-6378 even though we should not have been directly impacted. 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
