### PR TITLE
[Manual backport of #4049] Force logback to version 1.2.13 to resolve CVE-2023-6378

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,7 @@ configurations.all {
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
         force "org.apache.zookeeper:zookeeper:3.9.1"
+        force "ch.qos.logback:logback-core:1.2.13"
         force "ch.qos.logback:logback-classic:1.2.13"
     }
 }
@@ -214,6 +215,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
+<<<<<<< HEAD
     integrationTestCompileOnly "org.opensearch:opensearch:${opensearch_version}"
     integrationTestImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     integrationTestImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
@@ -256,6 +258,16 @@ dependencies {
     integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.13"
     integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.16"
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
+=======
+
+
+configurations.runtimeClasspath {
+    // jackson-* is already included in OpenSearch
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-cbor'
+    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-smile'
+    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-yaml'
+>>>>>>> 131bb8da (Force logback)
 }
 
 group = 'org.opensearch'

--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,6 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
-<<<<<<< HEAD
     integrationTestCompileOnly "org.opensearch:opensearch:${opensearch_version}"
     integrationTestImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
     integrationTestImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
@@ -256,16 +255,6 @@ dependencies {
     integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.13"
     integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.16"
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
-=======
-
-
-configurations.runtimeClasspath {
-    // jackson-* is already included in OpenSearch
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
-    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-cbor'
-    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-smile'
-    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-yaml'
->>>>>>> 131bb8da (Force logback)
 }
 
 group = 'org.opensearch'


### PR DESCRIPTION
### Description
This change forces is a manual backport of the same type of change in #4049 . Instead of excluding the the logback-classic and logback-core transient dependencies we now just force them to be versions 1.2.13. This resolves CVE-2023-6378 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
