### PR TITLE
Fixed flaky BWC test.

### DIFF
--- a/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
@@ -229,7 +229,8 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
         ObjectMapper objectMapper = new ObjectMapper();
         int numberOfRequests = Randomness.get().nextInt(10);
         while (numberOfRequests-- > 0) {
-            for (int i = 0; i < Randomness.get().nextInt(100); i++) {
+            int numberOfDocuments = Randomness.get().nextInt(100) + 1;
+            for (int i = 0; i < numberOfDocuments; i++) {
                 Map<String, Map<String, String>> indexRequest = new HashMap<>();
                 indexRequest.put("index", new HashMap<>() {
                     {


### PR DESCRIPTION
### Description

Fixes flaky BWC test. Fixes #4445 
 
The test `SecurityBackwardsCompatibilityIT.testDataIngestionAndSearchBackwardsCompatibility` had a 1:100 chance to send empty bulk request bodies which would result in 400 Bad Request errors.


* Category: Test fix
* Why these changes are required? The CI was flaky
* What is the old behavior before changes and new behavior after changes? no behavioral change.

### Issues Resolved

- #4445 

### Testing

### Check List
- [ ] New functionality includes testing - this is a test fix
- [ ] New functionality has been documented - no new functionality
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
