### PR TITLE
[Backport 2.x] fix build errors caused by filterIndices method being moved from SnapshotUtils to IndexUtils (#4312)

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -3,7 +3,7 @@ name: Plugin Install
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  OPENSEARCH_VERSION: 2.14.0
+  OPENSEARCH_VERSION: 2.15.0
   PLUGIN_NAME: opensearch-security
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ import groovy.json.JsonBuilder
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.14.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.15.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,7 +44,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.14.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.15.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
         common_utils_version = System.getProperty("common_utils.version", '2.9.0.0-SNAPSHOT')
         jackson_version = System.getProperty("jackson_version", "2.15.2")
@@ -83,7 +83,7 @@ testingConventions.enabled = false
 validateNebulaPom.enabled = false
 
 String previousVersion = System.getProperty("bwc.version.previous", "2.10.0.0")
-String nextVersion = System.getProperty("bwc.version.next", "2.14.0.0")
+String nextVersion = System.getProperty("bwc.version.next", "2.15.0.0")
 
 String bwcVersion = previousVersion
 String baseName = "securityBwcCluster"

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -82,6 +82,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.util.IndexUtils;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.reindex.ReindexRequest;
@@ -91,7 +92,6 @@ import org.opensearch.security.securityconf.DynamicConfigModel;
 import org.opensearch.security.support.SnapshotRestoreHelper;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.TransportRequest;
 
@@ -694,7 +694,7 @@ public class IndexResolverReplacer {
                 );
                 provider.provide(new String[] { "*" }, request, false);
             } else {
-                final List<String> requestedResolvedIndices = SnapshotUtils.filterIndices(
+                final List<String> requestedResolvedIndices = IndexUtils.filterIndices(
                     snapshotInfo.indices(),
                     restoreRequest.indices(),
                     restoreRequest.indicesOptions()

--- a/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
+++ b/src/main/java/org/opensearch/security/support/SnapshotRestoreHelper.java
@@ -37,12 +37,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.SpecialPermission;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.common.util.IndexUtils;
 import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.repositories.Repository;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.snapshots.SnapshotId;
 import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotUtils;
 import org.opensearch.threadpool.ThreadPool;
 
 public class SnapshotRestoreHelper {
@@ -56,7 +56,7 @@ public class SnapshotRestoreHelper {
             log.warn("snapshot repository '{}', snapshot '{}' not found", restoreRequest.repository(), restoreRequest.snapshot());
             return null;
         } else {
-            return SnapshotUtils.filterIndices(snapshotInfo.indices(), restoreRequest.indices(), restoreRequest.indicesOptions());
+            return IndexUtils.filterIndices(snapshotInfo.indices(), restoreRequest.indices(), restoreRequest.indicesOptions());
         }
 
     }


### PR DESCRIPTION
Backport #4313 to 2.x

Also includes the version increment from https://github.com/opensearch-project/security/pull/4311