### PR TITLE
Skips authentication only for anonymous auth requests when anonymous-auth is enabled

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -295,7 +295,7 @@ public class BackendRegistry {
                         }
                         notifyIpAuthFailureListeners(request, authCredentials);
                         request.queueForSending(restResponse.get());
-
+                        return false;
                     }
                 } else {
                     // no reRequest possible

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -28,7 +28,6 @@ package org.opensearch.security.auth;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -39,14 +38,12 @@ import java.util.SortedSet;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator;
 import com.google.common.base.Strings;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Multimap;
-import io.netty.handler.codec.base64.Base64Decoder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -299,7 +296,6 @@ public class BackendRegistry {
                         notifyIpAuthFailureListeners(request, authCredentials);
                         request.queueForSending(restResponse.get());
 
-
                     }
                 } else {
                     // no reRequest possible
@@ -390,8 +386,6 @@ public class BackendRegistry {
                 log.debug("User still not authenticated after checking {} auth domains", restAuthDomains.size());
             }
 
-            log.info(request.uri());
-            log.info(request.getHeaders());
             if (anonymousAuthEnabled) {
                 assert authCredentials != null;
                 if (authCredentials.getUsername().equals(User.ANONYMOUS.getName())) {

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -60,6 +60,7 @@ import org.opensearch.security.test.helper.cluster.ClusterHelper;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+import org.opensearch.security.user.User;
 
 public class InitializationIntegrationTests extends SingleClusterTest {
 
@@ -255,6 +256,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
         }
 
+        Header anonyAuthHeader = encodeBasicHeader(User.ANONYMOUS.getName(), randomAsciiAlphanumOfLength(8));
         for (Iterator<TransportAddress> iterator = clusterInfo.httpAdresses.iterator(); iterator.hasNext();) {
             TransportAddress TransportAddress = iterator.next();
             HttpResponse res = rh.executeRequest(
@@ -265,7 +267,8 @@ public class InitializationIntegrationTests extends SingleClusterTest {
                         + TransportAddress.getPort()
                         + "/"
                         + "_opendistro/_security/authinfo?pretty=true"
-                )
+                ),
+                anonyAuthHeader
             );
             log.debug(res.getBody());
             Assert.assertTrue(res.getBody().contains("role_host1"));

--- a/src/test/java/org/opensearch/security/SecurityRolesTests.java
+++ b/src/test/java/org/opensearch/security/SecurityRolesTests.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.security;
 
+import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -37,6 +38,7 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+import org.opensearch.security.user.User;
 
 public class SecurityRolesTests extends SingleClusterTest {
 
@@ -51,8 +53,9 @@ public class SecurityRolesTests extends SingleClusterTest {
         );
 
         RestHelper rh = nonSslRestHelper();
+        Header anonyAuthHeader = encodeBasicHeader(User.ANONYMOUS.getName(), randomAsciiAlphanumOfLength(8));
 
-        HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
+        HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", anonyAuthHeader);
         Assert.assertTrue(resc.getBody().contains("anonymous"));
         Assert.assertFalse(resc.getBody().contains("xyz_sr"));
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());


### PR DESCRIPTION
### Description

This PR fixes a bug where SAML and Anonymous auth cannot co-exist. At present, enabling SAML along with anonymous auth causes SAML Login to fail before it hits the IdP because both  SAML and anonymous auth are wired to not have credentials on the first login attempt, causing the authn check against the auth domains to be skipped (see [here](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/auth/BackendRegistry.java#L287-L291)). This, eventually, results in setting the default user as anonymous (see [here](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/auth/BackendRegistry.java#L389)) since anonymous auth is enabled.


* Category: Bug fix
* Why these changes are required?
    * To allow SAML auth to work when anonymous auth is enabled
 

Security-dashboards companion PR: https://github.com/opensearch-project/security-dashboards-plugin/pull/1817

### Issues Resolved
- Related https://github.com/opensearch-project/security-dashboards-plugin/issues/1731


### Testing
- Automated + Manual

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
