### PR TITLE
Replaced uses of SecurityRoles by Set<String> mappedRoles where the SecurityRoles functionality is not needed

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -296,7 +296,7 @@ public class PrivilegesEvaluator {
                     "No cluster-level perm match for {} [Action [{}]] [RolesChecked {}]. No permissions for {}",
                     user,
                     action0,
-                    securityRoles.getRoleNames(),
+                    mappedRoles,
                     presponse.missingPrivileges
                 );
             } else {
@@ -333,7 +333,7 @@ public class PrivilegesEvaluator {
         }
 
         // Protected index access
-        if (protectedIndexAccessEvaluator.evaluate(request, task, action0, requestedResolved, presponse, securityRoles).isComplete()) {
+        if (protectedIndexAccessEvaluator.evaluate(request, task, action0, requestedResolved, presponse, mappedRoles).isComplete()) {
             return presponse;
         }
 
@@ -374,7 +374,7 @@ public class PrivilegesEvaluator {
                     user,
                     requestedResolved,
                     action0,
-                    securityRoles.getRoleNames(),
+                    mappedRoles,
                     presponse.missingPrivileges
                 );
                 return presponse;
@@ -471,7 +471,7 @@ public class PrivilegesEvaluator {
 
         if (isDebugEnabled) {
             log.debug("Requested resolved index types: {}", requestedResolved);
-            log.debug("Security roles: {}", securityRoles.getRoleNames());
+            log.debug("Security roles: {}", mappedRoles);
         }
 
         // TODO exclude Security index
@@ -561,7 +561,7 @@ public class PrivilegesEvaluator {
                 user,
                 requestedResolved,
                 action0,
-                securityRoles.getRoleNames()
+                mappedRoles
             );
             log.info("No permissions for {}", presponse.missingPrivileges);
         } else {


### PR DESCRIPTION
### Description

This code change is just in preparation for the change in #4380 as requested in https://github.com/opensearch-project/security/pull/4380#discussion_r1621325450 .

In the course of #4380 , the `SecurityRoles` class will be replaced by a new concept.  This PR already replaces the usages of `SecurityRoles` where no methods are used on it except the `getRoleNames()` method. This method call can be easily replaced by the `Set<String> mappedRoles`, which is computed by `PrivilegesEvaluator` before the `SecurityRoles` instance is created. This change elliminated the coupling of the interfaces that consume that information to the `SecurityRoles` class, thereby enhancing code quality.

* Category:  Refactoring
* Why these changes are required? The changes in #4380 will abolish the `SecurityRoles` class in the end.
* What is the old behavior before changes and new behavior after changes? No behavioral changes.

### Issues Resolved

- https://github.com/opensearch-project/security/pull/4380#discussion_r1621325450

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing - no new functionality
- [ ] New functionality has been documented - no new functionality
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
