### PR TITLE
Fixes flaky integration tests

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
@@ -9,8 +9,6 @@
  */
 package org.opensearch.security;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -18,10 +16,8 @@ import java.util.Set;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
-import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -42,7 +38,6 @@ import static org.junit.Assert.assertTrue;
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public abstract class AbstractDefaultConfigurationTests {
-    public final static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
     private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin");
     private static final TestSecurityConfig.User NEW_USER = new TestSecurityConfig.User("new-user");
     private static final TestSecurityConfig.User LIMITED_USER = new TestSecurityConfig.User("limited-user");
@@ -51,11 +46,6 @@ public abstract class AbstractDefaultConfigurationTests {
 
     protected AbstractDefaultConfigurationTests(LocalCluster cluster) {
         this.cluster = cluster;
-    }
-
-    @AfterClass
-    public static void cleanConfigurationDirectory() throws IOException {
-        FileUtils.deleteDirectory(configurationFolder.toFile());
     }
 
     @Test

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterTests.java
@@ -9,15 +9,21 @@
  */
 package org.opensearch.security;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
 public class DefaultConfigurationMultiNodeClusterTests extends AbstractDefaultConfigurationTests {
+
+    static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
@@ -32,6 +38,11 @@ public class DefaultConfigurationMultiNodeClusterTests extends AbstractDefaultCo
         .defaultConfigurationInitDirectory(configurationFolder.toString())
         .loadConfigurationIntoIndex(false)
         .build();
+
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
 
     public DefaultConfigurationMultiNodeClusterTests() {
         super(cluster);

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterUseClusterStateTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationMultiNodeClusterUseClusterStateTests.java
@@ -9,15 +9,21 @@
  */
 package org.opensearch.security;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
 public class DefaultConfigurationMultiNodeClusterUseClusterStateTests extends AbstractDefaultConfigurationTests {
+
+    static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
@@ -34,6 +40,11 @@ public class DefaultConfigurationMultiNodeClusterUseClusterStateTests extends Ab
         .defaultConfigurationInitDirectory(configurationFolder.toString())
         .loadConfigurationIntoIndex(false)
         .build();
+
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
 
     public DefaultConfigurationMultiNodeClusterUseClusterStateTests() {
         super(cluster);

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterTests.java
@@ -9,10 +9,14 @@
 */
 package org.opensearch.security;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 
@@ -22,6 +26,8 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class DefaultConfigurationSingleNodeClusterTests extends AbstractDefaultConfigurationTests {
+
+    static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
@@ -36,6 +42,11 @@ public class DefaultConfigurationSingleNodeClusterTests extends AbstractDefaultC
         .defaultConfigurationInitDirectory(configurationFolder.toString())
         .loadConfigurationIntoIndex(false)
         .build();
+
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
 
     public DefaultConfigurationSingleNodeClusterTests() {
         super(cluster);

--- a/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterUseClusterStateTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DefaultConfigurationSingleNodeClusterUseClusterStateTests.java
@@ -9,15 +9,21 @@
  */
 package org.opensearch.security;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
 public class DefaultConfigurationSingleNodeClusterUseClusterStateTests extends AbstractDefaultConfigurationTests {
+
+    static Path configurationFolder = ConfigurationFiles.createConfigurationDirectory();
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
@@ -34,6 +40,11 @@ public class DefaultConfigurationSingleNodeClusterUseClusterStateTests extends A
         .defaultConfigurationInitDirectory(configurationFolder.toString())
         .loadConfigurationIntoIndex(false)
         .build();
+
+    @AfterClass
+    public static void cleanConfigurationDirectory() throws IOException {
+        FileUtils.deleteDirectory(configurationFolder.toFile());
+    }
 
     public DefaultConfigurationSingleNodeClusterUseClusterStateTests() {
         super(cluster);


### PR DESCRIPTION
### Description
`AbstractDefaultConfigurationTests` used `configurationFolder` as a constant as result all inherited tests could use the same config folder which can be cleaned unpredictably.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
