### PR TITLE
Update BouncyCastle to address CVE-2024-30172, CVE-2024-30171 and CVE-2024-29857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,7 +170,7 @@ dependencies {
     implementation 'com.google.guava:guava:32.1.1-jre'
     implementation 'org.greenrobot:eventbus:3.2.0'
     implementation 'commons-cli:commons-cli:1.3.1'
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.75'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.2'
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'org.apache.httpcomponents:httpclient-cache:4.5.13'
@@ -245,8 +245,8 @@ dependencies {
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:2.17.1"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:2.17.1"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.75"
-    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.75"
+    integrationTestImplementation "org.bouncycastle:bcpkix-jdk15to18:1.78.1"
+    integrationTestImplementation "org.bouncycastle:bcutil-jdk15to18:1.78.1"
     integrationTestImplementation('org.awaitility:awaitility:4.2.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }


### PR DESCRIPTION
### Description
Upgrading BouncyCastle from 1.75 to 1.78.1 to address potential vulnerabilities.

A similar change was made to the OpenSearch core repo here.
https://github.com/opensearch-project/OpenSearch/pull/13484

### Issues Resolved
This will address the following potential vulnerabilities.
https://www.cve.org/CVERecord?id=CVE-2024-30172
https://www.cve.org/CVERecord?id=CVE-2024-30171
https://www.cve.org/CVERecord?id=CVE-2024-29857

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
