### PR TITLE
[Backport] [2.x] Bump io.dropwizard.metrics:metrics-core from 4.2.15 to 4.2.25 (#4193)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -605,7 +605,8 @@ dependencies {
     testImplementation 'org.apache.camel:camel-xmlsecurity:3.22.1'
 
     //OpenSAML
-    implementation 'net.shibboleth.utilities:java-support:8.4.0'
+    implementation 'net.shibboleth.utilities:java-support:8.4.1'
+    runtimeOnly "io.dropwizard.metrics:metrics-core:4.2.25"
     implementation "com.onelogin:java-saml:${one_login_java_saml}"
     implementation "com.onelogin:java-saml-core:${one_login_java_saml}"
     implementation "org.opensaml:opensaml-core:${open_saml_version}"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4193 to `2.x`