### PR TITLE
Fix spelling

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -74,7 +74,7 @@ import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;
 import static org.opensearch.security.dlic.rest.api.Responses.conflict;
 import static org.opensearch.security.dlic.rest.api.Responses.forbidden;
 import static org.opensearch.security.dlic.rest.api.Responses.forbiddenMessage;
-import static org.opensearch.security.dlic.rest.api.Responses.internalSeverError;
+import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
 import static org.opensearch.security.dlic.rest.api.Responses.payload;
 import static org.opensearch.security.dlic.rest.support.Utils.withIOException;
 
@@ -482,7 +482,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
             if (ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
                 conflict(channel, e.getMessage());
             } else {
-                internalSeverError(channel, "Error " + e.getMessage());
+                internalServerError(channel, "Error " + e.getMessage());
             }
         }
 
@@ -579,7 +579,7 @@ public abstract class AbstractApiAction extends BaseRestHandler {
 
         // check if .opendistro_security index has been initialized
         if (!ensureIndexExists()) {
-            return channel -> internalSeverError(channel, RequestContentValidator.ValidationError.SECURITY_NOT_INITIALIZED.message());
+            return channel -> internalServerError(channel, RequestContentValidator.ValidationError.SECURITY_NOT_INITIALIZED.message());
         }
 
         // check if request is authorized

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -28,7 +28,7 @@ import org.opensearch.security.action.configupdate.ConfigUpdateResponse;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
 
-import static org.opensearch.security.dlic.rest.api.Responses.internalSeverError;
+import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
@@ -73,7 +73,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
                         public void onResponse(ConfigUpdateResponse configUpdateResponse) {
                             if (configUpdateResponse.hasFailures()) {
                                 LOGGER.error("Cannot flush cache due to", configUpdateResponse.failures().get(0));
-                                internalSeverError(
+                                internalServerError(
                                     channel,
                                     "Cannot flush cache due to " + configUpdateResponse.failures().get(0).getMessage() + "."
                                 );
@@ -86,7 +86,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
                         @Override
                         public void onFailure(final Exception e) {
                             LOGGER.error("Cannot flush cache due to", e);
-                            internalSeverError(channel, "Cannot flush cache due to " + e.getMessage() + ".");
+                            internalServerError(channel, "Cannot flush cache due to " + e.getMessage() + ".");
                         }
 
                     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -61,7 +61,7 @@ import org.opensearch.security.securityconf.impl.v7.TenantV7;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.dlic.rest.api.Responses.badRequest;
-import static org.opensearch.security.dlic.rest.api.Responses.internalSeverError;
+import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 // CS-ENFORCE-SINGLE
@@ -209,7 +209,7 @@ public class MigrateApiAction extends AbstractApiAction {
                                         }
                                     } catch (final IOException e1) {
                                         LOGGER.error("Unable to create bulk request " + e1, e1);
-                                        internalSeverError(channel, "Unable to create bulk request.");
+                                        internalServerError(channel, "Unable to create bulk request.");
                                         return;
                                     }
 
@@ -226,7 +226,7 @@ public class MigrateApiAction extends AbstractApiAction {
                                                             "Unable to upload migrated configuration because of "
                                                                 + response.buildFailureMessage()
                                                         );
-                                                        internalSeverError(
+                                                        internalServerError(
                                                             channel,
                                                             "Unable to upload migrated configuration (bulk index failed)."
                                                         );
@@ -240,7 +240,7 @@ public class MigrateApiAction extends AbstractApiAction {
                                                 @Override
                                                 public void onFailure(Exception e) {
                                                     LOGGER.error("Unable to upload migrated configuration because of " + e, e);
-                                                    internalSeverError(channel, "Unable to upload migrated configuration.");
+                                                    internalServerError(channel, "Unable to upload migrated configuration.");
                                                 }
                                             }
                                         )
@@ -251,7 +251,7 @@ public class MigrateApiAction extends AbstractApiAction {
                                 @Override
                                 public void onFailure(Exception e) {
                                     LOGGER.error("Unable to create opendistro_security index because of " + e, e);
-                                    internalSeverError(channel, "Unable to create opendistro_security index.");
+                                    internalServerError(channel, "Unable to create opendistro_security index.");
                                 }
                             });
 
@@ -263,7 +263,7 @@ public class MigrateApiAction extends AbstractApiAction {
                 @Override
                 public void onFailure(Exception e) {
                     LOGGER.error("Unable to delete opendistro_security index because of " + e, e);
-                    internalSeverError(channel, "Unable to delete opendistro_security index.");
+                    internalServerError(channel, "Unable to delete opendistro_security index.");
                 }
             });
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/Responses.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/Responses.java
@@ -50,7 +50,7 @@ public class Responses {
         response(channel, RestStatus.CONFLICT, message);
     }
 
-    public static void internalSeverError(final RestChannel channel, final String message) {
+    public static void internalServerError(final RestChannel channel, final String message) {
         response(channel, RestStatus.INTERNAL_SERVER_ERROR, message);
     }
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ValidateApiAction.java
@@ -40,7 +40,7 @@ import org.opensearch.security.securityconf.impl.v7.TenantV7;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.dlic.rest.api.Responses.badRequest;
-import static org.opensearch.security.dlic.rest.api.Responses.internalSeverError;
+import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
@@ -125,7 +125,7 @@ public class ValidateApiAction extends AbstractApiAction {
 
             ok(channel, "OK.");
         } catch (Exception e) {
-            internalSeverError(channel, "Configuration is not valid.");
+            internalServerError(channel, "Configuration is not valid.");
         }
     }
 


### PR DESCRIPTION
### Description
Fixed spelling for the `internalSeverError` method in the `org.opensearch.security.dlic.rest.api.Responses` class


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
