### PR TITLE
Extracted the user attr handling methods from ConfigModelV7 into its own class

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/UserAttributes.java
+++ b/src/main/java/org/opensearch/security/privileges/UserAttributes.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.privileges;
+
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+
+import org.opensearch.security.user.User;
+
+/**
+ * Support for interpolating user attributes used in index patterns and DLS queries.
+ *
+ * This code was moved over from ConfigModelV7.
+ */
+public class UserAttributes {
+    public static String replaceProperties(String orig, User user) {
+
+        if (user == null || orig == null) {
+            return orig;
+        }
+
+        orig = orig.replace("${user.name}", user.getName()).replace("${user_name}", user.getName());
+        orig = replaceRoles(orig, user);
+        orig = replaceSecurityRoles(orig, user);
+        for (Map.Entry<String, String> entry : user.getCustomAttributesMap().entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            orig = orig.replace("${" + entry.getKey() + "}", entry.getValue());
+            orig = orig.replace("${" + entry.getKey().replace('.', '_') + "}", entry.getValue());
+        }
+        return orig;
+    }
+
+    private static String replaceRoles(final String orig, final User user) {
+        String retVal = orig;
+        if (orig.contains("${user.roles}") || orig.contains("${user_roles}")) {
+            final String commaSeparatedRoles = toQuotedCommaSeparatedString(user.getRoles());
+            retVal = orig.replace("${user.roles}", commaSeparatedRoles).replace("${user_roles}", commaSeparatedRoles);
+        }
+        return retVal;
+    }
+
+    private static String replaceSecurityRoles(final String orig, final User user) {
+        String retVal = orig;
+        if (orig.contains("${user.securityRoles}") || orig.contains("${user_securityRoles}")) {
+            final String commaSeparatedRoles = toQuotedCommaSeparatedString(user.getSecurityRoles());
+            retVal = orig.replace("${user.securityRoles}", commaSeparatedRoles).replace("${user_securityRoles}", commaSeparatedRoles);
+        }
+        return retVal;
+    }
+
+    private static String toQuotedCommaSeparatedString(final Set<String> roles) {
+        return Joiner.on(',').join(Iterables.transform(roles, s -> {
+            return new StringBuilder(s.length() + 2).append('"').append(s).append('"').toString();
+        }));
+    }
+}


### PR DESCRIPTION
### Description

This code change is just in preparation for the change in #4380 as requested in https://github.com/opensearch-project/security/pull/4380#discussion_r1621324272 .

The code for user attribute handling is moved from the class ConfigModelV7 into its own class, as other new code will need to use it. Additionally, it enhances the structuring of the code by moving code with a specific purpose into its own class.

Personal note: A thorough re-design of this code might be worthwhile.

* Category: Refactoring
* Why these changes are required? New code introduced in #4380 needs to use this code.
* What is the old behavior before changes and new behavior after changes? No behavioral changes.

### Issues Resolved

- https://github.com/opensearch-project/security/pull/4380#discussion_r1621324272

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing - no new functionality
- [ ] New functionality has been documented - no new functionality
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
