### PR TITLE
[Backport] [2.x] Bump commons-codec:commons-codec from 1.16.1 to 1.17.0 (#4293)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -472,7 +472,7 @@ bundlePlugin {
 configurations {
     all {
         resolutionStrategy {
-            force 'commons-codec:commons-codec:1.16.1'
+            force 'commons-codec:commons-codec:1.17.0'
             force 'org.slf4j:slf4j-api:1.7.36'
             force 'org.scala-lang:scala-library:2.13.13'
             force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
@@ -596,7 +596,7 @@ dependencies {
 
     runtimeOnly 'com.sun.activation:jakarta.activation:1.2.2'
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
-    runtimeOnly 'commons-codec:commons-codec:1.16.0'
+    runtimeOnly 'commons-codec:commons-codec:1.17.0'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.6'
     compileOnly 'com.google.errorprone:error_prone_annotations:2.26.1'
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4293 to `2.x`