### PR TITLE
System index permission grants reading access to documents in the index

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
-import org.greenrobot.eventbus.Subscribe;
+
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -46,6 +46,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.user.User;
+
+import org.greenrobot.eventbus.Subscribe;
 
 public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
 

--- a/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
@@ -64,7 +64,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
     private final Boolean systemIndexEnabled;
     private final WildcardMatcher systemIndexMatcher;
 
-    private final boolean isSystemIndexPermissionEnabled;
+    private final Boolean systemIndexPermissionEnabled;
 
     // constructor is called per index, so avoid costly operations here
     public SecurityIndexSearcherWrapper(
@@ -94,7 +94,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
         );
         this.systemIndexMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.SECURITY_SYSTEM_INDICES_KEY));
 
-        this.isSystemIndexPermissionEnabled = settings.getAsBoolean(
+        this.systemIndexPermissionEnabled = settings.getAsBoolean(
             ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_ENABLED_KEY,
             ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_DEFAULT
         );
@@ -115,7 +115,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
             return new EmptyFilterLeafReader.EmptyDirectoryReader(reader);
         }
 
-        if (systemIndexEnabled && !isSystemIndexPermissionEnabled && isBlockedSystemIndexRequest() && !isAdminDnOrPluginRequest()) {
+        if (systemIndexEnabled && !systemIndexPermissionEnabled && isBlockedSystemIndexRequest() && !isAdminDnOrPluginRequest()) {
             log.warn("search action for {} is not allowed for a non adminDN user", index.getName());
             return new EmptyFilterLeafReader.EmptyDirectoryReader(reader);
         }

--- a/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
@@ -64,6 +64,8 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
     private final Boolean systemIndexEnabled;
     private final WildcardMatcher systemIndexMatcher;
 
+    private final boolean isSystemIndexPermissionEnabled;
+
     // constructor is called per index, so avoid costly operations here
     public SecurityIndexSearcherWrapper(
         final IndexService indexService,
@@ -91,6 +93,11 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
             ConfigConstants.SECURITY_SYSTEM_INDICES_ENABLED_DEFAULT
         );
         this.systemIndexMatcher = WildcardMatcher.from(settings.getAsList(ConfigConstants.SECURITY_SYSTEM_INDICES_KEY));
+
+        this.isSystemIndexPermissionEnabled = settings.getAsBoolean(
+            ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_ENABLED_KEY,
+            ConfigConstants.SECURITY_SYSTEM_INDICES_PERMISSIONS_DEFAULT
+        );
     }
 
     @Subscribe
@@ -108,7 +115,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
             return new EmptyFilterLeafReader.EmptyDirectoryReader(reader);
         }
 
-        if (systemIndexEnabled && isBlockedSystemIndexRequest() && !isAdminDnOrPluginRequest()) {
+        if (systemIndexEnabled && !isSystemIndexPermissionEnabled && isBlockedSystemIndexRequest() && !isAdminDnOrPluginRequest()) {
             log.warn("search action for {} is not allowed for a non adminDN user", index.getName());
             return new EmptyFilterLeafReader.EmptyDirectoryReader(reader);
         }

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -193,7 +193,7 @@ public class PrivilegesEvaluator {
         this.dcm = dcm;
     }
 
-    private SecurityRoles getSecurityRoles(Set<String> roles) {
+    public SecurityRoles getSecurityRoles(Set<String> roles) {
         return configModel.getSecurityRoles().filter(roles);
     }
 

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV6.java
@@ -542,6 +542,26 @@ public class ConfigModelV6 extends ConfigModel {
             roles.stream().forEach(p -> ipatterns.addAll(p.getIpatterns()));
             return ConfigModelV6.impliesTypePerm(ipatterns, resolved, user, actions, resolver, cs);
         }
+
+        @Override
+        public boolean isPermittedOnSystemIndex(String indexName) {
+            boolean isPatternMatched = false;
+            boolean isPermitted = false;
+            for (SecurityRole role : roles) {
+                for (IndexPattern ip : role.getIpatterns()) {
+                    WildcardMatcher wildcardMatcher = WildcardMatcher.from(ip.indexPattern);
+                    if (wildcardMatcher.test(indexName)) {
+                        isPatternMatched = true;
+                    }
+                    for (TypePerm tp : ip.getTypePerms()) {
+                        if (tp.perms.contains(ConfigConstants.SYSTEM_INDEX_PERMISSION)) {
+                            isPermitted = true;
+                        }
+                    }
+                }
+            }
+            return isPatternMatched && isPermitted;
+        }
     }
 
     public static class SecurityRole {

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -563,6 +563,24 @@ public class ConfigModelV7 extends ConfigModel {
 
             return false;
         }
+
+        @Override
+        public boolean isPermittedOnSystemIndex(String indexName) {
+            boolean isPatternMatched = false;
+            boolean isPermitted = false;
+            for (SecurityRole role : roles) {
+                for (IndexPattern ip : role.getIpatterns()) {
+                    WildcardMatcher wildcardMatcher = WildcardMatcher.from(ip.indexPattern);
+                    if (wildcardMatcher.test(indexName)) {
+                        isPatternMatched = true;
+                    }
+                    if (ip.perms.contains(ConfigConstants.SYSTEM_INDEX_PERMISSION)) {
+                        isPermitted = true;
+                    }
+                }
+            }
+            return isPatternMatched && isPermitted;
+        }
     }
 
     public static class SecurityRole {

--- a/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
+++ b/src/main/java/org/opensearch/security/securityconf/SecurityRoles.java
@@ -96,4 +96,6 @@ public interface SecurityRoles {
     );
 
     SecurityRoles filter(Set<String> roles);
+
+    boolean isPermittedOnSystemIndex(String indexName);
 }

--- a/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsV6Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/SecurityRolesPermissionsV6Test.java
@@ -126,6 +126,17 @@ public class SecurityRolesPermissionsV6Test {
         );
     }
 
+    @Test
+    public void isPermittedOnSystemIndex() {
+        final SecurityRoles securityRoleWithExplicitAccess = configModel.getSecurityRoles()
+            .filter(ImmutableSet.of("has_system_index_permission"));
+        Assert.assertTrue(securityRoleWithExplicitAccess.isPermittedOnSystemIndex(TEST_INDEX));
+
+        final SecurityRoles securityRoleWithStarAccess = configModel.getSecurityRoles()
+            .filter(ImmutableSet.of("all_access_without_system_index_permission"));
+        Assert.assertFalse(securityRoleWithStarAccess.isPermittedOnSystemIndex(TEST_INDEX));
+    }
+
     static <T> SecurityDynamicConfiguration<T> createRolesConfig() throws IOException {
         final ObjectNode rolesNode = DefaultObjectMapper.objectMapper.createObjectNode();
         NO_EXPLICIT_SYSTEM_INDEX_PERMISSION.forEach(rolesNode::set);

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
@@ -79,7 +79,8 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
             if (index.equals(ACCESSIBLE_ONLY_BY_SUPER_ADMIN) || index.equals(SYSTEM_INDEX_WITH_NO_ASSOCIATED_ROLE_PERMISSIONS)) {
                 validateForbiddenResponse(response, "", normalUser);
             } else {
-                validateSearchResponse(response, 0);
+                // got 1 hits because system index permissions are enabled
+                validateSearchResponse(response, 1);
             }
         }
 


### PR DESCRIPTION
### Description

* Category: **Bug Fix**

* Why these changes are required? **User has `system:admin/system_index permission`, but cannot search documents in the custom system index.**

* What is the old behavior before changes and new behavior after changes? **It was modified to not return `EmptyFilterLeafReader` when the system index permission option is enable.**

### Issues Resolved
- Resolves #4188 

### Testing

- Update `SystemIndexPermissionEnabledTests.testSearchAsNormalUser`

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
