### PR TITLE
Use predictable serialization logic for transport headers

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -34,6 +34,7 @@ import org.opensearch.security.ssl.SslExceptionHandler;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.support.SerializationFormat;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
@@ -92,7 +93,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
 
         threadContext.putTransient(
             ConfigConstants.USE_JDK_SERIALIZATION,
-            channel.getVersion().before(ConfigConstants.FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION)
+            SerializationFormat.determineFormat(channel.getVersion()) == SerializationFormat.JDK
         );
 
         if (SSLRequestHelper.containsBadHeader(threadContext, "_opendistro_security_ssl_")) {

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
-import org.opensearch.Version;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.impl.AuditCategory;
 

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -332,6 +332,8 @@ public class ConfigConstants {
     public static final String TENANCY_GLOBAL_TENANT_NAME = "global";
     public static final String TENANCY_GLOBAL_TENANT_DEFAULT_NAME = "";
 
+    public static final String USE_JDK_SERIALIZATION = "plugins.security.use_jdk_serialization";
+
     // On-behalf-of endpoints settings
     // CS-SUPPRESS-SINGLE: RegexpSingleline get Extensions Settings
     public static final String EXTENSIONS_BWC_PLUGIN_MODE = "bwcPluginMode";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -333,9 +333,6 @@ public class ConfigConstants {
     public static final String TENANCY_GLOBAL_TENANT_NAME = "global";
     public static final String TENANCY_GLOBAL_TENANT_DEFAULT_NAME = "";
 
-    public static final String USE_JDK_SERIALIZATION = "plugins.security.use_jdk_serialization";
-    public static final Version FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION = Version.V_2_11_0;
-
     // On-behalf-of endpoints settings
     // CS-SUPPRESS-SINGLE: RegexpSingleline get Extensions Settings
     public static final String EXTENSIONS_BWC_PLUGIN_MODE = "bwcPluginMode";

--- a/src/main/java/org/opensearch/security/support/SerializationFormat.java
+++ b/src/main/java/org/opensearch/security/support/SerializationFormat.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.support;
+
+import org.opensearch.Version;
+
+public enum SerializationFormat {
+    /** Uses Java's native serialization system */
+    JDK,
+    /** Uses a custom serializer built ontop of OpenSearch 2.11 */
+    CustomSerializer_2_11;
+
+    private static final Version FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION = Version.V_2_11_0;
+    private static final Version CUSTOM_SERIALIZATION_NO_LONGER_SUPPORTED_OS_VERSION = Version.V_2_14_0;
+
+    /**
+     * Determines the format of serialization that should be used from a version identifier
+     */
+    public static SerializationFormat determineFormat(final Version version) {
+        if (version.onOrAfter(FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION)
+            && version.before(CUSTOM_SERIALIZATION_NO_LONGER_SUPPORTED_OS_VERSION)) {
+            return SerializationFormat.CustomSerializer_2_11;
+        }
+        return SerializationFormat.JDK;
+    }
+}

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
@@ -272,10 +273,11 @@ public class SecurityInterceptor {
     private static final String USE_JDK_SERIALIZATION = "plugins.security.use_jdk_serialization";
     private static final Version FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION = Version.V_2_11_0;
     private static final Version CUSTOM_SERIALIZATION_NO_LONGER_SUPPORTED_OS_VERSION = Version.V_2_14_0;
+
     private SerializationFormat shouldUseJdkSerialization(final Connection connection) {
         var version = connection.getVersion();
         if (version.after(FIRST_CUSTOM_SERIALIZATION_SUPPORTED_OS_VERSION)
-        && version.before(CUSTOM_SERIALIZATION_NO_LONGER_SUPPORTED_OS_VERSION)) {
+            && version.before(CUSTOM_SERIALIZATION_NO_LONGER_SUPPORTED_OS_VERSION)) {
             return SerializationFormat.CustomSerializer_2_11;
         }
         return SerializationFormat.JDK;

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.get.GetRequest;

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -17,8 +17,8 @@ import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.support.Base64Helper.deserializeObject;
 import static org.opensearch.security.support.Base64Helper.serializeObject;
 import static org.junit.Assert.assertThat;
@@ -59,18 +59,16 @@ public class Base64HelperTest {
         var largeObject = new HashMap<String, Object>();
         var hm = new HashMap<>();
         IntStream.range(0, 100).forEach(i -> { hm.put("c" + i, "cvalue" + i); });
-        IntStream.range(0, 100).forEach(i -> {
-            largeObject.put("b" + i, hm);
-        });
+        IntStream.range(0, 100).forEach(i -> { largeObject.put("b" + i, hm); });
 
         final var jdkSerialized = Base64Helper.serializeObject(largeObject, true);
         final var customSerialized = Base64Helper.serializeObject(largeObject, false);
         final var customSerializedOnlyHashMap = Base64Helper.serializeObject(hm, false);
 
         assertThat(jdkSerialized.length(), equalTo(3832));
-        // The custom serializer is ~50x larger than the jdk serialized version 
+        // The custom serializer is ~50x larger than the jdk serialized version
         assertThat(customSerialized.length(), equalTo(184792));
         // Show that the majority of the size of the custom serialized large object is the map duplicated ~100 times
-        assertThat( (double)customSerializedOnlyHashMap.length(), closeTo(customSerialized.length() / 100, 70d));
+        assertThat((double) customSerializedOnlyHashMap.length(), closeTo(customSerialized.length() / 100, 70d));
     }
 }

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -11,16 +11,12 @@
 package org.opensearch.security.support;
 
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.stream.IntStream;
 
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.assertThat;
 import static org.opensearch.security.support.Base64Helper.deserializeObject;
 import static org.opensearch.security.support.Base64Helper.serializeObject;
-import static org.hamcrest.Matchers.equalTo;
 
 public class Base64HelperTest {
 
@@ -51,24 +47,5 @@ public class Base64HelperTest {
         String customSerialized = Base64Helper.serializeObject(test, false);
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(jdkSerialized));
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(customSerialized));
-    }
-
-    @Test
-    public void testDifference() {
-        var largeObject = new HashMap<String, Object>();
-        var hm = new HashMap<>();
-        IntStream.range(0, 100).forEach(i -> {
-            hm.put("c" + i, "cvalue" + i);
-        });
-        IntStream.range(0, 100).forEach(i -> {
-            largeObject.put("a" + i, "value");
-            largeObject.put("a", "value" + 1);
-            largeObject.put("b" + i, hm);
-        });
-
-        String jdkSerialized = Base64Helper.serializeObject(largeObject, true);
-        String customSerialized = Base64Helper.serializeObject(largeObject, false);
-
-        assertThat(jdkSerialized.length(), equalTo(customSerialized.length()));
     }
 }

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -11,12 +11,16 @@
 package org.opensearch.security.support;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.stream.IntStream;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.junit.Assert.assertThat;
 import static org.opensearch.security.support.Base64Helper.deserializeObject;
 import static org.opensearch.security.support.Base64Helper.serializeObject;
+import static org.hamcrest.Matchers.equalTo;
 
 public class Base64HelperTest {
 
@@ -47,5 +51,24 @@ public class Base64HelperTest {
         String customSerialized = Base64Helper.serializeObject(test, false);
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(jdkSerialized));
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(customSerialized));
+    }
+
+    @Test
+    public void testDifference() {
+        var largeObject = new HashMap<String, Object>();
+        var hm = new HashMap<>();
+        IntStream.range(0, 100).forEach(i -> {
+            hm.put("c" + i, "cvalue" + i);
+        });
+        IntStream.range(0, 100).forEach(i -> {
+            largeObject.put("a" + i, "value");
+            largeObject.put("a", "value" + 1);
+            largeObject.put("b" + i, hm);
+        });
+
+        String jdkSerialized = Base64Helper.serializeObject(largeObject, true);
+        String customSerialized = Base64Helper.serializeObject(largeObject, false);
+
+        assertThat(jdkSerialized.length(), equalTo(customSerialized.length()));
     }
 }

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -11,12 +11,17 @@
 package org.opensearch.security.support;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.stream.IntStream;
 
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
 import static org.opensearch.security.support.Base64Helper.deserializeObject;
 import static org.opensearch.security.support.Base64Helper.serializeObject;
+import static org.junit.Assert.assertThat;
 
 public class Base64HelperTest {
 
@@ -47,5 +52,25 @@ public class Base64HelperTest {
         String customSerialized = Base64Helper.serializeObject(test, false);
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(jdkSerialized));
         Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(customSerialized));
+    }
+
+    @Test
+    public void testDuplicatedItemSizes() {
+        var largeObject = new HashMap<String, Object>();
+        var hm = new HashMap<>();
+        IntStream.range(0, 100).forEach(i -> { hm.put("c" + i, "cvalue" + i); });
+        IntStream.range(0, 100).forEach(i -> {
+            largeObject.put("b" + i, hm);
+        });
+
+        final var jdkSerialized = Base64Helper.serializeObject(largeObject, true);
+        final var customSerialized = Base64Helper.serializeObject(largeObject, false);
+        final var customSerializedOnlyHashMap = Base64Helper.serializeObject(hm, false);
+
+        assertThat(jdkSerialized.length(), equalTo(3832));
+        // The custom serializer is ~50x larger than the jdk serialized version 
+        assertThat(customSerialized.length(), equalTo(184792));
+        // Show that the majority of the size of the custom serialized large object is the map duplicated ~100 times
+        assertThat( (double)customSerializedOnlyHashMap.length(), closeTo(customSerialized.length() / 100, 70d));
     }
 }

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -13,8 +13,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecuritySSLRequestHandlerTests.java
@@ -94,9 +94,19 @@ public class SecuritySSLRequestHandlerTests {
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_13_0);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
+        threadPool.getThreadContext().stashContext();
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_14_0);
+        Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
+        threadPool.getThreadContext().stashContext();
+        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, transportChannel, task));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
     }
 
     @Test
@@ -118,9 +128,19 @@ public class SecuritySSLRequestHandlerTests {
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
 
         threadPool.getThreadContext().stashContext();
-        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_13_0);
         Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, wrappedChannel, task));
         Assert.assertFalse(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
+        threadPool.getThreadContext().stashContext();
+        when(transportChannel.getVersion()).thenReturn(Version.V_2_14_0);
+        Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, wrappedChannel, task));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
+
+        threadPool.getThreadContext().stashContext();
+        when(transportChannel.getVersion()).thenReturn(Version.V_3_0_0);
+        Assert.assertThrows(Exception.class, () -> securitySSLRequestHandler.messageReceived(transportRequest, wrappedChannel, task));
+        Assert.assertTrue(threadPool.getThreadContext().getTransient(ConfigConstants.USE_JDK_SERIALIZATION));
     }
 
     @Test


### PR DESCRIPTION
### Description
This change will prevent new clusters from using the 'custom serialization' format that was causing performance impact with customers in OpenSearch 2.11.

Background: the serialization changes from #2802 introduced issues where for certain serialization headers that were previously very small for over the wire transmission become much larger.  The root cause of this was that the JDK serialization process was able to detect duplicate entries and then use an encoding format to make it compressible.  Adding this logic into the serialization system from OpenSearch is non-trivial and is not being invested in. 

### Issues Resolved
- Related #2802
- Resolves https://github.com/opensearch-project/security/issues/4227
- Resolves https://github.com/opensearch-project/security/issues/3776

### Testing
BWC test should cover the scenarios
Before leaving draft, going to build tests that verify larger thread constructors are serialized in a compatible way.

### Check List
- [ ] New functionality includes testing
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
