### PR TITLE
Add index permissions for query insights exporters

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -429,3 +429,8 @@ query_insights_full_access:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opensearch/insights/top_queries/*'
+  index_permissions:
+    - index_patterns:
+        - 'top_queries_by_*'
+      allowed_actions:
+        - "indices_all"


### PR DESCRIPTION
### Description
Add index permissions in query insights role to allow only users with permissions to access top n queries indices.

### Issues Resolved
Related issue: https://github.com/opensearch-project/OpenSearch/issues/11296


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
