### PR TITLE
Fix NPE getting metaFields from mapperService on a close index request

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -24,6 +24,7 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,6 +60,7 @@ import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.log.LogsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -304,6 +306,9 @@ public class FlsAndFieldMaskingTests {
             USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
         )
         .build();
+
+    @Rule
+    public LogsRule logsRule = new LogsRule("org.opensearch.security.configuration.SecurityFlsDlsIndexSearcherWrapper");
 
     /**
     * Function that returns id assigned to song with title equal to given title or throws {@link RuntimeException}
@@ -1719,6 +1724,7 @@ public class FlsAndFieldMaskingTests {
         });
     }
 
+    @Test
     public void flsWithIncludesRulesIncludesFieldMappersFromPlugins() throws IOException {
         String indexName = "fls_includes_index";
         TestSecurityConfig.Role userRole = new TestSecurityConfig.Role("fls_include_stars_reader").clusterPermissions(
@@ -1726,6 +1732,36 @@ public class FlsAndFieldMaskingTests {
         ).indexPermissions("read").fls(FIELD_STARS).on("*");
         TestSecurityConfig.User user = createUserWithRole("fls_includes_user", userRole);
         List<String> docIds = createIndexWithDocs(indexName, SONGS[0], SONGS[1]);
+
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(user)) {
+            SearchRequest searchRequest = new SearchRequest(indexName);
+            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            MatchAllQueryBuilder matchAllQueryBuilder = QueryBuilders.matchAllQuery();
+            searchSourceBuilder.storedFields(List.of(SizeFieldMapper.NAME, SourceFieldMapper.NAME));
+            searchSourceBuilder.query(matchAllQueryBuilder);
+            searchRequest.source(searchSourceBuilder);
+            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            assertSearchHitsDoContainField(searchResponse, FIELD_STARS);
+            assertThat(searchResponse.toString(), containsString(SizeFieldMapper.NAME));
+            assertSearchHitsDoNotContainField(searchResponse, FIELD_ARTIST);
+        }
+    }
+
+    @Test
+    public void testFlsOnAClosedAndReopenedIndex() throws IOException {
+        String indexName = "fls_includes_index";
+        TestSecurityConfig.Role userRole = new TestSecurityConfig.Role("fls_include_stars_reader").clusterPermissions(
+            "cluster_composite_ops_ro"
+        ).indexPermissions("read").fls(FIELD_STARS).on("*");
+        TestSecurityConfig.User user = createUserWithRole("fls_includes_user", userRole);
+        List<String> docIds = createIndexWithDocs(indexName, SONGS[0], SONGS[1]);
+
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            client.post(indexName + "/_close");
+            client.post(indexName + "/_open");
+            logsRule.assertThatContainExactly(indexName + " was closed. Setting metadataFields to empty. Closed index is not searchable.");
+        }
 
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(user)) {
             SearchRequest searchRequest = new SearchRequest(indexName);

--- a/src/integrationTest/java/org/opensearch/test/framework/log/LogsRule.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/log/LogsRule.java
@@ -64,7 +64,7 @@ public class LogsRule extends ExternalResource {
     */
     public void assertThatContain(String messageFragment) {
         List<String> messages = LogCapturingAppender.getLogMessagesAsString();
-        ;
+
         String reason = reasonMessage(messageFragment, messages);
         assertThat(reason, messages, hasItem(containsString(messageFragment)));
     }

--- a/src/integrationTest/resources/log4j2-test.properties
+++ b/src/integrationTest/resources/log4j2-test.properties
@@ -28,8 +28,11 @@ logger.auditlogs.level = info
 # Logger required by test org.opensearch.security.http.JwtAuthenticationTests
 logger.httpjwtauthenticator.name = com.amazon.dlic.auth.http.jwt.HTTPJwtAuthenticator
 logger.httpjwtauthenticator.level = debug
-logger.backendreg.additivity = false
 logger.httpjwtauthenticator.appenderRef.capturing.ref = logCapturingAppender
+
+logger.securityflsdlsindexsearcherwrapper.name = org.opensearch.security.configuration.SecurityFlsDlsIndexSearcherWrapper
+logger.securityflsdlsindexsearcherwrapper.level = debug
+logger.securityflsdlsindexsearcherwrapper.appenderRef.capturing.ref = logCapturingAppender
 
 #Required by tests:
 # org.opensearch.security.IpBruteForceAttacksPreventionTests
@@ -43,5 +46,4 @@ logger.backendreg.appenderRef.capturing.ref = logCapturingAppender
 #logger.ldap.name=com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend
 logger.ldap.name=com.amazon.dlic.auth.ldap.backend
 logger.ldap.level=TRACE
-logger.backendreg.additivity = false
 logger.ldap.appenderRef.capturing.ref = logCapturingAppender

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -20,10 +20,13 @@ import java.util.Set;
 import java.util.function.LongSupplier;
 
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
 
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.shard.ShardId;
@@ -39,6 +42,8 @@ import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.support.SecurityUtils;
 
 public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWrapper {
+
+    public final Logger log = LogManager.getLogger(this.getClass());
 
     private final Set<String> metaFields;
     public static final Set<String> META_FIELDS_BEFORE_7DOT8 = Collections.unmodifiableSet(
@@ -62,10 +67,23 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         final Salt salt
     ) {
         super(indexService, settings, adminDNs, evaluator);
-        Set<String> metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
-        SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
-        metadataFieldsCopy.add(sequenceIDFields.primaryTerm.name());
-        metadataFieldsCopy.addAll(META_FIELDS_BEFORE_7DOT8);
+        Set<String> metadataFieldsCopy;
+        if (indexService.getMetadata().getState() == IndexMetadata.State.CLOSE) {
+            System.out.println("log debug: " + log.isDebugEnabled());
+            System.out.println("log name: " + log.getName());
+            if (log.isDebugEnabled()) {
+                log.debug(
+                    "{} was closed. Setting metadataFields to empty. Closed index is not searchable.",
+                    indexService.index().getName()
+                );
+            }
+            metadataFieldsCopy = Collections.emptySet();
+        } else {
+            metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
+            SeqNoFieldMapper.SequenceIDFields sequenceIDFields = SeqNoFieldMapper.SequenceIDFields.emptySeqID();
+            metadataFieldsCopy.add(sequenceIDFields.primaryTerm.name());
+            metadataFieldsCopy.addAll(META_FIELDS_BEFORE_7DOT8);
+        }
         metaFields = metadataFieldsCopy;
         ciol.setIs(indexService);
         this.clusterService = clusterService;

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -69,8 +69,6 @@ public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWra
         super(indexService, settings, adminDNs, evaluator);
         Set<String> metadataFieldsCopy;
         if (indexService.getMetadata().getState() == IndexMetadata.State.CLOSE) {
-            System.out.println("log debug: " + log.isDebugEnabled());
-            System.out.println("log name: " + log.getName());
             if (log.isDebugEnabled()) {
                 log.debug(
                     "{} was closed. Setting metadataFields to empty. Closed index is not searchable.",


### PR DESCRIPTION
### Description

Fixes a NullPointerException that occurs on a Closed index request. This fixes an issue seen after the merge of https://github.com/opensearch-project/security/pull/4370 which made a change to get the list of metaFields from the mapperService in core. On close index requests, `indexService.mapperService()` can return null so the call to `indexService.mapperService().getMetadataFields()` throws an NPE.

This fix checks for Close index requests and handles the scenario accordingly. Closed indices are not searchable so there's no need to have a list of metaFields for a closed index.

> The close index API operation closes an index. Once an index is closed, you cannot add data to it or search for any data within the index.

Ref: https://opensearch.org/docs/latest/api-reference/index-apis/close-index/

* Category

Bug fix

### Issues Resolved

- https://github.com/opensearch-project/security/issues/4475

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
