### PR TITLE
Remove static metaFields list and get version-specific values from core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -732,6 +732,7 @@ dependencies {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
     integrationTestImplementation 'com.unboundid:unboundid-ldapsdk:4.0.14'
+    integrationTestImplementation "org.opensearch.plugin:mapper-size:${opensearch_version}"
     integrationTestImplementation "org.apache.httpcomponents:httpclient-cache:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:httpclient:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.14"

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchHitDoesContainFieldMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchHitDoesContainFieldMatcher.java
@@ -1,0 +1,62 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+
+import static java.util.Objects.requireNonNull;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.readTotalHits;
+
+class SearchHitDoesContainFieldMatcher extends TypeSafeDiagnosingMatcher<SearchResponse> {
+
+    private final int hitIndex;
+
+    private final String fieldName;
+
+    public SearchHitDoesContainFieldMatcher(int hitIndex, String fieldName) {
+        this.hitIndex = hitIndex;
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse searchResponse, Description mismatchDescription) {
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Total number of hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        SearchHit searchHit = searchResponse.getHits().getAt(hitIndex);
+        Map<String, Object> source = searchHit.getSourceAsMap();
+        if (source == null) {
+            mismatchDescription.appendText("Source document is null, is fetch source option set to true?");
+            return false;
+        }
+        if (!source.containsKey(fieldName)) {
+            mismatchDescription.appendText(" document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("search hit with index ").appendValue(hitIndex).appendText(" does contain field ").appendValue(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/SearchResponseMatchers.java
@@ -44,6 +44,10 @@ public class SearchResponseMatchers {
         return new SearchHitDoesNotContainFieldMatcher(hitIndex, fieldName);
     }
 
+    public static Matcher<SearchResponse> searchHitDoesContainField(int hitIndex, String fieldName) {
+        return new SearchHitDoesContainFieldMatcher(hitIndex, fieldName);
+    }
+
     public static Matcher<SearchResponse> searchHitsContainDocumentWithId(int hitIndex, String indexName, String documentId) {
         return new SearchHitsContainDocumentWithIdMatcher(hitIndex, indexName, documentId);
     }

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -27,6 +27,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
 import org.opensearch.index.mapper.MapperService;
+import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.ShardUtils;
 import org.opensearch.security.auditlog.AuditLog;
@@ -59,6 +60,8 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         super(indexService, settings, adminDNs, evaluator);
         Set<String> metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
         metadataFieldsCopy.addAll(MapperService.META_FIELDS_BEFORE_7DOT8);
+        SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
+        metadataFieldsCopy.add(sequenceIDFields.primaryTerm.name());
         metaFields = metadataFieldsCopy;
         ciol.setIs(indexService);
         this.clusterService = clusterService;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -26,6 +26,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.ShardUtils;
 import org.opensearch.security.auditlog.AuditLog;
@@ -56,7 +57,9 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         final Salt salt
     ) {
         super(indexService, settings, adminDNs, evaluator);
-        metaFields = indexService.mapperService().getMetadataFields();
+        Set<String> metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
+        metadataFieldsCopy.addAll(MapperService.META_FIELDS_BEFORE_7DOT8);
+        metaFields = metadataFieldsCopy;
         ciol.setIs(indexService);
         this.clusterService = clusterService;
         this.indexService = indexService;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -26,7 +26,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.mapper.SeqNoFieldMapper;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.ShardUtils;
@@ -59,7 +58,6 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
     ) {
         super(indexService, settings, adminDNs, evaluator);
         Set<String> metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
-        metadataFieldsCopy.addAll(MapperService.META_FIELDS_BEFORE_7DOT8);
         SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
         metadataFieldsCopy.add(sequenceIDFields.primaryTerm.name());
         metaFields = metadataFieldsCopy;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -26,7 +26,6 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.mapper.IgnoredFieldMapper;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.ShardUtils;
 import org.opensearch.security.auditlog.AuditLog;
@@ -38,25 +37,7 @@ import org.opensearch.security.support.SecurityUtils;
 
 public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWrapper {
 
-    // TODO: the list is outdated. It is necessary to change how meta fields are handled in the near future.
-    // We may consider using MapperService.isMetadataField() instead of relying on the static set or
-    // (if it is too costly or does not meet requirements) use IndicesModule.getBuiltInMetadataFields()
-    // for OpenSearch version specific Set of meta fields
-    private static final Set<String> metaFields = Sets.newHashSet(
-        "_source",
-        "_version",
-        "_field_names",
-        "_seq_no",
-        "_primary_term",
-        "_id",
-        IgnoredFieldMapper.NAME,
-        "_index",
-        "_routing",
-        "_size",
-        "_timestamp",
-        "_ttl",
-        "_type"
-    );
+    private final Set<String> metaFields;
     private final ClusterService clusterService;
     private final IndexService indexService;
     private final AuditLog auditlog;
@@ -75,6 +56,7 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         final Salt salt
     ) {
         super(indexService, settings, adminDNs, evaluator);
+        metaFields = indexService.mapperService().getMetadataFields();
         ciol.setIs(indexService);
         this.clusterService = clusterService;
         this.indexService = indexService;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -12,6 +12,8 @@
 package org.opensearch.security.configuration;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -39,6 +41,9 @@ import org.opensearch.security.support.SecurityUtils;
 public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWrapper {
 
     private final Set<String> metaFields;
+    public static final Set<String> META_FIELDS_BEFORE_7DOT8 = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList("_size", "_timestamp", "_ttl", "_type"))
+    );
     private final ClusterService clusterService;
     private final IndexService indexService;
     private final AuditLog auditlog;
@@ -60,6 +65,7 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         Set<String> metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
         SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
         metadataFieldsCopy.add(sequenceIDFields.primaryTerm.name());
+        metadataFieldsCopy.addAll(META_FIELDS_BEFORE_7DOT8);
         metaFields = metadataFieldsCopy;
         ciol.setIs(indexService);
         this.clusterService = clusterService;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -42,7 +42,7 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
 
     private final Set<String> metaFields;
     public static final Set<String> META_FIELDS_BEFORE_7DOT8 = Collections.unmodifiableSet(
-        new HashSet<>(Arrays.asList("_size", "_timestamp", "_ttl", "_type"))
+        new HashSet<>(Arrays.asList("_timestamp", "_ttl", "_type"))
     );
     private final ClusterService clusterService;
     private final IndexService indexService;


### PR DESCRIPTION
### Description

Remove static metaFields list and get version-specific values from core.

The new list obtained from core is: `[_ignored, _routing, _seq_no, _doc_count, _index, _nested_path, _data_stream_timestamp, _field_names, _source, _id, _version, _primary_term]`

This doesn't match the hardcoded list because it removes many of the deprecated fields from [META_FIELDS_BEFORE_7DOT8](https://github.com/opensearch-project/OpenSearch/blob/8883e62a8f3d862739250cff1eb8d3d18680cfa2/server/src/main/java/org/opensearch/index/mapper/MapperService.java#L204-L208) 

When using FLS Includes rules, this list is used as the starting point for all metaFields to include by default.

* Category

Bug fix

### Issues Resolved

- https://github.com/opensearch-project/security/issues/4349

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
