### PR TITLE
Made sensitive header log statement more clear

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -502,7 +502,7 @@ public class AuditConfig {
             logger.info("Auditing of request body is {}.", logRequestBody ? "enabled" : "disabled");
             logger.info("Bulk requests resolution is {} during request auditing.", resolveBulkRequests ? "enabled" : "disabled");
             logger.info("Index resolution is {} during request auditing.", resolveIndices ? "enabled" : "disabled");
-            logger.info("Sensitive headers auditing is {}.", excludeSensitiveHeaders ? "enabled" : "disabled");
+            logger.info("Sensitive headers exclusion from auditing is {}.", excludeSensitiveHeaders ? "enabled" : "disabled");
             logger.info("Auditing requests from {} users is disabled.", ignoredAuditUsersMatcher);
             logger.info("Auditing request headers {} is disabled.", ignoredCustomHeadersMatcher);
             logger.info("Auditing request url params {} is disabled.", ignoredUrlParamsMatcher);


### PR DESCRIPTION
### Description
This is a bugfix of a logging statement that has caused a lot of confusion for our customers.

### Issues Resolved

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
