### PR TITLE
[Backport] [2.x] Bump org.scala-lang:scala-library from 2.13.13 to 2.13.14 (#4321)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -474,7 +474,7 @@ configurations {
         resolutionStrategy {
             force 'commons-codec:commons-codec:1.17.0'
             force 'org.slf4j:slf4j-api:1.7.36'
-            force 'org.scala-lang:scala-library:2.13.13'
+            force 'org.scala-lang:scala-library:2.13.14'
             force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
             force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
             force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
@@ -692,7 +692,7 @@ dependencies {
     testRuntimeOnly ("org.springframework:spring-core:${spring_version}") {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
-    testRuntimeOnly 'org.scala-lang:scala-library:2.13.13'
+    testRuntimeOnly 'org.scala-lang:scala-library:2.13.14'
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
     testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.2') {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4321 to `2.x`