### PR TITLE
[1.3] Force resolution of org.apache.zookeeper:zookeeper to 3.9.2 and org.bitbucket.b_c:jose4j to 0.9.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,9 +88,10 @@ configurations.all {
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
-        force "org.apache.zookeeper:zookeeper:3.9.1"
+        force "org.apache.zookeeper:zookeeper:3.9.2"
         force "ch.qos.logback:logback-core:1.2.13"
         force "ch.qos.logback:logback-classic:1.2.13"
+        force "org.bitbucket.b_c:jose4j:0.9.4"
     }
 }
 


### PR DESCRIPTION
### Description

Resolves WhiteSource security check failure seen [here](https://github.com/opensearch-project/security/pull/4134/checks?check_run_id=22835550566).

* Category

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
