### PR TITLE
New algorithm for resolving action groups

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/FlattenedActionGroups.java
+++ b/src/main/java/org/opensearch/security/securityconf/FlattenedActionGroups.java
@@ -1,0 +1,161 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.securityconf;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
+
+/**
+ * This class pre-computes a flattened/resolved view of all provided action groups. Afterwards, the resolve() method
+ * can be used to retrieve the resolved actions with just a lookup instead of an expensive computation.
+ *
+ * Instead of a recursive algorithm, this class uses a iterative algorithm that terminates as soon as the result set
+ * did not change during the previous iteration (i.e., when the result set "settled"). This will also terminate early
+ * for loops within the action group definition, as loops do not add any more elements to the result set after the first
+ * encounter of them.
+ *
+ * Still, if the algorithm has not settled after 1000 iterations, it will terminate "early". This will be only the case
+ * for nested action group definitions with a nesting level of more than 1000.
+ *
+ * Instances of this class are immutable. If the action group configuration is updated, a new instance needs to be
+ * created.
+ */
+public class FlattenedActionGroups {
+    public static final FlattenedActionGroups EMPTY = new FlattenedActionGroups();
+
+    private static final Logger log = LogManager.getLogger(FlattenedActionGroups.class);
+
+    private final ImmutableMap<String, Set<String>> resolvedActionGroups;
+
+    public FlattenedActionGroups(SecurityDynamicConfiguration<ActionGroupsV7> actionGroups) {
+        // Maps action group names to the actions and action groups the particular action group points to
+        Map<String, Set<String>> resolved = new HashMap<>(actionGroups.getCEntries().size());
+
+        // Maps action group names to further action group names found in the provided action group configuration.
+        // These will need an additional resolution step to resolve recursive definitions.
+        Map<String, Set<String>> needsResolution = new HashMap<>(actionGroups.getCEntries().size());
+
+        // First phase: Non-recursive definitions
+        //
+        // We iterate through all defined action groups and initialize the "resolved" map with the
+        // first, non-recursive action group mappings. If we discover that an action group maps to a value which
+        // is also a key in the action group config, we know that we have found a recursive definition. This is not
+        // yet resolved, but scheduled for resolution by putting the mapping additionally into "needsResolution".
+        for (Map.Entry<String, ActionGroupsV7> entry : actionGroups.getCEntries().entrySet()) {
+            String key = entry.getKey();
+
+            Set<String> actions = resolved.computeIfAbsent(key, (k) -> new HashSet<>());
+
+            for (String action : entry.getValue().getAllowed_actions()) {
+                actions.add(action);
+
+                if (actionGroups.getCEntries().containsKey(action) && !action.equals(key)) {
+                    needsResolution.computeIfAbsent(key, (k) -> new HashSet<>()).add(action);
+                }
+            }
+        }
+
+        // Second phase: recursive definitions
+        //
+        // We iterate through "needsResolution", i.e., the discovered recursive definitions and use the already
+        // computed mappings in "resolved" to resolve these recursive definitions. In this course, the mappings in
+        // "resolved" grow. As "resolved" might be not complete in the first iteration, we iterate until no further
+        // change is observed - only then "resolved" can be considered as complete.
+        //
+        // Note: "needsResolution" will be not changed in this phase. We certainly will not discover additional
+        // recursive definitions. One could argue that it might be possible to remove some entries from "needsResolution"
+        // as soon as these are discovered to be complete. But that would require additional copy operations and
+        // complicate the algorithm which does not seem to be worth the possible gain.
+        boolean settled = false;
+
+        for (int i = 0; !settled; i++) {
+            boolean changed = false;
+
+            for (Map.Entry<String, Set<String>> entry : needsResolution.entrySet()) {
+                String key = entry.getKey();
+                Set<String> resolvedActions = resolved.get(key);
+
+                for (String action : entry.getValue()) {
+                    Set<String> mappedActions = resolved.get(action);
+                    changed |= resolvedActions.addAll(mappedActions);
+                }
+            }
+
+            if (!changed) {
+                settled = true;
+                if (log.isDebugEnabled()) {
+                    log.debug("Action groups settled after {} loops.\nResolved: {}", i, resolved);
+                }
+            }
+
+            if (i >= 1000) {
+                log.error("Found too deeply nested action groups. Aborting resolution.\nResolved so far: {}", resolved);
+                break;
+            }
+        }
+
+        this.resolvedActionGroups = ImmutableMap.copyOf(resolved);
+    }
+
+    /**
+     * Resolves the given list of actions or action groups using the pre-computed flattened index.
+     * The result set will always contain AT LEAST the provided elements. IN ADDITION, any elements discovered
+     * in the index will be added.
+     *
+     * Thus, if you provide [a,b] as parameters, and the index contains [b=>1,2], then the result set
+     * will contain [a,b,1,2].
+     *
+     * This method will not perform any pattern matching. It will also not give the strings any semantics based on their
+     * contents.
+     */
+    public ImmutableSet<String> resolve(Collection<String> actions) {
+        ImmutableSet.Builder<String> result = ImmutableSet.builder();
+
+        for (String action : actions) {
+            if (action == null) {
+                continue;
+            }
+
+            result.add(action);
+
+            Set<String> mappedActions = this.resolvedActionGroups.get(action);
+            if (mappedActions != null) {
+                result.addAll(mappedActions);
+            }
+        }
+
+        return result.build();
+    }
+
+    /**
+     * Private constructor for creating an empty instance
+     */
+    private FlattenedActionGroups() {
+        this.resolvedActionGroups = ImmutableMap.of();
+    }
+
+    @Override
+    public String toString() {
+        return resolvedActionGroups.toString();
+    }
+
+}

--- a/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -38,6 +38,7 @@ import java.util.Map.Entry;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -116,6 +117,20 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
         sdc.version = version;
 
         return sdc;
+    }
+
+    /**
+     * For testing only
+     */
+    public static <T> SecurityDynamicConfiguration<T> fromMap(Map<String, Object> map, CType ctype, int version)
+        throws JsonProcessingException {
+        Class<?> implementationClass = ctype.getImplementationClass().get(version);
+        SecurityDynamicConfiguration<T> result = DefaultObjectMapper.objectMapper.convertValue(
+            map,
+            DefaultObjectMapper.getTypeFactory().constructParametricType(SecurityDynamicConfiguration.class, implementationClass)
+        );
+        result.ctype = ctype;
+        return result;
     }
 
     public static void validate(SecurityDynamicConfiguration<?> sdc, int version, CType ctype) throws IOException {

--- a/src/test/java/org/opensearch/security/securityconf/FlattenedActionGroupsTest.java
+++ b/src/test/java/org/opensearch/security/securityconf/FlattenedActionGroupsTest.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.securityconf;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
+
+public class FlattenedActionGroupsTest {
+    @Test
+    public void basicTest() throws Exception {
+        TestActionGroup testActionGroups = new TestActionGroup().with("Z", "C", "A")
+            .with("A", "A1", "A2", "A3")
+            .with("B", "B1", "B2", "B3")
+            .with("C", "A", "B", "C1");
+        SecurityDynamicConfiguration<ActionGroupsV7> config = SecurityDynamicConfiguration.fromMap(
+            testActionGroups.map,
+            CType.ACTIONGROUPS,
+            2
+        );
+
+        FlattenedActionGroups actionGroups = new FlattenedActionGroups(config);
+
+        Assert.assertEquals(
+            ImmutableSet.of("C", "A", "A1", "A2", "A3", "C1", "B", "B1", "B2", "B3", "Z"),
+            actionGroups.resolve(ImmutableSet.of("Z"))
+        );
+        Assert.assertEquals(ImmutableSet.of("A", "A1", "A2", "A3"), actionGroups.resolve(ImmutableSet.of("A")));
+    }
+
+    /**
+     * This tests an action group definition containing a cycle. Still, the resolution should settle without any
+     * stack overflow.
+     */
+    @Test
+    public void cycleTest() throws Exception {
+        TestActionGroup testActionGroups = new TestActionGroup().with("A", "A1", "B")
+            .with("B", "B1", "C")
+            .with("C", "C1", "A", "D")
+            .with("D", "D1");
+        SecurityDynamicConfiguration<ActionGroupsV7> config = SecurityDynamicConfiguration.fromMap(
+            testActionGroups.map,
+            CType.ACTIONGROUPS,
+            2
+        );
+
+        FlattenedActionGroups actionGroups = new FlattenedActionGroups(config);
+
+        Assert.assertEquals(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1"), actionGroups.resolve(ImmutableSet.of("A")));
+        Assert.assertEquals(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1"), actionGroups.resolve(ImmutableSet.of("C")));
+        Assert.assertEquals(ImmutableSet.of("D", "D1"), actionGroups.resolve(ImmutableSet.of("D")));
+    }
+
+    private static class TestActionGroup {
+        private Map<String, Object> map = new HashMap<>();
+
+        TestActionGroup with(String key, String... actions) {
+            map.put(key, ImmutableMap.of("allowed_actions", Arrays.asList(actions)));
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
### Description

This code change is just in preparation for the change in #4380 as requested in https://github.com/opensearch-project/security/pull/4416#pullrequestreview-2106138499 .

This replaces the previous action group resolution algorithm done in ConfigModelV7 by a new one, which has a number of enhancements:

- The new implementation forms an independent class, enhancing testability and use in other components that will be introduced in #4380.
- The new implementation handles action group configurations containing loops gracefully. The old one would wind up StackOverflowErrors.
- The new one pre-computes the resolved action groups, thus enhancing the performance.

* Category: Enhancement
* Why these changes are required? - The changes in #4380 will no longer use ConfigModelV7 and thus need an independent action group resolution mechanism.
* What is the old behavior before changes and new behavior after changes? - No behavioral changes except for action group definitions containing groups, which will be handled gracefully now.

### Testing

- Unit tests in `org.opensearch.security.securityconf.FlattenedActionGroupsTest`

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
