### PR TITLE
Prepare for setting security plugin 3.0.0 baseline JDK version to JDK-21 (update Github Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 17
+        java-version: 21
 
     - name: Checkout security
       uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
       matrix:
         gradle_task: ${{ fromJson(needs.generate-test-list.outputs.separateTestsNames) }}
         platform: [windows-latest, ubuntu-latest]
-        jdk: [11, 17, 21]
+        jdk: [21]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17, 21]
+        jdk: [21]
         platform: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 11
+        java-version: 21
     - uses: github/codeql-action/init@v3
       with:
         languages: java
@@ -219,7 +219,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: temurin # Temurin is a distribution of adoptium
-        java-version: 11
+        java-version: 21
 
     - run: |
         security_plugin_version=$(./gradlew properties -q | grep -E '^version:' | awk '{print $2}')

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 17, 21]
+        jdk: [21]
         test-run: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin # Temurin is a distribution of adoptium
-          java-version: 11
+          java-version: 21
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        jdk: [11, 17, 21]
+        jdk: [21]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
### Description
Prepare for setting security plugin 3.0.0 baseline JDK version to JDK-21 (update Github Actions)

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
Part of https://github.com/opensearch-project/security/issues/4407, changing GA first to unblock  https://github.com/opensearch-project/security/pull/4457

Is this a backport? If so, please add backport PR # and/or commits #

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
