### PR TITLE
Fix build dep for byte-buddy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -502,6 +502,7 @@ configurations {
             force "com.google.errorprone:error_prone_annotations:2.25.0"
             force "org.checkerframework:checker-qual:3.42.0"
             force "ch.qos.logback:logback-classic:1.5.3"
+            force "net.bytebuddy:byte-buddy:1.14.9"
         }
     }
 


### PR DESCRIPTION
### Description
Fix byte-buddy version for build. Due to conflict bvetween versions all new PRs fail with:

```bash

* What went wrong:
Execution failed for task ':integTestRemote'.
> Could not resolve all dependencies for configuration ':testRuntimeClasspath'.
   > Conflict found for the following module:
       - net.bytebuddy:byte-buddy between versions 1.14.9 and 1.14.7
```

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
