### PR TITLE
Add deprecate message that TLSv1 and TLSv1.1 support will be removed in the next major version

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -310,6 +310,20 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             return;
         }
 
+        if (settings.hasValue(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS)) {
+            verifyTLSVersion(
+                SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS,
+                settings.getAsList(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS)
+            );
+        }
+
+        if (settings.hasValue(SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS)) {
+            verifyTLSVersion(
+                SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS,
+                settings.getAsList(SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS)
+            );
+        }
+
         if (SSLConfig.isSslOnlyMode()) {
             this.sslCertReloadEnabled = false;
             log.warn("OpenSearch Security plugin run in ssl only mode. No authentication or authorization is performed");
@@ -434,6 +448,20 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 throw new RuntimeException("Unable to look for demo certificates");
             }
 
+        }
+    }
+
+    private void verifyTLSVersion(final String settings, final List<String> configuredProtocols) {
+        for (final var tls : configuredProtocols) {
+            if (tls.equalsIgnoreCase("TLSv1") || tls.equalsIgnoreCase("TLSv1.1")) {
+                deprecationLogger.deprecate(
+                    settings,
+                    "The '{}' setting contains {} protocol version which was deprecated since 2021 (RFC 8996). "
+                        + "Support for it will be removed in the next major release.",
+                    settings,
+                    tls
+                );
+            }
         }
     }
 

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -101,7 +101,7 @@ public final class SSLConfigConstants {
 
     private static final String[] _SECURE_SSL_PROTOCOLS = { "TLSv1.3", "TLSv1.2", "TLSv1.1" };
 
-    public static final String[] getSecureSSLProtocols(Settings settings, boolean http) {
+    public static String[] getSecureSSLProtocols(Settings settings, boolean http) {
         List<String> configuredProtocols = null;
 
         if (settings != null) {
@@ -233,7 +233,7 @@ public final class SSLConfigConstants {
     };
     // @formatter:on
 
-    public static final List<String> getSecureSSLCiphers(Settings settings, boolean http) {
+    public static List<String> getSecureSSLCiphers(Settings settings, boolean http) {
 
         List<String> configuredCiphers = null;
 

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.ssl.util;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
+import static org.junit.Assert.assertArrayEquals;
+
+public class SSLConfigConstantsTest {
+
+    @Test
+    public void testDefaultTLSProtocols() {
+        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false);
+        assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, tlsDefaultProtocols);
+    }
+
+    @Test
+    public void testDefaultSSLProtocols() {
+        final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, true);
+        assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, sslDefaultProtocols);
+    }
+
+    @Test
+    public void testCustomTLSProtocols() {
+        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
+            Settings.builder().putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
+            false
+        );
+        assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, tlsDefaultProtocols);
+    }
+
+    @Test
+    public void testCustomSSLProtocols() {
+        final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
+            Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
+            true
+        );
+        assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, sslDefaultProtocols);
+    }
+
+}


### PR DESCRIPTION
### Description
Since TLSv1.1 was deprecated in 2021 (RFC [8996](https://datatracker.ietf.org/doc/html/rfc8996)) and new deprication message was added.

By default JDK 18 uses TLS 1.2 and latest stable 1.3

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
