### PR TITLE
Add getProperty.org.bouncycastle.pkcs12.default to plugin-security.policy

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -63,6 +63,7 @@ grant {
   permission java.security.SecurityPermission "removeProviderProperty.BC";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.pkcs12.default";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   


### PR DESCRIPTION
### Description

Fixes issue related to [bouncycastle upgrade](https://github.com/opensearch-project/OpenSearch/pull/13243) where starting up a node with security plugin installed resulted in:

```
Caused by: java.lang.InternalError: cannot create instance of org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings : java.security.AccessControlException: access denied ("java.security.SecurityPermission" "getProperty.org.bouncycastle.pkcs12.default")
	at org.bouncycastle.jce.provider.BouncyCastleProvider.loadServiceClass(Unknown Source) ~[?:?]
	at org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source) ~[?:?]
        ...
```

* Category

Maintenance

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
