### PR TITLE
Add simple roles mapping integ test to test mapping of backend role to role

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
@@ -17,6 +17,7 @@ import static org.apache.http.HttpStatus.SC_OK;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
@@ -52,6 +53,7 @@ public class RolesMappingTests {
             List<String> roles = response.getTextArrayFromJsonBody("/roles");
             List<String> backendRoles = response.getTextArrayFromJsonBody("/backend_roles");
             assertThat(roles, contains(ROLE_A.getName()));
+            assertThat(roles, not(contains(ROLE_B.getName())));
             assertThat(backendRoles, contains("mapsToRoleA"));
             response.assertStatusCode(SC_OK);
         }
@@ -64,6 +66,7 @@ public class RolesMappingTests {
             List<String> roles = response.getTextArrayFromJsonBody("/roles");
             List<String> backendRoles = response.getTextArrayFromJsonBody("/backend_roles");
             assertThat(roles, contains(ROLE_B.getName()));
+            assertThat(roles, not(contains(ROLE_A.getName())));
             assertThat(backendRoles, contains("mapsToRoleB"));
             response.assertStatusCode(SC_OK);
         }

--- a/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.security.http;
 
 import java.util.List;

--- a/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/RolesMappingTests.java
@@ -1,0 +1,71 @@
+package org.opensearch.security.http;
+
+import java.util.List;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.RolesMapping;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.apache.http.HttpStatus.SC_OK;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class RolesMappingTests {
+    static final TestSecurityConfig.User USER_A = new TestSecurityConfig.User("userA").password("s3cret").backendRoles("mapsToRoleA");
+    static final TestSecurityConfig.User USER_B = new TestSecurityConfig.User("userB").password("P@ssw0rd").backendRoles("mapsToRoleB");
+
+    private static final TestSecurityConfig.Role ROLE_A = new TestSecurityConfig.Role("roleA").clusterPermissions("cluster_all");
+
+    private static final TestSecurityConfig.Role ROLE_B = new TestSecurityConfig.Role("roleB").clusterPermissions("cluster_all");
+
+    public static final TestSecurityConfig.AuthcDomain AUTHC_DOMAIN = new TestSecurityConfig.AuthcDomain("basic", 0)
+        .httpAuthenticatorWithChallenge("basic")
+        .backend("internal");
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_DOMAIN)
+        .roles(ROLE_A, ROLE_B)
+        .rolesMapping(new RolesMapping(ROLE_A).backendRoles("mapsToRoleA"), new RolesMapping(ROLE_B).backendRoles("mapsToRoleB"))
+        .users(USER_A, USER_B)
+        .build();
+
+    @Test
+    public void testBackendRoleToRoleMapping() {
+        try (TestRestClient client = cluster.getRestClient(USER_A)) {
+
+            TestRestClient.HttpResponse response = client.getAuthInfo();
+
+            assertThat(response, is(notNullValue()));
+            List<String> roles = response.getTextArrayFromJsonBody("/roles");
+            List<String> backendRoles = response.getTextArrayFromJsonBody("/backend_roles");
+            assertThat(roles, contains(ROLE_A.getName()));
+            assertThat(backendRoles, contains("mapsToRoleA"));
+            response.assertStatusCode(SC_OK);
+        }
+
+        try (TestRestClient client = cluster.getRestClient(USER_B)) {
+
+            TestRestClient.HttpResponse response = client.getAuthInfo();
+
+            assertThat(response, is(notNullValue()));
+            List<String> roles = response.getTextArrayFromJsonBody("/roles");
+            List<String> backendRoles = response.getTextArrayFromJsonBody("/backend_roles");
+            assertThat(roles, contains(ROLE_B.getName()));
+            assertThat(backendRoles, contains("mapsToRoleB"));
+            response.assertStatusCode(SC_OK);
+        }
+    }
+}


### PR DESCRIPTION
### Description

Adds a simple test to verify backend role to role mapping. There currently are not tests in the integrationTest framework around role mapping. I'm introducing this test fixture with a plan to expand this to test all forms of roles mapping like direct user mapping, backend role mapping, and_backend_role mapping and host mapping. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Related: https://github.com/opensearch-project/security/issues/4084

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
