### PR TITLE
Separated DLS/FLS privilege evaluation from action privilege evaluation

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1166,6 +1166,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             // Don't register if advanced modules is disabled in which case auditlog is instance of NullAuditLog
             dcf.registerDCFListener(auditLog);
         }
+        if (dlsFlsValve instanceof DlsFlsValveImpl) {
+            dcf.registerDCFListener(dlsFlsValve);
+        }
 
         cr.setDynamicConfigFactory(dcf);
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1118,8 +1118,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final CompatConfig compatConfig = new CompatConfig(environment, transportPassiveAuthSetting);
 
-        // DLS-FLS is enabled if not client and not disabled and not SSL only.
-        final boolean dlsFlsEnabled = !SSLConfig.isSslOnlyMode();
         evaluator = new PrivilegesEvaluator(
             clusterService,
             threadPool,
@@ -1130,7 +1128,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             privilegesInterceptor,
             cih,
             irr,
-            dlsFlsEnabled,
             namedXContentRegistry.get()
         );
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -58,6 +58,7 @@ import org.opensearch.script.mustache.SearchTemplateAction;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.security.privileges.DocumentAllowList;
+import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.queries.QueryBuilderTraverser;
 import org.opensearch.security.resolver.IndexResolverReplacer.Resolved;
 import org.opensearch.security.securityconf.EvaluatedDlsFlsConfig;
@@ -74,11 +75,9 @@ public class DlsFilterLevelActionHandler {
     );
 
     public static boolean handle(
-        String action,
-        ActionRequest request,
-        ActionListener<?> listener,
+        PrivilegesEvaluationContext context,
         EvaluatedDlsFlsConfig evaluatedDlsFlsConfig,
-        Resolved resolved,
+        ActionListener<?> listener,
         Client nodeClient,
         ClusterService clusterService,
         IndicesService indicesService,
@@ -90,6 +89,9 @@ public class DlsFilterLevelActionHandler {
         if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
             return true;
         }
+
+        String action = context.getAction();
+        ActionRequest request = context.getRequest();
 
         if (action.startsWith("cluster:")
             || action.startsWith("indices:admin/template/")
@@ -112,11 +114,9 @@ public class DlsFilterLevelActionHandler {
         }
 
         return new DlsFilterLevelActionHandler(
-            action,
-            request,
-            listener,
+            context,
             evaluatedDlsFlsConfig,
-            resolved,
+            listener,
             nodeClient,
             clusterService,
             indicesService,
@@ -142,11 +142,9 @@ public class DlsFilterLevelActionHandler {
     private DocumentAllowList documentAllowlist;
 
     DlsFilterLevelActionHandler(
-        String action,
-        ActionRequest request,
-        ActionListener<?> listener,
+        PrivilegesEvaluationContext context,
         EvaluatedDlsFlsConfig evaluatedDlsFlsConfig,
-        Resolved resolved,
+        ActionListener<?> listener,
         Client nodeClient,
         ClusterService clusterService,
         IndicesService indicesService,
@@ -154,11 +152,11 @@ public class DlsFilterLevelActionHandler {
         DlsQueryParser dlsQueryParser,
         ThreadContext threadContext
     ) {
-        this.action = action;
-        this.request = request;
+        this.action = context.getAction();
+        this.request = context.getRequest();
         this.listener = listener;
         this.evaluatedDlsFlsConfig = evaluatedDlsFlsConfig;
-        this.resolved = resolved;
+        this.resolved = context.getResolvedRequest();
         this.nodeClient = nodeClient;
         this.clusterService = clusterService;
         this.indicesService = indicesService;

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsRequestValve.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsRequestValve.java
@@ -31,19 +31,12 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.query.QuerySearchResult;
-import org.opensearch.security.resolver.IndexResolverReplacer.Resolved;
-import org.opensearch.security.securityconf.EvaluatedDlsFlsConfig;
+import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.threadpool.ThreadPool;
 
 public interface DlsFlsRequestValve {
 
-    boolean invoke(
-        String action,
-        ActionRequest request,
-        ActionListener<?> listener,
-        EvaluatedDlsFlsConfig evaluatedDlsFlsConfig,
-        Resolved resolved
-    );
+    boolean invoke(String action, ActionRequest request, ActionListener<?> listener, PrivilegesEvaluationContext context);
 
     void handleSearchContext(SearchContext context, ThreadPool threadPool, NamedXContentRegistry namedXContentRegistry);
 
@@ -52,13 +45,7 @@ public interface DlsFlsRequestValve {
     public static class NoopDlsFlsRequestValve implements DlsFlsRequestValve {
 
         @Override
-        public boolean invoke(
-            String action,
-            ActionRequest request,
-            ActionListener<?> listener,
-            EvaluatedDlsFlsConfig evaluatedDlsFlsConfig,
-            Resolved resolved
-        ) {
+        public boolean invoke(String action, ActionRequest request, ActionListener<?> listener, PrivilegesEvaluationContext context) {
             return true;
         }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsRequestValve.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsRequestValve.java
@@ -26,7 +26,6 @@
 
 package org.opensearch.security.configuration;
 
-import org.opensearch.action.ActionRequest;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.search.internal.SearchContext;
@@ -36,7 +35,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 public interface DlsFlsRequestValve {
 
-    boolean invoke(String action, ActionRequest request, ActionListener<?> listener, PrivilegesEvaluationContext context);
+    boolean invoke(PrivilegesEvaluationContext context, ActionListener<?> listener);
 
     void handleSearchContext(SearchContext context, ThreadPool threadPool, NamedXContentRegistry namedXContentRegistry);
 
@@ -45,7 +44,7 @@ public interface DlsFlsRequestValve {
     public static class NoopDlsFlsRequestValve implements DlsFlsRequestValve {
 
         @Override
-        public boolean invoke(String action, ActionRequest request, ActionListener<?> listener, PrivilegesEvaluationContext context) {
+        public boolean invoke(PrivilegesEvaluationContext context, ActionListener<?> listener) {
             return true;
         }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -144,7 +144,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     + request
                     + "\nevaluatedDlsFlsConfig: "
                     + evaluatedDlsFlsConfig
-                    + "\ncontext: "
+                    + "\nresolved: "
                     + resolved
                     + "\nmode: "
                     + mode

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -379,15 +379,8 @@ public class SecurityFilter implements ActionFilter {
                 log.trace("Evaluate permissions for user: {}", user.getName());
             }
 
-            PrivilegesEvaluationContext context = null;
-            PrivilegesEvaluatorResponse pres;
-
-            try {
-                context = eval.createContext(user, action, request, task, injectedRoles);
-                pres = eval.evaluate(context);
-            } catch (PrivilegesEvaluatorResponse.NotAllowedException e) {
-                pres = e.getResponse();
-            }
+            PrivilegesEvaluationContext context = eval.createContext(user, action, request, task, injectedRoles);
+            PrivilegesEvaluatorResponse pres = eval.evaluate(context);
 
             if (log.isDebugEnabled()) {
                 log.debug(pres.toString());

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -389,7 +389,7 @@ public class SecurityFilter implements ActionFilter {
             if (pres.isAllowed()) {
                 auditLog.logGrantedPrivileges(action, request, task);
                 auditLog.logIndexEvent(action, request, task);
-                if (!dlsFlsValve.invoke(action, request, listener, context)) {
+                if (!dlsFlsValve.invoke(context, listener)) {
                     return;
                 }
                 final CreateIndexRequestBuilder createIndexRequestBuilder = pres.getCreateIndexRequestBuilder();

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.privileges;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import com.google.common.collect.ImmutableSet;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.security.resolver.IndexResolverReplacer;
+import org.opensearch.security.support.WildcardMatcher;
+import org.opensearch.security.user.User;
+import org.opensearch.tasks.Task;
+
+/**
+ * Request-scoped context information for privilege evaluation.
+ *
+ * This class carries metadata about the request and provides caching facilities for data which might need to be
+ * evaluated several times per request.
+ *
+ * As this class is request-scoped, it is only used by a single thread. Thus, no thread synchronization mechanisms
+ * are necessary.
+ */
+public class PrivilegesEvaluationContext {
+    private final User user;
+    private final String action;
+    private final ActionRequest request;
+    private IndexResolverReplacer.Resolved resolvedRequest;
+    private final Task task;
+    private final ImmutableSet<String> mappedRoles;
+    private final IndexResolverReplacer indexResolverReplacer;
+
+    public PrivilegesEvaluationContext(
+        User user,
+        ImmutableSet<String> mappedRoles,
+        String action,
+        ActionRequest request,
+        Task task,
+        IndexResolverReplacer indexResolverReplacer
+    ) {
+        this.user = user;
+        this.mappedRoles = mappedRoles;
+        this.action = action;
+        this.request = request;
+        this.task = task;
+        this.indexResolverReplacer = indexResolverReplacer;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public ActionRequest getRequest() {
+        return request;
+    }
+
+    public IndexResolverReplacer.Resolved getResolvedRequest() {
+        IndexResolverReplacer.Resolved result = this.resolvedRequest;
+
+        if (result == null) {
+            result = indexResolverReplacer.resolveRequest(request);
+            this.resolvedRequest = result;
+        }
+
+        return result;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public ImmutableSet<String> getMappedRoles() {
+        return mappedRoles;
+    }
+
+}

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
@@ -10,17 +10,10 @@
  */
 package org.opensearch.security.privileges;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Supplier;
-
 import com.google.common.collect.ImmutableSet;
 
 import org.opensearch.action.ActionRequest;
-import org.opensearch.cluster.ClusterState;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.security.resolver.IndexResolverReplacer;
-import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.user.User;
 import org.opensearch.tasks.Task;
 

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
@@ -32,7 +32,7 @@ public class PrivilegesEvaluationContext {
     private final ActionRequest request;
     private IndexResolverReplacer.Resolved resolvedRequest;
     private final Task task;
-    private final ImmutableSet<String> mappedRoles;
+    private ImmutableSet<String> mappedRoles;
     private final IndexResolverReplacer indexResolverReplacer;
 
     public PrivilegesEvaluationContext(
@@ -80,6 +80,18 @@ public class PrivilegesEvaluationContext {
 
     public ImmutableSet<String> getMappedRoles() {
         return mappedRoles;
+    }
+
+    /**
+     * Note: Ideally, mappedRoles would be an unmodifiable attribute. PrivilegesEvaluator however contains logic
+     * related to OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION which first validates roles and afterwards modifies
+     * them again. Thus, we need to be able to set this attribute.
+     *
+     * However, this method should be only used for this one particular phase. Normally, all roles should be determined
+     * upfront and stay constant during the whole privilege evaluation process.
+     */
+    void setMappedRoles(ImmutableSet<String> mappedRoles) {
+        this.mappedRoles = mappedRoles;
     }
 
 }

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -38,7 +38,6 @@ public class PrivilegesEvaluatorResponse {
     Set<String> resolvedSecurityRoles = new HashSet<>();
     PrivilegesEvaluatorResponseState state = PrivilegesEvaluatorResponseState.PENDING;
     CreateIndexRequestBuilder createIndexRequestBuilder;
-    private String reason;
 
     public boolean isAllowed() {
         return allowed;
@@ -76,15 +75,6 @@ public class PrivilegesEvaluatorResponse {
 
     public boolean isPending() {
         return this.state == PrivilegesEvaluatorResponseState.PENDING;
-    }
-
-    public String getReason() {
-        return this.reason;
-    }
-
-    public PrivilegesEvaluatorResponse reason(String reason) {
-        this.reason = reason;
-        return this;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -89,11 +89,7 @@ public class PrivilegesEvaluatorResponse {
 
     @Override
     public String toString() {
-        return "PrivEvalResponse [allowed="
-            + allowed
-            + ", missingPrivileges="
-            + missingPrivileges
-            + "]";
+        return "PrivEvalResponse [allowed=" + allowed + ", missingPrivileges=" + missingPrivileges + "]";
     }
 
     public static enum PrivilegesEvaluatorResponseState {

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -96,27 +96,4 @@ public class PrivilegesEvaluatorResponse {
         PENDING,
         COMPLETE;
     }
-
-    /**
-     * This exception can be used to indicate that a method denies a user access to an OpenSearch action.
-     *
-     * Note: As exceptions take their performance toll, please use this exception only when there is
-     * no other way. Prefer to use PrivilegesEvaluatorResponse directly as a return value.
-     */
-    public static class NotAllowedException extends Exception {
-        private final PrivilegesEvaluatorResponse response;
-
-        public NotAllowedException(PrivilegesEvaluatorResponse response) {
-            super(response.reason);
-            this.response = response;
-            if (response.allowed) {
-                throw new IllegalArgumentException("Only possible for PrivilegesEvaluatorResponse with allowed=false");
-            }
-        }
-
-        public PrivilegesEvaluatorResponse getResponse() {
-            return response;
-        }
-    }
-
 }

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluatorResponse.java
@@ -40,9 +40,6 @@ public class PrivilegesEvaluatorResponse {
     CreateIndexRequestBuilder createIndexRequestBuilder;
     private String reason;
 
-    /**
-     * Returns true if the request can be fully allowed. See also isAllowedForSpecificIndices().
-     */
     public boolean isAllowed() {
         return allowed;
     }
@@ -104,22 +101,21 @@ public class PrivilegesEvaluatorResponse {
         COMPLETE;
     }
 
+    /**
+     * This exception can be used to indicate that a method denies a user access to an OpenSearch action.
+     *
+     * Note: As exceptions take their performance toll, please use this exception only when there is
+     * no other way. Prefer to use PrivilegesEvaluatorResponse directly as a return value.
+     */
     public static class NotAllowedException extends Exception {
         private final PrivilegesEvaluatorResponse response;
 
         public NotAllowedException(PrivilegesEvaluatorResponse response) {
             super(response.reason);
             this.response = response;
-        }
-
-        public NotAllowedException(PrivilegesEvaluatorResponse response, String message) {
-            super(message);
-            this.response = response;
-        }
-
-        public NotAllowedException(PrivilegesEvaluatorResponse response, String message, Throwable cause) {
-            super(message, cause);
-            this.response = response;
+            if (response.allowed) {
+                throw new IllegalArgumentException("Only possible for PrivilegesEvaluatorResponse with allowed=false");
+            }
         }
 
         public PrivilegesEvaluatorResponse getResponse() {


### PR DESCRIPTION
### Description

This change is in preparation for #3870 and #4380 .

This cuts off some parts from the quite big and monolithic method `PrivilegesEvaluator.evaluate()` into separate methods and modules.

This achieves several things:

- Better separation of concerns, thus better modularization and thus better understandability, re-usability and testability
- Computations of DLS/FLS privileges are done directly in the DLS/FLS valve code. Thus, if DLS/FLS valve is disabled, no DLS/FLS privileges are computed
- The new class `PrivilegesEvaluationContext` combines commonly needed information for privilege evaluation and thus allows to shorten the parameter lists of many methods in this context. For this PR, only the `PrivilegesEvaluator.evaluate()` method itself is changed, but further adaptions will follow up when due.


* Category - Refactoring
* Why these changes are required? 
   - For #3870, we need to re-build the privilege evaluation code both for the normal action privilege evaluation and for DLS/FLS. Even though these are quite separate and different things, these are currently intermingled in one big monolith. The changes for #3870 will be easier to understand if they are structured better.
* What is the old behavior before changes and new behavior after changes? - No changes.

### Issues Resolved

Contributes to #3870

### Testing

- Existing integration tests

### Check List
- [ ] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
