### PR TITLE
Add getProperty.org.bouncycastle.ec.max_f2m_field_size to plugin-security.policy

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -61,9 +61,10 @@ grant {
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
   permission java.security.SecurityPermission "removeProviderProperty.BC";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.ec.max_f2m_field_size";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.pkcs12.default";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
   permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
-  permission java.security.SecurityPermission "getProperty.org.bouncycastle.pkcs12.default";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   


### PR DESCRIPTION
### Description

Fixes issue related to [bouncycastle upgrade](https://github.com/opensearch-project/OpenSearch/pull/13243) where starting up a node with security plugin installed and SAML Authentication enabled resulted in:

```
Caused by: java.lang.InternalError: cannot create instance of org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings : java.security.AccessControlException: access denied ("java.security.SecurityPermission" "getProperty.org.bouncycastle.ec.max_f2m_field_sizet")
	at com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator.<init>(HTTPSamlAuthenticator.java:154) ~[opensearch-security-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
        ...
```

Ref: https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/8744995738/job/23999073639?pr=1899

* Category

Maintenance

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
