### PR TITLE
Fix syntax with the publish maven workflow

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -3,33 +3,26 @@ name: Publish snapshots to maven
 on:
   workflow_dispatch:
   push:
-      branches: [
-        main
-        1.*
-        2.*
-      ]
+      branches:
+        - 'main'
+        - '1.*'
+        - '2.*'
 
 jobs:
   build-and-publish-snapshots:
-    strategy:
-      fail-fast: false
-      matrix:
-        jdk: [11, 17]
-        platform: ["ubuntu-latest", "windows-latest", "macos-latest"]
-    if: github.repository == 'opensearch-project/security'
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
 
     permissions:
       id-token: write
       contents: write
 
     steps:
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: ${{ matrix.jdk }}
-      - uses: actions/checkout@v3
-      - uses: aws-actions/configure-aws-credentials@v1
+          java-version: 11
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.PUBLISH_SNAPSHOTS_ROLE }}
           aws-region: us-east-1


### PR DESCRIPTION
### Description
After backporting the failed backport to publish snapshot to maven it seems not to work. After inspection again in main/2.x branches I saw it has a different syntax. That may have been added in subsequent PRs. This copies the same workflow to 1.3 branch to hopefully make it publish again. 

### Issues Resolved


Is this a backport? If so, please add backport PR # and/or commits #

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
