### PR TITLE
Add support for ipv6 ip address in user injection

### DIFF
--- a/src/main/java/org/opensearch/security/auth/UserInjector.java
+++ b/src/main/java/org/opensearch/security/auth/UserInjector.java
@@ -93,14 +93,16 @@ public class UserInjector {
         }
 
         public void setTransportAddress(String addr) throws UnknownHostException, IllegalArgumentException {
-            // format is ip:port
-            String[] ipAndPort = addr.split(":");
-            if (ipAndPort.length != 2) {
+            int lastColonIndex = addr.lastIndexOf(':');
+            if (lastColonIndex == -1) {
                 throw new IllegalArgumentException("Remote address must have format ip:port");
             }
 
-            InetAddress iAdress = InetAddress.getByName(ipAndPort[0]);
-            int port = Integer.parseInt(ipAndPort[1]);
+            String ip = addr.substring(0, lastColonIndex);
+            String portString = addr.substring(lastColonIndex + 1);
+
+            InetAddress iAdress = InetAddress.getByName(ip);
+            int port = Integer.parseInt(portString);
 
             this.transportAddress = new TransportAddress(iAdress, port);
         }

--- a/src/main/java/org/opensearch/security/auth/UserInjector.java
+++ b/src/main/java/org/opensearch/security/auth/UserInjector.java
@@ -67,7 +67,7 @@ public class UserInjector {
     }
 
     public static class InjectedUser extends User {
-        transient TransportAddress transportAddress;
+        private transient TransportAddress transportAddress;
 
         public InjectedUser(String name) {
             super(name);

--- a/src/main/java/org/opensearch/security/auth/UserInjector.java
+++ b/src/main/java/org/opensearch/security/auth/UserInjector.java
@@ -67,7 +67,7 @@ public class UserInjector {
     }
 
     public static class InjectedUser extends User {
-        private transient TransportAddress transportAddress;
+        transient TransportAddress transportAddress;
 
         public InjectedUser(String name) {
             super(name);

--- a/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
@@ -65,6 +65,35 @@ public class UserInjectorTest {
     }
 
     @Test
+    public void testValidInjectUserIpV6() {
+        HashSet<String> roles = new HashSet<>();
+        roles.addAll(Arrays.asList("role1", "role2"));
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8:3333:4444:5555:6666:7777:8888:9200");
+        User injectedUser = userInjector.getInjectedUser();
+        assertEquals(injectedUser.getName(), "user");
+        assertEquals(injectedUser.getRoles(), roles);
+    }
+
+    @Test
+    public void testInvalidInjectUserIpV6() {
+        HashSet<String> roles = new HashSet<>();
+        roles.addAll(Arrays.asList("role1", "role2"));
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8:3333:5555:6666:7777:8888:9200");
+        User injectedUser = userInjector.getInjectedUser();
+        assertNull(injectedUser);
+    }
+
+    @Test
+    public void testValidInjectUserBracketsIpV6() {
+        HashSet<String> roles = new HashSet<>();
+        roles.addAll(Arrays.asList("role1", "role2"));
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|[2001:db8:3333:4444:5555:6666:7777:8888]:9200");
+        User injectedUser = userInjector.getInjectedUser();
+        assertEquals(injectedUser.getName(), "user");
+        assertEquals(injectedUser.getRoles(), roles);
+    }
+
+    @Test
     public void testInvalidInjectUser() {
         HashSet<String> roles = new HashSet<>();
         roles.addAll(Arrays.asList("role1", "role2"));

--- a/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
@@ -79,6 +79,17 @@ public class UserInjectorTest {
     }
 
     @Test
+    public void testValidInjectUserIpV6ShortFormat() {
+        HashSet<String> roles = new HashSet<>();
+        roles.addAll(Arrays.asList("role1", "role2"));
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8::1:9200");
+        UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
+        assertEquals("user", injectedUser.getName());
+        assertEquals(9200, injectedUser.getTransportAddress().getPort());
+        assertEquals("2001:db8::1", injectedUser.getTransportAddress().getAddress());
+    }
+
+    @Test
     public void testInvalidInjectUserIpV6() {
         HashSet<String> roles = new HashSet<>();
         roles.addAll(Arrays.asList("role1", "role2"));

--- a/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
@@ -68,7 +68,10 @@ public class UserInjectorTest {
     public void testValidInjectUserIpV6() {
         HashSet<String> roles = new HashSet<>();
         roles.addAll(Arrays.asList("role1", "role2"));
-        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8:3333:4444:5555:6666:7777:8888:9200");
+        threadContext.putTransient(
+            ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER,
+            "user|role1,role2|2001:db8:3333:4444:5555:6666:7777:8888:9200"
+        );
         User injectedUser = userInjector.getInjectedUser();
         assertEquals(injectedUser.getName(), "user");
         assertEquals(injectedUser.getRoles(), roles);
@@ -78,7 +81,10 @@ public class UserInjectorTest {
     public void testInvalidInjectUserIpV6() {
         HashSet<String> roles = new HashSet<>();
         roles.addAll(Arrays.asList("role1", "role2"));
-        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8:3333:5555:6666:7777:8888:9200");
+        threadContext.putTransient(
+            ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER,
+            "user|role1,role2|2001:db8:3333:5555:6666:7777:8888:9200"
+        );
         User injectedUser = userInjector.getInjectedUser();
         assertNull(injectedUser);
     }
@@ -87,7 +93,10 @@ public class UserInjectorTest {
     public void testValidInjectUserBracketsIpV6() {
         HashSet<String> roles = new HashSet<>();
         roles.addAll(Arrays.asList("role1", "role2"));
-        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|[2001:db8:3333:4444:5555:6666:7777:8888]:9200");
+        threadContext.putTransient(
+            ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER,
+            "user|role1,role2|[2001:db8:3333:4444:5555:6666:7777:8888]:9200"
+        );
         User injectedUser = userInjector.getInjectedUser();
         assertEquals(injectedUser.getName(), "user");
         assertEquals(injectedUser.getRoles(), roles);

--- a/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
@@ -72,9 +72,10 @@ public class UserInjectorTest {
             ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER,
             "user|role1,role2|2001:db8:3333:4444:5555:6666:7777:8888:9200"
         );
-        User injectedUser = userInjector.getInjectedUser();
-        assertEquals(injectedUser.getName(), "user");
-        assertEquals(injectedUser.getRoles(), roles);
+        UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
+        assertEquals("user", injectedUser.getName());
+        assertEquals(9200, injectedUser.getTransportAddress().getPort());
+        assertEquals("2001:db8:3333:4444:5555:6666:7777:8888", injectedUser.getTransportAddress().getAddress());
     }
 
     @Test
@@ -97,9 +98,11 @@ public class UserInjectorTest {
             ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER,
             "user|role1,role2|[2001:db8:3333:4444:5555:6666:7777:8888]:9200"
         );
-        User injectedUser = userInjector.getInjectedUser();
-        assertEquals(injectedUser.getName(), "user");
-        assertEquals(injectedUser.getRoles(), roles);
+        UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
+        assertEquals("user", injectedUser.getName());
+        assertEquals(roles, injectedUser.getRoles());
+        assertEquals(9200, injectedUser.getTransportAddress().getPort());
+        assertEquals("2001:db8:3333:4444:5555:6666:7777:8888", injectedUser.getTransportAddress().getAddress());
     }
 
     @Test


### PR DESCRIPTION
### Description
Enhances the parsing logic of user injection to support ipv6 addresses.
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug fix
* Why these changes are required?
Issue: https://github.com/opensearch-project/security/issues/4177

* What is the old behavior before changes and new behavior after changes?
Ipv6 IP addresses would throw a parsing error, now it doesn't

### Issues Resolved
Fix: https://github.com/opensearch-project/security/issues/4177

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Added unit test

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
