### PR TITLE
[Backport] [2.x] Bump com.google.errorprone:error_prone_annotations from 2.27.0 to 2.27.1 (#4323)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -598,11 +598,7 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.17.0'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.6'
-<<<<<<< HEAD
-    compileOnly 'com.google.errorprone:error_prone_annotations:2.26.1'
-=======
     compileOnly 'com.google.errorprone:error_prone_annotations:2.27.1'
->>>>>>> e3803d9c (Bump com.google.errorprone:error_prone_annotations from 2.27.0 to 2.27.1 (#4323))
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     runtimeOnly 'org.ow2.asm:asm:9.6'

--- a/build.gradle
+++ b/build.gradle
@@ -502,7 +502,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
             force 'org.checkerframework:checker-qual:3.40.0'
-            force "com.google.errorprone:error_prone_annotations:2.26.1"
+            force "com.google.errorprone:error_prone_annotations:2.27.1"
             force "org.checkerframework:checker-qual:3.42.0"
             force "ch.qos.logback:logback-classic:1.5.5"
         }
@@ -598,7 +598,11 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.17.0'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.6'
+<<<<<<< HEAD
     compileOnly 'com.google.errorprone:error_prone_annotations:2.26.1'
+=======
+    compileOnly 'com.google.errorprone:error_prone_annotations:2.27.1'
+>>>>>>> e3803d9c (Bump com.google.errorprone:error_prone_annotations from 2.27.0 to 2.27.1 (#4323))
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     runtimeOnly 'org.ow2.asm:asm:9.6'


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4323 to `2.x`