### PR TITLE
fix build errors caused by filterIndices method being moved from SnapshotUtils to IndexUtils

### DIFF
--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -82,6 +82,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.util.IndexUtils;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.reindex.ReindexRequest;
@@ -91,7 +92,6 @@ import org.opensearch.security.securityconf.DynamicConfigModel;
 import org.opensearch.security.support.SnapshotRestoreHelper;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.TransportRequest;
 
@@ -694,7 +694,7 @@ public class IndexResolverReplacer {
                 );
                 provider.provide(new String[] { "*" }, request, false);
             } else {
-                final List<String> requestedResolvedIndices = SnapshotUtils.filterIndices(
+                final List<String> requestedResolvedIndices = IndexUtils.filterIndices(
                     snapshotInfo.indices(),
                     restoreRequest.indices(),
                     restoreRequest.indicesOptions()

--- a/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
+++ b/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
@@ -37,12 +37,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.SpecialPermission;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.util.IndexUtils;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.threadpool.ThreadPool;
 
 public class SnapshotRestoreHelper {
@@ -56,7 +56,7 @@ public class SnapshotRestoreHelper {
             log.warn("snapshot repository '{}', snapshot '{}' not found", restoreRequest.repository(), restoreRequest.snapshot());
             return null;
         } else {
-            return SnapshotUtils.filterIndices(snapshotInfo.indices(), restoreRequest.indices(), restoreRequest.indicesOptions());
+            return IndexUtils.filterIndices(snapshotInfo.indices(), restoreRequest.indices(), restoreRequest.indicesOptions());
         }
 
     }


### PR DESCRIPTION
### Description
This PR fixes build errors caused by a recent change in Core where the _filderIndices()_ method got moved from SnapshotUtils to IndexUtils

### Issues Resolved
#4312

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
