### PR TITLE
Extract route paths prefixes into constants

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/AuthTokenProcessorHandler.java
@@ -137,7 +137,9 @@ class AuthTokenProcessorHandler {
         String samlResponseBase64,
         String samlRequestId,
         String acsEndpoint,
-        Saml2Settings saml2Settings
+        Saml2Settings saml2Settings,
+        String requestPath // the parameter will be removed in the future as soon as we will read of legacy paths aka
+                           // /_opendistro/_security/...
     ) {
         if (token_log.isDebugEnabled()) {
             try {
@@ -156,7 +158,7 @@ class AuthTokenProcessorHandler {
             final SamlResponse samlResponse = new SamlResponse(saml2Settings, acsEndpoint, samlResponseBase64);
 
             if (!samlResponse.isValid(samlRequestId)) {
-                log.warn("Error while validating SAML response in /_opendistro/_security/api/authtoken");
+                log.warn("Error while validating SAML response in {}", requestPath);
                 return null;
             }
 
@@ -178,17 +180,14 @@ class AuthTokenProcessorHandler {
 
             if (restRequest.getMediaType() != XContentType.JSON) {
                 throw new OpenSearchSecurityException(
-                    "/_opendistro/_security/api/authtoken expects content with type application/json",
+                    restRequest.path() + " expects content with type application/json",
                     RestStatus.UNSUPPORTED_MEDIA_TYPE
                 );
 
             }
 
             if (restRequest.method() != Method.POST) {
-                throw new OpenSearchSecurityException(
-                    "/_opendistro/_security/api/authtoken expects POST requests",
-                    RestStatus.METHOD_NOT_ALLOWED
-                );
+                throw new OpenSearchSecurityException(restRequest.path() + " expects POST requests", RestStatus.METHOD_NOT_ALLOWED);
             }
 
             Saml2Settings saml2Settings = this.saml2SettingsProvider.getCached();
@@ -218,7 +217,13 @@ class AuthTokenProcessorHandler {
                 acsEndpoint = getAbsoluteAcsEndpoint(((ObjectNode) jsonRoot).get("acsEndpoint").textValue());
             }
 
-            AuthTokenProcessorAction.Response responseBody = this.handleImpl(samlResponseBase64, samlRequestId, acsEndpoint, saml2Settings);
+            AuthTokenProcessorAction.Response responseBody = this.handleImpl(
+                samlResponseBase64,
+                samlRequestId,
+                acsEndpoint,
+                saml2Settings,
+                restRequest.path()
+            );
 
             if (responseBody == null) {
                 return Optional.empty();
@@ -228,7 +233,7 @@ class AuthTokenProcessorHandler {
 
             return Optional.of(new SecurityResponse(HttpStatus.SC_OK, null, responseBodyString, XContentType.JSON.mediaType()));
         } catch (JsonProcessingException e) {
-            log.warn("Error while parsing JSON for /_opendistro/_security/api/authtoken", e);
+            log.warn("Error while parsing JSON for {}", restRequest.path(), e);
             return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, "JSON could not be parsed"));
         }
     }

--- a/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
+++ b/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
@@ -32,13 +32,14 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.security.identity.SecurityTokenManager;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class CreateOnBehalfOfTokenAction extends BaseRestHandler {
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(new NamedRoute.Builder().method(POST).path("/generateonbehalfoftoken").uniqueName("security:obo/create").build()),
-        "/_plugins/_security/api"
+        PLUGIN_API_ROUTE_PREFIX
     );
 
     public static final long OBO_DEFAULT_EXPIRY_SECONDS = 5 * 60;

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -55,8 +55,18 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
+import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
+import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class Utils {
+
+    public final static String PLUGIN_ROUTE_PREFIX = "/" + PLUGINS_PREFIX;
+
+    public final static String LEGACY_PLUGIN_ROUTE_PREFIX = "/" + LEGACY_OPENDISTRO_PREFIX;
+
+    public final static String PLUGIN_API_ROUTE_PREFIX = PLUGIN_ROUTE_PREFIX + "/api";
+
+    public final static String LEGACY_PLUGIN_API_ROUTE_PREFIX = LEGACY_PLUGIN_ROUTE_PREFIX + "/api";
 
     private static final ObjectMapper internalMapper = new ObjectMapper();
 
@@ -217,7 +227,7 @@ public class Utils {
      *Total number of routes is expanded as twice as the number of routes passed in
      */
     public static List<Route> addRoutesPrefix(List<Route> routes) {
-        return addRoutesPrefix(routes, "/_opendistro/_security/api", "/_plugins/_security/api");
+        return addRoutesPrefix(routes, LEGACY_PLUGIN_API_ROUTE_PREFIX, PLUGIN_API_ROUTE_PREFIX);
     }
 
     /**
@@ -248,7 +258,7 @@ public class Utils {
      *Total number of routes is expanded as twice as the number of routes passed in
      */
     public static List<DeprecatedRoute> addDeprecatedRoutesPrefix(List<DeprecatedRoute> deprecatedRoutes) {
-        return addDeprecatedRoutesPrefix(deprecatedRoutes, "/_opendistro/_security/api", "/_plugins/_security/api");
+        return addDeprecatedRoutesPrefix(deprecatedRoutes, LEGACY_PLUGIN_API_ROUTE_PREFIX, PLUGIN_API_ROUTE_PREFIX);
     }
 
     /**

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -50,15 +50,19 @@ import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.dlic.rest.support.Utils.LEGACY_PLUGIN_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class DashboardsInfoAction extends BaseRestHandler {
 
     private static final List<Route> routes = ImmutableList.<Route>builder()
         .addAll(
-            addRoutesPrefix(ImmutableList.of(new Route(GET, "/dashboardsinfo"), new Route(POST, "/dashboardsinfo")), "/_plugins/_security")
+            addRoutesPrefix(ImmutableList.of(new Route(GET, "/dashboardsinfo"), new Route(POST, "/dashboardsinfo")), PLUGIN_ROUTE_PREFIX)
         )
-        .addAll(addRoutesPrefix(ImmutableList.of(new Route(GET, "/kibanainfo"), new Route(POST, "/kibanainfo")), "/_opendistro/_security"))
+        .addAll(
+            addRoutesPrefix(ImmutableList.of(new Route(GET, "/kibanainfo"), new Route(POST, "/kibanainfo")), LEGACY_PLUGIN_ROUTE_PREFIX)
+        )
         .build();
 
     private final Logger log = LogManager.getLogger(this.getClass());

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -44,13 +44,15 @@ import org.opensearch.security.auth.BackendRegistry;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.dlic.rest.support.Utils.LEGACY_PLUGIN_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityHealthAction extends BaseRestHandler {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(new Route(GET, "/health"), new Route(POST, "/health")),
-        "/_opendistro/_security",
-        "/_plugins/_security"
+        LEGACY_PLUGIN_ROUTE_PREFIX,
+        PLUGIN_ROUTE_PREFIX
     );
 
     private final BackendRegistry registry;

--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -57,13 +57,15 @@ import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.dlic.rest.support.Utils.LEGACY_PLUGIN_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityInfoAction extends BaseRestHandler {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(new Route(GET, "/authinfo"), new Route(POST, "/authinfo")),
-        "/_opendistro/_security",
-        "/_plugins/_security"
+        LEGACY_PLUGIN_ROUTE_PREFIX,
+        PLUGIN_ROUTE_PREFIX
     );
 
     private final Logger log = LogManager.getLogger(this.getClass());

--- a/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/TenantInfoAction.java
@@ -61,13 +61,15 @@ import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.dlic.rest.support.Utils.LEGACY_PLUGIN_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class TenantInfoAction extends BaseRestHandler {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(new Route(GET, "/tenantinfo"), new Route(POST, "/tenantinfo")),
-        "/_opendistro/_security",
-        "/_plugins/_security"
+        LEGACY_PLUGIN_ROUTE_PREFIX,
+        PLUGIN_ROUTE_PREFIX
     );
 
     private final Logger log = LogManager.getLogger(this.getClass());


### PR DESCRIPTION
Extracted route path prefixes into contants:

 - `/_plugins/_security` - `PLUGIN_ROUTE_PREFIX`
 - `/_opendistro/_security` - `LEGACY_PLUGIN_ROUTE_PREFIX`
 - `/_plugins/_security/api` - `PLUGIN_API_ROUTE_PREFIX`
 - `/_opendistro/_security/api` - `LEGACY_PLUGIN_API_ROUTE_PREFIX`

Same part of #4153 for simplicity of the final PR.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
