### PR TITLE
[Backport 2.x] Bump com.google.googlejavaformat:google-java-format from 1.19.1 to 1.20.0 (#4074)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -729,7 +729,7 @@ dependencies {
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
 
     //spotless
-    implementation('com.google.googlejavaformat:google-java-format:1.19.1') {
+    implementation('com.google.googlejavaformat:google-java-format:1.20.0') {
         exclude group: 'com.google.guava'
     }
 }


### PR DESCRIPTION
Manual backport `add96ad601ccf99b8420fe9dc95ece601357f8bd` from #4074 