### PR TITLE
Add space between definitions in gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
+
         kafka_version  = '3.7.0'
         apache_cxf_version = '4.0.4'
         open_saml_version = '4.3.2'


### PR DESCRIPTION
### Description
Added space between `common_utils` version and
java libs versions (`kafka_version`, `open_saml_version` etc.) n the `gradle.build` file.
in the `buildscript` `ext` section to avoid falires for auto backport to the 2.x branch

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
