### PR TITLE
Fix flaky tests

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -105,8 +105,6 @@ public class LocalOpenSearchCluster {
 
     private File snapshotDir;
 
-    private int nodeCounter = 0;
-
     public LocalOpenSearchCluster(
         String clusterName,
         ClusterManager clusterManager,
@@ -302,10 +300,9 @@ public class LocalOpenSearchCluster {
         Iterator<Integer> httpPortIterator = httpPorts.iterator();
         List<CompletableFuture<StartStage>> futures = new ArrayList<>();
 
-        for (NodeSettings nodeSettings : nodeSettingList) {
-            Node node = new Node(nodeCounter, nodeSettings, transportPortIterator.next(), httpPortIterator.next());
+        for (var i = 0; i < nodeSettingList.size(); i++) {
+            Node node = new Node(i, nodeSettingList.get(i), transportPortIterator.next(), httpPortIterator.next());
             futures.add(node.start());
-            nodeCounter += 1;
         }
         return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
@@ -518,7 +515,6 @@ public class LocalOpenSearchCluster {
                 .build();
 
             if (nodeSettingsSupplier != null) {
-                // TODO node number
                 return Settings.builder().put(settings).put(nodeSettingsSupplier.get(nodeNumber)).build();
             }
             return settings;


### PR DESCRIPTION
### Description

Fixed flaky integration tests, which were introduced in #4255. The node counter was defined as a global variable, as result it counted more nodes then an actual local cluster had.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
