### PR TITLE
Update Log4JSink Default from sgaudit to audit and add test for default values

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/Log4JSink.java
@@ -27,7 +27,7 @@ public final class Log4JSink extends AuditLogSink {
 
     public Log4JSink(final String name, final Settings settings, final String settingsPrefix, AuditLogSink fallbackSink) {
         super(name, settings, settingsPrefix, fallbackSink);
-        loggerName = settings.get(settingsPrefix + ".log4j.logger_name", "sgaudit");
+        loggerName = settings.get(settingsPrefix + ".log4j.logger_name", "audit");
         auditLogger = LogManager.getLogger(loggerName);
         logLevel = Level.toLevel(settings.get(settingsPrefix + ".log4j.level", "INFO").toUpperCase());
         enabled = auditLogger.isEnabled(logLevel);

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
@@ -88,6 +88,12 @@ public class SinkProviderTest {
         Assert.assertEquals("loggername", lsink.loggerName);
         Assert.assertEquals(Level.DEBUG, lsink.logLevel);
 
+        sink = provider.getSink("endpoint13");
+        Assert.assertEquals(Log4JSink.class, sink.getClass());
+        lsink = (Log4JSink) sink;
+        Assert.assertEquals("audit", lsink.loggerName);
+        Assert.assertEquals(Level.INFO, lsink.logLevel);
+
     }
 
     @Test

--- a/src/test/resources/auditlog/endpoints/sink/configuration_all_variants.yml
+++ b/src/test/resources/auditlog/endpoints/sink/configuration_all_variants.yml
@@ -45,3 +45,5 @@ plugins.security:
         config:
           log4j.logger_name: loggername
           log4j.level: invalid
+      endpoint13:
+        type: log4j


### PR DESCRIPTION
### Description

Changes the default logger name in the Log4JSink from `sgaudit` to `audit`. This PR also adds a test case that asserts the default value for the logger name.

### Issues Resolved

- https://github.com/opensearch-project/security/issues/4101

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
