### PR TITLE
[1.3] Remove and refactor console print statements

### DIFF
--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
@@ -56,7 +56,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSL() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
@@ -66,7 +65,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSLFail() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         final HttpResponse response = rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong"));
@@ -85,7 +83,6 @@ public class LdapBackendIntegTest extends SingleClusterTest {
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as", "jacksonm")
                 ,encodeBasicHeader("spock", "spocksecret"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.subschemaSubentry"));

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -990,7 +990,6 @@ public class LdapBackendTest {
                 .getBytes(StandardCharsets.UTF_8)));
         Assert.assertNotNull(user);
         Assert.assertEquals("cn=cabc,ou=people,o=TEST", user.getName());
-        System.out.println(user.getUserEntry().getAttribute("cn"));
     }
 
 

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
@@ -56,7 +56,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSL() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config_ldap2.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
@@ -66,7 +65,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
     public void testIntegLdapAuthenticationSSLFail() throws Exception {
         String securityConfigAsYamlString = FileHelper.loadFile("ldap/config_ldap2.yml");
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
-        System.out.println(securityConfigAsYamlString);
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode());
@@ -84,7 +82,6 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as", "jacksonm")
                 ,encodeBasicHeader("spock", "spocksecret"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.subschemaSubentry"));

--- a/src/test/java/org/opensearch/security/AggregationTests.java
+++ b/src/test/java/org/opensearch/security/AggregationTests.java
@@ -81,7 +81,6 @@ public class AggregationTests extends SingleClusterTest {
         
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("_search?pretty", "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");
@@ -94,7 +93,6 @@ public class AggregationTests extends SingleClusterTest {
         assertContains(res, "*\"failed\" : 0*");
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("*/_search?pretty", "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");
@@ -107,7 +105,6 @@ public class AggregationTests extends SingleClusterTest {
         assertContains(res, "*\"failed\" : 0*");
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("_search?pretty", "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",encodeBasicHeader("worf", "worf"))).getStatusCode());
-        System.out.println(res.getBody());
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
         assertNotContains(res, "*mpty*");

--- a/src/test/java/org/opensearch/security/ConfigTests.java
+++ b/src/test/java/org/opensearch/security/ConfigTests.java
@@ -58,18 +58,12 @@ public class ConfigTests {
         Tuple<SecurityDynamicConfiguration<RoleV7>, SecurityDynamicConfiguration<TenantV7>> rolesResult = Migration.migrateRoles((SecurityDynamicConfiguration<RoleV6>)load("./legacy/securityconfig_v6/roles.yml", CType.ROLES),
                 (SecurityDynamicConfiguration<RoleMappingsV6>)load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING));
         
-        System.out.println(Strings.toString(rolesResult.v2(), true, false));
-        System.out.println(Strings.toString(rolesResult.v1(), true, false));
         
         
         SecurityDynamicConfiguration<ActionGroupsV7> actionGroupsResult = Migration.migrateActionGroups((SecurityDynamicConfiguration<ActionGroupsV6>)load("./legacy/securityconfig_v6/action_groups.yml", CType.ACTIONGROUPS));
-        System.out.println(Strings.toString(actionGroupsResult, true, false));
         SecurityDynamicConfiguration<ConfigV7> configResult =Migration.migrateConfig((SecurityDynamicConfiguration<ConfigV6>)load("./legacy/securityconfig_v6/config.yml", CType.CONFIG));
-        System.out.println(Strings.toString(configResult, true, false));
         SecurityDynamicConfiguration<InternalUserV7> internalUsersResult = Migration.migrateInternalUsers((SecurityDynamicConfiguration<InternalUserV6>)load("./legacy/securityconfig_v6/internal_users.yml", CType.INTERNALUSERS));
-        System.out.println(Strings.toString(internalUsersResult, true, false));
         SecurityDynamicConfiguration<RoleMappingsV7> rolemappingsResult = Migration.migrateRoleMappings((SecurityDynamicConfiguration<RoleMappingsV6>)load("./legacy/securityconfig_v6/roles_mapping.yml", CType.ROLESMAPPING));
-        System.out.println(Strings.toString(rolemappingsResult, true, false));
     }
     
     @Test
@@ -97,14 +91,12 @@ public class ConfigTests {
     private void check(String file, CType cType) throws Exception {
         JsonNode jsonNode = YAML.readTree(FileUtils.readFileToString(new File(file), "UTF-8"));
         int configVersion = 1;
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST %%%%%%%");
         if(jsonNode.get("_meta") != null) {
             Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
 
 
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST: CONFIG VERSION: "+ configVersion + "%%%%%%%");
         
         SecurityDynamicConfiguration<?> dc = load(file, cType);
         Assert.assertNotNull(dc);
@@ -119,12 +111,10 @@ public class ConfigTests {
         JsonNode jsonNode = YAML.readTree(FileUtils.readFileToString(new File(file), "UTF-8"));
         int configVersion = 1;
 
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST LOAD: CONFIG VERSION: %%%%%%%");
         if(jsonNode.get("_meta") != null) {
             Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
-        System.out.println("%%%%%%%% THIS IS A LINE OF INTEREST: CONFIG VERSION: "+ configVersion + "%%%%%%%");
         return SecurityDynamicConfiguration.fromNode(jsonNode, cType, configVersion, 0, 0);
     }
 }

--- a/src/test/java/org/opensearch/security/HealthTests.java
+++ b/src/test/java/org/opensearch/security/HealthTests.java
@@ -49,13 +49,11 @@ public class HealthTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -68,13 +66,11 @@ public class HealthTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
         
         Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*DOWN*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*UP*");

--- a/src/test/java/org/opensearch/security/HttpIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/HttpIntegrationTests.java
@@ -183,8 +183,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             Assert.assertFalse(res.getBody().contains("\"nodes\" : { }"));
             
             res = rh.executePostRequest("*/_upgrade", "", encodeBasicHeader("nagilum", "nagilum"));
-            System.out.println(res.getBody());
-            System.out.println(res.getStatusReason());
             Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
             
             String bulkBody = 
@@ -194,7 +192,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator();
     
             res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("writer", "writer"));
-            System.out.println(res.getBody());
             Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
             Assert.assertTrue(res.getBody().contains("\"errors\":false"));
             Assert.assertTrue(res.getBody().contains("\"status\":201"));  
@@ -272,11 +269,9 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertNotContains(res, "*\"compression\":\"false\"*");
         assertContains(res, "*\"compression\":\"true\"*");
     }
@@ -293,11 +288,9 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res);
         assertContains(res, "*\"compression\":\"false\"*");
         assertNotContains(res, "*\"compression\":\"true\"*");
     }
@@ -318,12 +311,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
             Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
             
             resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty=true");
-            System.out.println(resc.getBody());
             Assert.assertTrue(resc.getBody().contains("\"remote_address\" : \"")); //check pretty print
             Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
             
             resc = rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("nagilum", "nagilum"));
-            System.out.println(resc.getBody());
             Assert.assertTrue(resc.getBody().contains("nagilum"));
             Assert.assertFalse(resc.getBody().contains("opendistro_security_anonymous"));
             Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
@@ -380,7 +371,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_CREATED, rh.executePutRequest(".opendistro_security/"+getType()+"/y", "{}").getStatusCode());
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/authinfo")).getStatusCode());
-        System.out.println(res.getBody());
     }
 
     @Test
@@ -512,7 +502,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePutRequest(".opendistro_security/config/0","{}",encodeBasicHeader("worf", "worf")).getStatusCode());
             
             HttpResponse resc = rh.executeGetRequest("_cat/indices/public",encodeBasicHeader("bug108", "nagilum"));
-            System.out.println(resc.getBody());
             //Assert.assertTrue(resc.getBody().contains("green"));
             Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
             
@@ -523,7 +512,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("spock/type01/_search?pretty",encodeBasicHeader("kirk", "kirk")).getStatusCode());
             Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("kirk/type01/_search?pretty",encodeBasicHeader("kirk", "kirk")).getStatusCode());
             
-            System.out.println("ok");
     //all
             
             
@@ -544,7 +532,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator();
     
         HttpResponse res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("bulk", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
         Assert.assertTrue(res.getBody().contains("\"errors\":false"));
         Assert.assertTrue(res.getBody().contains("\"status\":201"));
@@ -565,7 +552,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
                         "{ \"a\" : \"b\" }"+System.lineSeparator();
 
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("bulk_test_user", "nagilum"));
-        System.out.println(res.getBody());
         JsonNode jsonNode = readTree(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(jsonNode.get("errors").booleanValue());
@@ -595,11 +581,9 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executePostRequest("/*/_search", "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}", encodeBasicHeader("nagilum", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));
         res = rh.executePostRequest("/*/_search", "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}", encodeBasicHeader("557", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));  
     }
@@ -630,13 +614,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
         
         final RestHelper rh = nonSslRestHelper();
 
-        System.out.println("###1");
         HttpResponse res = rh.executeGetRequest("/esb-prod-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
-        System.out.println("###2");
         res = rh.executeGetRequest("/esb-alias-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println("###3");
         res = rh.executeGetRequest("/esb-prod-all/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
     }
@@ -685,7 +666,6 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());  
 
         res = rh.executeGetRequest("_opendistro/_security/tenantinfo?pretty", encodeBasicHeader("kibanaserver", "kibanaserver"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\".kibana_-1139640511_admin1\" : \"admin_1\""));
         Assert.assertTrue(res.getBody().contains("\".kibana_-1386441176_praxisrw\" : \"praxisrw\""));

--- a/src/test/java/org/opensearch/security/IndexIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IndexIntegrationTests.java
@@ -126,16 +126,13 @@ public class IndexIntegrationTests extends SingleClusterTest {
         "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
         "{ \"delete\" : { \"_index\" : \"lorem\", \"_type\" : \"type1\", \"_id\" : \"5\" } }"+System.lineSeparator();
        
-        System.out.println("############ _bulk");
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true&pretty=true", bulkBody, encodeBasicHeader("worf", "worf"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());  
         Assert.assertTrue(res.getBody().contains("\"errors\" : true"));
         Assert.assertTrue(res.getBody().contains("\"status\" : 201"));
         Assert.assertTrue(res.getBody().contains("no permissions for"));
         
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
         
     }
@@ -344,7 +341,6 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/_cat/indices?v" ,encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
 
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("logstash-b"));
         Assert.assertTrue(res.getBody().contains("logstash-new-20"));
         Assert.assertTrue(res.getBody().contains("logstash-cnew-20"));
@@ -386,16 +382,12 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/mysgi/_search?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
         assertContains(res, "*\"hits\" : {*\"value\" : 0,*\"hits\" : [ ]*");
         
-        System.out.println("#### add alias to allowed index");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePutRequest("/logstash-1/_alias/alog1", "",encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
 
-        System.out.println("#### add alias to not existing (no perm)");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executePutRequest("/nonexitent/_alias/alnp", "",encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
         
-        System.out.println("#### add alias to not existing (with perm)");
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, (res = rh.executePutRequest("/logstash-nonex/_alias/alnp", "",encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
         
-        System.out.println("#### add alias to not allowed index");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executePutRequest("/nopermindex/_alias/alnp", "",encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
 
         String aliasRemoveIndex = "{"+
@@ -405,19 +397,15 @@ public class IndexIntegrationTests extends SingleClusterTest {
             "]"+
         "}";
         
-        System.out.println("#### remove_index");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executePostRequest("/_aliases", aliasRemoveIndex,encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
 
         
-        System.out.println("#### get alias for permitted index");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-1/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
 
         
-        System.out.println("#### get alias for all indices");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executeGetRequest("/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
 
         
-        System.out.println("#### get alias no perm");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executeGetRequest("/_alias/nopermalias", encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());
         
         String alias =
@@ -428,7 +416,6 @@ public class IndexIntegrationTests extends SingleClusterTest {
         "}";
         
         
-        System.out.println("#### create alias along with index");
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res = rh.executePutRequest("/beats-withalias", alias,encodeBasicHeader("aliasmngt", "nagilum"))).getStatusCode());        
     }
 
@@ -519,10 +506,8 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("/*:noperm/_search", encodeBasicHeader("ccsresolv", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res.getBody());
         res = rh.executeGetRequest("/*:noexists/_search", encodeBasicHeader("ccsresolv", "nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        System.out.println(res.getBody());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -116,7 +116,6 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         
         try (TransportClient tc = getUserTransportClient(clusterInfo, "spock-keystore.jks", Settings.EMPTY)) {  
             WhoAmIResponse wres = tc.execute(WhoAmIAction.INSTANCE, new WhoAmIRequest()).actionGet();
-            System.out.println(wres);
             Assert.assertEquals(wres.toString(), "CN=spock,OU=client,O=client,L=Test,C=DE", wres.getDn());
             Assert.assertFalse(wres.toString(), wres.isAdmin());
             Assert.assertFalse(wres.toString(), wres.isAuthenticated());
@@ -126,7 +125,6 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         
         try (TransportClient tc = getUserTransportClient(clusterInfo, "node-0-keystore.jks", Settings.EMPTY)) {  
             WhoAmIResponse wres = tc.execute(WhoAmIAction.INSTANCE, new WhoAmIRequest()).actionGet();    
-            System.out.println(wres);
             Assert.assertEquals(wres.toString(), "CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE", wres.getDn());
             Assert.assertFalse(wres.toString(), wres.isAdmin());
             Assert.assertFalse(wres.toString(), wres.isAuthenticated());

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -97,19 +97,14 @@ public class IntegrationTests extends SingleClusterTest {
         }
         
         
-        System.out.println("########search");
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
         
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start+1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executePostRequest("/_search/scroll?pretty=true", "{\"scroll_id\" : \""+scrollid+"\"}", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
 
 
-        System.out.println("########search done");
         
         
     }
@@ -125,7 +120,6 @@ public class IntegrationTests extends SingleClusterTest {
             tc.index(new IndexRequest("lorem").type("type1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"field2\":\"init\"}", XContentType.JSON)).actionGet();      
         
             WhoAmIResponse wres = tc.execute(WhoAmIAction.INSTANCE, new WhoAmIRequest()).actionGet();
-            System.out.println(wres);
             Assert.assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", wres.getDn());
             Assert.assertTrue(wres.isAdmin());
             Assert.assertTrue(wres.toString(), wres.isAuthenticated());
@@ -280,7 +274,6 @@ public class IntegrationTests extends SingleClusterTest {
        
        RestHelper rh = nonSslRestHelper();
        HttpResponse resc = rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("picard", "picard"));
-       System.out.println(resc.getBody());
        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
        Assert.assertFalse(resc.getBody().contains("type2"));
         
@@ -309,7 +302,6 @@ public class IntegrationTests extends SingleClusterTest {
         Assert.assertFalse(resp.getBody().contains("spock"));
         
         resp = rh.executeGetRequest("/_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as", "userwhonotexists"), encodeBasicHeader("spock", "spock"));
-        System.out.println(resp.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resp.getStatusCode());
     
         resp = rh.executeGetRequest("/_opendistro/_security/authinfo", new BasicHeader("opendistro_security_impersonate_as", "invalid"), encodeBasicHeader("spock", "spock"));
@@ -332,7 +324,6 @@ public class IntegrationTests extends SingleClusterTest {
         //opendistro_security_shakespeare -> picard
     
         HttpResponse resc = rh.executeGetRequest("shakespeare/_search", encodeBasicHeader("picard", "picard"));
-        System.out.println(resc.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
         Assert.assertTrue(resc.getBody().contains("\"content\":1"));
         
@@ -397,7 +388,6 @@ public class IntegrationTests extends SingleClusterTest {
         }
         
         HttpResponse res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("\"content\":1"));
         Assert.assertFalse(res.getBody().contains("\"content\":2"));
@@ -410,7 +400,6 @@ public class IntegrationTests extends SingleClusterTest {
         }
         
         res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertTrue(res.getBody().contains("\"content\":1"));
         Assert.assertTrue(res.getBody().contains("\"content\":2"));
@@ -492,7 +481,6 @@ public class IntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executePostRequest("indexc/typec/0/_update?pretty=true&refresh=true", "{\"doc\" : {\"content\":2}}",
                 encodeBasicHeader("user_c", "user_c"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
     }
 
@@ -533,14 +521,12 @@ public class IntegrationTests extends SingleClusterTest {
 
         HttpResponse resc;
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("permission"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
@@ -553,10 +539,8 @@ public class IntegrationTests extends SingleClusterTest {
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
                 "{\"index\":\"index*\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
-        System.out.println("#### msearch");
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -566,7 +550,6 @@ public class IntegrationTests extends SingleClusterTest {
 
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -598,7 +581,6 @@ public class IntegrationTests extends SingleClusterTest {
                 "]"+
                 "}";
 
-        System.out.println("#### mget");
         resc = rh.executePostRequest("_mget?pretty",  mgetBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("\"content\" : \"indexa\""));
@@ -625,50 +607,36 @@ public class IntegrationTests extends SingleClusterTest {
         Assert.assertEquals(403, resc.getStatusCode());
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("permission"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
         
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, (resc=rh.executeGetRequest("permitnotexistentindex/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
         
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("permitnotexistentindex*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, (resc=rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode());
-        System.out.println(resc.getBody());
 
-        System.out.println("#### _all/_mapping/field/*");
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(resc.getBody());
     }
 
 
@@ -708,29 +676,23 @@ public class IntegrationTests extends SingleClusterTest {
 
         HttpResponse resc;
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         String msearchBody =
                 "{\"index\":\"indexa\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
                 "{\"index\":\"indexb\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
-        System.out.println("#### msearch a");
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
 
-        System.out.println("#### msearch b");
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
         Assert.assertEquals(200, resc.getStatusCode());
-        System.out.println(resc.getBody());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -742,9 +704,7 @@ public class IntegrationTests extends SingleClusterTest {
                 "{\"index\":\"indexd\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
-        System.out.println("#### msearch b2");
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        System.out.println(resc.getBody());
         Assert.assertEquals(200, resc.getStatusCode());
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
@@ -802,38 +762,24 @@ public class IntegrationTests extends SingleClusterTest {
 
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, (resc=rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-        System.out.println(resc.getBody());
 
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode());
-        System.out.println(resc.getBody());
 
-        System.out.println("#### _all/_mapping/field/*");
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(resc.getBody());
-        System.out.println("#### _mapping/field/*");
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(resc.getBody());
-        System.out.println("#### */_mapping/field/*");
         Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
-        System.out.println(resc.getBody());
     }
 
     @Test
@@ -880,7 +826,6 @@ public class IntegrationTests extends SingleClusterTest {
                 + "{ \"delete\" : { \"_index\" : \".opendistro_security\", \"_id\" : \"config\" } }\n";
         res = rh.executePostRequest("_bulk?refresh=true&pretty", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
         JsonNode jsonNode = readTree(res.getBody());
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertEquals(403, jsonNode.get("items").get(0).get("index").get("status").intValue());
         Assert.assertEquals(403, jsonNode.get("items").get(1).get("index").get("status").intValue());

--- a/src/test/java/org/opensearch/security/SecurityAdminTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminTests.java
@@ -125,7 +125,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -198,7 +197,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -233,7 +231,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -268,7 +265,6 @@ public class SecurityAdminTests extends SingleClusterTest {
         HttpResponse res;
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        System.out.println(res.getBody());
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -289,7 +285,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println(rh.executePutRequest(".opendistro_security/"+getType()+"/roles", FileHelper.loadFile("roles_invalidxcontent.yml")).getBody());;
+        rh.executePutRequest(".opendistro_security/"+getType()+"/roles", FileHelper.loadFile("roles_invalidxcontent.yml")).getBody();;
         Assert.assertEquals(HttpStatus.SC_OK, rh.executePutRequest(".opendistro_security/"+getType()+"/roles", "{\"roles\":\"dummy\"}").getStatusCode());
         
         

--- a/src/test/java/org/opensearch/security/SnapshotRestoreTests.java
+++ b/src/test/java/org/opensearch/security/SnapshotRestoreTests.java
@@ -208,7 +208,6 @@ public class SnapshotRestoreTests extends SingleClusterTest {
             ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[]{"config","roles","rolesmapping","internalusers","actiongroups"})).actionGet();
             Assert.assertFalse(cur.hasFailures());
             Assert.assertEquals(currentClusterConfig.getNodes(), cur.getNodes().size());
-            System.out.println(cur.getNodesMap());
         }
     
         RestHelper rh = nonSslRestHelper();

--- a/src/test/java/org/opensearch/security/TaskTests.java
+++ b/src/test/java/org/opensearch/security/TaskTests.java
@@ -39,7 +39,6 @@ public class TaskTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_tasks?group_by=parents&pretty"
                 , encodeBasicHeader("nagilum", "nagilum")
                 , new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().split("X-Opaque-Id").length > 2);
         Assert.assertTrue(!res.getBody().contains("failures"));
     }

--- a/src/test/java/org/opensearch/security/TracingTests.java
+++ b/src/test/java/org/opensearch/security/TracingTests.java
@@ -73,24 +73,20 @@ public class TracingTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ write into mapping 1");
         String data1 = FileHelper.loadFile("data1.json");
-        System.out.println(rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 2");
-        System.out.println(rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 3");
         String parent = FileHelper.loadFile("data2.json");
         String child = FileHelper.loadFile("data3.json");
-        System.out.println(rh.executePutRequest("myindex3/mytype3/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex3/mytype3/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex3/mytype3/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex3/mytype3/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ write into mapping 4");
-        System.out.println(rh.executePutRequest("myindex4/mytype4/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println(rh.executePutRequest("myindex4/mytype4/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePutRequest("myindex4/mytype4/1?refresh", parent, encodeBasicHeader("nagilum", "nagilum"));
+        rh.executePutRequest("myindex4/mytype4/2?routing=1&refresh", child, encodeBasicHeader("nagilum", "nagilum"));
     }
 
     @Test
@@ -130,10 +126,8 @@ public class TracingTests extends SingleClusterTest {
 
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -141,9 +135,8 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
         bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -151,51 +144,42 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ cat indices");
         //cluster:monitor/state
         //cluster:monitor/health
         //indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ _search");
         //indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ get 1");
         //indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum"));
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum"));
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index (+create index)");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index only");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ delete");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ msearch");
         String msearchBody =
                 "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
@@ -205,9 +189,8 @@ public class TracingTests extends SingleClusterTest {
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ mget");
         String mgetBody = "{"+
                 "\"docs\" : ["+
                     "{"+
@@ -232,9 +215,8 @@ public class TracingTests extends SingleClusterTest {
                 "]"+
             "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete by query");
         String dbqBody = "{"+
         ""+
         "  \"query\": { "+
@@ -244,7 +226,7 @@ public class TracingTests extends SingleClusterTest {
         "  }"+
         "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum"));
 
         Thread.sleep(5000);
     }
@@ -286,19 +268,12 @@ public class TracingTests extends SingleClusterTest {
 
         }
 
-        System.out.println("########pause1");
         Thread.sleep(5000);
-        System.out.println("########end pause1");
 
-        System.out.println("########search");
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
-        System.out.println("########search done");
 
-        System.out.println("########pause2");
         Thread.sleep(5000);
-        System.out.println("########end pause2");
 
-        System.out.println("############ _bulk");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -310,8 +285,7 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"index\" : { \"_index\" : \"myindex\", \"_type\" : \"myindex\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")).getBody());
-        System.out.println("############ _end");
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")).getBody();
         Thread.sleep(5000);
     }
 
@@ -339,19 +313,14 @@ public class TracingTests extends SingleClusterTest {
         }
 
 
-        System.out.println("########search");
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
 
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start+1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executePostRequest("/_search/scroll?pretty=true", "{\"scroll_id\" : \""+scrollid+"\"}", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
 
 
-        System.out.println("########search done");
 
 
     }
@@ -373,10 +342,8 @@ public class TracingTests extends SingleClusterTest {
 
 
         RestHelper rh = nonSslRestHelper();
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -384,9 +351,8 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ _bulk");
         bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -394,72 +360,60 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ cat indices");
         //cluster:monitor/state
         //cluster:monitor/health
         //indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ _search");
         //indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ get 1");
         //indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("nagilum", "nagilum"));
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("nagilum", "nagilum"));
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index (+create index)");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ index only");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ update");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ update2");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":44, \"b\":55}}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":44, \"b\":55}}",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ update3");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"b\":66}}",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"b\":66}}",encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ delete");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("nagilum", "nagilum")));
+        rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ reindex");
         String reindex =
         "{"+
         "  \"source\": {"+
@@ -470,10 +424,9 @@ public class TracingTests extends SingleClusterTest {
         "  }"+
         "}";
 
-        System.out.println(rh.executePostRequest("_reindex", reindex, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_reindex", reindex, encodeBasicHeader("nagilum", "nagilum"));
 
 
-        System.out.println("############ msearch");
         String msearchBody =
                 "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
@@ -483,9 +436,8 @@ public class TracingTests extends SingleClusterTest {
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ mget");
         String mgetBody = "{"+
                 "\"docs\" : ["+
                     "{"+
@@ -510,9 +462,8 @@ public class TracingTests extends SingleClusterTest {
                 "]"+
             "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("nagilum", "nagilum"));
 
-        System.out.println("############ delete by query");
         String dbqBody = "{"+
         ""+
         "  \"query\": { "+
@@ -522,7 +473,7 @@ public class TracingTests extends SingleClusterTest {
         "  }"+
         "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("nagilum", "nagilum"));
 
         Thread.sleep(5000);
     }

--- a/src/test/java/org/opensearch/security/TransportClientIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/TransportClientIntegrationTests.java
@@ -82,61 +82,49 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				.put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_ALIAS,"spock")
 				.build();
 
-		System.out.println("------- 0 ---------");
 
 		try (TransportClient tc = getInternalTransportClient(clusterInfo, tcSettings)) {         
 
 			Assert.assertEquals(clusterInfo.numNodes, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
 
-			System.out.println("------- 1 ---------");
 
 			CreateIndexResponse cir = tc.admin().indices().create(new CreateIndexRequest("vulcan")).actionGet();
 			Assert.assertTrue(cir.isAcknowledged());
 
-			System.out.println("------- 2 ---------");
 
 			IndexResponse ir = tc.index(new IndexRequest("vulcan").type("secrets").id("s1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"secret\":true}", XContentType.JSON)).actionGet();
 			Assert.assertTrue(ir.getResult() == Result.CREATED);
 
-			System.out.println("------- 3 ---------");
 
 			GetResponse gr =tc.prepareGet("vulcan", "secrets", "s1").setRealtime(true).get();
 			Assert.assertTrue(gr.isExists());
 
-			System.out.println("------- 4 ---------");
 
 			gr =tc.prepareGet("vulcan", "secrets", "s1").setRealtime(false).get();
 			Assert.assertTrue(gr.isExists());
 
-			System.out.println("------- 5 ---------");
 
 			SearchResponse actionGet = tc.search(new SearchRequest("vulcan").types("secrets")).actionGet();
 			Assert.assertEquals(1, actionGet.getHits().getHits().length);
-			System.out.println("------- 6 ---------");
 
 			gr =tc.prepareGet(".opendistro_security", "security", "config").setRealtime(false).get();
 			Assert.assertFalse(gr.isExists());
 
-			System.out.println("------- 7 ---------");
 
 			gr =tc.prepareGet(".opendistro_security", "security", "config").setRealtime(true).get();
 			Assert.assertFalse(gr.isExists());
 
-			System.out.println("------- 8 ---------");
 
 			actionGet = tc.search(new SearchRequest(".opendistro_security")).actionGet();
 			Assert.assertEquals(0, actionGet.getHits().getHits().length);
 
-			System.out.println("------- 9 ---------");
 
 			try {
 				tc.index(new IndexRequest(".opendistro_security").type(getType()).id("config").source("config", FileHelper.readYamlContent("config.yml"))).actionGet();
 				Assert.fail();
 			} catch (Exception e) {
-				System.out.println(e.getMessage());
 			}
 
-			System.out.println("------- 10 ---------");
 
 			//impersonation
 			try {
@@ -153,7 +141,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				Assert.assertTrue(e.getMessage(), e.getMessage().startsWith("no permissions for [indices:data/read/get]"));
 			}
 
-			System.out.println("------- 11 ---------");
 
 			StoredContext ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -167,7 +154,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 12 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				Header header = encodeBasicHeader("worf", "worf111");
@@ -180,8 +166,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			} finally {
 				ctx.close();
 			}
-
-			System.out.println("------- 13 ---------");       
 
 			//impersonation
 			try {
@@ -198,7 +182,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				Assert.assertEquals("'CN=spock,OU=client,O=client,L=Test,C=DE' is not allowed to impersonate as 'gkar'", e.getMessage());
 			}
 
-			System.out.println("------- 12 ---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -210,7 +193,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 13 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				tc.threadPool().getThreadContext().putHeader("opendistro_security_impersonate_as", "nagilum");
@@ -220,7 +202,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			} finally {
 				ctx.close();
 			}
-			System.out.println("------- 13.1 ---------");
 
 			String scrollId = null;
 			ctx = tc.threadPool().getThreadContext().stashContext();
@@ -232,7 +213,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 13.2 ---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -243,7 +223,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			}
 
 
-			System.out.println("------- 14 ---------");
 
 			boolean ok=false;
 			ctx = tc.threadPool().getThreadContext().stashContext();
@@ -265,7 +244,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 15 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				tc.threadPool().getThreadContext().putHeader("opendistro_security_impersonate_as", "nagilum");
@@ -276,7 +254,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 15 0---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -292,7 +269,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			}
 
 
-			System.out.println("------- 15 1---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -305,7 +281,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 16---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -354,10 +329,8 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- TRC end ---------");
 		}
 
-		System.out.println("------- CTC end ---------");
 	}
 
 	@Test
@@ -440,61 +413,49 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				.put(SSLConfigConstants.SECURITY_SSL_TRANSPORT_KEYSTORE_ALIAS,"spock")
 				.build();
 
-		System.out.println("------- 0 ---------");
 
 		try (TransportClient tc = getInternalTransportClient(clusterInfo, tcSettings)) {         
 
 			Assert.assertEquals(clusterInfo.numNodes, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
 
-			System.out.println("------- 1 ---------");
 
 			CreateIndexResponse cir = tc.admin().indices().create(new CreateIndexRequest("vulcan")).actionGet();
 			Assert.assertTrue(cir.isAcknowledged());
 
-			System.out.println("------- 2 ---------");
 
 			IndexResponse ir = tc.index(new IndexRequest("vulcan").type("secrets").id("s1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"secret\":true}", XContentType.JSON)).actionGet();
 			Assert.assertTrue(ir.getResult() == Result.CREATED);
 
-			System.out.println("------- 3 ---------");
 
 			GetResponse gr =tc.prepareGet("vulcan", "secrets", "s1").setRealtime(true).get();
 			Assert.assertTrue(gr.isExists());
 
-			System.out.println("------- 4 ---------");
 
 			gr =tc.prepareGet("vulcan", "secrets", "s1").setRealtime(false).get();
 			Assert.assertTrue(gr.isExists());
 
-			System.out.println("------- 5 ---------");
 
 			SearchResponse actionGet = tc.search(new SearchRequest("vulcan").types("secrets")).actionGet();
 			Assert.assertEquals(1, actionGet.getHits().getHits().length);
-			System.out.println("------- 6 ---------");
 
 			gr =tc.prepareGet(".opendistro_security", "security", "config").setRealtime(false).get();
 			Assert.assertFalse(gr.isExists());
 
-			System.out.println("------- 7 ---------");
 
 			gr =tc.prepareGet(".opendistro_security", "security", "config").setRealtime(true).get();
 			Assert.assertFalse(gr.isExists());
 
-			System.out.println("------- 8 ---------");
 
 			actionGet = tc.search(new SearchRequest(".opendistro_security")).actionGet();
 			Assert.assertEquals(0, actionGet.getHits().getHits().length);
 
-			System.out.println("------- 9 ---------");
 
 			try {
 				tc.index(new IndexRequest(".opendistro_security").type(getType()).id("config").source("config", FileHelper.readYamlContent("config.yml"))).actionGet();
 				Assert.fail();
 			} catch (Exception e) {
-				System.out.println(e.getMessage());
 			}
 
-			System.out.println("------- 10 ---------");
 
 			//impersonation
 			try {
@@ -511,7 +472,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				Assert.assertTrue(e.getMessage(), e.getMessage().startsWith("no permissions for [indices:data/read/get]"));
 			}
 
-			System.out.println("------- 11 ---------");
 
 			StoredContext ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -525,7 +485,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 12 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				Header header = encodeBasicHeader("worf", "worf111");
@@ -538,8 +497,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			} finally {
 				ctx.close();
 			}
-
-			System.out.println("------- 13 ---------");       
 
 			//impersonation
 			try {
@@ -556,7 +513,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				Assert.assertEquals("'CN=spock,OU=client,O=client,L=Test,C=DE' is not allowed to impersonate as 'gkar'", e.getMessage());
 			}
 
-			System.out.println("------- 12 ---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -568,7 +524,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 13 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				tc.threadPool().getThreadContext().putHeader("opendistro_security_impersonate_as", "nagilum");
@@ -578,7 +533,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			} finally {
 				ctx.close();
 			}
-			System.out.println("------- 13.1 ---------");
 
 			String scrollId = null;
 			ctx = tc.threadPool().getThreadContext().stashContext();
@@ -590,7 +544,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 13.2 ---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -601,7 +554,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			}
 
 
-			System.out.println("------- 14 ---------");
 
 			boolean ok=false;
 			ctx = tc.threadPool().getThreadContext().stashContext();
@@ -623,7 +575,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 15 ---------");
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
 				tc.threadPool().getThreadContext().putHeader("opendistro_security_impersonate_as", "nagilum");
@@ -634,7 +585,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 15 0---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -650,7 +600,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 			}
 
 
-			System.out.println("------- 15 1---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -663,7 +612,6 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- 16---------");
 
 			ctx = tc.threadPool().getThreadContext().stashContext();
 			try {
@@ -712,10 +660,8 @@ public class TransportClientIntegrationTests extends SingleClusterTest {
 				ctx.close();
 			}
 
-			System.out.println("------- TRC end ---------");
 		}
 
-		System.out.println("------- CTC end ---------");
 	}
 
 	@Test

--- a/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogiUnitTest.java
@@ -103,7 +103,6 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
             JsonNode node = DefaultObjectMapper.objectMapper.readTree(json);
 
             if(node.get("audit_request_body") != null) {
-                System.out.println("    Check audit_request_body for validity: "+node.get("audit_request_body").asText());
                 DefaultObjectMapper.objectMapper.readTree(node.get("audit_request_body").asText());
             }
 
@@ -130,7 +129,6 @@ public abstract class AbstractAuditlogiUnitTest extends SingleClusterTest {
         rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         RestHelper.HttpResponse response = rh.executePutRequest("_opendistro/_security/api/audit/config", payload, new Header[0]);
-        System.out.println(response);
         rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -117,7 +117,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         try {
             messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
                 rh.executePutRequest("emp/_doc/0?refresh", "{\"Designation\" : \"CEO\", \"Gender\" : \"female\", \"Salary\" : 100}");
-                System.out.println(rh.executeGetRequest("_cat/shards?v"));
+                rh.executeGetRequest("_cat/shards?v");
             }, 7);
         }  catch (final MessagesNotFoundException ex) {
             // indices:admin/mapping/auto_put can be logged twice, this handles if they were not found

--- a/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -49,7 +49,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         String body = "{ \"password\":\"test\",\"backend_roles\":[\"role1\",\"role2\"] }";
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body, encodeBasicHeader("admin", "admin"));
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size()+"",TestAuditlogImpl.messages.size() == 1);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -84,7 +83,6 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body);
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size()+"",TestAuditlogImpl.messages.size() == 1);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -116,10 +114,8 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println("----rest");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_all_access?pretty");
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));
@@ -146,10 +142,8 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         setup(additionalSettings);
         TestAuditlogImpl.clear();
         String body = "{ \"password\":\"test\",\"backend_roles\":[\"role1\",\"role2\"] }";
-        System.out.println("exec");
         HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body, encodeBasicHeader("admin", "admin"));
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size()+"", TestAuditlogImpl.messages.isEmpty());
     }
@@ -176,10 +170,8 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "kirk-keystore.jks";
-        System.out.println("req");
         HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/internalusers/admin?pretty");
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(TestAuditlogImpl.messages.size()+"",TestAuditlogImpl.messages.size() == 1);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_request_effective_user"));

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
@@ -94,7 +94,6 @@ public class AuditlogTest {
         TestAuditlogImpl.clear();
         al.logSSLException((SecurityRequest)null, new Exception("test rest"));
         al.logSSLException(null, new Exception("test rest"), null, null);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(2, TestAuditlogImpl.messages.size());
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
@@ -176,7 +176,6 @@ public class DisabledCategoriesTest {
 		List<AuditCategory> allButDisablesCategories = new LinkedList<>(Arrays.asList(AuditCategory.values()));
 		allButDisablesCategories.removeAll(Arrays.asList(disabledCategories));
 
-		System.out.println(result+"###"+disabledCategoriesString);
 		Assert.assertFalse(categoriesPresentInLog(result, disabledCategories));
 		Assert.assertTrue(categoriesPresentInLog(result, filterComplianceCategories(allButDisablesCategories.toArray(new AuditCategory[] {}))));
 	}
@@ -187,7 +186,6 @@ public class DisabledCategoriesTest {
 		result = result.replaceAll(" ", "");
 		for (AuditCategory category : categories) {
 			if(!result.contains("\""+AuditMessage.CATEGORY+"\":\""+category.name()+"\"")) {
-				System.out.println("MISSING: "+category.name());
 			    return false;
 			}
 		}

--- a/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
@@ -72,13 +72,10 @@ public class TracingTests extends SingleClusterTest {
         }
 
 
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_cat/shards?v", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ check shards");
-        System.out.println(rh.executeGetRequest("_opendistro/_security/authinfo",encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_opendistro/_security/authinfo",encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ _bulk");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -86,9 +83,8 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ _bulk");
         bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -96,67 +92,56 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"field2\" : \"value2\" }"+System.lineSeparator()+
                 "{ \"delete\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"2\" } }"+System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin"));
 
 
-        System.out.println("############ cat indices");
         //cluster:monitor/state
         //cluster:monitor/health
         //indices:monitor/stats
-        System.out.println(rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin"));
 
 
-        System.out.println("############ _search");
         //indices:data/read/search
-        System.out.println(rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ get 1");
         //indices:data/read/get
-        System.out.println(rh.executeGetRequest("a/b/1", encodeBasicHeader("admin", "admin")));
-        System.out.println("############ get 5");
-        System.out.println(rh.executeGetRequest("a/b/5", encodeBasicHeader("admin", "admin")));
-        System.out.println("############ get 17");
-        System.out.println(rh.executeGetRequest("a/b/17", encodeBasicHeader("admin", "admin")));
+        rh.executeGetRequest("a/b/1", encodeBasicHeader("admin", "admin"));
+        rh.executeGetRequest("a/b/5", encodeBasicHeader("admin", "admin"));
+        rh.executeGetRequest("a/b/17", encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index (+create index)");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("u/b/1?refresh=true", "{}",encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index only");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("u/b/2?refresh=true", "{}",encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ index updates");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":1, \"m\":1}",encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"m\":1, \"z\":1}",encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"z\":4}",encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5, \"z\":5}",encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5}",encodeBasicHeader("admin", "admin")));
-        System.out.println("############ update");
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":1, \"m\":1}",encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"m\":1, \"z\":1}",encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":2, \"z\":4}",encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5, \"z\":5}",encodeBasicHeader("admin", "admin"));
+        rh.executePostRequest("u/b/2?refresh=true", "{\"n\":5}",encodeBasicHeader("admin", "admin"));
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}",encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("u/b/2/_update?refresh=true", "{\"doc\" : {\"a\":1}}",encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ delete");
         //indices:data/write/index
         //indices:data/write/bulk
         //indices:admin/create
         //indices:data/write/bulk[s]
-        System.out.println(rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("admin", "admin")));
+        rh.executeDeleteRequest("u/b/2?refresh=true",encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ reindex");
         String reindex =
         "{"+
         "  \"source\": {"+
@@ -167,10 +152,9 @@ public class TracingTests extends SingleClusterTest {
         "  }"+
         "}";
 
-        System.out.println(rh.executePostRequest("_reindex", reindex, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_reindex", reindex, encodeBasicHeader("admin", "admin"));
 
 
-        System.out.println("############ msearch");
         String msearchBody =
                 "{\"index\":\"a\", \"type\":\"b\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
@@ -180,9 +164,8 @@ public class TracingTests extends SingleClusterTest {
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
 
-        System.out.println(rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ mget");
         String mgetBody = "{"+
                 "\"docs\" : ["+
                     "{"+
@@ -207,9 +190,8 @@ public class TracingTests extends SingleClusterTest {
                 "]"+
             "}";
 
-        System.out.println(rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ delete by query");
         String dbqBody = "{"+
         ""+
         "  \"query\": { "+
@@ -219,7 +201,7 @@ public class TracingTests extends SingleClusterTest {
         "  }"+
         "}";
 
-        System.out.println(rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("admin", "admin")));
+        rh.executePostRequest("a/b/_delete_by_query", dbqBody, encodeBasicHeader("admin", "admin"));
         Thread.sleep(5000);
     }
 
@@ -260,19 +242,12 @@ public class TracingTests extends SingleClusterTest {
 
         }
 
-        System.out.println("########pause1");
         Thread.sleep(5000);
-        System.out.println("########end pause1");
 
-        System.out.println("########search");
         Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")).getStatusCode());
-        System.out.println("########search done");
 
-        System.out.println("########pause2");
         Thread.sleep(5000);
-        System.out.println("########end pause2");
 
-        System.out.println("############ _bulk");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_type\" : \"type1\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -284,8 +259,7 @@ public class TracingTests extends SingleClusterTest {
                 "{ \"index\" : { \"_index\" : \"myindex\", \"_type\" : \"myindex\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator();
 
-        System.out.println(rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")).getBody());
-        System.out.println("############ _end");
+        rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("admin", "admin")).getBody();
         Thread.sleep(5000);
     }
 
@@ -313,19 +287,14 @@ public class TracingTests extends SingleClusterTest {
         }
 
 
-        System.out.println("########search");
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode());
 
-        System.out.println(res.getBody());
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start+1));
-        System.out.println(scrollid);
-        System.out.println("########search scroll");
         Assert.assertEquals(HttpStatus.SC_OK, (res=rh.executePostRequest("/_search/scroll?pretty=true", "{\"scroll_id\" : \""+scrollid+"\"}", encodeBasicHeader("admin", "admin"))).getStatusCode());
 
 
-        System.out.println("########search done");
 
 
     }
@@ -352,33 +321,26 @@ public class TracingTests extends SingleClusterTest {
             .mapping("mytype4", FileHelper.loadFile("mapping4.json"), XContentType.JSON)).actionGet();
         }
 
-        System.out.println("############ write into mapping 1");
         String data1 = FileHelper.loadFile("auditlog/data1.json");
         String data2 = FileHelper.loadFile("auditlog/data1mod.json");
-        System.out.println(rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println("############ write into mapping diffing");
-        System.out.println(rh.executePutRequest("myindex1/mytype1/1?refresh", data2, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex1/mytype1/1?refresh", data2, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 2");
-        System.out.println(rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex2/mytype2/2?refresh", data2, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex2/mytype2/2?refresh", data1, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex2/mytype2/2?refresh", data2, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 3");
         String parent = FileHelper.loadFile("auditlog/data2.json");
         String child = FileHelper.loadFile("auditlog/data3.json");
-        System.out.println(rh.executePutRequest("myindex3/mytype3/1?refresh", parent, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex3/mytype3/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex3/mytype3/1?refresh", parent, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex3/mytype3/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ write into mapping 4");
-        System.out.println(rh.executePutRequest("myindex4/mytype4/1?refresh", parent, encodeBasicHeader("admin", "admin")));
-        System.out.println(rh.executePutRequest("myindex4/mytype4/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin")));
+        rh.executePutRequest("myindex4/mytype4/1?refresh", parent, encodeBasicHeader("admin", "admin"));
+        rh.executePutRequest("myindex4/mytype4/2?routing=1&refresh", child, encodeBasicHeader("admin", "admin"));
 
-        System.out.println("############ get");
-        System.out.println(rh.executeGetRequest("myindex1/mytype1/1?pretty=true&_source=true&_source_include=*.id&_source_exclude=entities&stored_fields=tags,counter", encodeBasicHeader("admin", "admin")).getBody());
+        rh.executeGetRequest("myindex1/mytype1/1?pretty=true&_source=true&_source_include=*.id&_source_exclude=entities&stored_fields=tags,counter", encodeBasicHeader("admin", "admin")).getBody();
 
-        System.out.println("############ search");
-        System.out.println(rh.executeGetRequest("myindex1/_search", encodeBasicHeader("admin", "admin")).getStatusCode());
+        rh.executeGetRequest("myindex1/_search", encodeBasicHeader("admin", "admin")).getStatusCode();
 
     }
 
@@ -401,7 +363,6 @@ public class TracingTests extends SingleClusterTest {
             .mapping("mytype2", FileHelper.loadFile("mapping1.json"), XContentType.JSON)).actionGet();
         }
 
-        System.out.println("############ immutable 1");
         String data1 = FileHelper.loadFile("auditlog/data1.json");
         String data2 = FileHelper.loadFile("auditlog/data1mod.json");
         HttpResponse res = rh.executePutRequest("myindex1/mytype1/1?refresh", data1, encodeBasicHeader("admin", "admin"));
@@ -415,7 +376,6 @@ public class TracingTests extends SingleClusterTest {
         Assert.assertFalse(res.getBody().contains("city"));
         Assert.assertTrue(res.getBody().contains("\"found\":true,"));
 
-        System.out.println("############ immutable 2");
         res = rh.executePutRequest("myindex2/mytype2/1?refresh", data1, encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(201, res.getStatusCode());
         res = rh.executePutRequest("myindex2/mytype2/1?refresh", data2, encodeBasicHeader("admin", "admin"));

--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -153,21 +153,18 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         setupStarfleetIndex();
         TestAuditlogImpl.clear();
 
-        System.out.println("#### testSimpleAuthenticated");
         try (TransportClient tc = getUserTransportClient(clusterInfo, "spock-keystore.jks", Settings.EMPTY)) {
             StoredContext ctx = tc.threadPool().getThreadContext().stashContext();
             try {
                 Header header = encodeBasicHeader("admin", "admin");
                 tc.threadPool().getThreadContext().putHeader(header.getName(), header.getValue());
                 SearchResponse res = tc.search(new SearchRequest()).actionGet();
-                System.out.println(res);
             } finally {
                 ctx.close();
             }
         }
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue("Was "+TestAuditlogImpl.messages.size(), TestAuditlogImpl.messages.size() >= 2);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("GRANTED_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
@@ -198,14 +195,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
                 Header header = encodeBasicHeader("admin", "admin");
                 tc.threadPool().getThreadContext().putHeader(header.getName(), header.getValue());
                 SearchResponse res = tc.search(new SearchRequest()).actionGet();
-                System.out.println(res);
             } finally {
                 ctx.close();
             }
         }
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(String.valueOf(TestAuditlogImpl.messages.size()), TestAuditlogImpl.messages.size() >= 2);
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("GRANTED_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
@@ -236,7 +231,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
 
         Thread.sleep(1500);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(2, TestAuditlogImpl.messages.size());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("GRANTED_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
@@ -372,12 +366,10 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
     public void testUnauthenticated() throws Exception {
 
-        System.out.println("#### testUnauthenticated");
         HttpResponse response = rh.executeGetRequest("_search");
         Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
         Thread.sleep(1500);
         Assert.assertEquals(1, TestAuditlogImpl.messages.size());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("FAILED_LOGIN"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("<NONE>"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("/_search"));
@@ -443,10 +435,8 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
                 "{\"index\":\"sf\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":0,\"query\":{\"match_all\":{}}}"+System.lineSeparator();
 
-        System.out.println("##### msaerch");
         HttpResponse response = rh.executePostRequest("_msearch?pretty", msearch, encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(response.getStatusReason(), HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("indices:data/read/msearch"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("indices:data/read/search"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("match_all"));
@@ -459,7 +449,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
     public void testBulkAuth() throws Exception {
 
-        System.out.println("#### testBulkAuth");
         String bulkBody =
                 "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -474,7 +463,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("admin", "admin"));
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"errors\":false"));
         Assert.assertTrue(response.getBody().contains("\"status\":201"));
@@ -503,9 +491,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
                 "{ \"field1\" : \"value3x\" }"+System.lineSeparator();
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("worf", "worf"));
-        System.out.println(response.getBody());
 
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         Assert.assertTrue(response.getBody().contains("\"errors\":true"));
         Assert.assertTrue(response.getBody().contains("\"status\":200"));
@@ -606,7 +592,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executeGetRequest("sf/_search?pretty", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet_academy"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet_library"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("starfleet"));
@@ -648,7 +633,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (res=rh.executePostRequest("/_search/scroll?pretty=true", "{\"scroll_id\" : \""+scrollid+"\"}", encodeBasicHeader("admin2", "admin"))).getStatusCode());
         Thread.sleep(1000);
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("InternalScrollSearchRequest"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("MISSING_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.messages.size() > 2);
@@ -679,7 +663,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
         HttpResponse response = rh.executeGetRequest("thealias/_search?pretty", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("thealias"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("audit_trace_resolved_indices"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("vulcangov"));
@@ -704,7 +687,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
         HttpResponse response = rh.executeGetRequest("_search?pretty", new BasicHeader("_opendistro_security_user", "xxx"), encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("YWRtaW46YWRtaW4"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("BAD_HEADERS"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("xxx"));
@@ -738,7 +720,6 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rh.executePostRequest("index2/_close?pretty", "", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(TestAuditlogImpl.sb.toString());
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:admin/close"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:admin/delete"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.messages.size() >= 2);

--- a/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
@@ -91,7 +91,6 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
 
@@ -126,7 +125,6 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }
@@ -159,7 +157,6 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
         response = rhMon.executeGetRequest("security-auditlog-*/_search", encodeBasicHeader("admin", "admin"));
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -131,8 +131,7 @@ public class SinkProviderTLSTest {
 	}
 
 	private void assertStringContainsAllKeysAndValues(String in) {
-	    System.out.println(in);
-		Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
+			Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
 		Assert.assertTrue(in, in.contains(AuditMessage.CATEGORY));
 		Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
 		Assert.assertTrue(in, in.contains(AuditMessage.REMOTE_ADDRESS));

--- a/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -146,7 +146,6 @@ public class WebhookAuditLogTest {
 				.build();
 		auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
 		auditlog.store(msg);
-		System.out.println(auditlog.payload);
 		Assert.assertEquals(WebhookFormat.JSON, auditlog.webhookFormat);
 		Assert.assertEquals(ContentType.APPLICATION_JSON, auditlog.webhookFormat.getContentType());
 		Assert.assertTrue(auditlog.payload, !auditlog.payload.startsWith("{\"text\":"));
@@ -269,7 +268,6 @@ public class WebhookAuditLogTest {
 		auditlog.store(msg);
 		Assert.assertTrue(handler.method.equals("POST"));
 		Assert.assertTrue(handler.body != null);
-		System.out.println(handler.body);
 		Assert.assertFalse(handler.body.contains("{"));
 		assertStringContainsAllKeysAndValues(handler.body);
 		handler.reset();
@@ -722,8 +720,7 @@ public class WebhookAuditLogTest {
 	}
 
 	private void assertStringContainsAllKeysAndValues(String in) {
-	    System.out.println(in);
-		Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
+			Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
 		Assert.assertTrue(in, in.contains(AuditMessage.CATEGORY));
 		Assert.assertTrue(in, in.contains(AuditMessage.FORMAT_VERSION));
 		Assert.assertTrue(in, in.contains(AuditMessage.REMOTE_ADDRESS));

--- a/src/test/java/org/opensearch/security/cache/CachingTest.java
+++ b/src/test/java/org/opensearch/security/cache/CachingTest.java
@@ -47,13 +47,10 @@ public class CachingTest extends SingleClusterTest{
         setup(Settings.EMPTY, new DynamicSecurityConfig(), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
@@ -68,13 +65,10 @@ public class CachingTest extends SingleClusterTest{
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
@@ -89,16 +83,12 @@ public class CachingTest extends SingleClusterTest{
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", new BasicHeader("opendistro_security_impersonate_as", "impuser"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", new BasicHeader("opendistro_security_impersonate_as", "impuser"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", new BasicHeader("opendistro_security_impersonate_as", "impuser"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", new BasicHeader("opendistro_security_impersonate_as", "impuser2"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
 
         Assert.assertEquals(4, DummyHTTPAuthenticator.getCount());

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -156,7 +156,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         RestHelper rh = new RestHelper(clusterInfo, httpsEnabled, httpsEnabled, getResourceFolder());
         rh.sendAdminCertificate = httpsEnabled;
         rh.keystore = "restapi/kirk-keystore.jks";
-        System.out.println("### " + ch.getClusterName() + " complete ###");
         return new Tuple<>(clusterInfo, rh);
     }
     
@@ -192,31 +191,23 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("nagilum","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
 
 
-        System.out.println("###################### query 4");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:xx,xx/xx/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("nagilum","nagilum"));
-        System.out.println(ccs.getBody());
         //TODO fix exception nesting
         //Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, ccs.getStatusCode());
         //Assert.assertTrue(ccs.getBody().contains("Can not filter indices; index cross_cluster_two:xx exists but there is also a remote cluster named: cross_cluster_two"));
 
-        System.out.println("###################### query 5");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:abcnonext/xx/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("nagilum","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("index_not_found_exception"));
 
-        System.out.println("###################### query 6");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twutter/tweet/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("nagilum","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
@@ -255,143 +246,106 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 2");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
 
-        System.out.println("###################### query 3");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 4");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 5");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twutter,twitter/tweet/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 6");
         String msearchBody =
                 "{}"+System.lineSeparator()+
                         "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("cross_cluster_two:twitter,twitter/tweet/_msearch?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, msearchBody, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 7");
         msearchBody =
                 "{}"+System.lineSeparator()+
                         "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("cross_cluster_two:twitter/tweet/_msearch?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, msearchBody, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("_all/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("hfghgtdhfhuth*/_search", encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); //TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); //TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*:/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E,%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("#### Alias both");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("notexist,coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
         //TODO Fix for 25.0 to resolve coordalias (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("crusherw","crusherw"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
     }
@@ -426,151 +380,113 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 2");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
 
-        System.out.println("###################### query 3");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("twutter"));
 
-        System.out.println("###################### query 4");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
-        System.out.println("###################### query 5");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twutter,twitter/tweet/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("###################### query 6");
         String msearchBody =
                 "{}"+System.lineSeparator()+
                         "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("cross_cluster_two:twitter,twitter/tweet/_msearch?pretty", msearchBody, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
-        System.out.println("###################### query 7");
         msearchBody =
                 "{}"+System.lineSeparator()+
                         "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("cross_cluster_two:twitter/tweet/_msearch?pretty", msearchBody, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("_all/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
-        System.out.println("#####*");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:*,*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
         //wildcard in remote cluster names
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*cross*:*twit*,*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter,t*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*:*/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("hfghgtdhfhuth*/_search", encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); //TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); //TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("*:/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E,%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("worf","worf"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("crusherw","crusherw"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
     }
 
@@ -591,9 +507,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:twitter/tweet/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("twitter","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
@@ -627,7 +541,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### kibana indices agg");
         String dashboardsIndicesAgg = "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("*/_search?pretty", dashboardsIndicesAgg, encodeBasicHeader("nagilum","nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
@@ -712,7 +625,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### kibana indices agg");
         String dashboardsIndicesAgg = "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("*/_search?pretty", dashboardsIndicesAgg, encodeBasicHeader("twitter","nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
@@ -797,7 +709,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### aggs");
         final String agg = "{\"size\":0,\"aggs\":{\"clusteragg\":{\"terms\":{\"field\":\"cluster.keyword\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("*:*,*/_search?pretty", agg, encodeBasicHeader("nagilum","nagilum"));
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
@@ -867,7 +778,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### aggs");
         final String agg = "{\"size\":0,\"aggs\":{\"clusteragg\":{\"terms\":{\"field\":\"cluster.keyword\",\"size\":100}}}}";
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("cross_cluster_two:notfound,*/_search?pretty", agg, encodeBasicHeader("twitter","nagilum"));
         Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
@@ -944,7 +854,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/tweet/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         assertThat(ccs.getBody(), containsString("no OID or security.nodes_dn incorrect configured"));
     }
@@ -966,7 +875,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/tweet/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertThat(ccs.getBody(), not(containsString("security_exception")));
         assertThat(ccs.getBody(), containsString("\"timed_out\" : false"));
@@ -991,7 +899,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         String uri = "cross_cluster_two:twitter/tweet/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
-        System.out.println(ccs.getBody());
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertThat(ccs.getBody(), not(containsString("security_exception")));
         assertThat(ccs.getBody(), containsString("\"timed_out\" : false"));
@@ -1054,7 +961,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
 
         OpenSearchSecurityException exception = null;
 
-        System.out.println("###################### with invalid role injection");
         //1. With invalid roles injection
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "invalid_user|invalid_role";
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class,
@@ -1074,7 +980,6 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         Assert.assertNotNull(exception);
         Assert.assertTrue(exception.getMessage().contains("no permissions for"));
 
-        System.out.println("###################### with valid role injection");
         //2. With valid roles injection
         RolesInjectorIntegTest.RolesInjectorPlugin.injectedRoles = "valid_user|opendistro_security_all_access";
         try (Node node = new PluginAwareNode(false, tcSettings, Netty4Plugin.class,

--- a/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
@@ -120,13 +120,10 @@ public class RemoteReindexTests extends AbstractSecurityUnitTest {
             "}"+
         "}";
         
-        System.out.println(reindex);
         
         HttpResponse ccs = null;
         
-        System.out.println("###################### reindex");
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest("_reindex?pretty", reindex, encodeBasicHeader("nagilum","nagilum"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("created\" : 1"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
@@ -69,7 +69,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest{
 
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
 
         Assert.assertTrue(res.getBody().contains("win 8"));
         Assert.assertTrue(res.getBody().contains("win xp"));
@@ -90,7 +89,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest{
 
         for(int i=0;i<10;i++) {
             Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc1", "password"))).getStatusCode());
-            System.out.println(res.getBody());
         }
 
 
@@ -98,7 +96,6 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest{
         for(int i=0;i<10;i++) {
 
             Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc", "password"))).getStatusCode());
-            System.out.println(res.getBody());
 
             Assert.assertFalse(res.getBody().contains("\"aaa"));
 

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
@@ -67,7 +67,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
                 "}"+
             "}";
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
@@ -92,7 +91,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
@@ -117,7 +115,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        System.out.println(res.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
@@ -189,7 +186,6 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("XXX"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked_custom", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("cust1"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
@@ -60,7 +60,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -69,7 +68,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/logs/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -86,13 +84,11 @@ public class DateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -106,7 +102,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("logstash-*/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -115,7 +110,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("logstash-*/logs/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -132,7 +126,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("logstash-1-*,logstash-20*/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -141,7 +134,6 @@ public class DateMathTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("logstash-1-*,logstash-20*/logs/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
@@ -61,12 +61,10 @@ public class DlsDateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }
@@ -78,12 +76,10 @@ public class DlsDateMathTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("'now' is not allowed in DLS queries"));
         Assert.assertTrue(res.getBody().contains("error"));
         
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
@@ -65,13 +65,10 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         cl2Info = cl2.startCluster(minimumSecuritySettings(Settings.EMPTY), ClusterConfiguration.DEFAULT);
         initialize(cl2Info, Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles(remoteRoles));
-        System.out.println("### cl2 complete ###");
 
         //cl1 is coordinating
         cl1Info = cl1.startCluster(minimumSecuritySettings(crossClusterNodeSettings(cl2Info)), ClusterConfiguration.DEFAULT);
-        System.out.println("### cl1 start ###");
         initialize(cl1Info, Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles("roles_983.yml"));
-        System.out.println("### cl1 initialized ###");
     }
 
     @After
@@ -124,10 +121,8 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         //on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:humanresources/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("human_resources_trainee", "password"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
@@ -181,10 +176,8 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         //on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:humanresources/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("human_resources_trainee", "password"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
@@ -261,10 +254,8 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
         HttpResponse ccs = null;
 
-        System.out.println("###################### query 1");
         //on coordinating cluster
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest("cross_cluster_two:humanresources,humanresources/_search?pretty&ccs_minimize_roundtrips="+ccsMinimizeRoundtrips, encodeBasicHeader("human_resources_trainee", "password"));
-        System.out.println(ccs.getBody());
         Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
         Assert.assertTrue(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
@@ -78,7 +78,6 @@ public class DlsNestedTest extends AbstractDlsFlsTest{
 
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/mytype/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"my_nested_object\" : {"));
         Assert.assertTrue(res.getBody().contains("\"field\" : \"my_nested_object\","));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
@@ -52,11 +52,9 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 5,\n      \"relation"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
@@ -48,8 +48,7 @@ public class DlsTest extends AbstractDlsFlsTest{
             // TODO Auto-generated catch block
             e.printStackTrace();
         }
-        System.out.println("q");
-        System.out.println(Strings.toString(tc.search(new SearchRequest().indices(".opendistro_security")).actionGet()));
+        tc.search(new SearchRequest().indices(".opendistro_security")).actionGet();
         tc.search(new SearchRequest().indices("deals")).actionGet();
     }
 

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
@@ -47,7 +47,6 @@ public class Fls983Test extends AbstractDlsFlsTest{
         "}}";
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/.kibana/config/0/_update?pretty", doc, encodeBasicHeader("human_resources_trainee", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("updated"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
@@ -60,7 +60,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -75,7 +74,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest{
 
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -89,7 +87,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest{
         Assert.assertFalse(res.getBody().contains("f1_b"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));
@@ -104,7 +101,6 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest{
 
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("\"x\""));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
@@ -154,7 +154,6 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("user_combined", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("customer"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
@@ -100,7 +100,6 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK,
                 (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));
         Assert.assertTrue(res.getBody().contains("response"));
@@ -110,7 +109,6 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
         //therefore non-existing does not exist so we expect c-missing2-0 to be returned
         Assert.assertEquals(HttpStatus.SC_OK,
                 (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("fls_exists", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));
         Assert.assertTrue(res.getBody().contains("c-missing2-0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
@@ -133,7 +133,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("field50\""));
         Assert.assertTrue(res.getBody().contains("field997\""));
 
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -180,7 +179,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest{
         Assert.assertFalse(res.getBody().contains("field50\""));
         Assert.assertFalse(res.getBody().contains("field997\""));
 
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -227,7 +225,6 @@ public class FlsPerfTest extends AbstractDlsFlsTest{
         Assert.assertFalse(res.getBody().contains("field50\""));
         Assert.assertFalse(res.getBody().contains("field997\""));
 
-        System.out.println(sw.prettyPrint());
     }
 
     @Test
@@ -271,6 +268,5 @@ public class FlsPerfTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("field50\""));
         Assert.assertTrue(res.getBody().contains("field997\""));
 
-        System.out.println(sw.prettyPrint());
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
@@ -61,7 +61,6 @@ public class FlsTest extends AbstractDlsFlsTest{
         Assert.assertFalse(res.getBody().contains("secret"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/deals/_field_caps?fields=*&pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("customer.name"));
         Assert.assertFalse(res.getBody().contains("zip"));
@@ -95,7 +94,6 @@ public class FlsTest extends AbstractDlsFlsTest{
         Assert.assertFalse(res.getBody().contains("secret"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("name"));
         Assert.assertFalse(res.getBody().contains("zip"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
@@ -48,7 +48,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-2016/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -57,7 +56,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-2016/logs/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -74,13 +72,11 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-2016/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-2016/_field_caps?fields=*&pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
@@ -94,7 +90,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-20*/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -103,7 +98,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-20*/logs/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));
@@ -120,7 +114,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         HttpResponse res;
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-20*/logs/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertTrue(res.getBody().contains("ipaddr"));
@@ -129,7 +122,6 @@ public class IndexPatternTest extends AbstractDlsFlsTest{
         Assert.assertTrue(res.getBody().contains("msgid"));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("/logstash-20*/logs/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
         Assert.assertFalse(res.getBody().contains("ipaddr"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
@@ -43,7 +43,6 @@ public class MFlsTest extends AbstractDlsFlsTest{
 
         HttpResponse res;
 
-        System.out.println("### normal search");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("deals,finance/_search?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode());
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -62,7 +61,6 @@ public class MFlsTest extends AbstractDlsFlsTest{
                 "{\"index\":\"finance\", \"type\":\"finance\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
-        System.out.println("### msearch");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode());
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -89,7 +87,6 @@ public class MFlsTest extends AbstractDlsFlsTest{
                 "]"+
             "}";
 
-        System.out.println("### mget");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode());
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -75,7 +75,6 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
 						FileHelper.getAbsoluteFilePathFromClassPath("restapi/truststore.jks"))
 				.put(nodeOverride);
 
-		System.out.println(builder.toString());
 
 		setup(Settings.EMPTY, new DynamicSecurityConfig(), builder.build(), init);
 		rh = restHelper();

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiTest.java
@@ -186,7 +186,6 @@ public class AccountApiTest extends AbstractRestApiUnitTest {
         body = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         assertEquals("CN=kirk,OU=client,O=client,L=Test,C=DE", body.get("user_name"));
         assertEquals(HttpStatus.SC_OK, response.getStatusCode());        // check admin user exists
-        System.out.println(response.getBody());
         payload = "{\"password\":\"" + testPass + "\", \"current_password\":\"" + "admin" + "\"}";
         response = rh.executePutRequest(ENDPOINT, payload, encodeBasicHeader("admin", "admin"));
         assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());

--- a/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
@@ -67,7 +67,6 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
 		HttpResponse response = rh.executeGetRequest(ENDPOINT + "/roles");
 		Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
 		String errorString = response.getBody();
-		System.out.println(errorString);
 		Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
 
 		// GET roles

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -222,7 +222,6 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
             testCrudScenarios(HttpStatus.SC_OK, nonAdminCredsHeader);
         }
 
-        System.out.println(TestAuditlogImpl.sb.toString());
 
         final Map<AuditCategory, Long> expectedCategoryCounts = ImmutableMap.of(
             AuditCategory.COMPLIANCE_INTERNAL_CONFIG_READ, 4L,

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiTest.java
@@ -64,15 +64,12 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
         rh.sendAdminCertificate = true;
         // check roles exists
         HttpResponse response = rh.executePutRequest(ENDPOINT + "/roles/admin", FileHelper.loadFile("restapi/simple_role.json"));
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         response = rh.executePutRequest(ENDPOINT + "/roles/lala", "{ \"cluster_permissions\": [\"*\"] }");
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
 
         response = rh.executePutRequest(ENDPOINT + "/roles/empty", "{ \"cluster_permissions\": [] }");
-        System.out.println(response.getBody());
         Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
     }
 
@@ -318,7 +315,6 @@ public class RolesApiTest extends AbstractRestApiUnitTest {
 
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", new Header[0]);
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         settings = DefaultObjectMapper.readTree(response.getBody());
         Assert.assertEquals(1, settings.size());
         Assert.assertEquals(new SecurityJsonNode(settings).getDotted("opendistro_security_role_starfleet_captains.tenant_permissions").get(1).get("tenant_patterns").get(0).asString(), "tenant1");

--- a/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/UserApiTest.java
@@ -448,7 +448,6 @@ public class UserApiTest extends AbstractRestApiUnitTest {
         HttpResponse response = rh
                 .executeGetRequest("_plugins/_security/api/" + CType.INTERNALUSERS.toLCString());
         Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        System.out.println(response.getBody());
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertEquals(56, settings.size());
 

--- a/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
@@ -87,29 +87,23 @@ public class MultitenancyTests extends SingleClusterTest {
 
             HttpResponse resc;
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             String msearchBody =
                     "{\"index\":\"indexa\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                     "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator()+
                     "{\"index\":\"indexb\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                     "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
-            System.out.println("#### msearch a");
             resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
             Assert.assertEquals(200, resc.getStatusCode());
-            System.out.println(resc.getBody());
             Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
             Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
             Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
             Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
 
-            System.out.println("#### msearch b");
             resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
             Assert.assertEquals(200, resc.getStatusCode());
-            System.out.println(resc.getBody());
             Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
             Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
             Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -121,9 +115,7 @@ public class MultitenancyTests extends SingleClusterTest {
                     "{\"index\":\"indexd\", \"type\":\"doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
                     "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
-            System.out.println("#### msearch b2");
             resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-            System.out.println(resc.getBody());
             Assert.assertEquals(200, resc.getStatusCode());
             Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
             Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
@@ -181,28 +173,20 @@ public class MultitenancyTests extends SingleClusterTest {
 
 
             Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_NOT_FOUND, (resc=rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_FORBIDDEN, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode());
-            System.out.println(resc.getBody());
 
             Assert.assertEquals(HttpStatus.SC_OK, (resc=rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode());
-            System.out.println(resc.getBody());
 
     }
 
@@ -222,15 +206,12 @@ public class MultitenancyTests extends SingleClusterTest {
 
         body = "{\"buildNum\": 15460, \"defaultIndex\": \"humanresources\", \"tenant\": \"human_resources\"}";
         Assert.assertEquals(HttpStatus.SC_CREATED, (res = rh.executePutRequest(".kibana/config/5.6.0?pretty",body, new BasicHeader("securitytenant", "human_resources"), encodeBasicHeader("hr_employee", "hr_employee"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertEquals(".kibana_1592542611_humanresources_1", DefaultObjectMapper.readTree(res.getBody()).get("_index").asText());
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana/config/5.6.0?pretty",new BasicHeader("securitytenant", "human_resources"), encodeBasicHeader("hr_employee", "hr_employee"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(WildcardMatcher.from("*human_resources*").test(res.getBody()));
 
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana_1592542611_humanresources_1/_alias", encodeBasicHeader("admin", "admin"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertNotNull(DefaultObjectMapper.readTree(res.getBody()).get(".kibana_1592542611_humanresources_1").get("aliases").get(".kibana_1592542611_humanresources"));
 
     }
@@ -266,7 +247,6 @@ public class MultitenancyTests extends SingleClusterTest {
 
         final RestHelper rh = nonSslRestHelper();
 
-        System.out.println("#### search");
         HttpResponse res;
         String body = "{\"query\" : {\"term\" : { \"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}}}";
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest(".kibana/_search/?pretty",body, new BasicHeader("securitytenant", "__user__"), encodeBasicHeader("admin", "admin"))).getStatusCode());
@@ -276,7 +256,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("\"value\" : 1"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### msearch");
         body =
                 "{\"index\":\".kibana\", \"type\":\"doc\", \"ignore_unavailable\": false}"+System.lineSeparator()+
                 "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
@@ -288,7 +267,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("\"value\" : 1"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### get");
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana/doc/index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b?pretty", new BasicHeader("securitytenant", "__user__"), encodeBasicHeader("admin", "admin"))).getStatusCode());
         //System.out.println(res.getBody());
         Assert.assertFalse(res.getBody().contains("exception"));
@@ -296,7 +274,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### mget");
         body = "{\"docs\" : [{\"_index\" : \".kibana\",\"_type\" : \"doc\",\"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}]}";
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("_mget/?pretty",body, new BasicHeader("securitytenant", "__user__"), encodeBasicHeader("admin", "admin"))).getStatusCode());
         //System.out.println(res.getBody());
@@ -304,7 +281,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("humanresources"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### index");
         body = "{"+
                 "\"type\" : \"index-pattern\","+
                 "\"updated_at\" : \"2017-09-29T08:56:59.066Z\","+
@@ -317,7 +293,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("\"result\" : \"created\""));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
-        System.out.println("#### bulk");
         body =
                 "{ \"index\" : { \"_index\" : \".kibana\", \"_type\" : \"doc\", \"_id\" : \"b1\" } }"+System.lineSeparator()+
                 "{ \"field1\" : \"value1\" }" +System.lineSeparator()+
@@ -362,7 +337,6 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana-6/doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode());
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana/doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode());
 
-        System.out.println(res.getBody());
 
     }
 
@@ -391,7 +365,6 @@ public class MultitenancyTests extends SingleClusterTest {
 
         HttpResponse res;
         Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest(".kibana/doc/6.2.2?pretty", new BasicHeader("securitytenant", "__user__"), encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode());
-        System.out.println(res.getBody());
         Assert.assertTrue(res.getBody().contains(".kibana_-900636979_kibanaro"));
     }
 

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -138,8 +138,7 @@ public class OpenSSLTest extends SSLTest {
 
         // Set<String> openSSLAvailCiphers = new
         // HashSet<>(OpenSsl.availableCipherSuites());
-        // System.out.println("OpenSSL available ciphers: "+openSSLAvailCiphers);
-        // ECDHE-RSA-AES256-SHA, ECDH-ECDSA-AES256-SHA, DH-DSS-DES-CBC-SHA,
+        //        // ECDHE-RSA-AES256-SHA, ECDH-ECDSA-AES256-SHA, DH-DSS-DES-CBC-SHA,
         // ADH-AES256-SHA256, ADH-CAMELLIA128-SHA
 
         final Set<String> openSSLSecureCiphers = new HashSet<>();
@@ -149,7 +148,6 @@ public class OpenSSLTest extends SSLTest {
             }
         }
 
-        System.out.println("OpenSSL secure ciphers: " + openSSLSecureCiphers);
         Assert.assertTrue(openSSLSecureCiphers.size() > 0);
     }
     

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -101,7 +101,7 @@ public class SSLTest extends SingleClusterTest {
         rh.sendAdminCertificate = true;
         rh.keystore = "node-untspec5-keystore.p12";
         
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true").contains("EMAILADDRESS=unt@tst.com"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=true").contains("local_certificates_list"));
         Assert.assertFalse(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty&show_dn=false").contains("local_certificates_list"));
@@ -117,8 +117,6 @@ public class SSLTest extends SingleClusterTest {
     public void testCipherAndProtocols() throws Exception {
         
         Security.setProperty("jdk.tls.disabledAlgorithms","");
-        System.out.println("Disabled algos: "+Security.getProperty("jdk.tls.disabledAlgorithms"));
-        System.out.println("allowOpenSSL: "+allowOpenSSL);
 
         Settings settings = Settings.builder().put("plugins.security.ssl.transport.enabled", false)
                 .put(ConfigConstants.SECURITY_SSL_ONLY, true)
@@ -195,7 +193,6 @@ public class SSLTest extends SingleClusterTest {
                 Assert.assertEquals("SSL_RSA_EXPORT_WITH_RC4_40_MD5",enabledCiphers[0]);
             }
         } catch (OpenSearchSecurityException e) {
-            System.out.println("EXPECTED "+e.getClass().getSimpleName()+" for "+System.getProperty("java.specification.version")+": "+e.toString());
             e.printStackTrace();
             Assert.assertTrue("Check if error contains 'no valid cipher suites' -> "+e.toString(),e.toString().contains("no valid cipher suites")
                     || e.toString().contains("failed to set cipher suite")
@@ -224,7 +221,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
         Assert.assertFalse(rh.executeSimpleRequest("_nodes/settings?pretty").contains("\"opendistro_security\""));
@@ -258,7 +255,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -299,7 +296,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -336,7 +333,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -372,7 +369,6 @@ public class SSLTest extends SingleClusterTest {
             Assert.fail();
         } catch (Exception e1) {
             e1.printStackTrace();
-            System.out.println("##1 "+e1.toString());
             Throwable e = ExceptionUtils.getRootCause(e1);
             Assert.assertTrue(e.toString(), e.toString().contains("no valid cipher"));
         }
@@ -452,7 +448,6 @@ public class SSLTest extends SingleClusterTest {
             Assert.fail();
         } catch (SocketException | SSLException e) {
             //expected
-            System.out.println("Expected SSLHandshakeException "+e.toString());
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail("Unexpected exception "+e.toString());
@@ -676,7 +671,6 @@ public class SSLTest extends SingleClusterTest {
         // example
         // TLS_RSA_WITH_AES_128_CBC_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
         // TLS_RSA_WITH_AES_128_CBC_SHA, TLS_DHE_RSA_WITH_AES_128_CBC_SHA
-        System.out.println("JDK enabled ciphers: " + jdkEnabledCiphers);
         Assert.assertTrue(jdkEnabledCiphers.size() > 0);
     }
     
@@ -913,7 +907,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -962,7 +956,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));
@@ -1039,7 +1033,7 @@ public class SSLTest extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
 
-        System.out.println(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty"));
+        rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty");
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").contains("TLS"));
         Assert.assertTrue(rh.executeSimpleRequest("_opendistro/_security/sslinfo?pretty").length() > 0);
         Assert.assertTrue(rh.executeSimpleRequest("_nodes/settings?pretty").contains(clusterInfo.clustername));

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -364,16 +364,6 @@ public class RestHelper {
                     + ", statusReason=" + statusReason + "]";
         }
 
-        private static void findArrayAccessor(String input) {
-			final Pattern r = Pattern.compile("(.+?)\\[(\\d+)\\]");
-			final Matcher m = r.matcher(input);
-			if(m.find()) {
-				System.out.println("'" + input + "'\t Name was: " + m.group(1) + ",\t index position: " + m.group(2));
-			} else {
-				System.out.println("'" + input + "'\t No Match");
-			}
-		}
-
 		/**
 		 * Given a json path with dots delimiated returns the object at the leaf
 		 */


### PR DESCRIPTION
### Description
Remove and refactor console print statements.  There are a large number of print statements that write out information that should not be present in the artifact output for this GitHub action workflows for space and security considerations.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
