### PR TITLE
Add maven publish workflow for 1.3

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,0 +1,42 @@
+name: Publish snapshots to maven
+
+on:
+  workflow_dispatch:
+  push:
+      branches: [
+        main
+        1.*
+        2.*
+      ]
+
+jobs:
+  build-and-publish-snapshots:
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: [11, 17]
+        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
+    if: github.repository == 'opensearch-project/security'
+    runs-on: ${{ matrix.platform }}
+
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin # Temurin is a distribution of adoptium
+          java-version: ${{ matrix.jdk }}
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
+          aws-region: us-east-1
+      - name: publish snapshots to maven
+        run: |
+          export SONATYPE_USERNAME=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-username --query SecretString --output text)
+          export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
+          echo "::add-mask::$SONATYPE_USERNAME"
+          echo "::add-mask::$SONATYPE_PASSWORD"
+          ./gradlew publishPluginZipPublicationToSnapshotsRepository

--- a/build.gradle
+++ b/build.gradle
@@ -278,7 +278,18 @@ publishing {
             artifact(testsJar)
         }
     }
+    repositories {
+        maven {
+            name = "Snapshots" //  optional target repository name
+            url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
 }
+
 
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'


### PR DESCRIPTION
### Description
Adds the maven publish workflow for 1.3. This should start publishing plugin zips to the maven repo for consumption.

* Category
Enhancement
* Why these changes are required?
Failed backport - https://github.com/opensearch-project/security/issues/4281
* What is the old behavior before changes and new behavior after changes?
Should start publishing zips to maven

### Issues Resolved
https://github.com/opensearch-project/security/issues/4281

Is this a backport? If so, please add backport PR # and/or commits #
Backport of: https://github.com/opensearch-project/security/pull/2438



### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
