### PR TITLE
Updates admin password string only if correct hash is present

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
@@ -14,6 +14,7 @@ package org.opensearch.security.tools.democonfig;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -97,7 +98,7 @@ public class Installer {
      * Installs the demo security configuration
      * @param options the options passed to the script
      */
-    public void installDemoConfiguration(String[] options) {
+    public void installDemoConfiguration(String[] options) throws IOException {
         readOptions(options);
         printScriptHeaders();
         gatherUserInputs();
@@ -108,7 +109,7 @@ public class Installer {
         finishScriptExecution();
     }
 
-    public static void main(String[] options) {
+    public static void main(String[] options) throws IOException {
         Installer installer = Installer.getInstance();
         installer.buildOptions();
         installer.installDemoConfiguration(options);

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -79,7 +79,7 @@ public class SecuritySettingsConfigurer {
     static String ADMIN_USERNAME = "admin";
 
     private final Installer installer;
-    static final String DEFAULT_ADMIN_PASSWORD = "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG";
+    static final String DEFAULT_ADMIN_PASSWORD_HASH = "$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG";
 
     public SecuritySettingsConfigurer(Installer installer) {
         this.installer = installer;
@@ -134,7 +134,7 @@ public class SecuritySettingsConfigurer {
             return;
         }
 
-        // if hashed value for "admin" password found, update it with the custom password
+        // if hashed value for default password "admin" is found, update it with the custom password.
         try {
             final PasswordValidator passwordValidator = PasswordValidator.of(
                 Settings.builder()
@@ -176,9 +176,9 @@ public class SecuritySettingsConfigurer {
                 System.exit(-1);
             }
 
+            // Update the custom password in internal_users.yml file
             writePasswordToInternalUsersFile(ADMIN_PASSWORD, INTERNAL_USERS_FILE_PATH);
 
-            // Print an update to the logs
             System.out.println("Admin password set successfully.");
 
         } catch (IOException e) {
@@ -195,7 +195,7 @@ public class SecuritySettingsConfigurer {
      */
     private boolean isAdminPasswordSetToAdmin(String internalUsersFile) throws IOException {
         JsonNode internalUsers = YAML_MAPPER.readTree(new FileInputStream(internalUsersFile));
-        return internalUsers.has("admin") && internalUsers.get("admin").get("hash").asText().equals(DEFAULT_ADMIN_PASSWORD);
+        return internalUsers.has("admin") && internalUsers.get("admin").get("hash").asText().equals(DEFAULT_ADMIN_PASSWORD_HASH);
     }
 
     /**
@@ -216,15 +216,15 @@ public class SecuritySettingsConfigurer {
             var map = YAML_MAPPER.readValue(new File(internalUsersFile), new TypeReference<Map<String, Map<String, String>>>() {
             });
             var admin = map.get("admin");
-            if (admin != null && admin.get("hash").equals(DEFAULT_ADMIN_PASSWORD)) {
+            if (admin != null && admin.get("hash").equals(DEFAULT_ADMIN_PASSWORD_HASH)) {
                 // Replace the password if the default password was found
                 admin.put("hash", hashedAdminPassword);
             }
 
-            // Write the updated map back to the YAML file
+            // Write the updated map back to the internal_users.yml file
             YAML_MAPPER.writeValue(new File(internalUsersFile), map);
         } catch (IOException e) {
-            throw new IOException("Unable to update the internal users file with the hashed password.", e);
+            throw new IOException("Unable to update the internal users file with the hashed password.");
         }
     }
 

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -213,7 +213,7 @@ public class SecuritySettingsConfigurer {
         }
 
         try {
-            var map = YAML_MAPPER.readValue(new File(internalUsersFile), new TypeReference<Map<String, Map<String, String>>>() {
+            var map = YAML_MAPPER.readValue(new File(internalUsersFile), new TypeReference<Map<String, LinkedHashMap<String, Object>>>() {
             });
             var admin = map.get("admin");
             if (admin != null && admin.get("hash").equals(DEFAULT_ADMIN_PASSWORD_HASH)) {

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_TOO_SHORT;
-import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_ADMIN_PASSWORD;
+import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_ADMIN_PASSWORD_HASH;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_PASSWORD_MIN_LENGTH;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.REST_ENABLED_ROLES;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.SYSTEM_INDICES;
@@ -405,7 +405,7 @@ public class SecuritySettingsConfigurerTests {
     private void setUpInternalUsersYML() throws IOException {
         String internalUsersFile = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         Path internalUsersFilePath = Paths.get(internalUsersFile);
-        List<String> defaultContent = Arrays.asList("admin:", "  hash: " + DEFAULT_ADMIN_PASSWORD);
+        List<String> defaultContent = Arrays.asList("admin:", "  hash: " + DEFAULT_ADMIN_PASSWORD_HASH);
         Files.write(internalUsersFilePath, defaultContent, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_TOO_SHORT;
+import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_ADMIN_PASSWORD;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_PASSWORD_MIN_LENGTH;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.REST_ENABLED_ROLES;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.SYSTEM_INDICES;
@@ -181,7 +182,13 @@ public class SecuritySettingsConfigurerTests {
         String internalUsersFile = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         Path internalUsersFilePath = Paths.get(internalUsersFile);
 
-        List<String> newContent = Arrays.asList("admin:", "  hash: \"$2b$12$totallyAHashString\"");
+        List<String> newContent = Arrays.asList(
+            "_meta:",
+            "  type: \"internalusers\"",
+            "  config_version: 2",
+            "admin:",
+            "  hash: \"$2b$12$totallyAHashString\""
+        );
         // overwriting existing content
         Files.write(internalUsersFilePath, newContent, StandardCharsets.UTF_8);
 
@@ -191,7 +198,7 @@ public class SecuritySettingsConfigurerTests {
     }
 
     @Test
-    public void testUpdateAdminPasswordWithDefaultInternalUsersYml() throws IOException {
+    public void testUpdateAdminPasswordWithDefaultInternalUsersYml() {
 
         SecuritySettingsConfigurer.ADMIN_PASSWORD = ""; // to ensure 0 flaky-ness
         try {
@@ -398,7 +405,7 @@ public class SecuritySettingsConfigurerTests {
     private void setUpInternalUsersYML() throws IOException {
         String internalUsersFile = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         Path internalUsersFilePath = Paths.get(internalUsersFile);
-        List<String> defaultContent = Arrays.asList("admin:", "  hash: \"$2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG\"");
+        List<String> defaultContent = Arrays.asList("admin:", "  hash: " + DEFAULT_ADMIN_PASSWORD);
         Files.write(internalUsersFilePath, defaultContent, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -29,12 +29,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.tools.Hasher;
 import org.opensearch.security.tools.democonfig.util.NoExitSecurityManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -43,7 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX;
 import static org.opensearch.security.dlic.rest.validation.RequestContentValidator.ValidationError.INVALID_PASSWORD_TOO_SHORT;
-import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_ADMIN_PASSWORD_HASH;
+import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_ADMIN_PASSWORD;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.DEFAULT_PASSWORD_MIN_LENGTH;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.REST_ENABLED_ROLES;
 import static org.opensearch.security.tools.democonfig.SecuritySettingsConfigurer.SYSTEM_INDICES;
@@ -187,7 +189,7 @@ public class SecuritySettingsConfigurerTests {
             "  type: \"internalusers\"",
             "  config_version: 2",
             "admin:",
-            "  hash: \"$2b$12$totallyAHashString\"",
+            "  hash: " + Hasher.hash(RandomStringUtils.randomAlphanumeric(16).toCharArray()),
             "  backend_roles:",
             "  - \"admin\""
         );
@@ -412,7 +414,7 @@ public class SecuritySettingsConfigurerTests {
             "  type: \"internalusers\"",
             "  config_version: 2",
             "admin:",
-            "  hash: " + DEFAULT_ADMIN_PASSWORD_HASH,
+            "  hash: " + Hasher.hash(DEFAULT_ADMIN_PASSWORD.toCharArray()),
             "  reserved: " + true,
             "  backend_roles:",
             "  - \"admin\"",

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -187,7 +187,9 @@ public class SecuritySettingsConfigurerTests {
             "  type: \"internalusers\"",
             "  config_version: 2",
             "admin:",
-            "  hash: \"$2b$12$totallyAHashString\""
+            "  hash: \"$2b$12$totallyAHashString\"",
+            "  backend_roles:",
+            "  - \"admin\""
         );
         // overwriting existing content
         Files.write(internalUsersFilePath, newContent, StandardCharsets.UTF_8);
@@ -405,7 +407,17 @@ public class SecuritySettingsConfigurerTests {
     private void setUpInternalUsersYML() throws IOException {
         String internalUsersFile = installer.OPENSEARCH_CONF_DIR + "opensearch-security" + File.separator + "internal_users.yml";
         Path internalUsersFilePath = Paths.get(internalUsersFile);
-        List<String> defaultContent = Arrays.asList("admin:", "  hash: " + DEFAULT_ADMIN_PASSWORD_HASH);
+        List<String> defaultContent = Arrays.asList(
+            "_meta:",
+            "  type: \"internalusers\"",
+            "  config_version: 2",
+            "admin:",
+            "  hash: " + DEFAULT_ADMIN_PASSWORD_HASH,
+            "  reserved: " + true,
+            "  backend_roles:",
+            "  - \"admin\"",
+            "  description: Demo admin user"
+        );
         Files.write(internalUsersFilePath, defaultContent, StandardCharsets.UTF_8);
     }
 }


### PR DESCRIPTION
### Description
This PR solves an edge case where someone is trying to load custom internal_users.yml onto a docker distribution while trying to use the demo configuration for setting up security in v2.12.0

* Category: Enhancement
* Why these changes are required?
   * So distributions like Docker and HELM can load custom internal_users.yml with a hashed custom admin password that is not `admin` string.
* What is the old behavior before changes and new behavior after changes?
   * Unable to support internal_users.yml in HELM without a work-around. With this fix, no workaround is needed.

### Issues Resolved
 - Resolves #4098
 - Resolves #3891

### Testing
Automated testing

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--   
*NOTE: This fix comes with a caveat there is no way to validate the supplied hash for strong password, and onus will be left onto users to ensure a strong password hash is supplied to setup secure admin credentials*
--
