### PR TITLE
Log password requirement details in demo environment

### DIFF
--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -273,11 +273,9 @@ public class ConfigConstants {
     public static final String SECURITY_RESTAPI_ADMIN_ENABLED = "plugins.security.restapi.admin.enabled";
     public static final String SECURITY_RESTAPI_ENDPOINTS_DISABLED = "plugins.security.restapi.endpoints_disabled";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX = "plugins.security.restapi.password_validation_regex";
-    public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT = "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE =
         "plugins.security.restapi.password_validation_error_message";
     public static final String SECURITY_RESTAPI_PASSWORD_MIN_LENGTH = "plugins.security.restapi.password_min_length";
-    public static final Integer SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT = 8;
     public static final String SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH =
         "plugins.security.restapi.password_score_based_validation_strength";
     // Illegal Opcodes from here on

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -273,9 +273,11 @@ public class ConfigConstants {
     public static final String SECURITY_RESTAPI_ADMIN_ENABLED = "plugins.security.restapi.admin.enabled";
     public static final String SECURITY_RESTAPI_ENDPOINTS_DISABLED = "plugins.security.restapi.endpoints_disabled";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX = "plugins.security.restapi.password_validation_regex";
+    public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT = "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}";
     public static final String SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE =
         "plugins.security.restapi.password_validation_error_message";
     public static final String SECURITY_RESTAPI_PASSWORD_MIN_LENGTH = "plugins.security.restapi.password_min_length";
+    public static final Integer SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT = 8;
     public static final String SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH =
         "plugins.security.restapi.password_score_based_validation_strength";
     // Illegal Opcodes from here on

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -39,9 +39,7 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH;
-import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
-import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT;
 
 /**
  * This class updates the security related configuration, as needed.
@@ -78,6 +76,7 @@ public class SecuritySettingsConfigurer {
         ".plugins-flow-framework-templates",
         ".plugins-flow-framework-state"
     );
+    static final Integer DEFAULT_PASSWORD_MIN_LENGTH = 8;
     static String ADMIN_PASSWORD = "";
     static String ADMIN_USERNAME = "admin";
 
@@ -132,8 +131,8 @@ public class SecuritySettingsConfigurer {
         try {
             final PasswordValidator passwordValidator = PasswordValidator.of(
                 Settings.builder()
-                    .put(SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT)
-                    .put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT)
+                    .put(SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}")
+                    .put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, DEFAULT_PASSWORD_MIN_LENGTH)
                     .build()
             );
 
@@ -148,10 +147,12 @@ public class SecuritySettingsConfigurer {
                 RequestContentValidator.ValidationError response = passwordValidator.validate(ADMIN_USERNAME, ADMIN_PASSWORD);
                 if (!RequestContentValidator.ValidationError.NONE.equals(response)) {
                     System.out.println(
-                            String.format(
-                                    "Password %s failed validation: \"%s\". Please re-try with a minimum %d character password that is strong per zxcvbn validation."
-                                    , ADMIN_PASSWORD, response.message(), SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT
-                            )
+                        String.format(
+                            "Password %s failed validation: \"%s\". Please re-try with a minimum %d character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong. Password strength can be tested here: https://lowe.github.io/tryzxcvbn",
+                            ADMIN_PASSWORD,
+                            response.message(),
+                            DEFAULT_PASSWORD_MIN_LENGTH
+                        )
                     );
                     System.exit(-1);
                 }

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -39,7 +39,9 @@ import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT;
 
 /**
  * This class updates the security related configuration, as needed.
@@ -130,8 +132,8 @@ public class SecuritySettingsConfigurer {
         try {
             final PasswordValidator passwordValidator = PasswordValidator.of(
                 Settings.builder()
-                    .put(SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}")
-                    .put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, 8)
+                    .put(SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX_DEFAULT)
+                    .put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT)
                     .build()
             );
 
@@ -142,11 +144,17 @@ public class SecuritySettingsConfigurer {
             }
 
             // If script execution environment is set to demo, validate custom password, else if set to test, skip validation
-            if (shouldValidatePassword
-                && !ADMIN_PASSWORD.isEmpty()
-                && passwordValidator.validate(ADMIN_USERNAME, ADMIN_PASSWORD) != RequestContentValidator.ValidationError.NONE) {
-                System.out.println("Password " + ADMIN_PASSWORD + " is weak. Please re-try with a stronger password.");
-                System.exit(-1);
+            if (shouldValidatePassword && !ADMIN_PASSWORD.isEmpty()) {
+                RequestContentValidator.ValidationError response = passwordValidator.validate(ADMIN_USERNAME, ADMIN_PASSWORD);
+                if (!RequestContentValidator.ValidationError.NONE.equals(response)) {
+                    System.out.println(
+                            String.format(
+                                    "Password %s failed validation: \"%s\". Please re-try with a minimum %d character password that is strong per zxcvbn validation."
+                                    , ADMIN_PASSWORD, response.message(), SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT
+                            )
+                    );
+                    System.exit(-1);
+                }
             }
 
             // if ADMIN_PASSWORD is still an empty string, it implies no custom password was provided. We exit the setup.

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -58,6 +58,9 @@ public class SecuritySettingsConfigurerTests {
 
     private final String adminPasswordKey = ConfigConstants.OPENSEARCH_INITIAL_ADMIN_PASSWORD;
 
+    private static final String PASSWORD_VALIDATION_FAILURE_MESSAGE =
+        "Password %s failed validation: \"%s\". Please re-try with a minimum %d character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong. Password strength can be tested here: https://lowe.github.io/tryzxcvbn";
+
     private static SecuritySettingsConfigurer securitySettingsConfigurer;
 
     private static Installer installer;
@@ -130,7 +133,8 @@ public class SecuritySettingsConfigurerTests {
 
         verifyStdOutContainsString(
             String.format(
-                "Password weakpassword failed validation: \"%s\". Please re-try with a minimum %d character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong. Password strength can be tested here: https://lowe.github.io/tryzxcvbn",
+                PASSWORD_VALIDATION_FAILURE_MESSAGE,
+                "weakpassword",
                 INVALID_PASSWORD_INVALID_REGEX.message(),
                 DEFAULT_PASSWORD_MIN_LENGTH
             )
@@ -151,11 +155,7 @@ public class SecuritySettingsConfigurerTests {
         }
 
         verifyStdOutContainsString(
-            String.format(
-                "Password short failed validation: \"%s\". Please re-try with a minimum %d character password and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character that is strong. Password strength can be tested here: https://lowe.github.io/tryzxcvbn",
-                INVALID_PASSWORD_TOO_SHORT.message(),
-                DEFAULT_PASSWORD_MIN_LENGTH
-            )
+            String.format(PASSWORD_VALIDATION_FAILURE_MESSAGE, "short", INVALID_PASSWORD_TOO_SHORT.message(), DEFAULT_PASSWORD_MIN_LENGTH)
         );
     }
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -37,6 +37,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.REST_ENABLED_ROLES;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.SYSTEM_INDICES;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.isKeyPresentInYMLFile;
@@ -125,7 +127,13 @@ public class SecuritySettingsConfigurerTests {
             System.setSecurityManager(null);
         }
 
-        verifyStdOutContainsString("Password weakpassword is weak. Please re-try with a stronger password.");
+        verifyStdOutContainsString(
+                String.format(
+                        "Password weakpassword failed validation: \"%s\". Please re-try with a minimum %d character password that is strong per zxcvbn validation.",
+                        INVALID_PASSWORD_INVALID_REGEX.message(),
+                        SECURITY_RESTAPI_PASSWORD_MIN_LENGTH_DEFAULT
+                )
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description

Logs details about the password validations done when demo clusters are created. The current message "Password $ADMIN_PASSWORD is weak. Please re-try with a stronger password." doesn't provide enough information communicate what the user needs to set the password to.

* Category: Enhancement
* Why these changes are required?
   * See #4048 - to improve UX when creating test OpenSearch clusters by logging details on password requirements
* What is the old behavior before changes and new behavior after changes?
    * Before: OS 2.12 fails to start with message `Password sample@1029 is weak. Please re-try with a stronger password.`
    * After: security plugin fails to start with message `Password weakpassword failed validation with error "Weak password". Please re-try with a minimum 8 character password that is "strong" per zxcvbn validation.`

### Issues Resolved

Potentially can resolve #4048, though would need issue author @derek-ho to confirm this is the intended change.

### Testing

Updated existing unit test that tests "password validation failure". 

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented <-- In a separate PR, I also want to update relevant docs, including [docker getting started docs](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/#run-opensearch-in-a-docker-container) docs with perhaps the zxcvbn "validation" tool.
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
