### PR TITLE
Support multiple audience for jwt authentication

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -16,6 +16,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.ParseException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -61,7 +62,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final String jwtUrlParameter;
     private final String subjectKey;
     private final String rolesKey;
-    private final String requiredAudience;
+    private final List<String> requiredAudience;
     private final String requiredIssuer;
 
     public static final int DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS = 30;
@@ -74,7 +75,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
-        requiredAudience = settings.get("required_audience");
+        requiredAudience = settings.getAsList("required_audience");
         requiredIssuer = settings.get("required_issuer");
 
         if (!jwtHeaderName.equals(AUTHORIZATION)) {
@@ -255,7 +256,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         );
     }
 
-    public String getRequiredAudience() {
+    public List<String> getRequiredAudience() {
         return requiredAudience;
     }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -16,6 +16,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -37,6 +38,7 @@ import org.opensearch.security.filter.SecurityResponse;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.KeyUtils;
 
+import com.nimbusds.jwt.proc.BadJWTException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtParser;
 import io.jsonwebtoken.JwtParserBuilder;
@@ -58,7 +60,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final String jwtUrlParameter;
     private final String rolesKey;
     private final String subjectKey;
-    private final String requireAudience;
+    private final List<String> requiredAudience;
     private final String requireIssuer;
 
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
@@ -70,7 +72,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.get("roles_key");
         subjectKey = settings.get("subject_key");
-        requireAudience = settings.get("required_audience");
+        requiredAudience = settings.getAsList("required_audience");
         requireIssuer = settings.get("required_issuer");
 
         if (!jwtHeaderName.equals(AUTHORIZATION)) {
@@ -84,10 +86,6 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         if (jwtParserBuilder == null) {
             jwtParser = null;
         } else {
-            if (requireAudience != null) {
-                jwtParserBuilder.requireAudience(requireAudience);
-            }
-
             if (requireIssuer != null) {
                 jwtParserBuilder.requireIssuer(requireIssuer);
             }
@@ -161,6 +159,10 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         try {
             final Claims claims = jwtParser.parseClaimsJws(jwtToken).getBody();
 
+            if (!requiredAudience.isEmpty()) {
+                assertValidAudienceClaim(claims);
+            }
+
             final String subject = extractSubject(claims, request);
 
             if (subject == null) {
@@ -186,6 +188,16 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                 log.debug("Invalid or expired JWT token.", e);
             }
             return null;
+        }
+    }
+
+    private void assertValidAudienceClaim(Claims claims) throws BadJWTException {
+        if (requiredAudience.isEmpty()) {
+            return;
+        }
+
+        if (Collections.disjoint(claims.getAudience(), requiredAudience)) {
+            throw new BadJWTException("Claim of 'aud' doesn't contain any required audience.");
         }
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -483,6 +483,33 @@ public class HTTPJwtAuthenticatorTest {
     }
 
     @Test
+    public void testRequiredAudienceWithCorrectAtLeastOneAudience() {
+
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .put("required_audience", "test_audience,test_audience_2"),
+            Jwts.builder().setSubject("Leonard McCoy").setAudience("test_audience_2")
+        );
+
+        Assert.assertNotNull(credentials);
+        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+    }
+
+    @Test
+    public void testRequiredAudienceWithInCorrectAtLeastOneAudience() {
+
+        final AuthCredentials credentials = extractCredentialsFromJwtHeader(
+            Settings.builder()
+                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .put("required_audience", "test_audience,test_audience_2"),
+            Jwts.builder().setSubject("Leonard McCoy").setAudience("wrong_audience")
+        );
+
+        Assert.assertNull(credentials);
+    }
+
+    @Test
     public void testRequiredIssuerWithCorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(


### PR DESCRIPTION
### Description

Related: https://github.com/opensearch-project/security/issues/3723

Currently OpenSearch doesn't support multiple audience for JWT authentication.
I want to pass the audience claims if `aud` value in JWT is at least one of the required audiences.

For example, If I set my OpenSearch security configuration for JWT like below.
I want to pass verification if there is either `project1` or `admin` audience in the JWT token.

This may be useful for some cases, like if someone need to access opensearch for all projects(project1, project2, ....) via `admin` aud.

```yaml
required_audience: project1,admin
```

Please confirm this concept positively.
Thanks in advance.

### Testing

I added unit tests.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
