### PR TITLE
Remove Pom task dependenices rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,8 @@ jobs:
 
     - run: ./gradlew clean assemble -Dbuild.version_qualifier=${{ env.TEST_QUALIFIER }} && test -s ./build/distributions/opensearch-security-${{ env.SECURITY_PLUGIN_VERSION_ONLY_NUMBER }}-${{ env.TEST_QUALIFIER }}-SNAPSHOT.zip
 
+    - run: ./gradlew clean publishPluginZipPublicationToZipStagingRepository && test -s ./build/distributions/opensearch-security-${{ env.SECURITY_PLUGIN_VERSION }}.zip && test -s ./build/distributions/opensearch-security-${{ env.SECURITY_PLUGIN_VERSION }}.pom
+
     - name: List files in the build directory if there was an error
       run: ls -al ./build/distributions/
       if: failure()

--- a/build.gradle
+++ b/build.gradle
@@ -407,11 +407,6 @@ opensearchplugin {
 // This requires an additional Jar not published as part of build-tools
 loggerUsageCheck.enabled = false
 
-// No need to validate pom, as we do not upload to maven/sonatype
-tasks.matching {it.path in [":validateMavenPom", ":validateNebulaPom", ":validatePluginZipPom"]}.all { task ->
-    task.dependsOn ':generatePomFileForNebulaPublication', ':generatePomFileForPluginZipPublication', ':generatePomFileForMavenPublication'
-}
-
 publishing {
     publications {
         pluginZip(MavenPublication) { publication ->


### PR DESCRIPTION
### Description
The underlying issue associated with Pom validation was fixed in OpenSearch [1], this causes the 'hack' that was used to unblock pom generation in security to start causing problems in the distribution builds.

- [1] https://github.com/opensearch-project/OpenSearch/pull/12807

### Issues Resolved
- Fixes https://github.com/opensearch-project/security/issues/4160

### Testing
Added new CI test that executes the same job used by the distribution build and checks the expected artifacts exist

### Check List
- [X] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
