### PR TITLE
[Fix #4280] Introduce new endpoint _plugins/_security/api/certificates

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
@@ -245,9 +245,13 @@ public abstract class AbstractApiIntegrationTest extends RandomizedTest {
         }
     }
 
+    protected String apiPathPrefix() {
+        return randomFrom(List.of(LEGACY_OPENDISTRO_PREFIX, PLUGINS_PREFIX));
+    }
+
     protected String securityPath(String... path) {
         final var fullPath = new StringJoiner("/");
-        fullPath.add(randomFrom(List.of(LEGACY_OPENDISTRO_PREFIX, PLUGINS_PREFIX)));
+        fullPath.add(apiPathPrefix());
         if (path != null) {
             for (final var p : path)
                 fullPath.add(p);

--- a/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.stream.Collectors;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Test;
+
+import org.opensearch.security.dlic.rest.api.Endpoint;
+import org.opensearch.security.dlic.rest.api.ssl.CertificateType;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.certificate.TestCertificates;
+import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+
+public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTest {
+
+    final static String REST_API_ADMIN_SSL_INFO = "rest-api-admin-ssl-info";
+
+    final static String REGULAR_USER = "regular_user";
+
+    static {
+        clusterSettings.put(SECURITY_RESTAPI_ADMIN_ENABLED, true);
+        testSecurityConfig.roles(
+            new TestSecurityConfig.Role("simple_user_role").clusterPermissions("cluster:admin/security/certificates/info")
+        )
+            .rolesMapping(new TestSecurityConfig.RoleMapping("simple_user_role").users(REGULAR_USER, ADMIN_USER_NAME))
+            .user(new TestSecurityConfig.User(REGULAR_USER))
+            .withRestAdminUser(REST_ADMIN_USER, allRestAdminPermissions())
+            .withRestAdminUser(REST_API_ADMIN_SSL_INFO, restAdminPermission(Endpoint.SSL, CERTS_INFO_ACTION));
+    }
+
+    @Override
+    protected String apiPathPrefix() {
+        return PLUGINS_PREFIX;
+    }
+
+    protected String sslCertsPath(String... path) {
+        final var fullPath = new StringJoiner("/");
+        fullPath.add(super.apiPath("certificates"));
+        if (path != null) {
+            for (final var p : path) {
+                fullPath.add(p);
+            }
+        }
+        return fullPath.toString();
+    }
+
+    @Test
+    public void forbiddenForRegularUser() throws Exception {
+        withUser(REGULAR_USER, client -> forbidden(() -> client.get(sslCertsPath())));
+    }
+
+    @Test
+    public void forbiddenForAdminUser() throws Exception {
+        withUser(ADMIN_USER_NAME, client -> forbidden(() -> client.get(sslCertsPath())));
+    }
+
+    @Test
+    public void availableForTlsAdmin() throws Exception {
+        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifySSLCertsInfo);
+    }
+
+    @Test
+    public void availableForRestAdmin() throws Exception {
+        withUser(REST_ADMIN_USER, this::verifySSLCertsInfo);
+        withUser(REST_API_ADMIN_SSL_INFO, this::verifySSLCertsInfo);
+    }
+
+    private void verifySSLCertsInfo(final TestRestClient client) throws Exception {
+        assertSSLCertsInfo(
+            localCluster.nodes(),
+            Set.of(CertificateType.HTTP, CertificateType.TRANSPORT),
+            ok(() -> client.get(sslCertsPath()))
+        );
+        if (localCluster.nodes().size() > 1) {
+            final var randomNodes = randomNodes();
+            final var nodeIds = randomNodes.stream().map(n -> n.esNode().getNodeEnvironment().nodeId()).collect(Collectors.joining(","));
+            assertSSLCertsInfo(
+                randomNodes,
+                Set.of(CertificateType.HTTP, CertificateType.TRANSPORT),
+                ok(() -> client.get(sslCertsPath(nodeIds)))
+            );
+        }
+        final var randomCertType = randomFrom(List.of(CertificateType.HTTP, CertificateType.TRANSPORT));
+        assertSSLCertsInfo(
+            localCluster.nodes(),
+            Set.of(randomCertType),
+            ok(() -> client.get(String.format("%s?cert_type=%s", sslCertsPath(), randomCertType)))
+        );
+
+    }
+
+    private void assertSSLCertsInfo(
+        final List<LocalOpenSearchCluster.Node> expectedNode,
+        final Set<CertificateType> expectedCertTypes,
+        final TestRestClient.HttpResponse response
+    ) {
+        final var body = response.bodyAsJsonNode();
+        final var prettyStringBody = body.toPrettyString();
+
+        final var _nodes = body.get("_nodes");
+        assertThat(prettyStringBody, _nodes.get("total").asInt(), is(expectedNode.size()));
+        assertThat(prettyStringBody, _nodes.get("successful").asInt(), is(expectedNode.size()));
+        assertThat(prettyStringBody, _nodes.get("failed").asInt(), is(0));
+        assertThat(prettyStringBody, body.get("cluster_name").asText(), is(localCluster.getClusterName()));
+
+        final var nodes = body.get("nodes");
+
+        for (final var n : expectedNode) {
+            final var esNode = n.esNode();
+            final var node = nodes.get(esNode.getNodeEnvironment().nodeId());
+            assertThat(prettyStringBody, node.get("name").asText(), is(n.getNodeName()));
+            assertThat(prettyStringBody, node.has("certificates"));
+            final var certificates = node.get("certificates");
+            if (expectedCertTypes.contains(CertificateType.HTTP)) {
+                final var httpCertificates = certificates.get(CertificateType.HTTP.value());
+                assertThat(prettyStringBody, httpCertificates.isArray());
+                assertThat(prettyStringBody, httpCertificates.size(), is(1));
+                verifyCertsJson(n.nodeNumber(), httpCertificates.get(0));
+            }
+            if (expectedCertTypes.contains(CertificateType.TRANSPORT)) {
+                final var transportCertificates = certificates.get(CertificateType.TRANSPORT.value());
+                assertThat(prettyStringBody, transportCertificates.isArray());
+                assertThat(prettyStringBody, transportCertificates.size(), is(1));
+                verifyCertsJson(n.nodeNumber(), transportCertificates.get(0));
+            }
+        }
+
+    }
+
+    private void verifyCertsJson(final int nodeNumber, final JsonNode jsonNode) {
+        assertThat(jsonNode.toPrettyString(), jsonNode.get("issuer_dn").asText(), is(TestCertificates.CA_SUBJECT));
+        assertThat(
+            jsonNode.toPrettyString(),
+            jsonNode.get("subject_dn").asText(),
+            is(String.format(TestCertificates.NODE_SUBJECT_PATTERN, nodeNumber))
+        );
+        assertThat(
+            jsonNode.toPrettyString(),
+            jsonNode.get("san").asText(),
+            containsString(String.format("node-%s.example.com", nodeNumber))
+        );
+        assertThat(jsonNode.toPrettyString(), jsonNode.has("not_before"));
+        assertThat(jsonNode.toPrettyString(), jsonNode.has("not_after"));
+    }
+
+    private List<LocalOpenSearchCluster.Node> randomNodes() {
+        final var nodes = localCluster.nodes();
+        int leaveElements = randomIntBetween(1, nodes.size() - 1);
+        return randomSubsetOf(leaveElements, nodes);
+    }
+
+    public <T> List<T> randomSubsetOf(int size, Collection<T> collection) {
+        if (size > collection.size()) {
+            throw new IllegalArgumentException(
+                "Can't pick " + size + " random objects from a collection of " + collection.size() + " objects"
+            );
+        }
+        List<T> tempList = new ArrayList<>(collection);
+        Collections.shuffle(tempList, RandomizedContext.current().getRandom());
+        return tempList.subList(0, size);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
+@Deprecated
 public class SslCertsRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     final static String REST_API_ADMIN_SSL_INFO = "rest-api-admin-ssl-info";

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -45,6 +45,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -163,7 +164,9 @@ public class LocalOpenSearchCluster {
         this.initialClusterManagerHosts = toHostList(clusterManagerPorts);
 
         started = true;
+        final var nodeCounter = new AtomicInteger(0);
         CompletableFuture<Void> clusterManagerNodeFuture = startNodes(
+            nodeCounter,
             clusterManager.getClusterManagerNodeSettings(),
             clusterManagerNodeTransportPorts,
             clusterManagerNodeHttpPorts
@@ -177,6 +180,7 @@ public class LocalOpenSearchCluster {
         SortedSet<Integer> nonClusterManagerNodeHttpPorts = TCP.allocate(clusterName, nonClusterManagerNodeCount, 5000 + 42 * 1000 + 210);
 
         CompletableFuture<Void> nonClusterManagerNodeFuture = startNodes(
+            nodeCounter,
             clusterManager.getNonClusterManagerNodeSettings(),
             nonClusterManagerNodeTransportPorts,
             nonClusterManagerNodeHttpPorts
@@ -292,6 +296,7 @@ public class LocalOpenSearchCluster {
     }
 
     private CompletableFuture<Void> startNodes(
+        AtomicInteger nodeCounter,
         List<NodeSettings> nodeSettingList,
         SortedSet<Integer> transportPorts,
         SortedSet<Integer> httpPorts
@@ -300,8 +305,8 @@ public class LocalOpenSearchCluster {
         Iterator<Integer> httpPortIterator = httpPorts.iterator();
         List<CompletableFuture<StartStage>> futures = new ArrayList<>();
 
-        for (var i = 0; i < nodeSettingList.size(); i++) {
-            Node node = new Node(i, nodeSettingList.get(i), transportPortIterator.next(), httpPortIterator.next());
+        for (final var nodeSettings : nodeSettingList) {
+            Node node = new Node(nodeCounter.getAndIncrement(), nodeSettings, transportPortIterator.next(), httpPortIterator.next());
             futures.add(node.start());
         }
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
@@ -385,6 +390,10 @@ public class LocalOpenSearchCluster {
         private boolean portCollision = false;
         private final int nodeNumber;
 
+        boolean hasAssignedType(NodeType type) {
+            return requireNonNull(type, "Node type is required.").equals(this.nodeType);
+        }
+
         Node(int nodeNumber, NodeSettings nodeSettings, int transportPort, int httpPort) {
             this.nodeNumber = nodeNumber;
             this.nodeName = createNextNodeName(requireNonNull(nodeSettings, "Node settings are required."));
@@ -402,8 +411,8 @@ public class LocalOpenSearchCluster {
             nodes.add(this);
         }
 
-        boolean hasAssignedType(NodeType type) {
-            return requireNonNull(type, "Node type is required.").equals(this.nodeType);
+        public int nodeNumber() {
+            return nodeNumber;
         }
 
         CompletableFuture<StartStage> start() {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/CertificatesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/CertificatesApiAction.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestActions;
+import org.opensearch.security.dlic.rest.api.ssl.CertificateType;
+import org.opensearch.security.dlic.rest.api.ssl.CertificatesActionType;
+import org.opensearch.security.dlic.rest.api.ssl.CertificatesInfoNodesRequest;
+import org.opensearch.security.dlic.rest.api.ssl.CertificatesNodesResponse;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.threadpool.ThreadPool;
+
+import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
+import static org.opensearch.security.dlic.rest.api.Responses.ok;
+import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
+public class CertificatesApiAction extends AbstractApiAction {
+
+    private final static Logger LOGGER = LogManager.getLogger(CertificatesApiAction.class);
+
+    private static final List<Route> ROUTES = addRoutesPrefix(
+        ImmutableList.of(new Route(RestRequest.Method.GET, "/certificates"), new Route(RestRequest.Method.GET, "/certificates/{nodeId}")),
+        PLUGIN_API_ROUTE_PREFIX
+    );
+
+    public CertificatesApiAction(
+        final ClusterService clusterService,
+        final ThreadPool threadPool,
+        final SecurityApiDependencies securityApiDependencies
+    ) {
+        super(Endpoint.SSL, clusterService, threadPool, securityApiDependencies);
+        this.requestHandlersBuilder.configureRequestHandlers(this::securitySSLCertsRequestHandlers);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return ROUTES;
+    }
+
+    @Override
+    public String getName() {
+        return "HTTP and Transport Certificates Actions";
+    }
+
+    @Override
+    protected CType getConfigType() {
+        return null;
+    }
+
+    @Override
+    protected void consumeParameters(RestRequest request) {
+        request.param("nodeId");
+        request.param("cert_type");
+    }
+
+    private void securitySSLCertsRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {
+        requestHandlersBuilder.withAccessHandler(this::accessHandler)
+            .allMethodsNotImplemented()
+            .verifyAccessForAllMethods()
+            .override(
+                RestRequest.Method.GET,
+                (channel, request, client) -> client.execute(
+                    CertificatesActionType.INSTANCE,
+                    new CertificatesInfoNodesRequest(
+                        CertificateType.from(request.param("cert_type")),
+                        true,
+                        request.paramAsStringArrayOrEmptyIfAll("nodeId")
+                    ).timeout(request.param("timeout")),
+                    new ActionListener<>() {
+                        @Override
+                        public void onResponse(final CertificatesNodesResponse response) {
+                            ok(channel, (builder, params) -> {
+                                builder.startObject();
+                                RestActions.buildNodesHeader(builder, channel.request(), response);
+                                builder.field("cluster_name", response.getClusterName().value());
+                                response.toXContent(builder, channel.request());
+                                builder.endObject();
+                                return builder;
+                            });
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            LOGGER.error("Cannot load SSL certificates info due to", e);
+                            internalServerError(channel, "Cannot load SSL certificates info " + e.getMessage() + ".");
+                        }
+                    }
+                )
+            );
+    }
+
+    boolean accessHandler(final RestRequest request) {
+        if (request.method() == RestRequest.Method.GET) {
+            return securityApiDependencies.restApiAdminPrivilegesEvaluator().isCurrentUserAdminFor(endpoint, CERTS_INFO_ACTION);
+        } else {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -95,8 +95,9 @@ public class SecurityRestApiActions {
             new AllowlistApiAction(Endpoint.ALLOWLIST, clusterService, threadPool, securityApiDependencies),
             new AuditApiAction(clusterService, threadPool, securityApiDependencies),
             new MultiTenancyConfigApiAction(clusterService, threadPool, securityApiDependencies),
+            new ConfigUpgradeApiAction(clusterService, threadPool, securityApiDependencies),
             new SecuritySSLCertsApiAction(clusterService, threadPool, securityKeyStore, certificatesReloadEnabled, securityApiDependencies),
-            new ConfigUpgradeApiAction(clusterService, threadPool, securityApiDependencies)
+            new CertificatesApiAction(clusterService, threadPool, securityApiDependencies)
         );
     }
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiAction.java
@@ -20,6 +20,8 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.cluster.service.ClusterService;
@@ -48,9 +50,16 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  * This action serves GET request for _plugins/_security/api/ssl/certs endpoint and
  * PUT _plugins/_security/api/ssl/{certType}/reloadcerts
  */
+@Deprecated
 public class SecuritySSLCertsApiAction extends AbstractApiAction {
+
+    private final static Logger LOGGER = LogManager.getLogger(SecuritySSLCertsApiAction.class);
+
     private static final List<Route> ROUTES = addRoutesPrefix(
-        ImmutableList.of(new Route(Method.GET, "/ssl/certs"), new Route(Method.PUT, "/ssl/{certType}/reloadcerts"))
+        ImmutableList.of(
+            new DeprecatedRoute(Method.GET, "/ssl/certs", "[/ssl/certs] is a deprecated endpoint. Please use [/certificates] instead."),
+            new Route(Method.PUT, "/ssl/{certType}/reloadcerts")
+        )
     );
 
     private final SecurityKeyStore securityKeyStore;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificateInfo.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificateInfo.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.Objects;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class CertificateInfo implements Writeable, ToXContent {
+
+    private final String subject;
+
+    private final String san;
+
+    private final String issuer;
+
+    private final String notAfter;
+
+    private final String notBefore;
+
+    public CertificateInfo(String subject, String san, String issuer, String notAfter, String notBefore) {
+        this.subject = subject;
+        this.san = san;
+        this.issuer = issuer;
+        this.notAfter = notAfter;
+        this.notBefore = notBefore;
+    }
+
+    public CertificateInfo(final StreamInput in) throws IOException {
+        this.subject = in.readOptionalString();
+        this.san = in.readOptionalString();
+        this.issuer = in.readOptionalString();
+        this.notAfter = in.readOptionalString();
+        this.notBefore = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeOptionalString(subject);
+        out.writeOptionalString(san);
+        out.writeOptionalString(issuer);
+        out.writeOptionalString(notAfter);
+        out.writeOptionalString(notBefore);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+        return builder.startObject()
+            .field("subject_dn", subject)
+            .field("san", san)
+            .field("issuer_dn", issuer)
+            .field("not_after", notAfter)
+            .field("not_before", notAfter)
+            .endObject();
+    }
+
+    public static CertificateInfo from(final X509Certificate x509Certificate, final String subjectAlternativeNames) {
+        String subject = null;
+        String issuer = null;
+        String notAfter = null;
+        String notBefore = null;
+        if (x509Certificate != null) {
+            if (x509Certificate.getSubjectX500Principal() != null) {
+                subject = x509Certificate.getSubjectX500Principal().getName();
+            }
+            if (x509Certificate.getIssuerX500Principal() != null) {
+                issuer = x509Certificate.getIssuerX500Principal().getName();
+            }
+            if (x509Certificate.getNotAfter() != null) {
+                notAfter = x509Certificate.getNotAfter().toInstant().toString();
+            }
+            if (x509Certificate.getNotBefore() != null) {
+                notBefore = x509Certificate.getNotBefore().toInstant().toString();
+            }
+        }
+        return new CertificateInfo(subject, subjectAlternativeNames, issuer, notAfter, notBefore);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CertificateInfo that = (CertificateInfo) o;
+        return Objects.equals(subject, that.subject)
+            && Objects.equals(san, that.san)
+            && Objects.equals(issuer, that.issuer)
+            && Objects.equals(notAfter, that.notAfter)
+            && Objects.equals(notBefore, that.notBefore);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subject, san, issuer, notAfter, notBefore);
+    }
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificateType.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificateType.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.util.Locale;
+
+public enum CertificateType {
+    HTTP("http"),
+    TRANSPORT("transport"),
+    ALL("all");
+
+    private final String value;
+
+    private CertificateType(String value) {
+        this.value = value;
+    }
+
+    public static boolean isHttp(final CertificateType certificateType) {
+        return certificateType == HTTP || certificateType == ALL;
+    }
+
+    public static boolean isTransport(final CertificateType certificateType) {
+        return certificateType == TRANSPORT || certificateType == ALL;
+    }
+
+    public String value() {
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    public static CertificateType from(final String certType) {
+        if (certType == null) {
+            return ALL;
+        }
+        for (final var t : values())
+            if (t.value.equalsIgnoreCase(certType)) return t;
+        throw new IllegalArgumentException("Invalid certificate type: " + certType);
+    }
+
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesActionType.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesActionType.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import org.opensearch.action.ActionType;
+
+public class CertificatesActionType extends ActionType<CertificatesNodesResponse> {
+
+    public static final CertificatesActionType INSTANCE = new CertificatesActionType();
+
+    public static final String NAME = "cluster:admin/security/certificates/info";
+
+    public CertificatesActionType() {
+        super(NAME, CertificatesNodesResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfo.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfo.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.common.io.stream.Writeable;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class CertificatesInfo implements Writeable, ToXContent {
+
+    private final Map<CertificateType, List<CertificateInfo>> certificates;
+
+    public CertificatesInfo(final Map<CertificateType, List<CertificateInfo>> certificates) {
+        this.certificates = certificates;
+    }
+
+    public CertificatesInfo(final StreamInput in) throws IOException {
+        certificates = in.readMap(keyIn -> keyIn.readEnum(CertificateType.class), listIn -> listIn.readList(CertificateInfo::new));
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeMap(certificates, StreamOutput::writeEnum, StreamOutput::writeList);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.startObject("certificates")
+            .field(CertificateType.HTTP.value(), certificates.get(CertificateType.HTTP))
+            .field(CertificateType.TRANSPORT.value(), certificates.get(CertificateType.TRANSPORT))
+            .endObject();
+    }
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfoNodesRequest.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesInfoNodesRequest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.io.IOException;
+
+import org.opensearch.action.support.nodes.BaseNodesRequest;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+public class CertificatesInfoNodesRequest extends BaseNodesRequest<CertificatesInfoNodesRequest> {
+
+    private final CertificateType certificateType;
+
+    private final boolean inMemory;
+
+    public CertificatesInfoNodesRequest(CertificateType certificateType, boolean inMemory, String... nodesIds) {
+        super(nodesIds);
+        this.certificateType = certificateType;
+        this.inMemory = inMemory;
+    }
+
+    public CertificatesInfoNodesRequest(final StreamInput in) throws IOException {
+        super(in);
+        certificateType = in.readEnum(CertificateType.class);
+        inMemory = in.readBoolean();
+    }
+
+    public CertificateType certificateType() {
+        return certificateType;
+    }
+
+    public boolean inMemory() {
+        return inMemory;
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeEnum(certificateType);
+        out.writeBoolean(inMemory);
+    }
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesNodesResponse.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/CertificatesNodesResponse.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.nodes.BaseNodeResponse;
+import org.opensearch.action.support.nodes.BaseNodesResponse;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentFragment;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+public class CertificatesNodesResponse extends BaseNodesResponse<CertificatesNodesResponse.CertificatesNodeResponse>
+    implements
+        ToXContentFragment {
+
+    public CertificatesNodesResponse(StreamInput in) throws IOException {
+        super(in);
+    }
+
+    public CertificatesNodesResponse(ClusterName clusterName, List<CertificatesNodeResponse> nodes, List<FailedNodeException> failures) {
+        super(clusterName, nodes, failures);
+    }
+
+    @Override
+    protected List<CertificatesNodeResponse> readNodesFrom(StreamInput in) throws IOException {
+        return in.readList(CertificatesNodeResponse::new);
+    }
+
+    @Override
+    protected void writeNodesTo(StreamOutput out, List<CertificatesNodeResponse> nodes) throws IOException {
+        out.writeList(nodes);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject("nodes");
+        for (final CertificatesNodeResponse node : getNodes()) {
+            builder.startObject(node.getNode().getId());
+            builder.field("name", node.getNode().getName());
+            if (node.exception() != null) {
+                builder.startObject("load_exception");
+                OpenSearchException.generateThrowableXContent(builder, params, node.exception);
+                builder.endObject();
+            }
+            if (node.certificates() != null) {
+                node.certificates.toXContent(builder, params);
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static class CertificatesNodeResponse extends BaseNodeResponse {
+
+        private final Exception exception;
+
+        private final CertificatesInfo certificates;
+
+        public CertificatesNodeResponse(final DiscoveryNode node, final Exception exception) {
+            super(node);
+            this.exception = exception;
+            this.certificates = null;
+        }
+
+        public CertificatesNodeResponse(final DiscoveryNode node, final CertificatesInfo certificates) {
+            super(node);
+            this.exception = null;
+            this.certificates = certificates;
+        }
+
+        public CertificatesNodeResponse(StreamInput in) throws IOException {
+            super(in);
+            if (in.readBoolean()) {
+                this.exception = in.readException();
+                this.certificates = null;
+            } else {
+                this.exception = null;
+                this.certificates = in.readOptionalWriteable(CertificatesInfo::new);
+            }
+        }
+
+        public CertificatesInfo certificates() {
+            return certificates;
+        }
+
+        public Exception exception() {
+            return exception;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            if (exception != null) {
+                out.writeBoolean(true);
+                out.writeException(exception);
+            }
+            if (certificates != null) {
+                out.writeBoolean(false);
+                out.writeOptionalWriteable(certificates);
+            }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CertificatesNodeResponse that = (CertificatesNodeResponse) o;
+            return Objects.equals(exception, that.exception) && Objects.equals(certificates, that.certificates);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(exception, certificates);
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ssl/TransportCertificatesInfoNodesAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ssl/TransportCertificatesInfoNodesAction.java
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlic.rest.api.ssl;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+
+import org.opensearch.action.FailedNodeException;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.nodes.TransportNodesAction;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.security.ssl.DefaultSecurityKeyStore;
+import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportRequest;
+import org.opensearch.transport.TransportService;
+
+public class TransportCertificatesInfoNodesAction extends TransportNodesAction<
+    CertificatesInfoNodesRequest,
+    CertificatesNodesResponse,
+    TransportCertificatesInfoNodesAction.NodeRequest,
+    CertificatesNodesResponse.CertificatesNodeResponse> {
+
+    private final DefaultSecurityKeyStore securityKeyStore;
+
+    private final boolean httpsEnabled;
+
+    @Inject
+    public TransportCertificatesInfoNodesAction(
+        final Settings settings,
+        final ThreadPool threadPool,
+        final ClusterService clusterService,
+        final TransportService transportService,
+        final ActionFilters actionFilters,
+        final DefaultSecurityKeyStore securityKeyStore
+    ) {
+        super(
+            CertificatesActionType.NAME,
+            threadPool,
+            clusterService,
+            transportService,
+            actionFilters,
+            CertificatesInfoNodesRequest::new,
+            NodeRequest::new,
+            ThreadPool.Names.GENERIC,
+            CertificatesNodesResponse.CertificatesNodeResponse.class
+        );
+        this.httpsEnabled = settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED, true);
+        this.securityKeyStore = securityKeyStore;
+    }
+
+    @Override
+    protected CertificatesNodesResponse newResponse(
+        CertificatesInfoNodesRequest request,
+        List<CertificatesNodesResponse.CertificatesNodeResponse> nodeResponses,
+        List<FailedNodeException> failures
+    ) {
+        return new CertificatesNodesResponse(clusterService.getClusterName(), nodeResponses, failures);
+    }
+
+    @Override
+    protected NodeRequest newNodeRequest(final CertificatesInfoNodesRequest request) {
+        return new NodeRequest(request);
+    }
+
+    @Override
+    protected CertificatesNodesResponse.CertificatesNodeResponse newNodeResponse(final StreamInput in) throws IOException {
+        return new CertificatesNodesResponse.CertificatesNodeResponse(in);
+    }
+
+    @Override
+    protected CertificatesNodesResponse.CertificatesNodeResponse nodeOperation(final NodeRequest request) {
+        final var sslCertRequest = request.sslCertsInfoNodesRequest;
+
+        if (securityKeyStore == null) {
+            return new CertificatesNodesResponse.CertificatesNodeResponse(
+                clusterService.localNode(),
+                new IllegalStateException("keystore is not initialized")
+            );
+        }
+        try {
+            return new CertificatesNodesResponse.CertificatesNodeResponse(
+                clusterService.localNode(),
+                loadCertificates(sslCertRequest.certificateType())
+            );
+        } catch (final Exception e) {
+            return new CertificatesNodesResponse.CertificatesNodeResponse(clusterService.localNode(), e);
+        }
+    }
+
+    protected CertificatesInfo loadCertificates(final CertificateType certificateType) {
+        var httpCertificates = List.<CertificateInfo>of();
+        var transportsCertificates = List.<CertificateInfo>of();
+        if (CertificateType.isHttp(certificateType)) {
+            httpCertificates = httpsEnabled ? certificatesDetails(securityKeyStore.getHttpCerts()) : List.of();
+        }
+        if (CertificateType.isTransport(certificateType)) {
+            transportsCertificates = certificatesDetails(securityKeyStore.getTransportCerts());
+        }
+        return new CertificatesInfo(Map.of(CertificateType.HTTP, httpCertificates, CertificateType.TRANSPORT, transportsCertificates));
+    }
+
+    private List<CertificateInfo> certificatesDetails(final X509Certificate[] certs) {
+        if (certs == null) {
+            return null;
+        }
+        final var certificates = ImmutableList.<CertificateInfo>builder();
+        for (final var c : certs) {
+            certificates.add(CertificateInfo.from(c, securityKeyStore.getSubjectAlternativeNames(c)));
+        }
+        return certificates.build();
+    }
+
+    public static class NodeRequest extends TransportRequest {
+
+        CertificatesInfoNodesRequest sslCertsInfoNodesRequest;
+
+        public NodeRequest(StreamInput in) throws IOException {
+            super(in);
+            sslCertsInfoNodesRequest = new CertificatesInfoNodesRequest(in);
+        }
+
+        NodeRequest(CertificatesInfoNodesRequest request) {
+            this.sslCertsInfoNodesRequest = request;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            sslCertsInfoNodesRequest.writeTo(out);
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

Introduce new endpoint:
 - `_plugins/_security/api/certificates` 
 - `_plugins/_security/api/certificates/{nodeId}`

which provides information about SSL certificates for each node in the cluster. The endpoint works only with Default key store but not with external key store.  

Path parameters:
 - `nodeId` - (Optional, string) The names of particular nodes in the cluster to target. For example, `nodeId1,nodeId2`

Query string parameters:
- `cert_type` - (Optional, string) The SSL certificate type. Expected values are: `http`, `transport` and `all`. The default value is `all`
- `timeout` - node request timeout

HTTP Response:
```json
{
  "_nodes" : {
    "total" : 0,
    "successful" : 0,
    "failed" : 0
  },
  "cluster_name" : "...",
  "nodes" : {
    "..." : {
      "name" : "...",
      "certificates" : {
        "http" : [{
          "issuer_dn" : "...",
          "not_after" : "...",
          "san" : "...",
          "subject_dn" : "...",
          "not_before" : "..."
        }, ...],
        "transport" : [{
          "issuer_dn" : "...",
          "not_after" : "...",
          "san" : "...",
          "subject_dn" : "...",
          "not_before" : "..."
        }, ...]
      }
    }
  }
}

```

Example HTTP response:
```json
{
  "_nodes" : {
    "total" : 5,
    "successful" : 5,
    "failed" : 0
  },
  "cluster_name" : "local_cluster_1",
  "nodes" : {
    "fxxUhP__T_-hAn-A_____w" : {
      "name" : "cluster_manager_0",
      "certificates" : {
        "http" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-0.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-0.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ],
        "transport" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-0.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-0.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ]
      }
    },
    "i7LgEwAAQACap1QkAAAAAA" : {
      "name" : "cluster_manager_1",
      "certificates" : {
        "http" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-1.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-1.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ],
        "transport" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-1.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-1.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ]
      }
    },
    "58zZ5v__T_-GFzPu_____w" : {
      "name" : "cluster_manager_2",
      "certificates" : {
        "http" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-2.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-2.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ],
        "transport" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-2.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-2.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ]
      }
    },
    "YOYidQAAQACP5uIKAAAAAA" : {
      "name" : "data_0",
      "certificates" : {
        "http" : [ {
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-3.example.com",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-3.example.com], [2, localhost], [7, 127.0.0.1]]",
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "not_before" : "2024-04-28T09:23:47Z"
        } ],
        "transport" : [ {
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-3.example.com",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-3.example.com], [2, localhost], [7, 127.0.0.1]]",
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "not_before" : "2024-04-28T09:23:47Z"
        } ]
      }
    },
    "fcavYQAAQACJuOUMAAAAAA" : {
      "name" : "data_1",
      "certificates" : {
        "http" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-4.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-4.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ],
        "transport" : [ {
          "issuer_dn" : "DC=com,DC=example,O=Example Com Inc.,OU=Example Com Inc. Root CA,CN=Example Com Inc. Root CA",
          "not_after" : "2025-04-28T09:23:47Z",
          "san" : "[[8, 1.2.3.4.5.5], [2, node-4.example.com], [2, localhost], [7, 127.0.0.1]]",
          "subject_dn" : "DC=de,L=test,O=node,OU=node,CN=node-4.example.com",
          "not_before" : "2024-04-28T09:23:47Z"
        } ]
      }
    }
  }
}
```

### Issues Resolved
#4280


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
