### PR TITLE
[Backport] [2.x] Bump org.eclipse.platform:org.eclipse.core.runtime from 3.31.0 to 3.3.1.100 (#4467)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -492,7 +492,8 @@ configurations {
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
 
             // for spotless transitive dependency CVE
-            force "org.eclipse.platform:org.eclipse.core.runtime:3.30.0"
+            force "org.eclipse.platform:org.eclipse.core.runtime:3.31.100"
+            force "org.eclipse.platform:org.eclipse.equinox.common:3.19.100"
 
             // For integrationTest
             force "org.apache.httpcomponents:httpclient-cache:4.5.14"


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4467 to `2.x`