### PR TITLE
Bump org.apache.zookeeper:zookeeper from 3.9.1. to 3.9.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -706,7 +706,7 @@ dependencies {
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.13'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
-    testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.1') {
+    testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.2') {
         exclude(group:'ch.qos.logback', module: 'logback-classic' )
         exclude(group:'ch.qos.logback', module: 'logback-core' )
     }


### PR DESCRIPTION
### Description

Bumps org.apache.zookeeper:zookeeper from 3.9.1. to 3.9.2

Resolves WhiteSource Security check seen on byte-buddy upgrade: https://github.com/opensearch-project/security/pull/4127/checks?check_run_id=22820167922

* Category

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
