### PR TITLE
[Backport 2.x] Bump Wandalen/wretry.action from 3.3.0 to 3.5.0 (#4335)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
         working-directory: downloaded-artifacts
 
       - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@v3.3.0
+        uses: Wandalen/wretry.action@v3.5.0
         with:
           attempt_limit: 5
           attempt_delay: 2000


### PR DESCRIPTION
### Description
Backport c1110b2223cd4ad378b07f24f8702a696225cee7 from #4335.

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
