### PR TITLE
Set security plugin 3.0.0 baseline JDK version to JDK-21

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -32,6 +32,12 @@ runs:
         ref: ${{ inputs.plugin-branch }}
         path: ${{ inputs.plugin-branch }}
 
+    - uses: actions/setup-java@v4
+      if: ${{ inputs.plugin-branch == 'current_branch' }}
+      with:
+        distribution: temurin # Temurin is a distribution of adoptium
+        java-version: 21
+
     - name: Build
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 17
+        java-version: 21
 
     - name: Checkout security
       uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
       matrix:
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
         platform: [windows-latest, ubuntu-latest]
-        jdk: [11, 17, 21]
+        jdk: [21]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17, 21]
+        jdk: [21]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [17]
+        jdk: [21]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 17
+          java-version: 21
 
       - name: Checkout Security Repo
         uses: actions/checkout@v4
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 11
+        java-version: 21
     - uses: github/codeql-action/init@v3
       with:
         languages: java
@@ -219,7 +219,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 11
+        java-version: 21
 
     - run: |
         security_plugin_version=$(./gradlew properties -q | grep -E '^version:' | awk '{print $2}')

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 17
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17, 21]
+        jdk: [21]
         test-run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        jdk: [11, 17, 21]
+        jdk: [21]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -40,12 +40,13 @@ jobs:
         shell: bash
 
       - name: Run Opensearch with A Single Plugin
-        uses: derek-ho/start-opensearch@v4
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ steps.random-password.outputs.generated_name }}
+          jdk-version: 21
 
       - name: Run sanity tests
         uses: gradle/gradle-build-action@v3

--- a/build.gradle
+++ b/build.gradle
@@ -94,8 +94,8 @@ spotbugsTest {
     enabled = false
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_21
+java.targetCompatibility = JavaVersion.VERSION_21
 
 
 compileJava {

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -63,6 +63,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final List<String> requiredAudience;
     private final String requireIssuer;
 
+    @SuppressWarnings("removal")
     public HTTPJwtAuthenticator(final Settings settings, final Path configPath) {
         super();
 

--- a/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/kerberos/HTTPSpnegoAuthenticator.java
@@ -190,6 +190,7 @@ public class HTTPSpnegoAuthenticator implements HTTPAuthenticator {
         return creds;
     }
 
+    @SuppressWarnings("removal")
     private AuthCredentials extractCredentials0(final SecurityRequest request) {
 
         if (acceptorPrincipal == null || acceptorKeyTabPath == null) {

--- a/src/main/java/org/opensearch/security/DefaultObjectMapper.java
+++ b/src/main/java/org/opensearch/security/DefaultObjectMapper.java
@@ -139,6 +139,7 @@ public class DefaultObjectMapper {
         return value != null ? value : defaultValue;
     }
 
+    @SuppressWarnings("removal")
     public static <T> T readTree(JsonNode node, Class<T> clazz) throws IOException {
 
         final SecurityManager sm = System.getSecurityManager();

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -655,6 +655,7 @@ public class ConfigurationRepository implements ClusterStateListener {
         return ConfigurationRepository.DEFAULT_CONFIG_VERSION;
     }
 
+    @SuppressWarnings("removal")
     private class AccessControllerWrappedThread extends Thread {
         private final Thread innerThread;
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
@@ -265,6 +265,7 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
         return ConfigHelper.fromYamlFile(filepath, cType, ConfigurationRepository.DEFAULT_CONFIG_VERSION, 0, 0);
     }
 
+    @SuppressWarnings("removal")
     JsonNode loadConfigFileAsJson(final CType cType) throws IOException {
         final var cd = securityApiDependencies.configurationRepository().getConfigDirectory();
         final var filepath = cType.configFile(Path.of(cd)).toString();

--- a/src/main/java/org/opensearch/security/hasher/BCryptPasswordHasher.java
+++ b/src/main/java/org/opensearch/security/hasher/BCryptPasswordHasher.java
@@ -30,6 +30,7 @@ public class BCryptPasswordHasher implements PasswordHasher {
 
     private static final HashingFunction DEFAULT_BCRYPT_FUNCTION = BcryptFunction.getInstance(Bcrypt.Y, 12);
 
+    @SuppressWarnings("removal")
     @Override
     public String hash(char[] password) {
         if (password == null || password.length == 0) {
@@ -49,6 +50,7 @@ public class BCryptPasswordHasher implements PasswordHasher {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override
     public boolean check(char[] password, String hash) {
         if (password == null || password.length == 0) {

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -66,6 +66,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
 
     private final EncryptionDecryptionUtil encryptionUtil;
 
+    @SuppressWarnings("removal")
     public OnBehalfOfAuthenticator(Settings settings, String clusterName) {
         String oboEnabledSetting = settings.get("enabled", "true");
         oboEnabled = Boolean.parseBoolean(oboEnabledSetting);

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -425,6 +425,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
         }
     }
 
+    @SuppressWarnings("removal")
     private <T> T newInstance(final String clazzOrShortcut, String type, final Settings settings, final Path configPath) {
         final String clazz = authImplMap.computeIfAbsent(clazzOrShortcut + "_" + type, k -> clazzOrShortcut);
         return AccessController.doPrivileged((PrivilegedAction<T>) () -> {

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -972,6 +972,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
         enabledTransportProtocolsJDKProvider.retainAll(allowedSecureTransportSSLProtocols);
     }
 
+    @SuppressWarnings("removal")
     private SslContext buildSSLServerContext(
         final PrivateKey _key,
         final X509Certificate[] _cert,
@@ -1003,6 +1004,7 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
         }
     }
 
+    @SuppressWarnings("removal")
     private SslContext buildSSLServerContext(
         final File _key,
         final File _cert,

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -66,6 +66,7 @@ public class ConfigHelper {
         uploadFile(tc, filepath, index, cType, configVersion, false);
     }
 
+    @SuppressWarnings("removal")
     public static void uploadFile(
         Client tc,
         String filepath,

--- a/src/main/java/org/opensearch/security/support/SecurityIndexHandler.java
+++ b/src/main/java/org/opensearch/security/support/SecurityIndexHandler.java
@@ -87,6 +87,7 @@ public class SecurityIndexHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     public void uploadDefaultConfiguration(final Path configDir, final ActionListener<Set<SecurityConfig>> listener) {
         try (final ThreadContext.StoredContext threadContext = client.threadPool().getThreadContext().stashContext()) {
             AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/src/main/java/org/opensearch/security/util/KeyUtils.java
+++ b/src/main/java/org/opensearch/security/util/KeyUtils.java
@@ -33,6 +33,7 @@ import io.jsonwebtoken.security.Keys;
 
 public class KeyUtils {
 
+    @SuppressWarnings("removal")
     public static JwtParserBuilder createJwtParserBuilderFromSigningKey(final String signingKey, final Logger log) {
         final SecurityManager sm = System.getSecurityManager();
 

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("removal")
 public class OnBehalfOfAuthenticatorTest {
     final static String clusterName = "cluster_0";
     final static String enableOBO = "true";

--- a/src/test/java/org/opensearch/security/tools/democonfig/CertificateGeneratorTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/CertificateGeneratorTests.java
@@ -42,6 +42,7 @@ import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil
 import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil.deleteDirectoryRecursive;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("removal")
 public class CertificateGeneratorTests {
 
     private static Installer installer;

--- a/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
@@ -44,6 +44,7 @@ import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("removal")
 public class InstallerTests {
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;

--- a/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurerTests.java
@@ -55,6 +55,7 @@ import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil
 import static org.opensearch.security.tools.democonfig.util.DemoConfigHelperUtil.deleteDirectoryRecursive;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("removal")
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 public class SecuritySettingsConfigurerTests {
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/util/NoExitSecurityManager.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/util/NoExitSecurityManager.java
@@ -14,6 +14,7 @@ package org.opensearch.security.tools.democonfig.util;
 /**
  * Helper class to allow capturing and testing exit codes and block test execution from exiting mid-way
  */
+@SuppressWarnings("removal")
 public class NoExitSecurityManager extends SecurityManager {
     @Override
     public void checkPermission(java.security.Permission perm) {


### PR DESCRIPTION
### Description
Set security plugin 3.0.0 baseline JDK version to JDK-21

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/4407

### Testing
N/A

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
