### PR TITLE
Remove special handling for do_not_fail_on_forbidden on cluster actions

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -411,34 +411,6 @@ public class PrivilegesEvaluator {
                         }
                     }
 
-                    if (dnfofEnabled && (action0.startsWith("indices:data/read/")) && !requestedResolved.getAllIndices().isEmpty()) {
-
-                        if (requestedResolved.getAllIndices().isEmpty()) {
-                            presponse.missingPrivileges.clear();
-                            presponse.allowed = true;
-                            return presponse;
-                        }
-
-                        Set<String> reduced = securityRoles.reduce(
-                            requestedResolved,
-                            user,
-                            new String[] { action0 },
-                            resolver,
-                            clusterService
-                        );
-
-                        if (reduced.isEmpty()) {
-                            presponse.allowed = false;
-                            return presponse;
-                        }
-
-                        if (irr.replace(request, true, reduced.toArray(new String[0]))) {
-                            presponse.missingPrivileges.clear();
-                            presponse.allowed = true;
-                            return presponse;
-                        }
-                    }
-
                     if (isDebugEnabled) {
                         log.debug("Allowed because we have cluster permissions for {}", action0);
                     }

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -659,7 +659,9 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(403, resc.getStatusCode());
+        Assert.assertEquals(resc.getBody(), 200, resc.getStatusCode());
+        Assert.assertEquals(resc.getBody(), "security_exception", resc.findValueInJson("responses[0].error.type"));
+        Assert.assertEquals(resc.getBody(), "security_exception", resc.findValueInJson("responses[1].error.type"));
 
         String mgetBody = "{"
             + "\"docs\" : ["
@@ -696,7 +698,9 @@ public class IntegrationTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(403, resc.getStatusCode());
+        Assert.assertEquals(resc.getBody(), 200, resc.getStatusCode());
+        Assert.assertEquals(resc.getBody(), "index_not_found_exception", resc.findValueInJson("docs[0].error.type"));
+        Assert.assertEquals(resc.getBody(), "index_not_found_exception", resc.findValueInJson("docs[1].error.type"));
 
         Assert.assertEquals(
             HttpStatus.SC_OK,


### PR DESCRIPTION
The special handling for `do_not_fail_on_forbidden` on cluster actions does not provide any benefits - rather it just causes some inconsistent behavior. See #4485 for the details.

This is part of the work done for #3870

### Description

* Category: Enhancement and bug fix
* Why these changes are required? - The present behavior is inconsistent and confusing. Additionally, it does unnecessary computations on index sets, which can potentially decrease action throughput
* What is the old behavior before changes and new behavior after changes? - Both clusters with `do_not_fail_on_forbidden` set to `true`  and to `false` will need the same set of privileges for multi actions and scroll actions. The need to specify `indices:data/read/mget`, `indices:data/read/msearch`, `indices:data/read/mtv`, `indices:data/read/scroll` and `indices:data/read/search/template/render` as index permissions in the roles config will go away.

### Issues Resolved

- Resolves #4485 

### Testing

- Tests in `DoNotFailOnForbiddenTests` have been adapted.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR - not necessary
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
