### PR TITLE
Move Dave Lago to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cliu123 @cwperks @DarshitChanpura @davidlago @peternied @RyanL1997 @scrawfor99 @reta @willyborankin
+* @cliu123 @cwperks @DarshitChanpura @peternied @RyanL1997 @scrawfor99 @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,13 +16,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Chang Liu        | [cliu123](https://github.com/cliu123)                 | Amazon      |
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
-| Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
+
+## Emeritus
+
+| Maintainer    | GitHub ID                                           | Affiliation |
+| ------------- | --------------------------------------------------- | ----------- |
+| Dave Lago     | [davidlago](https://github.com/davidlago)           | Contributor |
 
 ## Practices
 


### PR DESCRIPTION
### Description
This PR moves Dave Lago from the codeowners file, and moves him from active to emeritus maintainer. We need confirmation from @davidlago somehow on making this change.

### Issues Resolved
- Resolves #4234 

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
None
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
