### PR TITLE
[Backport 2.x] Replace BouncyCastle's OpenBSDBCrypt use with password4j for password hashing and verification 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -573,7 +573,7 @@ dependencies {
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
     implementation 'com.rfksystems:blake2b:2.0.0'
-
+    implementation 'com.password4j:password4j:1.8.2'
     //JWT
     implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
     implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"

--- a/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
@@ -35,6 +35,8 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.security.ConfigurationFiles;
 import org.opensearch.security.dlic.rest.api.Endpoint;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.certificate.CertificateData;
@@ -82,6 +84,8 @@ public abstract class AbstractApiIntegrationTest extends RandomizedTest {
     protected static TestSecurityConfig testSecurityConfig = new TestSecurityConfig();
 
     public static LocalCluster localCluster;
+
+    public static PasswordHasher passwordHasher = new BCryptPasswordHasher();
 
     @BeforeClass
     public static void startCluster() throws IOException {

--- a/src/integrationTest/java/org/opensearch/security/api/AccountRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AccountRestApiIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
-import static org.opensearch.security.dlic.rest.support.Utils.hash;
 
 public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
@@ -110,7 +109,10 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
             TEST_USER,
             TEST_USER_PASSWORD,
             client -> ok(
-                () -> client.putJson(accountPath(), changePasswordWithHashPayload(TEST_USER_PASSWORD, hash(newPassword.toCharArray())))
+                () -> client.putJson(
+                    accountPath(),
+                    changePasswordWithHashPayload(TEST_USER_PASSWORD, passwordHasher.hash(newPassword.toCharArray()))
+                )
             )
         );
         withUser(

--- a/src/main/java/org/opensearch/security/auth/internal/InternalAuthenticationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/internal/InternalAuthenticationBackend.java
@@ -35,11 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
-
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.security.auth.AuthenticationBackend;
 import org.opensearch.security.auth.AuthorizationBackend;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.InternalUsersModel;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.user.User;
@@ -48,7 +47,12 @@ import org.greenrobot.eventbus.Subscribe;
 
 public class InternalAuthenticationBackend implements AuthenticationBackend, AuthorizationBackend {
 
+    private final PasswordHasher passwordHasher;
     private InternalUsersModel internalUsersModel;
+
+    public InternalAuthenticationBackend(PasswordHasher passwordHasher) {
+        this.passwordHasher = passwordHasher;
+    }
 
     @Override
     public boolean exists(User user) {
@@ -91,7 +95,7 @@ public class InternalAuthenticationBackend implements AuthenticationBackend, Aut
      * @return Whether the hash matches the provided password
      */
     public boolean passwordMatchesHash(String hash, char[] array) {
-        return OpenBSDBCrypt.checkPassword(hash, array);
+        return passwordHasher.check(array, hash);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -31,6 +31,7 @@ import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.Hashed;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
@@ -47,9 +48,10 @@ import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.api.Responses.payload;
 import static org.opensearch.security.dlic.rest.api.Responses.response;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
-import static org.opensearch.security.dlic.rest.support.Utils.hash;
 
 public class InternalUsersApiAction extends AbstractApiAction {
+
+    private final PasswordHasher passwordHasher;
 
     @Override
     protected void consumeParameters(final RestRequest request) {
@@ -87,11 +89,13 @@ public class InternalUsersApiAction extends AbstractApiAction {
         final ClusterService clusterService,
         final ThreadPool threadPool,
         final UserService userService,
-        final SecurityApiDependencies securityApiDependencies
+        final SecurityApiDependencies securityApiDependencies,
+        final PasswordHasher passwordHasher
     ) {
         super(Endpoint.INTERNALUSERS, clusterService, threadPool, securityApiDependencies);
         this.userService = userService;
         this.requestHandlersBuilder.configureRequestHandlers(this::internalUsersApiRequestHandlers);
+        this.passwordHasher = passwordHasher;
     }
 
     @Override
@@ -268,7 +272,7 @@ public class InternalUsersApiAction extends AbstractApiAction {
                 if (content.has("password")) {
                     final var plainTextPassword = content.get("password").asText();
                     content.remove("password");
-                    content.put("hash", hash(plainTextPassword.toCharArray()));
+                    content.put("hash", passwordHasher.hash(plainTextPassword.toCharArray()));
                 }
                 return ValidationResult.success(securityConfiguration);
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityRestApiActions.java
@@ -23,6 +23,7 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.ssl.SecurityKeyStore;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
@@ -47,7 +48,8 @@ public class SecurityRestApiActions {
         final AuditLog auditLog,
         final UserService userService,
         final SecurityKeyStore securityKeyStore,
-        final boolean certificatesReloadEnabled
+        final boolean certificatesReloadEnabled,
+        final PasswordHasher passwordHasher
     ) {
         final var securityApiDependencies = new SecurityApiDependencies(
             adminDns,
@@ -64,7 +66,7 @@ public class SecurityRestApiActions {
             settings
         );
         return List.of(
-            new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies),
+            new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies, passwordHasher),
             new RolesMappingApiAction(clusterService, threadPool, securityApiDependencies),
             new RolesApiAction(clusterService, threadPool, securityApiDependencies),
             new ActionGroupsApiAction(clusterService, threadPool, securityApiDependencies),
@@ -88,7 +90,7 @@ public class SecurityRestApiActions {
             new TenantsApiAction(clusterService, threadPool, securityApiDependencies),
             new MigrateApiAction(clusterService, threadPool, securityApiDependencies),
             new ValidateApiAction(clusterService, threadPool, securityApiDependencies),
-            new AccountApiAction(clusterService, threadPool, securityApiDependencies),
+            new AccountApiAction(clusterService, threadPool, securityApiDependencies, passwordHasher),
             new NodesDnApiAction(clusterService, threadPool, securityApiDependencies),
             new WhitelistApiAction(clusterService, threadPool, securityApiDependencies),
             // FIXME change it as soon as WhitelistApiAction will be removed

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -16,12 +16,10 @@ import java.io.UncheckedIOException;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
@@ -31,7 +29,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.tuple.Pair;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchParseException;
@@ -193,21 +190,6 @@ public class Utils {
                 throw new RuntimeException(e.getCause());
             }
         }
-    }
-
-    /**
-     * This generates hash for a given password
-     * @param clearTextPassword plain text password for which hash should be generated.
-     *                          This will be cleared from memory.
-     * @return hash of the password
-     */
-    public static String hash(final char[] clearTextPassword) {
-        final byte[] salt = new byte[16];
-        new SecureRandom().nextBytes(salt);
-        final String hash = OpenBSDBCrypt.generate((Objects.requireNonNull(clearTextPassword)), salt, 12);
-        Arrays.fill(salt, (byte) 0);
-        Arrays.fill(clearTextPassword, '\0');
-        return hash;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/hasher/BCryptPasswordHasher.java
+++ b/src/main/java/org/opensearch/security/hasher/BCryptPasswordHasher.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.hasher;
+
+import java.nio.CharBuffer;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Arrays;
+
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.SpecialPermission;
+
+import com.password4j.BcryptFunction;
+import com.password4j.HashingFunction;
+import com.password4j.Password;
+import com.password4j.types.Bcrypt;
+
+import static org.opensearch.core.common.Strings.isNullOrEmpty;
+
+public class BCryptPasswordHasher implements PasswordHasher {
+
+    private static final HashingFunction DEFAULT_BCRYPT_FUNCTION = BcryptFunction.getInstance(Bcrypt.Y, 12);
+
+    @Override
+    public String hash(char[] password) {
+        if (password == null || password.length == 0) {
+            throw new OpenSearchSecurityException("Password cannot be empty or null");
+        }
+        CharBuffer passwordBuffer = CharBuffer.wrap(password);
+        try {
+            SecurityManager securityManager = System.getSecurityManager();
+            if (securityManager != null) {
+                securityManager.checkPermission(new SpecialPermission());
+            }
+            return AccessController.doPrivileged(
+                (PrivilegedAction<String>) () -> Password.hash(passwordBuffer).with(DEFAULT_BCRYPT_FUNCTION).getResult()
+            );
+        } finally {
+            cleanup(passwordBuffer);
+        }
+    }
+
+    @Override
+    public boolean check(char[] password, String hash) {
+        if (password == null || password.length == 0) {
+            throw new OpenSearchSecurityException("Password cannot be empty or null");
+        }
+        if (isNullOrEmpty(hash)) {
+            throw new OpenSearchSecurityException("Hash cannot be empty or null");
+        }
+        CharBuffer passwordBuffer = CharBuffer.wrap(password);
+        try {
+            SecurityManager securityManager = System.getSecurityManager();
+            if (securityManager != null) {
+                securityManager.checkPermission(new SpecialPermission());
+            }
+            return AccessController.doPrivileged(
+                (PrivilegedAction<Boolean>) () -> Password.check(passwordBuffer, hash).with(getBCryptFunctionFromHash(hash))
+            );
+        } finally {
+            cleanup(passwordBuffer);
+        }
+    }
+
+    private void cleanup(CharBuffer password) {
+        password.clear();
+        char[] passwordOverwrite = new char[password.capacity()];
+        Arrays.fill(passwordOverwrite, '\0');
+        password.put(passwordOverwrite);
+    }
+
+    private HashingFunction getBCryptFunctionFromHash(String hash) {
+        return BcryptFunction.getInstanceFromHash(hash);
+    }
+}

--- a/src/main/java/org/opensearch/security/hasher/PasswordHasher.java
+++ b/src/main/java/org/opensearch/security/hasher/PasswordHasher.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.hasher;
+
+public interface PasswordHasher {
+
+    String hash(char[] password);
+
+    boolean check(char[] password, String hashedPassword);
+}

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -50,6 +50,7 @@ import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.configuration.ConfigurationChangeListener;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.configuration.StaticResourceException;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.impl.AllowlistingSettings;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.NodesDn;
@@ -127,7 +128,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     private final EventBus eventBus = EVENT_BUS_BUILDER.build();
     private final Settings opensearchSettings;
     private final Path configPath;
-    private final InternalAuthenticationBackend iab = new InternalAuthenticationBackend();
+    private final InternalAuthenticationBackend iab;
     private final ClusterInfoHolder cih;
 
     SecurityDynamicConfiguration<?> config;
@@ -138,13 +139,15 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         final Path configPath,
         Client client,
         ThreadPool threadPool,
-        ClusterInfoHolder cih
+        ClusterInfoHolder cih,
+        PasswordHasher passwordHasher
     ) {
         super();
         this.cr = cr;
         this.opensearchSettings = opensearchSettings;
         this.configPath = configPath;
         this.cih = cih;
+        this.iab = new InternalAuthenticationBackend(passwordHasher);
 
         if (opensearchSettings.getAsBoolean(ConfigConstants.SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES, true)) {
             try {

--- a/src/main/java/org/opensearch/security/tools/Hasher.java
+++ b/src/main/java/org/opensearch/security/tools/Hasher.java
@@ -27,9 +27,6 @@
 package org.opensearch.security.tools;
 
 import java.io.Console;
-import java.security.SecureRandom;
-import java.util.Arrays;
-import java.util.Objects;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
@@ -37,7 +34,9 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+
+import org.opensearch.security.hasher.BCryptPasswordHasher;
+import org.opensearch.security.hasher.PasswordHasher;
 
 public class Hasher {
 
@@ -82,11 +81,7 @@ public class Hasher {
     }
 
     public static String hash(final char[] clearTextPassword) {
-        final byte[] salt = new byte[16];
-        new SecureRandom().nextBytes(salt);
-        final String hash = OpenBSDBCrypt.generate((Objects.requireNonNull(clearTextPassword)), salt, 12);
-        Arrays.fill(salt, (byte) 0);
-        Arrays.fill(clearTextPassword, '\0');
-        return hash;
+        PasswordHasher passwordHasher = new BCryptPasswordHasher();
+        return passwordHasher.hash(clearTextPassword);
     }
 }

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -24,14 +24,14 @@ import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.support.ConfigConstants;
-import org.opensearch.security.tools.Hasher;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
@@ -83,10 +83,12 @@ public class SecuritySettingsConfigurer {
     static String ADMIN_USERNAME = "admin";
 
     private final Installer installer;
+    private final PasswordHasher passwordHasher;
     static final String DEFAULT_ADMIN_PASSWORD = "admin";
 
     public SecuritySettingsConfigurer(Installer installer) {
         this.installer = installer;
+        this.passwordHasher = new BCryptPasswordHasher();
     }
 
     /**
@@ -199,8 +201,9 @@ public class SecuritySettingsConfigurer {
      */
     private boolean isAdminPasswordSetToAdmin(String internalUsersFile) throws IOException {
         JsonNode internalUsers = YAML_MAPPER.readTree(new FileInputStream(internalUsersFile));
+        PasswordHasher passwordHasher = new BCryptPasswordHasher();
         return internalUsers.has("admin")
-            && OpenBSDBCrypt.checkPassword(internalUsers.get("admin").get("hash").asText(), DEFAULT_ADMIN_PASSWORD.toCharArray());
+            && passwordHasher.check(DEFAULT_ADMIN_PASSWORD.toCharArray(), internalUsers.get("admin").get("hash").asText());
     }
 
     /**
@@ -210,7 +213,7 @@ public class SecuritySettingsConfigurer {
      * @throws IOException while reading, writing to files
      */
     void writePasswordToInternalUsersFile(String adminPassword, String internalUsersFile) throws IOException {
-        String hashedAdminPassword = Hasher.hash(adminPassword.toCharArray());
+        String hashedAdminPassword = passwordHasher.hash(adminPassword.toCharArray());
 
         if (hashedAdminPassword.isEmpty()) {
             System.out.println("Failure while hashing the admin password, see console for details.");

--- a/src/test/java/org/opensearch/security/UserServiceUnitTests.java
+++ b/src/test/java/org/opensearch/security/UserServiceUnitTests.java
@@ -26,6 +26,8 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.user.UserFilterType;
@@ -52,7 +54,8 @@ public class UserServiceUnitTests {
     public void setup() throws Exception {
         String usersYmlFile = "./internal_users.yml";
         Settings.Builder builder = Settings.builder();
-        userService = new UserService(clusterService, configurationRepository, builder.build(), client);
+        PasswordHasher passwordHasher = new BCryptPasswordHasher();
+        userService = new UserService(clusterService, configurationRepository, passwordHasher, builder.build(), client);
         config = readConfigFromYml(usersYmlFile, CType.INTERNALUSERS);
     }
 

--- a/src/test/java/org/opensearch/security/auth/InternalAuthBackendTests.java
+++ b/src/test/java/org/opensearch/security/auth/InternalAuthBackendTests.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
 import org.opensearch.security.securityconf.InternalUsersModel;
 import org.opensearch.security.user.AuthCredentials;
 
@@ -42,7 +43,7 @@ public class InternalAuthBackendTests {
 
     @Before
     public void internalAuthBackendTestsSetup() {
-        internalAuthenticationBackend = spy(new InternalAuthenticationBackend());
+        internalAuthenticationBackend = spy(new InternalAuthenticationBackend(new BCryptPasswordHasher()));
         internalUsersModel = mock(InternalUsersModel.class);
         internalAuthenticationBackend.onInternalUsersModelChanged(internalUsersModel);
     }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
@@ -28,6 +28,8 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
+import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.threadpool.ThreadPool;
@@ -62,6 +64,8 @@ public abstract class AbstractApiActionValidationTest {
 
     ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
 
+    PasswordHasher passwordHasher;
+
     @Before
     public void setup() {
         securityApiDependencies = new SecurityApiDependencies(
@@ -73,6 +77,8 @@ public abstract class AbstractApiActionValidationTest {
             null,
             Settings.EMPTY
         );
+
+        passwordHasher = new BCryptPasswordHasher();
     }
 
     void setupRolesConfiguration() throws IOException {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
@@ -11,38 +11,35 @@ package org.opensearch.security.dlic.rest.api;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.securityconf.impl.v7.InternalUserV7;
 
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class AccountApiActionConfigValidationsTest extends AbstractApiActionValidationTest {
 
     @Test
     public void verifyValidCurrentPassword() {
-        final var accountApiAction = new AccountApiAction(clusterService, threadPool, securityApiDependencies);
+        final var accountApiAction = new AccountApiAction(clusterService, threadPool, securityApiDependencies, passwordHasher);
 
         final var u = createExistingUser();
 
         var result = accountApiAction.validCurrentPassword(SecurityConfiguration.of(requestContent(), "u", configuration));
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
+        assertThat(result.isValid(), is(false));
+        assertThat(RestStatus.BAD_REQUEST, is(result.status()));
 
-        u.setHash(Utils.hash("aaaa".toCharArray()));
+        u.setHash(passwordHasher.hash("aaaa".toCharArray()));
         result = accountApiAction.validCurrentPassword(SecurityConfiguration.of(requestContent(), "u", configuration));
-        assertTrue(result.isValid());
+        assertThat(result.isValid(), is(true));
     }
 
     @Test
     public void updatePassword() {
-        final var accountApiAction = new AccountApiAction(clusterService, threadPool, securityApiDependencies);
+        final var accountApiAction = new AccountApiAction(clusterService, threadPool, securityApiDependencies, passwordHasher);
 
         final var requestContent = requestContent();
         requestContent.remove("password");
@@ -50,19 +47,19 @@ public class AccountApiActionConfigValidationsTest extends AbstractApiActionVali
         u.setHash(null);
 
         var result = accountApiAction.updatePassword(SecurityConfiguration.of(requestContent, "u", configuration));
-        assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
+        assertThat(result.isValid(), is(false));
+        assertThat(RestStatus.BAD_REQUEST, is(result.status()));
 
         requestContent.put("password", "cccccc");
         result = accountApiAction.updatePassword(SecurityConfiguration.of(requestContent, "u", configuration));
-        assertTrue(result.isValid());
-        assertTrue(OpenBSDBCrypt.checkPassword(u.getHash(), "cccccc".toCharArray()));
+        assertThat(result.isValid(), is(true));
+        assertThat(passwordHasher.check("cccccc".toCharArray(), u.getHash()), is(true));
 
         requestContent.remove("password");
-        requestContent.put("hash", Utils.hash("dddddd".toCharArray()));
+        requestContent.put("hash", passwordHasher.hash("dddddd".toCharArray()));
         result = accountApiAction.updatePassword(SecurityConfiguration.of(requestContent, "u", configuration));
-        assertTrue(result.isValid());
-        assertTrue(OpenBSDBCrypt.checkPassword(u.getHash(), "dddddd".toCharArray()));
+        assertThat(result.isValid(), is(true));
+        assertThat(passwordHasher.check("dddddd".toCharArray(), u.getHash()), is(true));
     }
 
     private ObjectNode requestContent() {
@@ -71,7 +68,7 @@ public class AccountApiActionConfigValidationsTest extends AbstractApiActionVali
 
     private InternalUserV7 createExistingUser() {
         final var u = new InternalUserV7();
-        u.setHash(Utils.hash("sssss".toCharArray()));
+        u.setHash(passwordHasher.hash("sssss".toCharArray()));
         Mockito.<Object>when(configuration.getCEntry("u")).thenReturn(u);
         return u;
     }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
@@ -17,12 +17,12 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
 
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
+import org.opensearch.security.hasher.BCryptPasswordHasher;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.InternalUserV7;
@@ -98,7 +98,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         assertEquals(RestStatus.OK, result.status());
         assertFalse(securityConfiguration.requestContent().has("password"));
         assertTrue(securityConfiguration.requestContent().has("hash"));
-        assertTrue(OpenBSDBCrypt.checkPassword(securityConfiguration.requestContent().get("hash").asText(), "aaaaaa".toCharArray()));
+        assertTrue(passwordHasher.check("aaaaaa".toCharArray(), securityConfiguration.requestContent().get("hash").asText()));
     }
 
     @Test
@@ -193,7 +193,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
     }
 
     private InternalUsersApiAction createInternalUsersApiAction() {
-        return new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies);
+        return new InternalUsersApiAction(clusterService, threadPool, userService, securityApiDependencies, new BCryptPasswordHasher());
     }
 
 }

--- a/src/test/java/org/opensearch/security/hasher/BCryptPasswordHasherTests.java
+++ b/src/test/java/org/opensearch/security/hasher/BCryptPasswordHasherTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.hasher;
+
+import java.nio.CharBuffer;
+
+import org.junit.Test;
+
+import org.opensearch.OpenSearchSecurityException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThrows;
+
+public class BCryptPasswordHasherTests {
+
+    private final PasswordHasher passwordHasher = new BCryptPasswordHasher();
+
+    private final String password = "testPassword";
+    private final String wrongPassword = "wrongTestPassword";
+
+    @Test
+    public void shouldMatchHashToCorrectPassword() {
+        String hashedPassword = passwordHasher.hash(password.toCharArray());
+        assertThat(passwordHasher.check(password.toCharArray(), hashedPassword), is(true));
+    }
+
+    @Test
+    public void shouldNotMatchHashToWrongPassword() {
+        String hashedPassword = passwordHasher.hash(password.toCharArray());
+        assertThat(passwordHasher.check(wrongPassword.toCharArray(), hashedPassword), is(false));
+
+    }
+
+    /**
+     * Ensures that the hashes that were previously created by OpenBSDBCrypt are still valid
+     */
+    @Test
+    public void shouldBeBackwardsCompatible() {
+        String legacyHash = "$2y$12$gdh2ecVBQmwpmcAeyReicuNtXyR6GMWSfXHxtcBBqFeFz2VQ8kDZe";
+        assertThat(passwordHasher.check(password.toCharArray(), legacyHash), is(true));
+        assertThat(passwordHasher.check(wrongPassword.toCharArray(), legacyHash), is(false));
+    }
+
+    @Test
+    public void shouldGenerateDifferentHashesForTheSamePassword() {
+        String hash1 = passwordHasher.hash(password.toCharArray());
+        String hash2 = passwordHasher.hash(password.toCharArray());
+        assertThat(hash1, is(not(hash2)));
+    }
+
+    @Test
+    public void shouldHandleNullPasswordWhenHashing() {
+        char[] nullPassword = null;
+        assertThrows(OpenSearchSecurityException.class, () -> { passwordHasher.hash(nullPassword); });
+    }
+
+    @Test
+    public void shouldHandleNullPasswordWhenChecking() {
+        char[] nullPassword = null;
+        assertThrows(OpenSearchSecurityException.class, () -> { passwordHasher.check(nullPassword, "some hash"); });
+    }
+
+    @Test
+    public void shouldHandleEmptyHashWhenChecking() {
+        String emptyHash = "";
+        assertThrows(OpenSearchSecurityException.class, () -> { passwordHasher.check(password.toCharArray(), emptyHash); });
+    }
+
+    @Test
+    public void shouldHandleNullHashWhenChecking() {
+        String nullHash = null;
+        assertThrows(OpenSearchSecurityException.class, () -> { passwordHasher.check(password.toCharArray(), nullHash); });
+    }
+
+    @Test
+    public void shouldCleanupPasswordCharArray() {
+        char[] password = new char[] { 'p', 'a', 's', 's', 'w', 'o', 'r', 'd' };
+        passwordHasher.hash(password);
+        assertThat("\0\0\0\0\0\0\0\0", is(new String(password)));
+    }
+
+    @Test
+    public void shouldCleanupPasswordCharBuffer() {
+        char[] password = new char[] { 'p', 'a', 's', 's', 'w', 'o', 'r', 'd' };
+        CharBuffer passwordBuffer = CharBuffer.wrap(password);
+        passwordHasher.hash(password);
+        assertThat("\0\0\0\0\0\0\0\0", is(new String(password)));
+        assertThat("\0\0\0\0\0\0\0\0", is(passwordBuffer.toString()));
+    }
+}


### PR DESCRIPTION
Manual backport https://github.com/opensearch-project/security/commit/20c524ad994a9cc7d8757999f92f6d2fec6cb8ca from https://github.com/opensearch-project/security/pull/4381. 

Auto-merge failed due to slight differences in code between 2.x and main branches.