### PR TITLE
[BUG] Blake2b hashing for Masked Fields does not apply salt correctly

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/MaskedField.java
+++ b/src/main/java/org/opensearch/security/configuration/MaskedField.java
@@ -152,7 +152,7 @@ public class MaskedField {
     private byte[] blake2bHash(byte[] in) {
         // Salt is passed incorrectly but order of parameters is retained at present to ensure full backwards compatibility
         // Tracking with https://github.com/opensearch-project/security/issues/4274
-        final Blake2b hash = new Blake2b(null, 32, null, defaultSalt);
+        final Blake2b hash = new Blake2b(null, 32, defaultSalt, null);
         hash.update(in, 0, in.length);
         final byte[] out = new byte[hash.getDigestSize()];
         hash.digest(out, 0);


### PR DESCRIPTION
### Description
As per: https://github.com/opensearch-project/security/issues/4274 change the calling Blake hash function to set the salt to to the default salt rather than the personalization.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Bug fix

* Why these changes are required?
Refer to: https://github.com/opensearch-project/security/issues/4274

* What is the old behavior before changes and new behavior after changes?
Hashes for field masking should be different, but this behavior should be the expected behavior since the salt is set to the actual default salt value.

### Issues Resolved
https://github.com/opensearch-project/security/issues/4274

Is this a backport? If so, please add backport PR # and/or commits #
No

### Testing
Fixed field masking tests accordingly to reflect new hashes.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
