### PR TITLE
Update ci.yml to use upload-artifact@v4 for better build time

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -67,7 +67,7 @@ jobs:
         asset_content_type: application/zip
 
     - name: Upload Workflow Artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts
         path: artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./build/reports/jacoco/test/jacocoTestReport.xml
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports


### PR DESCRIPTION
upload-artifact@v4 is 10x faster (according to GitHub), It has significantly reduced build time



https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/
