### PR TITLE
[1.3] Bump bouncycastle to 1.78.1 and kafka to 3.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
@@ -245,8 +245,8 @@ dependencies {
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:2.17.1"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:2.17.1"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.78"
-    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.78"
+    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.78.1"
+    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.78.1"
     integrationTestImplementation('org.awaitility:awaitility:4.2.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'
-    kafka_version  = '3.6.2'
+    kafka_version  = '3.7.0'
 
     if (buildVersionQualifier) {
         opensearch_build += "-${buildVersionQualifier}"

--- a/build.gradle
+++ b/build.gradle
@@ -210,6 +210,7 @@ dependencies {
     testImplementation 'com.unboundid:unboundid-ldapsdk:4.0.9'
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}"
+    testImplementation "org.apache.kafka:kafka-server:${kafka_version}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     compileOnly "org.opensearch:opensearch:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'
-    kafka_version  = '3.5.1'
+    kafka_version  = '3.6.2'
 
     if (buildVersionQualifier) {
         opensearch_build += "-${buildVersionQualifier}"
@@ -170,7 +170,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.75'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
@@ -245,8 +245,8 @@ dependencies {
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:2.17.1"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:2.17.1"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.75"
-    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.75"
+    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.78"
+    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.78"
     integrationTestImplementation('org.awaitility:awaitility:4.2.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }

--- a/build.gradle
+++ b/build.gradle
@@ -211,8 +211,11 @@ dependencies {
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}"
     testImplementation "org.apache.kafka:kafka-server:${kafka_version}"
+    testImplementation "org.apache.kafka:kafka-server-common:${kafka_version}"
+    testImplementation "org.apache.kafka:kafka-server-common:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
+    testImplementation 'commons-validator:commons-validator:1.7'
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 
     integrationTestCompileOnly "org.opensearch:opensearch:${opensearch_version}"

--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -64,7 +64,10 @@ grant {
   permission java.security.SecurityPermission "putProviderProperty.BC";
   permission java.security.SecurityPermission "insertProvider.BC";
   permission java.security.SecurityPermission "removeProviderProperty.BC";
-  permission java.util.PropertyPermission "jdk.tls.rejectClientInitiatedRenegotiation", "write";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.ec.max_f2m_field_size";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.pkcs12.default";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_size";
+  permission java.security.SecurityPermission "getProperty.org.bouncycastle.rsa.max_mr_tests";
 
   permission java.lang.RuntimePermission "accessUserInformation";
   


### PR DESCRIPTION
### Description

Bump bouncycastle from 1.75 to 1.78.1 and kafka to 3.7.0

* Category

Maintenance

### Issues Resolved

Resolves Whitesource issues seen in the 1.3.18 version bump: https://github.com/opensearch-project/security/pull/4415/checks?check_run_id=25964867842

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
