### PR TITLE
Fix : Compliance config's readEnabledFieldsCache is not aware of date change

### DIFF
--- a/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
@@ -539,6 +539,12 @@ public class ComplianceConfig {
         if (securityIndex.equals(index)) {
             return logInternalConfig;
         }
+        // if the index is used for audit logging (rolling index name), return false
+        if (auditLogPattern != null) {
+            if (index.equalsIgnoreCase(getExpandedIndexName(auditLogPattern, null))) {
+                return false;
+            }
+        }
         try {
             return readEnabledFieldsCache.get(index) != WildcardMatcher.NONE;
         } catch (ExecutionException e) {
@@ -560,6 +566,12 @@ public class ComplianceConfig {
         // if security index (internal index) check if internal config logging is enabled
         if (securityIndex.equals(index)) {
             return logInternalConfig;
+        }
+        // if the index is used for audit logging (rolling index name), return false
+        if (auditLogPattern != null) {
+            if (index.equalsIgnoreCase(getExpandedIndexName(auditLogPattern, null))) {
+                return false;
+            }
         }
         WildcardMatcher matcher;
         try {

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceConfigTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceConfigTest.java
@@ -201,7 +201,7 @@ public class ComplianceConfigTest {
         // act: Log for current audit log when it does not match the date
         setYear.accept(2048);
         // See https://github.com/opensearch-project/security/issues/3950
-        // assertThat(complianceConfig.readHistoryEnabledForIndex("audit-log-index-1337-01-01"), equalTo(true));
+        assertThat(complianceConfig.readHistoryEnabledForIndex("audit-log-index-1337-01-01"), equalTo(true));
         assertThat(complianceConfig.writeHistoryEnabledForIndex("audit-log-index-1337-01-01"), equalTo(true));
 
         // act: Log for any matching index


### PR DESCRIPTION
Fix : Compliance config's readEnabledFieldsCache is not aware of date change



### Description
* when the date and audit-log index matches, it is not required to check in cache.
* avoid using readEnabledFieldsCache when the date and audit-log index matches

### Issues Resolved
#3950 

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
* already commented test works after the fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
