### PR TITLE
Add "cluster:monitor/term" to DNFOF tests

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -117,7 +117,8 @@ public class DoNotFailOnForbiddenTests {
             "indices:data/read/msearch",
             "indices:data/read/scroll",
             "cluster:monitor/state",
-            "cluster:monitor/health"
+            "cluster:monitor/health",
+            "cluster:monitor/term"
         )
             .indexPermissions(
                 "indices:data/read/search",


### PR DESCRIPTION
### Description
Add "cluster:monitor/term" to DNFOF tests since the failing integration test is caused by this line being missing 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
