### PR TITLE
[Backport 2.x] Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 (#4123)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -680,7 +680,7 @@ dependencies {
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
-    testImplementation('org.awaitility:awaitility:4.2.0') {
+    testImplementation('org.awaitility:awaitility:4.2.1') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
@@ -723,7 +723,7 @@ dependencies {
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
     integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:${versions.bouncycastle}"
     integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:${versions.bouncycastle}"
-    integrationTestImplementation('org.awaitility:awaitility:4.2.0') {
+    integrationTestImplementation('org.awaitility:awaitility:4.2.1') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
     integrationTestImplementation 'com.unboundid:unboundid-ldapsdk:4.0.14'


### PR DESCRIPTION
Backport 9806699cc727489c8d46637986f7860e81ed7066 from #4123 