### PR TITLE
Check block request only if system index

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityIndexSearcherWrapper.java
@@ -152,6 +152,11 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
     }
 
     protected final boolean isBlockedSystemIndexRequest() {
+        boolean isSystemIndex = systemIndexMatcher.test(index.getName());
+        if (!isSystemIndex) {
+            return false;
+        }
+
         if (systemIndexPermissionEnabled) {
             final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
             if (user == null) {
@@ -163,7 +168,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
             final SecurityRoles securityRoles = evaluator.getSecurityRoles(mappedRoles);
             return !securityRoles.isPermittedOnSystemIndex(index.getName());
         }
-        return systemIndexMatcher.test(index.getName());
+        return true;
     }
 
     protected final boolean isAdminDnOrPluginRequest() {

--- a/src/test/java/org/opensearch/security/IndexIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IndexIntegrationTests.java
@@ -831,28 +831,4 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, resc.getStatusCode());
 
     }
-
-    @Test
-    public void testNormalIndexCanBeSearchedEvenWithoutSystemIndexPermissions() throws Exception {
-
-        setup(
-            Settings.EMPTY,
-            new DynamicSecurityConfig().setConfig("composite_config.yml").setSecurityRoles("roles_composite.yml"),
-            Settings.builder().put("plugins.security.system_indices.enabled", true)
-                .put("plugins.security.system_indices.permission.enabled", true).build(),
-            true
-        );
-        final RestHelper rh = nonSslRestHelper();
-
-        try (Client tc = getClient()) {
-            tc.index(new IndexRequest("klingonempire").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON))
-                .actionGet();
-        }
-
-        HttpResponse resc = rh.executeGetRequest("klingonempire/_search", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(200, resc.getStatusCode());
-        Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"_index\":\"klingonempire\""));
-        Assert.assertTrue(resc.getBody(), resc.getBody().contains("hits"));
-        Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"content\":1"));
-    }
 }

--- a/src/test/java/org/opensearch/security/IndexIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IndexIntegrationTests.java
@@ -831,4 +831,28 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, resc.getStatusCode());
 
     }
+
+    @Test
+    public void testNormalIndexCanBeSearchedEvenWithoutSystemIndexPermissions() throws Exception {
+
+        setup(
+            Settings.EMPTY,
+            new DynamicSecurityConfig().setConfig("composite_config.yml").setSecurityRoles("roles_composite.yml"),
+            Settings.builder().put("plugins.security.system_indices.enabled", true)
+                .put("plugins.security.system_indices.permission.enabled", true).build(),
+            true
+        );
+        final RestHelper rh = nonSslRestHelper();
+
+        try (Client tc = getClient()) {
+            tc.index(new IndexRequest("klingonempire").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"content\":1}", XContentType.JSON))
+                .actionGet();
+        }
+
+        HttpResponse resc = rh.executeGetRequest("klingonempire/_search", encodeBasicHeader("worf", "worf"));
+        Assert.assertEquals(200, resc.getStatusCode());
+        Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"_index\":\"klingonempire\""));
+        Assert.assertTrue(resc.getBody(), resc.getBody().contains("hits"));
+        Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"content\":1"));
+    }
 }

--- a/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
@@ -54,10 +54,7 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
         SYSTEM_INDEX_WITH_NO_ASSOCIATED_ROLE_PERMISSIONS,
         ACCESSIBLE_ONLY_BY_SUPER_ADMIN
     );
-    static final List<String> NO_SYSTEM_INDICES = List.of(
-        ".no_system_index_1",
-        ".no_system_index_2"
-    );
+    static final List<String> NO_SYSTEM_INDICES = List.of(".no_system_index_1", ".no_system_index_2");
 
     static final List<String> INDICES_FOR_CREATE_REQUEST = List.of(".system_index_2");
     static final String matchAllQuery = "{\n\"query\": {\"match_all\": {}}}";

--- a/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
@@ -54,6 +54,10 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
         SYSTEM_INDEX_WITH_NO_ASSOCIATED_ROLE_PERMISSIONS,
         ACCESSIBLE_ONLY_BY_SUPER_ADMIN
     );
+    static final List<String> NO_SYSTEM_INDICES = List.of(
+        ".no_system_index_1",
+        ".no_system_index_2"
+    );
 
     static final List<String> INDICES_FOR_CREATE_REQUEST = List.of(".system_index_2");
     static final String matchAllQuery = "{\n\"query\": {\"match_all\": {}}}";
@@ -111,6 +115,14 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
                 if (!index.equals(ACCESSIBLE_ONLY_BY_SUPER_ADMIN)) {
                     tc.admin().indices().create(new CreateIndexRequest(index)).actionGet();
                 }
+                tc.index(
+                    new IndexRequest(index).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                        .id("document1")
+                        .source("{ \"foo\": \"bar\" }", XContentType.JSON)
+                ).actionGet();
+            }
+
+            for (String index : NO_SYSTEM_INDICES) {
                 tc.index(
                     new IndexRequest(index).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                         .id("document1")

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
@@ -112,11 +112,19 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search system indices
         for (String index : NO_SYSTEM_INDICES) {
-            RestHelper.HttpResponse responseWithoutSystemIndexPermission = restHelper.executeGetRequest(index + "/_search", "", normalUserWithoutSystemIndexHeader);
+            RestHelper.HttpResponse responseWithoutSystemIndexPermission = restHelper.executeGetRequest(
+                index + "/_search",
+                "",
+                normalUserWithoutSystemIndexHeader
+            );
             validateSearchResponse(responseWithoutSystemIndexPermission, 1);
 
-			RestHelper.HttpResponse responseWithSystemIndexPermission = restHelper.executeGetRequest(index + "/_search", "", normalUserHeader);
-			validateSearchResponse(responseWithSystemIndexPermission, 1);
+            RestHelper.HttpResponse responseWithSystemIndexPermission = restHelper.executeGetRequest(
+                index + "/_search",
+                "",
+                normalUserHeader
+            );
+            validateSearchResponse(responseWithSystemIndexPermission, 1);
         }
     }
 

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
@@ -106,6 +106,17 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
         validateForbiddenResponse(response, "indices:data/read/search", normalUserWithoutSystemIndex);
     }
 
+    @Test
+    public void testNormalIndexShouldAlwaysBeSearchable() throws Exception {
+        RestHelper restHelper = sslRestHelper();
+
+        // search system indices
+        for (String index : NO_SYSTEM_INDICES) {
+            RestHelper.HttpResponse response = restHelper.executePostRequest(index + "/_search", "", normalUserWithoutSystemIndexHeader);
+            validateSearchResponse(response, 1);
+        }
+    }
+
     /**
      *  DELETE document + index
      */

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
@@ -112,8 +112,11 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search system indices
         for (String index : NO_SYSTEM_INDICES) {
-            RestHelper.HttpResponse response = restHelper.executePostRequest(index + "/_search", "", normalUserWithoutSystemIndexHeader);
-            validateSearchResponse(response, 1);
+            RestHelper.HttpResponse responseWithoutSystemIndexPermission = restHelper.executeGetRequest(index + "/_search", "", normalUserWithoutSystemIndexHeader);
+            validateSearchResponse(responseWithoutSystemIndexPermission, 1);
+
+			RestHelper.HttpResponse responseWithSystemIndexPermission = restHelper.executeGetRequest(index + "/_search", "", normalUserHeader);
+			validateSearchResponse(responseWithSystemIndexPermission, 1);
         }
     }
 

--- a/src/test/resources/system_indices/roles.yml
+++ b/src/test/resources/system_indices/roles.yml
@@ -31,5 +31,6 @@ normal_role_without_system_index:
   index_permissions:
     - index_patterns:
         - '.system*'
+        - '.no_system*'
       allowed_actions:
         - '*'

--- a/src/test/resources/system_indices/roles.yml
+++ b/src/test/resources/system_indices/roles.yml
@@ -20,6 +20,7 @@ normal_role:
   index_permissions:
     - index_patterns:
         - '.system*'
+        - '.no_system*'
       allowed_actions:
         - '*'
         - 'system:admin/system_index'


### PR DESCRIPTION
### Description

* Category : Bug Fix
* Why these changes are required? : There was an issue where documents could not be queried without system index permissions, even if the index was not a system index. This has been fixed.
* What is the old behavior before changes and new behavior after changes?
   - old : Documents could not be searched without system index permissions when `plugins.security.system_indices.permission.enabled` enabled
   - new : Documents in normal indexes can always be searched regardless of system index permissions.

### Issues Resolved

issue: https://github.com/opensearch-project/security/issues/4429


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
