### PR TITLE
Ensure that challenge response contains body

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/BasicAuthTests.java
@@ -107,6 +107,19 @@ public class BasicAuthTests {
     }
 
     @Test
+    public void shouldRespondWithChallengeWhenNoCredentialsArePresent() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            HttpResponse response = client.getAuthInfo();
+
+            assertThat(response, is(notNullValue()));
+            response.assertStatusCode(SC_UNAUTHORIZED);
+            assertThat(response.getHeader("WWW-Authenticate"), is(notNullValue()));
+            assertThat(response.getHeader("WWW-Authenticate").getValue(), equalTo("Basic realm=\"OpenSearch Security\""));
+            assertThat(response.getBody(), equalTo("Unauthorized"));
+        }
+    }
+
+    @Test
     public void testUserShouldNotHaveAssignedCustomAttributes() {
         try (TestRestClient client = cluster.getRestClient(TEST_USER)) {
 

--- a/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
@@ -68,7 +68,11 @@ public class HTTPBasicAuthenticator implements HTTPAuthenticator {
     @Override
     public Optional<SecurityResponse> reRequestAuthentication(final SecurityRequest request, AuthCredentials creds) {
         return Optional.of(
-            new SecurityResponse(HttpStatus.SC_UNAUTHORIZED, Map.of("WWW-Authenticate", "Basic realm=\"OpenSearch Security\""), "")
+            new SecurityResponse(
+                HttpStatus.SC_UNAUTHORIZED,
+                Map.of("WWW-Authenticate", "Basic realm=\"OpenSearch Security\""),
+                "Unauthorized"
+            )
         );
     }
 


### PR DESCRIPTION
### Description

Included `Unauthorized` in the body of the challenge response to be consistent with the behavior from 2.10 and before.

* Category

Bug fix

### Issues Resolved

- https://github.com/opensearch-project/security/issues/3803
- https://github.com/opensearch-project/security/issues/4214

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
