### PR TITLE
Adds validation for the action groups type key

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -13,6 +13,7 @@ package org.opensearch.security.dlic.rest.api;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,9 +23,11 @@ import com.google.common.collect.ImmutableSet;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
@@ -40,6 +43,14 @@ import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class ActionGroupsApiAction extends AbstractApiAction {
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(OpenSearchSecurityPlugin.class);
+
+    static final String CLUSTER_TYPE = "cluster";
+
+    static final String INDEX_TYPE = "index";
+
+    static final Set<String> ALLOWED_TYPES = Set.of(CLUSTER_TYPE, INDEX_TYPE);
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
@@ -88,6 +99,7 @@ public class ActionGroupsApiAction extends AbstractApiAction {
     @Override
     protected EndpointValidator createEndpointValidator() {
         return new EndpointValidator() {
+
             @Override
             public Endpoint endpoint() {
                 return endpoint;
@@ -100,7 +112,8 @@ public class ActionGroupsApiAction extends AbstractApiAction {
 
             @Override
             public ValidationResult<SecurityConfiguration> onConfigChange(SecurityConfiguration securityConfiguration) throws IOException {
-                return EndpointValidator.super.onConfigChange(securityConfiguration).map(this::actionGroupNameIsNotSameAsRoleName)
+                return EndpointValidator.super.onConfigChange(securityConfiguration).map(this::validateType)
+                    .map(this::actionGroupNameIsNotSameAsRoleName)
                     .map(this::hasSelfReference);
             }
 
@@ -132,6 +145,27 @@ public class ActionGroupsApiAction extends AbstractApiAction {
                             securityConfiguration.entityName()
                                 + " is an existing role. A action group cannot be named with an existing role name."
                         )
+                    );
+                }
+                return ValidationResult.success(securityConfiguration);
+            }
+
+            private ValidationResult<SecurityConfiguration> validateType(final SecurityConfiguration securityConfiguration) {
+                final var requestContent = securityConfiguration.requestContent();
+                if (requestContent.has("type") && !ALLOWED_TYPES.contains(requestContent.get("type").asText().toLowerCase(Locale.ROOT))) {
+                    final var supportedTypesMessage = String.format("Supported types are: %s, %s.", CLUSTER_TYPE, INDEX_TYPE);
+                    return ValidationResult.error(
+                        RestStatus.BAD_REQUEST,
+                        badRequestMessage(
+                            "Invalid action group type: " + requestContent.get("type").asText() + ". " + supportedTypesMessage
+                        )
+
+                    );
+                }
+                if (!requestContent.has("type")) {
+                    deprecationLogger.deprecate(
+                        "type",
+                        "Possibility to creation or update of action groups without type is deprecated and will be removed in next major release."
                     );
                 }
                 return ValidationResult.success(securityConfiguration);


### PR DESCRIPTION
### Description
Added validation for the action groups `type` key.


### Issues Resolved
#4374 

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
