### PR TITLE
Add cat/alias support for DNFOF 

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -127,7 +127,8 @@ public class DoNotFailOnForbiddenTests {
                 "indices:data/read/msearch",
                 "indices:data/read/scroll",
                 "indices:monitor/settings/get",
-                "indices:monitor/stats"
+                "indices:monitor/stats",
+                "indices:admin/aliases/get"
             )
             .on(MARVELOUS_SONGS)
     );
@@ -440,6 +441,24 @@ public class DoNotFailOnForbiddenTests {
 
             assertThat(indexes.size(), equalTo(1));
             assertThat(indexes.get(0), containsString("marvelous_songs"));
+        }
+    }
+
+    @Test
+    public void shouldPerformCatAliases_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            Request getAliasesRequest = new Request("GET", "/_cat/aliases");
+            // High level client doesn't support _cat/_indices API
+            Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
+            List<String> aliases = new BufferedReader(new InputStreamReader(getAliasesResponse.getEntity().getContent())).lines()
+                .collect(Collectors.toList());
+
+            // Does not fail on forbidden, but alias response only contains index which user has access to
+            assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));
+            assertThat(aliases.size(), equalTo(1));
+            assertThat(aliases.get(0), containsString("marvelous_songs"));
+            assertThat(aliases.get(0), not(containsString("horrible_songs")));
+
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -448,7 +448,6 @@ public class DoNotFailOnForbiddenTests {
     public void shouldPerformCatAliases_positive() throws IOException {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
             Request getAliasesRequest = new Request("GET", "/_cat/aliases");
-            // High level client doesn't support _cat/_indices API
             Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
             List<String> aliases = new BufferedReader(new InputStreamReader(getAliasesResponse.getEntity().getContent())).lines()
                 .collect(Collectors.toList());

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -48,7 +48,16 @@ import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.client.RequestOptions.DEFAULT;

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -111,7 +111,8 @@ public class PrivilegesEvaluator {
             "indices:admin/shards/search_shards",
             "indices:admin/resolve/index",
             "indices:monitor/settings/get",
-            "indices:monitor/stats"
+            "indices:monitor/stats",
+            "indices:admin/aliases/get"
         )
     );
 

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -41,13 +41,13 @@ public class PrivilegesEvaluatorUnitTest {
         "indices:data/read/search/template",
         "indices:data/read/tv",
         "indices:monitor/settings/get",
-        "indices:monitor/stats"
+        "indices:monitor/stats",
+        "indices:admin/aliases/get"
     );
 
     private static final List<String> disallowedDnfof = ImmutableList.of(
         "indices:admin/aliases",
         "indices:admin/aliases/exists",
-        "indices:admin/aliases/get",
         "indices:admin/analyze",
         "indices:admin/cache/clear",
         "indices:admin/close",


### PR DESCRIPTION
### Description
This adds DNFOF support for Cat Aliases API. The behavior prior to this change is that cat alias API would fail with error: no permissions for [indices:admin/aliases/get], even with DNFOF is enabled. Now the behavior is that cat alias API will return the aliases with indices that you have access to. I added a DNFOF test show casing this behavior. 
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug fix
* Why these changes are required?
Fix: #4413 
* What is the old behavior before changes and new behavior after changes?
See description

### Issues Resolved
Fix: #4413
Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Manual testing, added a test case, fixed a unit test
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
