### PR TITLE
[Backport 2.x] Add getProperty.org.bouncycastle.pkcs12.default to plugin-security.policy

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -63,6 +63,7 @@ grant {
   permission java.security.SecurityPermission "removeProviderProperty.BC";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.pkcs12.default";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   


### PR DESCRIPTION
Backport #4265 to 2.x