### PR TITLE
[Backport 2.x] [Enhancement] Replace JUnit assertEquals() with Hamcrest matchers assertThat()

### DIFF
--- a/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
@@ -27,7 +27,6 @@ import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 
@@ -43,10 +42,12 @@ import org.opensearch.common.util.io.IOUtils;
 import org.opensearch.security.bwc.helper.RestHelper;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
 
 public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
@@ -184,7 +185,7 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
 
     public void testNodeStats() throws IOException {
         List<Response> responses = RestHelper.requestAgainstAllNodes(client(), "GET", "_nodes/stats", null);
-        responses.forEach(r -> Assert.assertEquals(200, r.getStatusLine().getStatusCode()));
+        responses.forEach(r -> assertThat(r.getStatusLine().getStatusCode(), is(200)));
     }
 
     @SuppressWarnings("unchecked")
@@ -231,7 +232,7 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                 "_bulk?refresh=wait_for",
                 RestHelper.toHttpEntity(bulkRequestBody.toString())
             );
-            responses.forEach(r -> assertEquals(200, r.getStatusLine().getStatusCode()));
+            responses.forEach(r -> assertThat(r.getStatusLine().getStatusCode(), is(200)));
         }
     }
 
@@ -249,7 +250,7 @@ public class SecurityBackwardsCompatibilityIT extends OpenSearchRestTestCase {
                 index + "/_search",
                 RestHelper.toHttpEntity(matchAllQuery)
             );
-            responses.forEach(r -> assertEquals(200, r.getStatusLine().getStatusCode()));
+            responses.forEach(r -> assertThat(r.getStatusLine().getStatusCode(), is(200)));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
@@ -707,7 +707,7 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                     case HttpStatus.SC_OK:
                         break;
                     default:
-                        Assert.assertEquals(HttpStatus.SC_CONFLICT, sc);
+                        assertThat(sc, is(HttpStatus.SC_CONFLICT));
                         break;
                 }
             }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -70,11 +70,12 @@ import org.opensearch.test.framework.cluster.ClusterManager.NodeSettings;
 import org.opensearch.transport.BindTransportException;
 
 import static java.util.Objects.requireNonNull;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.test.framework.cluster.NodeType.CLIENT;
 import static org.opensearch.test.framework.cluster.NodeType.CLUSTER_MANAGER;
 import static org.opensearch.test.framework.cluster.NodeType.DATA;
 import static org.opensearch.test.framework.cluster.PortAllocator.TCP;
-import static org.junit.Assert.assertEquals;
 
 /**
 * Encapsulates all the logic to start a local OpenSearch cluster - without any configuration of the security plugin.
@@ -339,7 +340,7 @@ public class LocalOpenSearchCluster {
             log.debug("... cluster state ok {} with {} nodes", healthResponse.getStatus().name(), healthResponse.getNumberOfNodes());
         }
 
-        assertEquals(expectedNodeCount, healthResponse.getNumberOfNodes());
+        assertThat(healthResponse.getNumberOfNodes(), is(expectedNodeCount));
 
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -38,6 +38,8 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -156,11 +158,11 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("horst", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
-        Assert.assertEquals(5, credentials.getAttributes().size());
-        Assert.assertEquals("854113533", credentials.getAttributes().get("attr.jwt.nbf"));
-        Assert.assertEquals("4853843133", credentials.getAttributes().get("attr.jwt.exp"));
+        assertThat(credentials.getUsername(), is("horst"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
+        assertThat(credentials.getAttributes().size(), is(5));
+        assertThat(credentials.getAttributes().get("attr.jwt.nbf"), is("854113533"));
+        assertThat(credentials.getAttributes().get("attr.jwt.exp"), is("4853843133"));
     }
 
     @Test
@@ -211,9 +213,9 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
-        Assert.assertEquals(2, credentials.getAttributes().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
+        assertThat(credentials.getAttributes().size(), is(2));
     }
 
     @Test
@@ -259,8 +261,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(2, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(2));
     }
 
     @Test
@@ -272,8 +274,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -285,8 +287,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(1, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(1));
         Assert.assertTrue(credentials.getBackendRoles().contains("123"));
     }
 
@@ -299,8 +301,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -323,8 +325,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Dr. Who", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Dr. Who"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -336,8 +338,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("false", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("false"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -358,8 +360,8 @@ public class HTTPJwtAuthenticatorTest {
         AuthCredentials credentials = jwtAuth.extractCredentials(req.asSecurityRequest(), null);
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
-        Assert.assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -411,8 +413,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        assertThat(creds.getUsername(), is("Leonard McCoy"));
+        assertThat(creds.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -437,8 +439,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals("Leonard McCoy", creds.getUsername());
-        Assert.assertEquals(0, creds.getBackendRoles().size());
+        assertThat(creds.getUsername(), is("Leonard McCoy"));
+        assertThat(creds.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -452,8 +454,8 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("John Doe", credentials.getUsername());
-        Assert.assertEquals(3, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("John Doe"));
+        assertThat(credentials.getBackendRoles().size(), is(3));
         Assert.assertTrue(credentials.getBackendRoles().contains("a"));
         Assert.assertTrue(credentials.getBackendRoles().contains("b"));
         Assert.assertTrue(credentials.getBackendRoles().contains("3rd"));
@@ -468,7 +470,7 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
     }
 
     @Test
@@ -493,7 +495,7 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
     }
 
     @Test
@@ -518,7 +520,7 @@ public class HTTPJwtAuthenticatorTest {
         );
 
         Assert.assertNotNull(credentials);
-        Assert.assertEquals("Leonard McCoy", credentials.getUsername());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
     }
 
     @Test

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -24,6 +24,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
     protected static MockIpdServer mockIdpServer;
@@ -58,10 +61,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -80,10 +83,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -134,10 +137,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -185,8 +188,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
         });
 
-        Assert.assertEquals("Authentication backend failed", exception.getMessage());
-        Assert.assertEquals(OpenSearchSecurityException.class, exception.getClass());
+        assertThat(exception.getMessage(), is("Authentication backend failed"));
+        assertThat(exception.getClass(), is(OpenSearchSecurityException.class));
     }
 
     @Test
@@ -208,10 +211,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -231,10 +234,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -255,8 +258,8 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(TestJwts.TEST_ROLES, creds.getBackendRoles());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getBackendRoles(), is(TestJwts.TEST_ROLES));
     }
 
     @Test
@@ -366,10 +369,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
     @Test
@@ -404,10 +407,10 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
         );
 
         Assert.assertNotNull(creds);
-        Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-        Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-        Assert.assertEquals(0, creds.getBackendRoles().size());
-        Assert.assertEquals(4, creds.getAttributes().size());
+        assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+        assertThat(creds.getBackendRoles().size(), is(0));
+        assertThat(creds.getAttributes().size(), is(4));
     }
 
 }

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetrieverTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetrieverTest.java
@@ -31,7 +31,6 @@ import org.apache.http.ssl.PrivateKeyStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.ssl.SSLContexts;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,6 +38,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.network.SocketUtils;
 
 import com.amazon.dlic.util.SettingsBasedSSLConfigurator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class KeySetRetrieverTest {
     protected static MockIpdServer mockIdpServer;
@@ -63,12 +65,12 @@ public class KeySetRetrieverTest {
 
         keySetRetriever.get();
 
-        Assert.assertEquals(1, keySetRetriever.getOidcCacheMisses());
-        Assert.assertEquals(0, keySetRetriever.getOidcCacheHits());
+        assertThat(keySetRetriever.getOidcCacheMisses(), is(1));
+        assertThat(keySetRetriever.getOidcCacheHits(), is(0));
 
         keySetRetriever.get();
-        Assert.assertEquals(1, keySetRetriever.getOidcCacheMisses());
-        Assert.assertEquals(1, keySetRetriever.getOidcCacheHits());
+        assertThat(keySetRetriever.getOidcCacheMisses(), is(1));
+        assertThat(keySetRetriever.getOidcCacheHits(), is(1));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class KeySetRetrieverTest {
                 try {
                     String sha256Fingerprint = Hashing.sha256().hashBytes(peerCert.getEncoded()).toString();
 
-                    Assert.assertEquals("04b2b8baea7a0a893f0223d95b72081e9a1e154a0f9b1b4e75998085972b1b68", sha256Fingerprint);
+                    assertThat(sha256Fingerprint, is("04b2b8baea7a0a893f0223d95b72081e9a1e154a0f9b1b4e75998085972b1b68"));
 
                 } catch (CertificateEncodingException e) {
                     throw new RuntimeException(e);

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SelfRefreshingKeySetTest.java
@@ -22,6 +22,9 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.OctetSequenceKey;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SelfRefreshingKeySetTest {
 
     @Test
@@ -29,18 +32,18 @@ public class SelfRefreshingKeySetTest {
         SelfRefreshingKeySet selfRefreshingKeySet = new SelfRefreshingKeySet(new MockKeySetProvider());
 
         OctetSequenceKey key1 = (OctetSequenceKey) selfRefreshingKeySet.getKey("kid/a");
-        Assert.assertEquals(TestJwk.OCT_1_K, key1.getKeyValue().decodeToString());
-        Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
+        assertThat(key1.getKeyValue().decodeToString(), is(TestJwk.OCT_1_K));
+        assertThat(selfRefreshingKeySet.getRefreshCount(), is(1));
 
         OctetSequenceKey key2 = (OctetSequenceKey) selfRefreshingKeySet.getKey("kid/b");
-        Assert.assertEquals(TestJwk.OCT_2_K, key2.getKeyValue().decodeToString());
-        Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
+        assertThat(key2.getKeyValue().decodeToString(), is(TestJwk.OCT_2_K));
+        assertThat(selfRefreshingKeySet.getRefreshCount(), is(1));
 
         try {
             selfRefreshingKeySet.getKey("kid/X");
             Assert.fail("Expected a BadCredentialsException");
         } catch (BadCredentialsException e) {
-            Assert.assertEquals(2, selfRefreshingKeySet.getRefreshCount());
+            assertThat(selfRefreshingKeySet.getRefreshCount(), is(2));
         }
 
     }
@@ -65,11 +68,11 @@ public class SelfRefreshingKeySetTest {
 
         provider.unblock();
 
-        Assert.assertEquals(TestJwk.OCT_1_K, ((OctetSequenceKey) f1.get()).getKeyValue().decodeToString());
-        Assert.assertEquals(TestJwk.OCT_2_K, ((OctetSequenceKey) f2.get()).getKeyValue().decodeToString());
+        assertThat(((OctetSequenceKey) f1.get()).getKeyValue().decodeToString(), is(TestJwk.OCT_1_K));
+        assertThat(((OctetSequenceKey) f2.get()).getKeyValue().decodeToString(), is(TestJwk.OCT_2_K));
 
-        Assert.assertEquals(1, selfRefreshingKeySet.getRefreshCount());
-        Assert.assertEquals(1, selfRefreshingKeySet.getQueuedGetCount());
+        assertThat(selfRefreshingKeySet.getRefreshCount(), is(1));
+        assertThat(selfRefreshingKeySet.getQueuedGetCount(), is(1));
 
     }
 

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -22,6 +22,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
 
     @Test
@@ -39,10 +42,10 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
 
             Assert.assertNotNull(creds);
-            Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-            Assert.assertEquals(0, creds.getBackendRoles().size());
-            Assert.assertEquals(4, creds.getAttributes().size());
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+            assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+            assertThat(creds.getBackendRoles().size(), is(0));
+            assertThat(creds.getAttributes().size(), is(4));
 
         } finally {
             try {
@@ -89,10 +92,10 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
 
             Assert.assertNotNull(creds);
-            Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-            Assert.assertEquals(0, creds.getBackendRoles().size());
-            Assert.assertEquals(4, creds.getAttributes().size());
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+            assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+            assertThat(creds.getBackendRoles().size(), is(0));
+            assertThat(creds.getAttributes().size(), is(4));
         } finally {
             try {
                 mockIdpServer.close();
@@ -139,10 +142,10 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
 
             Assert.assertNotNull(creds);
-            Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-            Assert.assertEquals(0, creds.getBackendRoles().size());
-            Assert.assertEquals(4, creds.getAttributes().size());
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+            assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+            assertThat(creds.getBackendRoles().size(), is(0));
+            assertThat(creds.getAttributes().size(), is(4));
 
             creds = jwtAuth.extractCredentials(
                 new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.NoKid.MC_COY_SIGNED_RSA_2), new HashMap<String, String>())
@@ -167,10 +170,10 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
 
             Assert.assertNotNull(creds);
-            Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-            Assert.assertEquals(0, creds.getBackendRoles().size());
-            Assert.assertEquals(4, creds.getAttributes().size());
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+            assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+            assertThat(creds.getBackendRoles().size(), is(0));
+            assertThat(creds.getAttributes().size(), is(4));
 
         } finally {
             try {
@@ -190,10 +193,10 @@ public class SingleKeyHTTPJwtKeyByOpenIdConnectAuthenticatorTest {
             );
 
             Assert.assertNotNull(creds);
-            Assert.assertEquals(TestJwts.MCCOY_SUBJECT, creds.getUsername());
-            Assert.assertEquals(List.of(TestJwts.TEST_AUDIENCE).toString(), creds.getAttributes().get("attr.jwt.aud"));
-            Assert.assertEquals(0, creds.getBackendRoles().size());
-            Assert.assertEquals(4, creds.getAttributes().size());
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+            assertThat(creds.getAttributes().get("attr.jwt.aud"), is(List.of(TestJwts.TEST_AUDIENCE).toString()));
+            assertThat(creds.getBackendRoles().size(), is(0));
+            assertThat(creds.getAttributes().size(), is(4));
 
         } finally {
             try {

--- a/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -62,6 +62,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.opensaml.saml.saml2.core.NameIDType;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator.IDP_METADATA_CONTENT;
 import static com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator.IDP_METADATA_URL;
 
@@ -158,7 +159,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
     }
 
     @Test
@@ -200,7 +201,7 @@ public class HTTPSamlAuthenticatorTest {
 
             SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-            Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+            assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
         }
     }
 
@@ -254,7 +255,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
     }
 
     @Test
@@ -296,10 +297,10 @@ public class HTTPSamlAuthenticatorTest {
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
-        Assert.assertEquals("ABC\\User1", jwt.getJWTClaimsSet().getClaim("sub"));
-        Assert.assertEquals("ABC\\User1", samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()));
-        Assert.assertEquals("[ABC\\Admin]", String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")));
-        Assert.assertEquals("ABC\\Admin", samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0]);
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("ABC\\User1"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()), is("ABC\\User1"));
+        assertThat(String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")), is("[ABC\\Admin]"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0], is("ABC\\Admin"));
 
     }
 
@@ -342,10 +343,10 @@ public class HTTPSamlAuthenticatorTest {
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
-        Assert.assertEquals("ABC\"User1", jwt.getJWTClaimsSet().getClaim("sub"));
-        Assert.assertEquals("ABC\"User1", samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()));
-        Assert.assertEquals("[ABC\"Admin]", String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")));
-        Assert.assertEquals("ABC\"Admin", samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0]);
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("ABC\"User1"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()), is("ABC\"User1"));
+        assertThat(String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")), is("[ABC\"Admin]"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0], is("ABC\"Admin"));
     }
 
     @Test
@@ -387,10 +388,10 @@ public class HTTPSamlAuthenticatorTest {
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
-        Assert.assertEquals("ABC/User1", jwt.getJWTClaimsSet().getClaim("sub"));
-        Assert.assertEquals("ABC/User1", samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()));
-        Assert.assertEquals("[ABC/Admin]", String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")));
-        Assert.assertEquals("ABC/Admin", samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0]);
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("ABC/User1"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractSubject(jwt.getJWTClaimsSet()), is("ABC/User1"));
+        assertThat(String.valueOf(jwt.getJWTClaimsSet().getClaim("roles")), is("[ABC/Admin]"));
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0], is("ABC/Admin"));
     }
 
     @Test
@@ -432,7 +433,7 @@ public class HTTPSamlAuthenticatorTest {
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
-        Assert.assertEquals("ABC/Admin", samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0]);
+        assertThat(samlAuthenticator.httpJwtAuthenticator.extractRoles(jwt.getJWTClaimsSet())[0], is("ABC/Admin"));
 
     }
 
@@ -475,7 +476,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
     }
 
     @Test(expected = RuntimeException.class)
@@ -535,7 +536,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
     }
 
     @Test
@@ -571,7 +572,7 @@ public class HTTPSamlAuthenticatorTest {
         );
         SecurityResponse response = sendToAuthenticator(samlAuthenticator, tokenRestRequest).orElseThrow();
 
-        Assert.assertEquals(RestStatus.UNAUTHORIZED.getStatus(), response.getStatus());
+        assertThat(response.getStatus(), is(RestStatus.UNAUTHORIZED.getStatus()));
     }
 
     @Test
@@ -601,7 +602,7 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         SecurityResponse response = sendToAuthenticator(samlAuthenticator, tokenRestRequest).orElseThrow();
 
-        Assert.assertEquals(401, response.getStatus());
+        assertThat(response.getStatus(), is(401));
     }
 
     @Test
@@ -628,7 +629,7 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         SecurityResponse response = sendToAuthenticator(samlAuthenticator, tokenRestRequest).orElseThrow();
 
-        Assert.assertEquals(401, response.getStatus());
+        assertThat(response.getStatus(), is(401));
     }
 
     @SuppressWarnings("unchecked")
@@ -669,7 +670,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
         Assert.assertArrayEquals(
             new String[] { "a ", "c", "b   ", "d", "   e", "f", "g", "h", " ", "i" },
             ((List<String>) jwt.getJWTClaimsSet().getClaim("roles")).toArray(new String[0])
@@ -711,7 +712,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
     }
 
     @Test
@@ -760,7 +761,7 @@ public class HTTPSamlAuthenticatorTest {
 
         SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
 
-        Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+        assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
         Assert.assertArrayEquals(
             new String[] { "a", "b" },
             ((List<String>) jwt.getJWTClaimsSet().getClaim("roles")).toArray(new String[0])
@@ -879,7 +880,7 @@ public class HTTPSamlAuthenticatorTest {
             Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
 
             SignedJWT jwt = SignedJWT.parse(authorization.replaceAll("\\s*bearer\\s*", ""));
-            Assert.assertEquals("horst", jwt.getJWTClaimsSet().getClaim("sub"));
+            assertThat(jwt.getJWTClaimsSet().getClaim("sub"), is("horst"));
         }
     }
 
@@ -897,9 +898,9 @@ public class HTTPSamlAuthenticatorTest {
             Assert.fail("Invalid WWW-Authenticate header: " + wwwAuthenticateHeader);
         }
 
-        Assert.assertEquals("X-Security-IdP", wwwAuthenticateHeaderMatcher.group(1));
-        Assert.assertEquals("location", wwwAuthenticateHeaderMatcher.group(4));
-        Assert.assertEquals("requestId", wwwAuthenticateHeaderMatcher.group(6));
+        assertThat(wwwAuthenticateHeaderMatcher.group(1), is("X-Security-IdP"));
+        assertThat(wwwAuthenticateHeaderMatcher.group(4), is("location"));
+        assertThat(wwwAuthenticateHeaderMatcher.group(6), is("requestId"));
 
         String location = wwwAuthenticateHeaderMatcher.group(5);
         String requestId = wwwAuthenticateHeaderMatcher.group(7);

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendIntegTest.java
@@ -28,6 +28,9 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import com.amazon.dlic.auth.ldap.srv.EmbeddedLDAPServer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class LdapBackendIntegTest extends SingleClusterTest {
 
     private static EmbeddedLDAPServer ldapServer = null;
@@ -55,7 +58,7 @@ public class LdapBackendIntegTest extends SingleClusterTest {
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -64,7 +67,7 @@ public class LdapBackendIntegTest extends SingleClusterTest {
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
     }
 
     @Test
@@ -77,13 +80,15 @@ public class LdapBackendIntegTest extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "_opendistro/_security/authinfo",
-                new BasicHeader("opendistro_security_impersonate_as", "jacksonm"),
-                encodeBasicHeader("spock", "spocksecret")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "_opendistro/_security/authinfo",
+                    new BasicHeader("opendistro_security_impersonate_as", "jacksonm"),
+                    encodeBasicHeader("spock", "spocksecret")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTest.java
@@ -39,7 +39,9 @@ import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.ReturnAttributes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class LdapBackendTest {
@@ -73,7 +75,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -120,7 +122,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -197,7 +199,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -219,7 +221,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -232,7 +234,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -256,7 +258,7 @@ public class LdapBackendTest {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (Exception e) {
-            Assert.assertEquals(e.getCause().getClass(), org.ldaptive.LdapException.class);
+            assertThat(org.ldaptive.LdapException.class, is(e.getCause().getClass()));
             Assert.assertTrue(e.getCause().getMessage().contains("Unable to connec"));
         }
 
@@ -283,7 +285,7 @@ public class LdapBackendTest {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (Exception e) {
-            Assert.assertEquals(e.getCause().getClass(), org.ldaptive.LdapException.class);
+            assertThat(org.ldaptive.LdapException.class, is(e.getCause().getClass()));
             Assert.assertTrue(e.getCause().getMessage().contains("Unable to connec"));
         }
 
@@ -310,7 +312,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
 
     }
 
@@ -333,7 +335,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -350,7 +352,7 @@ public class LdapBackendTest {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (final Exception e) {
-            Assert.assertEquals(org.ldaptive.LdapException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(org.ldaptive.LdapException.class));
         }
     }
 
@@ -388,10 +390,10 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -416,7 +418,7 @@ public class LdapBackendTest {
         final String[] attributes = user.getUserEntry().getAttributeNames();
 
         Assert.assertNotNull(user);
-        Assert.assertEquals(3, attributes.length);
+        assertThat(attributes.length, is(3));
         Assert.assertTrue(Arrays.asList(attributes).contains("mail"));
         Assert.assertTrue(Arrays.asList(attributes).contains("cn"));
         Assert.assertTrue(Arrays.asList(attributes).contains("uid"));
@@ -433,7 +435,7 @@ public class LdapBackendTest {
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
             final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), true);
-            Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
+            assertThat(ref1.getDn(), is("cn=refsolved,ou=people,o=TEST"));
         } finally {
             con.close();
         }
@@ -481,10 +483,10 @@ public class LdapBackendTest {
             new AuthCredentials("ssign", "ssignsecret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(4));
         Assert.assertTrue(user.getRoles().toString().contains("ceo"));
     }
 
@@ -507,11 +509,11 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("Michael Jackson", user.getOriginalUsername());
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getUserEntry().getDn());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getOriginalUsername(), is("Michael Jackson"));
+        assertThat(user.getUserEntry().getDn(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -531,8 +533,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
     }
 
@@ -553,8 +555,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo-ceo"));
     }
 
@@ -576,8 +578,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
     }
 
@@ -600,8 +602,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
         // filtered out
         MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested1")));
         MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested2")));
@@ -628,8 +630,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
         // filtered out
         MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested1")));
         MatcherAssert.assertThat(user.getRoles(), not(hasItem("nested2")));
@@ -656,8 +658,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested2"));
         // filtered out
@@ -684,8 +686,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested2"));
     }
@@ -708,8 +710,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
         MatcherAssert.assertThat(user.getRoles(), hasItem("cn=nested1,ou=groups,o=TEST"));
     }
 
@@ -732,8 +734,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("cn=ceo,ou=groups,o=TEST"));
     }
 
@@ -751,7 +753,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
+        assertThat(user.getName(), is("jacksonm"));
     }
 
     @Test
@@ -773,7 +775,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -796,9 +798,9 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(0, user.getRoles().size());
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -821,9 +823,9 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(0, user.getRoles().size());
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -846,8 +848,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(8, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(8));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested3"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("rolemo4"));
     }
@@ -873,8 +875,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(6, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(6));
         MatcherAssert.assertThat(user.getRoles(), hasItem("role2"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
 
@@ -901,8 +903,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -927,8 +929,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -952,8 +954,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(3));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested3"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("rolemo4"));
     }
@@ -970,8 +972,8 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 16, user.getCustomAttributesMap().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(16));
         Assert.assertFalse(
             user.getCustomAttributesMap().toString(),
             user.getCustomAttributesMap().keySet().contains("attr.ldap.userpassword")
@@ -987,7 +989,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
         settings = Settings.builder()
             .putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + ldapPort)
@@ -999,7 +1001,7 @@ public class LdapBackendTest {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
     }
 
@@ -1023,8 +1025,8 @@ public class LdapBackendTest {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("nondnroles", user.getName());
-        Assert.assertEquals(5, user.getRoles().size());
+        assertThat(user.getName(), is("nondnroles"));
+        assertThat(user.getRoles().size(), is(5));
         Assert.assertTrue("Roles do not contain non-LDAP role 'kibanauser'", user.getRoles().contains("kibanauser"));
         Assert.assertTrue("Roles do not contain non-LDAP role 'humanresources'", user.getRoles().contains("humanresources"));
         Assert.assertTrue("Roles do not contain LDAP role 'dummyempty'", user.getRoles().contains("dummyempty"));
@@ -1052,11 +1054,11 @@ public class LdapBackendTest {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLEx(186n) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186nn) consists of\\, special="));
@@ -1100,11 +1102,11 @@ public class LdapBackendTest {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186n) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186nn) consists of\\, special\\=chars\\ "));
@@ -1167,7 +1169,7 @@ public class LdapBackendTest {
             new AuthCredentials("multi", "multi".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=cabc,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=cabc,ou=people,o=TEST"));
     }
 
     @AfterClass

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestClientCert.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestClientCert.java
@@ -29,6 +29,9 @@ import org.opensearch.security.user.AuthCredentials;
 import com.amazon.dlic.auth.ldap.backend.LDAPAuthenticationBackend;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 @Ignore
 public class LdapBackendTestClientCert {
 
@@ -158,7 +161,7 @@ public class LdapBackendTestClientCert {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -187,7 +190,7 @@ public class LdapBackendTestClientCert {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -219,7 +222,7 @@ public class LdapBackendTestClientCert {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -248,7 +251,7 @@ public class LdapBackendTestClientCert {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     public void testLdapAuthenticationSSL() throws Exception {
@@ -283,7 +286,7 @@ public class LdapBackendTestClientCert {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     public static File getAbsoluteFilePathFromClassPath(final String fileNameFromClasspath) {

--- a/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -38,7 +38,9 @@ import org.ldaptive.Connection;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.ReturnAttributes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 
 public class LdapBackendTestNewStyleConfig {
 
@@ -72,7 +74,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -120,7 +122,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -197,7 +199,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -219,7 +221,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -233,7 +235,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -257,7 +259,7 @@ public class LdapBackendTestNewStyleConfig {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (Exception e) {
-            Assert.assertEquals(e.getCause().getClass(), org.ldaptive.LdapException.class);
+            assertThat(org.ldaptive.LdapException.class, is(e.getCause().getClass()));
             Assert.assertTrue(e.getCause().getMessage().contains("Unable to connec"));
         }
 
@@ -284,7 +286,7 @@ public class LdapBackendTestNewStyleConfig {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (Exception e) {
-            Assert.assertEquals(e.getCause().getClass(), org.ldaptive.LdapException.class);
+            assertThat(org.ldaptive.LdapException.class, is(e.getCause().getClass()));
             Assert.assertTrue(e.getCause().getMessage().contains("Unable to connec"));
         }
 
@@ -311,7 +313,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
 
     }
 
@@ -334,7 +336,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -351,7 +353,7 @@ public class LdapBackendTestNewStyleConfig {
                 new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
             );
         } catch (final Exception e) {
-            Assert.assertEquals(org.ldaptive.LdapException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(org.ldaptive.LdapException.class));
         }
     }
 
@@ -389,10 +391,10 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -406,7 +408,7 @@ public class LdapBackendTestNewStyleConfig {
         final Connection con = LDAPAuthorizationBackend.getConnection(settings, null);
         try {
             final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), true);
-            Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
+            assertThat(ref1.getDn(), is("cn=refsolved,ou=people,o=TEST"));
         } finally {
             con.close();
         }
@@ -455,10 +457,10 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("ssign", "ssignsecret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(4));
         Assert.assertTrue(user.getRoles().toString().contains("ceo"));
     }
 
@@ -481,11 +483,11 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("Michael Jackson", user.getOriginalUsername());
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getUserEntry().getDn());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getOriginalUsername(), is("Michael Jackson"));
+        assertThat(user.getUserEntry().getDn(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -505,8 +507,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
     }
 
@@ -528,8 +530,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
     }
 
@@ -552,8 +554,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested2"));
     }
@@ -576,8 +578,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
         MatcherAssert.assertThat(user.getRoles(), hasItem("cn=nested1,ou=groups,o=TEST"));
     }
 
@@ -600,8 +602,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("cn=ceo,ou=groups,o=TEST"));
     }
 
@@ -619,7 +621,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
+        assertThat(user.getName(), is("jacksonm"));
     }
 
     @Test
@@ -641,7 +643,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -664,9 +666,9 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(0, user.getRoles().size());
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -689,8 +691,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(8, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(8));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested3"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("rolemo4"));
     }
@@ -716,8 +718,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(6, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(6));
         MatcherAssert.assertThat(user.getRoles(), hasItem("role2"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested1"));
 
@@ -744,8 +746,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -771,8 +773,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -796,8 +798,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(3));
         MatcherAssert.assertThat(user.getRoles(), hasItem("nested3"));
         MatcherAssert.assertThat(user.getRoles(), hasItem("rolemo4"));
     }
@@ -814,8 +816,8 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 16, user.getCustomAttributesMap().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(16));
         Assert.assertFalse(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().containsKey("attr.ldap.userpassword"));
 
         settings = Settings.builder()
@@ -828,7 +830,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
         settings = Settings.builder()
             .putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + ldapPort)
@@ -840,7 +842,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
     }
 
@@ -864,8 +866,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("nondnroles", user.getName());
-        Assert.assertEquals(5, user.getRoles().size());
+        assertThat(user.getName(), is("nondnroles"));
+        assertThat(user.getRoles().size(), is(5));
         Assert.assertTrue("Roles do not contain non-LDAP role 'kibanauser'", user.getRoles().contains("kibanauser"));
         Assert.assertTrue("Roles do not contain non-LDAP role 'humanresources'", user.getRoles().contains("humanresources"));
         Assert.assertTrue("Roles do not contain LDAP role 'dummyempty'", user.getRoles().contains("dummyempty"));
@@ -891,7 +893,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -909,7 +911,7 @@ public class LdapBackendTestNewStyleConfig {
             new AuthCredentials("presleye", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Elvis Presley,ou=people2,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Elvis Presley,ou=people2,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -969,14 +971,14 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(3));
 
         Assert.assertTrue(user.getRoles().contains("ceo"));
         Assert.assertTrue(user.getRoles().contains("king"));
         Assert.assertTrue(user.getRoles().contains("role2"));
 
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -1000,8 +1002,8 @@ public class LdapBackendTestNewStyleConfig {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Freddy Mercury,ou=people2,o=TEST", user.getName());
-        Assert.assertEquals(1, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Freddy Mercury,ou=people2,o=TEST"));
+        assertThat(user.getRoles().size(), is(1));
 
         Assert.assertTrue(user.getRoles().contains("crossnested2"));
         // The user is NOT in crossnested1!

--- a/src/test/java/com/amazon/dlic/auth/ldap/UtilsTest.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap/UtilsTest.java
@@ -17,24 +17,27 @@ import javax.naming.ldap.LdapName;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class UtilsTest {
 
     @Test
     public void testLDAPName() throws Exception {
         // same ldapname
-        Assert.assertEquals(new LdapName("CN=1,OU=2,O=3,C=4"), new LdapName("CN=1,OU=2,O=3,C=4"));
+        assertThat(new LdapName("CN=1,OU=2,O=3,C=4"), is(new LdapName("CN=1,OU=2,O=3,C=4")));
 
         // case differ
-        Assert.assertEquals(new LdapName("CN=1,OU=2,O=3,C=4".toLowerCase()), new LdapName("CN=1,OU=2,O=3,C=4".toUpperCase()));
+        assertThat(new LdapName("CN=1,OU=2,O=3,C=4".toUpperCase()), is(new LdapName("CN=1,OU=2,O=3,C=4".toLowerCase())));
 
         // case differ
-        Assert.assertEquals(new LdapName("CN=abc,OU=xyz,O=3,C=4".toLowerCase()), new LdapName("CN=abc,OU=xyz,O=3,C=4".toUpperCase()));
+        assertThat(new LdapName("CN=abc,OU=xyz,O=3,C=4".toUpperCase()), is(new LdapName("CN=abc,OU=xyz,O=3,C=4".toLowerCase())));
 
         // same ldapname
-        Assert.assertEquals(new LdapName("CN=a,OU=2,O=3,C=xxx"), new LdapName("CN=A,OU=2,O=3,C=XxX"));
+        assertThat(new LdapName("CN=A,OU=2,O=3,C=XxX"), is(new LdapName("CN=a,OU=2,O=3,C=xxx")));
 
         // case differ and spaces
-        Assert.assertEquals(new LdapName("Cn =1 ,OU=2, O = 3,C=4"), new LdapName("CN= 1,Ou=2,O=3,c=4"));
+        assertThat(new LdapName("CN= 1,Ou=2,O=3,c=4"), is(new LdapName("Cn =1 ,OU=2, O = 3,C=4")));
 
         // same components, different order
         Assert.assertNotEquals(new LdapName("CN=1,OU=2,C=4,O=3"), new LdapName("CN=1,OU=2,O=3,C=4"));

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendIntegTest2.java
@@ -28,6 +28,9 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import com.amazon.dlic.auth.ldap.srv.EmbeddedLDAPServer;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class LdapBackendIntegTest2 extends SingleClusterTest {
 
     private static EmbeddedLDAPServer ldapServer = null;
@@ -55,7 +58,7 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("jacksonm", "secret")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -64,7 +67,7 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
         securityConfigAsYamlString = securityConfigAsYamlString.replace("${ldapsPort}", String.valueOf(ldapsPort));
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("wrong", "wrong")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
     }
 
     @Test
@@ -77,13 +80,15 @@ public class LdapBackendIntegTest2 extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfigAsYamlString(securityConfigAsYamlString), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "_opendistro/_security/authinfo",
-                new BasicHeader("opendistro_security_impersonate_as", "jacksonm"),
-                encodeBasicHeader("spock", "spocksecret")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "_opendistro/_security/authinfo",
+                    new BasicHeader("opendistro_security_impersonate_as", "jacksonm"),
+                    encodeBasicHeader("spock", "spocksecret")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("ldap.dn"));
         Assert.assertTrue(res.getBody().contains("attr.ldap.entryDN"));

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestClientCert2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestClientCert2.java
@@ -29,6 +29,9 @@ import org.opensearch.security.user.AuthCredentials;
 import com.amazon.dlic.auth.ldap.LdapUser;
 import com.amazon.dlic.auth.ldap.util.ConfigConstants;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 @Ignore
 public class LdapBackendTestClientCert2 {
 
@@ -161,7 +164,7 @@ public class LdapBackendTestClientCert2 {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -190,7 +193,7 @@ public class LdapBackendTestClientCert2 {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -222,7 +225,7 @@ public class LdapBackendTestClientCert2 {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     @Test
@@ -251,7 +254,7 @@ public class LdapBackendTestClientCert2 {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     public void testLdapAuthenticationSSL() throws Exception {
@@ -286,7 +289,7 @@ public class LdapBackendTestClientCert2 {
             new AuthCredentials("ldap_hr_employee", "ldap_hr_employee".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("ldap_hr_employee", user.getName());
+        assertThat(user.getName(), is("ldap_hr_employee"));
     }
 
     public static File getAbsoluteFilePathFromClassPath(final String fileNameFromClasspath) {

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -48,7 +48,9 @@ import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.ReturnAttributes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 
 @RunWith(Parameterized.class)
 public class LdapBackendTestNewStyleConfig2 {
@@ -98,7 +100,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -143,7 +145,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -220,7 +222,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -241,7 +243,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -255,7 +257,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -279,7 +281,7 @@ public class LdapBackendTestNewStyleConfig2 {
             );
             Assert.fail("Expected Exception");
         } catch (Exception e) {
-            Assert.assertEquals(org.ldaptive.provider.ConnectionException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(org.ldaptive.provider.ConnectionException.class));
             Assert.assertTrue(ExceptionUtils.getStackTrace(e).contains("No appropriate protocol"));
         }
 
@@ -306,7 +308,7 @@ public class LdapBackendTestNewStyleConfig2 {
             );
             Assert.fail("Expected Exception");
         } catch (Exception e) {
-            Assert.assertEquals(org.ldaptive.provider.ConnectionException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(org.ldaptive.provider.ConnectionException.class));
             Assert.assertTrue(
                 ExceptionUtils.getStackTrace(e),
                 WildcardMatcher.from("*unsupported*ciphersuite*aaa*").test(ExceptionUtils.getStackTrace(e).toLowerCase())
@@ -335,7 +337,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
 
     }
 
@@ -357,7 +359,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -374,7 +376,7 @@ public class LdapBackendTestNewStyleConfig2 {
             );
             Assert.fail("Expected exception");
         } catch (final Exception e) {
-            Assert.assertEquals(IllegalStateException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(IllegalStateException.class));
         }
     }
 
@@ -410,10 +412,10 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -437,7 +439,7 @@ public class LdapBackendTestNewStyleConfig2 {
         final String[] attributes = user.getUserEntry().getAttributeNames();
 
         Assert.assertNotNull(user);
-        Assert.assertEquals(3, attributes.length);
+        assertThat(attributes.length, is(3));
         Assert.assertTrue(Arrays.asList(attributes).contains("mail"));
         Assert.assertTrue(Arrays.asList(attributes).contains("cn"));
         Assert.assertTrue(Arrays.asList(attributes).contains("uid"));
@@ -454,7 +456,7 @@ public class LdapBackendTestNewStyleConfig2 {
         try {
             con.open();
             final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), true);
-            Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
+            assertThat(ref1.getDn(), is("cn=refsolved,ou=people,o=TEST"));
         } finally {
             con.close();
         }
@@ -502,10 +504,10 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("ssign", "ssignsecret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(4));
         Assert.assertTrue(user.getRoles().toString().contains("ceo"));
     }
 
@@ -527,11 +529,11 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("Michael Jackson", user.getOriginalUsername());
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getUserEntry().getDn());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getOriginalUsername(), is("Michael Jackson"));
+        assertThat(user.getUserEntry().getDn(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -550,9 +552,9 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
     }
 
     @Test
@@ -573,8 +575,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend2(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().contains("nested1"));
         Assert.assertFalse(user.getRoles().contains("nested2"));
     }
@@ -597,10 +599,10 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals("nested2", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("nested2"));
     }
 
     @Test
@@ -620,9 +622,9 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
-        Assert.assertEquals("cn=nested1,ou=groups,o=TEST", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("cn=nested1,ou=groups,o=TEST"));
     }
 
     @Test
@@ -643,9 +645,9 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("cn=ceo,ou=groups,o=TEST", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("cn=ceo,ou=groups,o=TEST"));
     }
 
     @Test
@@ -661,7 +663,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
+        assertThat(user.getName(), is("jacksonm"));
     }
 
     @Test
@@ -682,7 +684,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -704,9 +706,9 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(0, user.getRoles().size());
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -728,10 +730,10 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(8, user.getRoles().size());
-        Assert.assertEquals("nested3", new ArrayList<>(new TreeSet<>(user.getRoles())).get(4));
-        Assert.assertEquals("rolemo4", new ArrayList<>(new TreeSet<>(user.getRoles())).get(7));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(8));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(4), is("nested3"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(7), is("rolemo4"));
     }
 
     @Test
@@ -754,10 +756,10 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(6, user.getRoles().size());
-        Assert.assertEquals("role2", new ArrayList<>(new TreeSet<>(user.getRoles())).get(4));
-        Assert.assertEquals("nested1", new ArrayList<>(new TreeSet<>(user.getRoles())).get(2));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(6));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(4), is("role2"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(2), is("nested1"));
 
     }
 
@@ -781,8 +783,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
     }
 
     @Test
@@ -806,8 +808,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -830,10 +832,10 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
-        Assert.assertEquals("nested3", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
-        Assert.assertEquals("rolemo4", new ArrayList<>(new TreeSet<>(user.getRoles())).get(2));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(3));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("nested3"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(2), is("rolemo4"));
     }
 
     @Test
@@ -847,8 +849,8 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 16, user.getCustomAttributesMap().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(16));
         Assert.assertFalse(
             user.getCustomAttributesMap().toString(),
             user.getCustomAttributesMap().keySet().contains("attr.ldap.userpassword")
@@ -863,7 +865,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
         settings = createBaseSettings().putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + ldapPort)
             .put("users.u1.search", "(uid={0})")
@@ -874,7 +876,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
     }
 
@@ -897,8 +899,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("nondnroles", user.getName());
-        Assert.assertEquals(5, user.getRoles().size());
+        assertThat(user.getName(), is("nondnroles"));
+        assertThat(user.getRoles().size(), is(5));
         Assert.assertTrue("Roles do not contain non-LDAP role 'kibanauser'", user.getRoles().contains("kibanauser"));
         Assert.assertTrue("Roles do not contain non-LDAP role 'humanresources'", user.getRoles().contains("humanresources"));
         Assert.assertTrue("Roles do not contain LDAP role 'dummyempty'", user.getRoles().contains("dummyempty"));
@@ -923,7 +925,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -940,7 +942,7 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("presleye", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Elvis Presley,ou=people2,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Elvis Presley,ou=people2,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -997,14 +999,14 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(3));
 
         Assert.assertTrue(user.getRoles().contains("ceo"));
         Assert.assertTrue(user.getRoles().contains("king"));
         Assert.assertTrue(user.getRoles().contains("role2"));
 
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -1027,8 +1029,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Freddy Mercury,ou=people2,o=TEST", user.getName());
-        Assert.assertEquals(1, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Freddy Mercury,ou=people2,o=TEST"));
+        assertThat(user.getRoles().size(), is(1));
 
         Assert.assertTrue(user.getRoles().contains("crossnested2"));
         // The user is NOT in crossnested1!
@@ -1051,8 +1053,8 @@ public class LdapBackendTestNewStyleConfig2 {
         new LDAPAuthorizationBackend2(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo-ceo"));
     }
 
@@ -1073,11 +1075,11 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLEx(186n) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186nn) consists of\\, special="));
@@ -1121,11 +1123,11 @@ public class LdapBackendTestNewStyleConfig2 {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186n) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186nn) consists of\\, special\\=chars\\ "));

--- a/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
+++ b/src/test/java/com/amazon/dlic/auth/ldap2/LdapBackendTestOldStyleConfig2.java
@@ -47,7 +47,9 @@ import org.ldaptive.LdapAttribute;
 import org.ldaptive.LdapEntry;
 import org.ldaptive.ReturnAttributes;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
 
 @RunWith(Parameterized.class)
 public class LdapBackendTestOldStyleConfig2 {
@@ -99,7 +101,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -114,7 +116,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -159,7 +161,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -248,7 +250,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -270,7 +272,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -291,7 +293,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -305,7 +307,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -329,7 +331,7 @@ public class LdapBackendTestOldStyleConfig2 {
             );
             Assert.fail("Expected Exception");
         } catch (Exception e) {
-            Assert.assertEquals(org.ldaptive.provider.ConnectionException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(org.ldaptive.provider.ConnectionException.class));
             Assert.assertTrue(ExceptionUtils.getStackTrace(e).contains("No appropriate protocol"));
         }
 
@@ -356,11 +358,7 @@ public class LdapBackendTestOldStyleConfig2 {
             );
             Assert.fail("Expected Exception");
         } catch (Exception e) {
-            Assert.assertEquals(
-                e.getCause().getClass().toString(),
-                org.ldaptive.provider.ConnectionException.class,
-                e.getCause().getClass()
-            );
+            assertThat(e.getCause().getClass().toString(), org.ldaptive.provider.ConnectionException.class, is(e.getCause().getClass()));
             Assert.assertTrue(ExceptionUtils.getStackTrace(e), EXCEPTION_MATCHER.test(ExceptionUtils.getStackTrace(e).toLowerCase()));
         }
 
@@ -386,7 +384,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
 
     }
 
@@ -408,7 +406,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -425,7 +423,7 @@ public class LdapBackendTestOldStyleConfig2 {
             );
             Assert.fail("Expected exception");
         } catch (final Exception e) {
-            Assert.assertEquals(IllegalStateException.class, e.getCause().getClass());
+            assertThat(e.getCause().getClass(), is(IllegalStateException.class));
         }
     }
 
@@ -461,10 +459,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -488,10 +486,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -505,7 +503,7 @@ public class LdapBackendTestOldStyleConfig2 {
         try {
             con.open();
             final LdapEntry ref1 = LdapHelper.lookup(con, "cn=Ref1,ou=people,o=TEST", ReturnAttributes.ALL.value(), true);
-            Assert.assertEquals("cn=refsolved,ou=people,o=TEST", ref1.getDn());
+            assertThat(ref1.getDn(), is("cn=refsolved,ou=people,o=TEST"));
         } finally {
             con.close();
         }
@@ -553,10 +551,10 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("ssign", "ssignsecret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
-        Assert.assertEquals("cn=Special\\, Sign,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("cn=Special\\, Sign,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(4));
         Assert.assertTrue(user.getRoles().toString().contains("ceo"));
     }
 
@@ -578,11 +576,11 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("Michael Jackson", user.getOriginalUsername());
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getUserEntry().getDn());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getOriginalUsername(), is("Michael Jackson"));
+        assertThat(user.getUserEntry().getDn(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -601,9 +599,9 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
     }
 
     @Test
@@ -623,9 +621,9 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
-        Assert.assertEquals("nested1", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("nested1"));
     }
 
     @Test
@@ -646,10 +644,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("ceo", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
-        Assert.assertEquals("nested2", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("ceo"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("nested2"));
     }
 
     @Test
@@ -669,9 +667,9 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
-        Assert.assertEquals("cn=nested1,ou=groups,o=TEST", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("cn=nested1,ou=groups,o=TEST"));
     }
 
     @Test
@@ -692,9 +690,9 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
-        Assert.assertEquals("cn=ceo,ou=groups,o=TEST", new ArrayList<>(new TreeSet<>(user.getRoles())).get(0));
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(0), is("cn=ceo,ou=groups,o=TEST"));
     }
 
     @Test
@@ -710,7 +708,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
+        assertThat(user.getName(), is("jacksonm"));
     }
 
     @Test
@@ -731,7 +729,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
     }
 
     @Test
@@ -753,9 +751,9 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(0, user.getRoles().size());
-        Assert.assertEquals(user.getName(), user.getUserEntry().getDn());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(user.getUserEntry().getDn(), is(user.getName()));
     }
 
     @Test
@@ -777,10 +775,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(8, user.getRoles().size());
-        Assert.assertEquals("nested3", new ArrayList<>(new TreeSet<>(user.getRoles())).get(4));
-        Assert.assertEquals("rolemo4", new ArrayList<>(new TreeSet<>(user.getRoles())).get(7));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(8));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(4), is("nested3"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(7), is("rolemo4"));
     }
 
     @Test
@@ -803,10 +801,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(6, user.getRoles().size());
-        Assert.assertEquals("role2", new ArrayList<>(new TreeSet<>(user.getRoles())).get(4));
-        Assert.assertEquals("nested1", new ArrayList<>(new TreeSet<>(user.getRoles())).get(2));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(6));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(4), is("role2"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(2), is("nested1"));
 
     }
 
@@ -830,8 +828,8 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -856,8 +854,8 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(4, user.getRoles().size());
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(4));
 
     }
 
@@ -880,10 +878,10 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("spock", user.getName());
-        Assert.assertEquals(3, user.getRoles().size());
-        Assert.assertEquals("nested3", new ArrayList<>(new TreeSet<>(user.getRoles())).get(1));
-        Assert.assertEquals("rolemo4", new ArrayList<>(new TreeSet<>(user.getRoles())).get(2));
+        assertThat(user.getName(), is("spock"));
+        assertThat(user.getRoles().size(), is(3));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(1), is("nested3"));
+        assertThat(new ArrayList<>(new TreeSet<>(user.getRoles())).get(2), is("rolemo4"));
     }
 
     @Test
@@ -897,8 +895,8 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("cn=Michael Jackson,ou=people,o=TEST", user.getName());
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 16, user.getCustomAttributesMap().size());
+        assertThat(user.getName(), is("cn=Michael Jackson,ou=people,o=TEST"));
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(16));
         Assert.assertFalse(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().containsKey("attr.ldap.userpassword"));
 
         settings = createBaseSettings().putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + ldapPort)
@@ -910,7 +908,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
         settings = createBaseSettings().putList(ConfigConstants.LDAP_HOSTS, "127.0.0.1:4", "localhost:" + ldapPort)
             .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
@@ -921,7 +919,7 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("jacksonm", "secret".getBytes(StandardCharsets.UTF_8))
         );
 
-        Assert.assertEquals(user.getCustomAttributesMap().toString(), 2, user.getCustomAttributesMap().size());
+        assertThat(user.getCustomAttributesMap().toString(), user.getCustomAttributesMap().size(), is(2));
 
     }
 
@@ -944,8 +942,8 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("nondnroles", user.getName());
-        Assert.assertEquals(5, user.getRoles().size());
+        assertThat(user.getName(), is("nondnroles"));
+        assertThat(user.getRoles().size(), is(5));
         Assert.assertTrue("Roles do not contain non-LDAP role 'kibanauser'", user.getRoles().contains("kibanauser"));
         Assert.assertTrue("Roles do not contain non-LDAP role 'humanresources'", user.getRoles().contains("humanresources"));
         Assert.assertTrue("Roles do not contain LDAP role 'dummyempty'", user.getRoles().contains("dummyempty"));
@@ -973,8 +971,8 @@ public class LdapBackendTestOldStyleConfig2 {
         new LDAPAuthorizationBackend2(settings, null).fillRoles(user, null);
 
         Assert.assertNotNull(user);
-        Assert.assertEquals("jacksonm", user.getName());
-        Assert.assertEquals(2, user.getRoles().size());
+        assertThat(user.getName(), is("jacksonm"));
+        assertThat(user.getRoles().size(), is(2));
         MatcherAssert.assertThat(user.getRoles(), hasItem("ceo-ceo"));
     }
 
@@ -995,11 +993,11 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLEx(186n) consists of\\, special="));
         Assert.assertTrue(user.getRoles().toString().contains("ROLE/(186nn) consists of\\, special="));
@@ -1043,11 +1041,11 @@ public class LdapBackendTestOldStyleConfig2 {
             new AuthCredentials("spec186", "spec186".getBytes(StandardCharsets.UTF_8))
         );
         Assert.assertNotNull(user);
-        Assert.assertEquals("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST", user.getName());
-        Assert.assertEquals("AA BB/CC (DD) my, company end=with=whitespace ", user.getUserEntry().getAttribute("cn").getStringValue());
+        assertThat(user.getName(), is("CN=AA BB/CC (DD) my\\, company end\\=with\\=whitespace\\ ,ou=people,o=TEST"));
+        assertThat(user.getUserEntry().getAttribute("cn").getStringValue(), is("AA BB/CC (DD) my, company end=with=whitespace "));
         new LDAPAuthorizationBackend(settings, null).fillRoles(user, null);
 
-        Assert.assertEquals(3, user.getRoles().size());
+        assertThat(user.getRoles().size(), is(3));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186n) consists of\\, special\\=chars\\ "));
         Assert.assertTrue(user.getRoles().toString().contains("cn=ROLE/(186nn) consists of\\, special\\=chars\\ "));

--- a/src/test/java/org/opensearch/security/AdvancedSecurityMigrationTests.java
+++ b/src/test/java/org/opensearch/security/AdvancedSecurityMigrationTests.java
@@ -17,7 +17,6 @@ import java.util.Arrays;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +26,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.cluster.ClusterHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class AdvancedSecurityMigrationTests extends SingleClusterTest {
 
@@ -218,7 +220,7 @@ public class AdvancedSecurityMigrationTests extends SingleClusterTest {
         RestHelper.HttpResponse res;
         RestHelper rh = nonSslRestHelper();
         res = rh.executeGetRequest("/_cluster/health");
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_INTERNAL_SERVER_ERROR, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
     }
 
     @Test
@@ -241,7 +243,7 @@ public class AdvancedSecurityMigrationTests extends SingleClusterTest {
         RestHelper.HttpResponse res;
         RestHelper rh = nonSslRestHelper();
         res = rh.executeGetRequest("/_cluster/health");
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_INTERNAL_SERVER_ERROR, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
     }
 
@@ -250,15 +252,15 @@ public class AdvancedSecurityMigrationTests extends SingleClusterTest {
 
         RestHelper.HttpResponse res;
         res = rh.executePutRequest("testindex", getIndexSettingsForAdvSec(), basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executePutRequest("testindex2", getIndexSettingForSSLOnlyNode(), basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/_cluster/health", basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/_cat/shards", basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
 
         commonTestsForAnIndex(rh, "testindex", basicHeaders);
         commonTestsForAnIndex(rh, "testindex2", basicHeaders);
@@ -269,15 +271,15 @@ public class AdvancedSecurityMigrationTests extends SingleClusterTest {
         String slashIndex = "/" + index;
 
         res = rh.executeGetRequest(slashIndex, basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executePutRequest(slashIndex + "/_doc/1", "{}", basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_CREATED, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_CREATED));
         res = rh.executePutRequest(slashIndex + "/_doc/1", "{}", basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeDeleteRequest(slashIndex + "/_doc/1", basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeDeleteRequest(slashIndex, basicHeaders);
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     private Settings.Builder getAdvSecSettings() {

--- a/src/test/java/org/opensearch/security/AggregationTests.java
+++ b/src/test/java/org/opensearch/security/AggregationTests.java
@@ -27,7 +27,6 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -41,6 +40,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class AggregationTests extends SingleClusterTest {
 
@@ -106,13 +108,15 @@ public class AggregationTests extends SingleClusterTest {
         }
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "_search?pretty",
-                "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "_search?pretty",
+                    "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
@@ -125,13 +129,15 @@ public class AggregationTests extends SingleClusterTest {
         assertContains(res, "*role01_role02*");
         assertContains(res, "*\"failed\" : 0*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "*/_search?pretty",
-                "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "*/_search?pretty",
+                    "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
@@ -144,13 +150,15 @@ public class AggregationTests extends SingleClusterTest {
         assertContains(res, "*role01_role02*");
         assertContains(res, "*\"failed\" : 0*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "_search?pretty",
-                "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
-                encodeBasicHeader("worf", "worf")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "_search?pretty",
+                    "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
+                    encodeBasicHeader("worf", "worf")
+                )).getStatusCode()
+            )
         );
         assertNotContains(res, "*xception*");
         assertNotContains(res, "*erial*");
@@ -163,13 +171,15 @@ public class AggregationTests extends SingleClusterTest {
         assertContains(res, "*xyz*");
         assertContains(res, "*\"failed\" : 0*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_search?pretty",
-                "{\"size\":0,\"aggs\":{\"myindices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
-                encodeBasicHeader("worf", "worf")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_search?pretty",
+                    "{\"size\":0,\"aggs\":{\"myindices\":{\"terms\":{\"field\":\"_index\",\"size\":40}}}}",
+                    encodeBasicHeader("worf", "worf")
+                ).getStatusCode()
+            )
         );
 
     }

--- a/src/test/java/org/opensearch/security/ConfigTests.java
+++ b/src/test/java/org/opensearch/security/ConfigTests.java
@@ -45,6 +45,9 @@ import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.securityconf.impl.v7.TenantV7;
 import org.opensearch.security.test.SingleClusterTest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class ConfigTests {
 
     private static final ObjectMapper YAML = new ObjectMapper(new YAMLFactory());
@@ -104,7 +107,7 @@ public class ConfigTests {
         JsonNode jsonNode = YAML.readTree(Files.readString(new File(adjustedFilePath).toPath(), StandardCharsets.UTF_8));
         int configVersion = 1;
         if (jsonNode.get("_meta") != null) {
-            Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
+            assertThat(cType.toLCString(), is(jsonNode.get("_meta").get("type").asText()));
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
 
@@ -123,7 +126,7 @@ public class ConfigTests {
         int configVersion = 1;
 
         if (jsonNode.get("_meta") != null) {
-            Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
+            assertThat(cType.toLCString(), is(jsonNode.get("_meta").get("type").asText()));
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
         return SecurityDynamicConfiguration.fromNode(jsonNode, cType, configVersion, 0, 0);

--- a/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/DataStreamIntegrationTests.java
@@ -19,6 +19,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DataStreamIntegrationTests extends SingleClusterTest {
 
     final String bulkDocsBody = "{ \"create\" : {} }"
@@ -64,29 +67,29 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
             getIndexTemplateBody(),
             encodeBasicHeader("ds0", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePutRequest(
             "/_index_template/my-data-stream-template",
             getIndexTemplateBody(),
             encodeBasicHeader("ds1", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePutRequest("/_data_stream/my-data-stream11", getIndexTemplateBody(), encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePutRequest("/_data_stream/my-data-stream11", getIndexTemplateBody(), encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePutRequest("/_data_stream/my-data-stream22", getIndexTemplateBody(), encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePutRequest("/_data_stream/my-data-stream33", getIndexTemplateBody(), encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePutRequest("/_data_stream/my-data-stream33", getIndexTemplateBody(), encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -98,40 +101,40 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         HttpResponse response;
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream33", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -143,43 +146,43 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         HttpResponse response;
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream11", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream33", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream21,my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeDeleteRequest("/_data_stream/my-data-stream*", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -191,43 +194,43 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         HttpResponse response;
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11/_stats", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11/_stats", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream11/_stats", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream22/_stats", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream22/_stats", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream33/_stats", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22/_stats", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream2*/_stats", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream21,my-data-stream22/_stats", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("/_data_stream/my-data-stream*/_stats", encodeBasicHeader("ds3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -239,40 +242,40 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         HttpResponse response;
 
         response = rh.executeGetRequest("my-data-stream11", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("my-data-stream22", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream11-000001", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest(".ds-my-data-stream22-000001", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream21-000001,.ds-my-data-stream22-000001", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream2*", encodeBasicHeader("ds0", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("my-data-stream11", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest("my-data-stream22", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream11-000001", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executeGetRequest(".ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream21-000001,.ds-my-data-stream22-000001", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest(".ds-my-data-stream2*", encodeBasicHeader("ds2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -287,59 +290,59 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
 
         response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_dls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_dls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(response.getBody().contains("l7gk7f82"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_dls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_dls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_dls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_dls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("8a4f500d"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_dls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(response.getBody().contains("l7gk7f82"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
 
         response = rh.executePostRequest("/.ds-my-*/_search", searchQuery2, encodeBasicHeader("ds_dls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(response.getBody().contains("l7gk7f82"));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
     }
@@ -356,67 +359,67 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
 
         response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\""));
         Assert.assertTrue(response.getBody().contains("\"message\":\"Login successful\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\""));
         Assert.assertTrue(response.getBody().contains("\"message\":\"Login successful\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_fls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\""));
         Assert.assertTrue(response.getBody().contains("\"message\":\"Login attempt failed\""));
 
         response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_fls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_fls1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
         Assert.assertFalse(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
         Assert.assertFalse(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fls2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_fls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
         Assert.assertFalse(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_fls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
         Assert.assertFalse(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_fls3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Pam\""));
         Assert.assertFalse(response.getBody().contains("\"message\":\""));
@@ -434,7 +437,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         rh.executePutRequest("/my-data-stream21/_bulk?refresh=true", bulkDocsBody, encodeBasicHeader("ds_admin", "nagilum"));
 
         response = rh.executePostRequest("/my-data-stream11/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
@@ -442,7 +445,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
@@ -450,7 +453,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream11-000001/_search", searchQuery2, encodeBasicHeader("ds_fm1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Pam\""));
@@ -458,13 +461,13 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/my-data-stream22/_search", searchQuery1, encodeBasicHeader("ds_fm1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream22-000001/_search", searchQuery2, encodeBasicHeader("ds_fm1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
@@ -472,7 +475,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-data-stream2*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\"Dam\""));
@@ -480,13 +483,13 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/.ds-my-data-stream1*/_search", searchQuery1, encodeBasicHeader("ds_fm2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery1, encodeBasicHeader("ds_fm3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"hits\":{\"total\":{\"value\":2,\"relation\":\"eq\"}"));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\"Dam\""));
@@ -495,7 +498,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/.ds-my-*/_search", searchQuery1, encodeBasicHeader("ds_fm3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"id\":\"8a4f500d\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\"Dam\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\""));
@@ -503,7 +506,7 @@ public class DataStreamIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(response.getBody().contains("\"message\":\""));
 
         response = rh.executePostRequest("/my-*/_search", searchQuery2, encodeBasicHeader("ds_fm3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"id\":\"l7gk7f82\""));
         Assert.assertFalse(response.getBody().contains("\"name\":\"Pam\""));
         Assert.assertTrue(response.getBody().contains("\"name\":\""));

--- a/src/test/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
+++ b/src/test/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
@@ -21,6 +21,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class EncryptionInTransitMigrationTests extends SingleClusterTest {
 
     @Test
@@ -42,59 +45,59 @@ public class EncryptionInTransitMigrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executePutRequest("/xyz/_doc/1", "{\"a\":5}");
-        Assert.assertEquals(HttpStatus.SC_CREATED, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_CREATED));
 
         res = rh.executeGetRequest("/_mappings");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/_search");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         if (dualModeEnabled) {
             res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
             Assert.assertTrue(res.getBody().contains("\"plugins.security_config.ssl_dual_mode_enabled\":\"true\""));
 
             String disableDualModeClusterSetting = "{ \"persistent\": { \""
                 + ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED
                 + "\": false } }";
             res = rh.executePutRequest("_cluster/settings", disableDualModeClusterSetting);
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-            Assert.assertEquals(
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 "{\"acknowledged\":true,\"persistent\":{\"plugins\":{\"security_config\":{\"ssl_dual_mode_enabled\":\"false\"}}},\"transient\":{}}",
-                res.getBody()
+                is(res.getBody())
             );
 
             res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
             Assert.assertTrue(res.getBody().contains("\"plugins.security_config.ssl_dual_mode_enabled\":\"false\""));
 
             String enableDualModeClusterSetting = "{ \"persistent\": { \""
                 + ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED
                 + "\": true } }";
             res = rh.executePutRequest("_cluster/settings", enableDualModeClusterSetting);
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-            Assert.assertEquals(
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 "{\"acknowledged\":true,\"persistent\":{\"plugins\":{\"security_config\":{\"ssl_dual_mode_enabled\":\"true\"}}},\"transient\":{}}",
-                res.getBody()
+                is(res.getBody())
             );
 
             res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
             Assert.assertTrue(res.getBody().contains("\"plugins.security_config.ssl_dual_mode_enabled\":\"true\""));
 
             res = rh.executePutRequest("_cluster/settings", disableDualModeClusterSetting);
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-            Assert.assertEquals(
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 "{\"acknowledged\":true,\"persistent\":{\"plugins\":{\"security_config\":{\"ssl_dual_mode_enabled\":\"false\"}}},\"transient\":{}}",
-                res.getBody()
+                is(res.getBody())
             );
 
             res = rh.executeGetRequest("_cluster/settings?flat_settings&include_defaults");
-            Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
             Assert.assertTrue(res.getBody().contains("\"plugins.security_config.ssl_dual_mode_enabled\":\"false\""));
         }
     }
@@ -109,7 +112,7 @@ public class EncryptionInTransitMigrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("/_search");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -122,7 +125,7 @@ public class EncryptionInTransitMigrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("/_search");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -130,17 +133,17 @@ public class EncryptionInTransitMigrationTests extends SingleClusterTest {
         final Settings legacySettings = Settings.builder()
             .put(ConfigConstants.LEGACY_OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true)
             .build();
-        Assert.assertEquals(SecuritySettings.SSL_DUAL_MODE_SETTING.get(legacySettings), true);
+        assertThat(true, is(SecuritySettings.SSL_DUAL_MODE_SETTING.get(legacySettings)));
 
         final Settings legacySettings2 = Settings.builder()
             .put(ConfigConstants.LEGACY_OPENDISTRO_SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, false)
             .build();
-        Assert.assertEquals(SecuritySettings.SSL_DUAL_MODE_SETTING.get(legacySettings2), false);
+        assertThat(false, is(SecuritySettings.SSL_DUAL_MODE_SETTING.get(legacySettings2)));
 
         final Settings settings = Settings.builder().put(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true).build();
-        Assert.assertEquals(SecuritySettings.SSL_DUAL_MODE_SETTING.get(settings), true);
+        assertThat(true, is(SecuritySettings.SSL_DUAL_MODE_SETTING.get(settings)));
 
         final Settings settings2 = Settings.builder().put(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, false).build();
-        Assert.assertEquals(SecuritySettings.SSL_DUAL_MODE_SETTING.get(settings2), false);
+        assertThat(false, is(SecuritySettings.SSL_DUAL_MODE_SETTING.get(settings2)));
     }
 }

--- a/src/test/java/org/opensearch/security/HealthTests.java
+++ b/src/test/java/org/opensearch/security/HealthTests.java
@@ -27,7 +27,6 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -35,6 +34,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class HealthTests extends SingleClusterTest {
 
@@ -44,15 +46,12 @@ public class HealthTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is((res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()));
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -64,17 +63,14 @@ public class HealthTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is((res = rh.executeGetRequest("_opendistro/_security/health?pretty&mode=lenient")).getStatusCode()));
         assertContains(res, "*UP*");
         assertNotContains(res, "*DOWN*");
         assertNotContains(res, "*strict*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_SERVICE_UNAVAILABLE,
-            (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode()
+            is((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode())
         );
         assertContains(res, "*DOWN*");
         assertContains(res, "*strict*");

--- a/src/test/java/org/opensearch/security/HttpIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/HttpIntegrationTests.java
@@ -57,6 +57,8 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.DefaultObjectMapper.readTree;
 
 public class HttpIntegrationTests extends SingleClusterTest {
@@ -120,166 +122,155 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         }
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("_search").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("_search").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeDeleteRequest("nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeDeleteRequest("nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(".nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest(".nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("xxxxyyyy/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("xxxxyyyy/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("abc", "abc:abc")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("abc", "abc:abc")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", encodeBasicHeader("userwithnopassword", "")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", encodeBasicHeader("userwithnopassword", "")).getStatusCode()
+            is(rh.executeGetRequest("", encodeBasicHeader("userwithblankpassword", "")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", encodeBasicHeader("userwithblankpassword", "")).getStatusCode()
+            is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic " + "wrongheader")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode());
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic " + "wrongheader")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic ")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic")).getStatusCode()
-        );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", new BasicHeader("Authorization", "")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("picard", "picard")).getStatusCode());
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic ")).getStatusCode()));
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic")).getStatusCode()));
+        assertThat(rh.executeGetRequest("", new BasicHeader("Authorization", "")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("picard", "picard")).getStatusCode(), is(HttpStatus.SC_OK));
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
-                HttpStatus.SC_UNAUTHORIZED,
-                rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode()
-            );
+            assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode()));
         }
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest("/theindex", "{}", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executePutRequest("/theindex", "{}", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            rh.executePutRequest("/theindex/_doc/1?refresh=true", "{\"a\":0}", encodeBasicHeader("theindexadmin", "theindexadmin"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("/theindex/_doc/1?refresh=true", "{\"a\":0}", encodeBasicHeader("theindexadmin", "theindexadmin"))
+                    .getStatusCode()
+            )
         );
-        // Assert.assertEquals(HttpStatus.SC_OK,
+        // assertThat(HttpStatus.SC_OK,
         // rh.executeGetRequest("/theindex/_analyze?text=this+is+a+test",encodeBasicHeader("theindexadmin",
         // "theindexadmin")).getStatusCode());
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN,
+        // assertThat(HttpStatus.SC_FORBIDDEN,
         // rh.executeGetRequest("_analyze?text=this+is+a+test",encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeDeleteRequest("/theindex", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executeDeleteRequest("/theindex", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest("/klingonempire", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executeDeleteRequest("/klingonempire", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("starfleet/_search", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("starfleet/_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeDeleteRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/.opendistro_security/_close", null, encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePostRequest("/.opendistro_security/_close", null, encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/.opendistro_security/_upgrade", null, encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePostRequest("/.opendistro_security/_upgrade", null, encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("/.opendistro_security/_mapping", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest("/.opendistro_security/_mapping", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeDeleteRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         HttpResponse resc = rh.executeGetRequest("_cat/indices/public?v", encodeBasicHeader("bug108", "nagilum"));
         Assert.assertTrue(resc.getBody().contains("green"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "role01_role02/_search?pretty",
-                encodeBasicHeader("user_role01_role02_role03", "user_role01_role02_role03")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "role01_role02/_search?pretty",
+                    encodeBasicHeader("user_role01_role02_role03", "user_role01_role02_role03")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("role01_role02/_search?pretty", encodeBasicHeader("user_role01", "user_role01")).getStatusCode()
+            is(rh.executeGetRequest("role01_role02/_search?pretty", encodeBasicHeader("user_role01", "user_role01")).getStatusCode())
         );
 
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("spock", "spock")).getStatusCode()
-        );
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("spock", "spock")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()
+            is(rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("kirk/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("kirk/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()));
 
         // all
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(".opendistro_security/_mget", "{\"ids\" : [\"0\"]}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(
+                rh.executePostRequest(".opendistro_security/_mget", "{\"ids\" : [\"0\"]}", encodeBasicHeader("worf", "worf"))
+                    .getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         try (Client tc = getClient()) {
@@ -290,12 +281,12 @@ public class HttpIntegrationTests extends SingleClusterTest {
             ).actionGet();
             ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[] { "roles" }))
                 .actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         try (Client tc = getClient()) {
@@ -306,27 +297,27 @@ public class HttpIntegrationTests extends SingleClusterTest {
             ).actionGet();
             ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[] { "roles" }))
                 .actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
         HttpResponse res = rh.executeGetRequest("_search?pretty", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"value\" : 11"));
         Assert.assertFalse(res.getBody().contains(".opendistro_security"));
 
         res = rh.executeGetRequest("_nodes/stats?pretty", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("total_in_bytes"));
         Assert.assertTrue(res.getBody().contains("max_file_descriptors"));
         Assert.assertTrue(res.getBody().contains("buffer_pools"));
         Assert.assertFalse(res.getBody().contains("\"nodes\" : { }"));
 
         res = rh.executePostRequest("*/_upgrade", "", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
             + System.lineSeparator()
@@ -338,7 +329,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("writer", "writer"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"errors\":false"));
         Assert.assertTrue(res.getBody().contains("\"status\":201"));
 
@@ -347,14 +338,14 @@ public class HttpIntegrationTests extends SingleClusterTest {
             new BasicHeader("security_tenant", "unittesttenant"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("tenant"));
         Assert.assertTrue(res.getBody().contains("unittesttenant"));
         Assert.assertTrue(res.getBody().contains("\"kltentrw\":true"));
         Assert.assertTrue(res.getBody().contains("\"user_name\":\"worf\""));
 
         res = rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("tenant"));
         Assert.assertTrue(res.getBody().contains("\"user_requested_tenant\":null"));
         Assert.assertTrue(res.getBody().contains("\"kltentrw\":true"));
@@ -363,7 +354,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertFalse(res.getBody().contains("attributes="));
 
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("custattr", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("tenants"));
         Assert.assertTrue(res.getBody().contains("\"user_requested_tenant\" : null"));
         Assert.assertTrue(res.getBody().contains("\"user_name\" : \"custattr\""));
@@ -372,10 +363,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains("attr.internal.c1"));
 
         res = rh.executeGetRequest("v2/_search", encodeBasicHeader("custattr", "nagilum"));
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("v3/_search", encodeBasicHeader("custattr", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         final String reindex = "{"
             + "\"source\": {"
@@ -387,7 +378,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + "}";
 
         res = rh.executePostRequest("_reindex?pretty", reindex, encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"total\" : 1"));
         Assert.assertTrue(res.getBody().contains("\"batches\" : 1"));
         Assert.assertTrue(res.getBody().contains("\"failures\" : [ ]"));
@@ -398,7 +389,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "knuddel"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("name=knuddel"));
         Assert.assertTrue(res.getBody().contains("attr.internal.test1"));
         Assert.assertFalse(res.getBody().contains("worf"));
@@ -408,14 +399,14 @@ public class HttpIntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "nonexists"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader("opendistro_security_impersonate_as", "notallowed"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -430,11 +421,11 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = restHelper(); // ssl resthelper
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
 
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         assertNotContains(res, "*\"compression\":\"false\"*");
         assertContains(res, "*\"compression\":\"true\"*");
     }
@@ -450,11 +441,11 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = restHelper(); // ssl resthelper
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*ssl_protocol\":\"TLSv1.2*");
 
         res = rh.executeGetRequest("_nodes", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*\"compression\":\"false\"*");
         assertNotContains(res, "*\"compression\":\"true\"*");
     }
@@ -466,22 +457,22 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
 
         HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo");
         Assert.assertTrue(resc.getBody().contains("opendistro_security_anonymous"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty=true");
         Assert.assertTrue(resc.getBody().contains("\"remote_address\" : \"")); // check pretty print
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("_opendistro/_security/authinfo", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertTrue(resc.getBody().contains("nagilum"));
         Assert.assertFalse(resc.getBody().contains("opendistro_security_anonymous"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         try (Client tc = getClient()) {
             tc.index(
@@ -499,13 +490,13 @@ public class HttpIntegrationTests extends SingleClusterTest {
                 new ConfigUpdateRequest(new String[] { "config", "roles", "rolesmapping", "internalusers", "actiongroups" })
             ).actionGet();
             Assert.assertFalse(cur.hasFailures());
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "wrong")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -533,7 +524,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
                 new ConfigUpdateRequest(new String[] { "config", "roles", "rolesmapping", "internalusers", "actiongroups" })
             ).actionGet();
             Assert.assertFalse(cur.hasFailures());
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
         RestHelper rh = restHelper();
@@ -542,12 +533,12 @@ public class HttpIntegrationTests extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
         rh.keystore = "spock-keystore.jks";
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executePutRequest(".opendistro_security/_doc/x", "{}").getStatusCode());
+        assertThat(rh.executeGetRequest("_search").getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executePutRequest(".opendistro_security/_doc/x", "{}").getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         rh.keystore = "kirk-keystore.jks";
-        Assert.assertEquals(HttpStatus.SC_CREATED, rh.executePutRequest(".opendistro_security/_doc/y", "{}").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode());
+        assertThat(rh.executePutRequest(".opendistro_security/_doc/y", "{}").getStatusCode(), is(HttpStatus.SC_CREATED));
+        assertThat(rh.executeGetRequest("_opendistro/_security/authinfo").getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -578,63 +569,78 @@ public class HttpIntegrationTests extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setConfig("config_proxy.yml"), Settings.EMPTY, true);
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
-                new BasicHeader("x-proxy-user", "scotty"),
-                encodeBasicHeader("nagilum-wrong", "nagilum-wrong")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
+                    new BasicHeader("x-proxy-user", "scotty"),
+                    encodeBasicHeader("nagilum-wrong", "nagilum-wrong")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
-                new BasicHeader("x-proxy-user-wrong", "scotty"),
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
+                    new BasicHeader("x-proxy-user-wrong", "scotty"),
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "a"),
-                new BasicHeader("x-proxy-user", "scotty"),
-                encodeBasicHeader("nagilum-wrong", "nagilum-wrong")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "a"),
+                    new BasicHeader("x-proxy-user", "scotty"),
+                    encodeBasicHeader("nagilum-wrong", "nagilum-wrong")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executeGetRequest("", new BasicHeader("x-forwarded-for", "a,b,c"), new BasicHeader("x-proxy-user", "scotty")).getStatusCode()
+            is(
+                rh.executeGetRequest("", new BasicHeader("x-forwarded-for", "a,b,c"), new BasicHeader("x-proxy-user", "scotty"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
-                new BasicHeader("x-proxy-user", "scotty")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
+                    new BasicHeader("x-proxy-user", "scotty")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
-                new BasicHeader("X-Proxy-User", "scotty")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
+                    new BasicHeader("X-Proxy-User", "scotty")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "",
-                new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
-                new BasicHeader("x-proxy-user", "scotty"),
-                new BasicHeader("x-proxy-roles", "starfleet,engineer")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "",
+                    new BasicHeader("x-forwarded-for", "localhost,192.168.0.1,10.0.0.2"),
+                    new BasicHeader("x-proxy-user", "scotty"),
+                    new BasicHeader("x-proxy-roles", "starfleet,engineer")
+                ).getStatusCode()
+            )
         );
 
     }
@@ -728,155 +734,141 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeDeleteRequest("nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeDeleteRequest("nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(".nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest(".nonexistentindex*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("xxxxyyyy/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("xxxxyyyy/_doc/0", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("abc", "abc:abc")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("abc", "abc:abc")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", encodeBasicHeader("userwithnopassword", "")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", encodeBasicHeader("userwithnopassword", "")).getStatusCode()
+            is(rh.executeGetRequest("", encodeBasicHeader("userwithblankpassword", "")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", encodeBasicHeader("userwithblankpassword", "")).getStatusCode()
+            is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic " + "wrongheader")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode());
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic " + "wrongheader")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic ")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("", new BasicHeader("Authorization", "Basic")).getStatusCode()
-        );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", new BasicHeader("Authorization", "")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("picard", "picard")).getStatusCode());
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic ")).getStatusCode()));
+        assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", new BasicHeader("Authorization", "Basic")).getStatusCode()));
+        assertThat(rh.executeGetRequest("", new BasicHeader("Authorization", "")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("picard", "picard")).getStatusCode(), is(HttpStatus.SC_OK));
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
-                HttpStatus.SC_UNAUTHORIZED,
-                rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode()
-            );
+            assertThat(HttpStatus.SC_UNAUTHORIZED, is(rh.executeGetRequest("", encodeBasicHeader("worf", "wrongpasswd")).getStatusCode()));
         }
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest("/theindex", "{}", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executePutRequest("/theindex", "{}", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            rh.executePutRequest("/theindex/_doc/1?refresh=true", "{\"a\":0}", encodeBasicHeader("theindexadmin", "theindexadmin"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("/theindex/_doc/1?refresh=true", "{\"a\":0}", encodeBasicHeader("theindexadmin", "theindexadmin"))
+                    .getStatusCode()
+            )
         );
-        // Assert.assertEquals(HttpStatus.SC_OK,
+        // assertThat(HttpStatus.SC_OK,
         // rh.executeGetRequest("/theindex/_analyze?text=this+is+a+test",encodeBasicHeader("theindexadmin",
         // "theindexadmin")).getStatusCode());
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN,
+        // assertThat(HttpStatus.SC_FORBIDDEN,
         // rh.executeGetRequest("_analyze?text=this+is+a+test",encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeDeleteRequest("/theindex", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executeDeleteRequest("/theindex", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest("/klingonempire", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode()
+            is(rh.executeDeleteRequest("/klingonempire", encodeBasicHeader("theindexadmin", "theindexadmin")).getStatusCode())
         );
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("starfleet/_search", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("starfleet/_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeDeleteRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/.opendistro_security/_close", null, encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePostRequest("/.opendistro_security/_close", null, encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/.opendistro_security/_upgrade", null, encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePostRequest("/.opendistro_security/_upgrade", null, encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("/.opendistro_security/_mapping", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest("/.opendistro_security/_mapping", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/2", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeDeleteRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeDeleteRequest(".opendistro_security/_doc/0", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         HttpResponse resc = rh.executeGetRequest("_cat/indices/public", encodeBasicHeader("bug108", "nagilum"));
         // Assert.assertTrue(resc.getBody().contains("green"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "role01_role02/_search?pretty",
-                encodeBasicHeader("user_role01_role02_role03", "user_role01_role02_role03")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "role01_role02/_search?pretty",
+                    encodeBasicHeader("user_role01_role02_role03", "user_role01_role02_role03")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("role01_role02/_search?pretty", encodeBasicHeader("user_role01", "user_role01")).getStatusCode()
+            is(rh.executeGetRequest("role01_role02/_search?pretty", encodeBasicHeader("user_role01", "user_role01")).getStatusCode())
         );
 
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("spock", "spock")).getStatusCode()
-        );
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("spock", "spock")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()
+            is(rh.executeGetRequest("spock/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("kirk/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("kirk/_search?pretty", encodeBasicHeader("kirk", "kirk")).getStatusCode()));
 
         // all
 
@@ -898,7 +890,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         HttpResponse res = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("bulk", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"errors\":false"));
         Assert.assertTrue(res.getBody().contains("\"status\":201"));
     }
@@ -920,10 +912,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true", bulkBody, encodeBasicHeader("bulk_test_user", "nagilum"));
         JsonNode jsonNode = readTree(res.getBody());
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(jsonNode.get("errors").booleanValue());
-        Assert.assertEquals(201, jsonNode.get("items").get(0).get("index").get("status").intValue());
-        Assert.assertEquals(403, jsonNode.get("items").get(1).get("index").get("status").intValue());
+        assertThat(jsonNode.get("items").get(0).get("index").get("status").intValue(), is(201));
+        assertThat(jsonNode.get("items").get(1).get("index").get("status").intValue(), is(403));
     }
 
     @Test
@@ -954,14 +946,14 @@ public class HttpIntegrationTests extends SingleClusterTest {
             "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));
         res = rh.executePostRequest(
             "/*/_search",
             "{\"size\":0,\"aggs\":{\"indices\":{\"terms\":{\"field\":\"_index\",\"size\":10}}}}",
             encodeBasicHeader("557", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("starfleet_academy"));
     }
 
@@ -1019,11 +1011,11 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("/esb-prod-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/esb-alias-*/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/esb-prod-all/_search?pretty", encodeBasicHeader("itt1635", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -1100,10 +1092,10 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/tenantinfo?pretty", encodeBasicHeader("itt1635", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         res = rh.executeGetRequest("_opendistro/_security/tenantinfo?pretty", encodeBasicHeader("kibanaserver", "kibanaserver"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\".kibana_-1139640511_admin1\" : \"admin_1\""));
         Assert.assertTrue(res.getBody().contains("\".kibana_-1386441176_praxisrw\" : \"praxisrw\""));
         Assert.assertTrue(res.getBody().contains(".kibana_-2014056163_kltentrw\" : \"kltentrw\""));
@@ -1129,7 +1121,7 @@ public class HttpIntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "someotherusernotininternalusersfile"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("name=someotherusernotininternalusersfile"));
         Assert.assertFalse(res.getBody().contains("worf"));
     }
@@ -1141,16 +1133,16 @@ public class HttpIntegrationTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/sslinfo");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executePutRequest("/xyz/_doc/1", "{\"a\":5}");
-        Assert.assertEquals(HttpStatus.SC_CREATED, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_CREATED));
 
         res = rh.executeGetRequest("/_mappings");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/_search");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -1164,12 +1156,9 @@ public class HttpIntegrationTests extends SingleClusterTest {
                 .actionGet();
         }
 
-        Assert.assertEquals(
-            HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("_all/_search", encodeBasicHeader("worf", "worf")).getStatusCode()
-        );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("*/_search", encodeBasicHeader("worf", "worf")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode());
+        assertThat(HttpStatus.SC_FORBIDDEN, is(rh.executeGetRequest("_all/_search", encodeBasicHeader("worf", "worf")).getStatusCode()));
+        assertThat(rh.executeGetRequest("*/_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        assertThat(rh.executeGetRequest("_search", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
 }

--- a/src/test/java/org/opensearch/security/IndexIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IndexIntegrationTests.java
@@ -55,6 +55,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class IndexIntegrationTests extends SingleClusterTest {
 
     @Test
@@ -92,7 +95,7 @@ public class IndexIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         HttpResponse resc = rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"_index\":\"klingonempire\""));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("hits"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("no permissions for [indices:data/read/search]"));
@@ -159,7 +162,7 @@ public class IndexIntegrationTests extends SingleClusterTest {
         // _bulk
         HttpResponse res = rh.executePostRequest("_bulk?refresh=true&pretty=true", bulkBody, encodeBasicHeader("worf", "worf"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"errors\" : true"));
         Assert.assertTrue(res.getBody().contains("\"status\" : 201"));
         Assert.assertTrue(res.getBody().contains("no permissions for"));
@@ -176,39 +179,36 @@ public class IndexIntegrationTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             "Unable to create index 'nag'",
-            HttpStatus.SC_OK,
-            rh.executePutRequest("nag1", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            rh.executePutRequest("nag1", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode(),
+            is(HttpStatus.SC_OK)
         );
-        Assert.assertEquals(
+        assertThat(
             "Unable to create index 'starfleet_library'",
-            HttpStatus.SC_OK,
-            rh.executePutRequest("starfleet_library", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            rh.executePutRequest("starfleet_library", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode(),
+            is(HttpStatus.SC_OK)
         );
 
         clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), clusterInfo.numNodes);
 
-        Assert.assertEquals(
+        assertThat(
             "Unable to close index 'starfleet_library'",
-            HttpStatus.SC_OK,
-            rh.executePostRequest("starfleet_library/_close", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            rh.executePostRequest("starfleet_library/_close", null, encodeBasicHeader("nagilum", "nagilum")).getStatusCode(),
+            is(HttpStatus.SC_OK)
         );
 
-        Assert.assertEquals(
+        assertThat(
             "Unable to open index 'starfleet_library'",
-            HttpStatus.SC_OK,
-            (res = rh.executePostRequest("starfleet_library/_open", null, encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            (res = rh.executePostRequest("starfleet_library/_open", null, encodeBasicHeader("nagilum", "nagilum"))).getStatusCode(),
+            is(HttpStatus.SC_OK)
         );
         Assert.assertTrue("open index 'starfleet_library' not acknowledged", res.getBody().contains("acknowledged"));
         Assert.assertFalse("open index 'starfleet_library' not acknowledged", res.getBody().contains("false"));
 
         clusterHelper.waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), clusterInfo.numNodes);
 
-        Assert.assertEquals(
-            HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("public", null, encodeBasicHeader("spock", "spock")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_FORBIDDEN, is(rh.executePutRequest("public", null, encodeBasicHeader("spock", "spock")).getStatusCode()));
 
     }
 
@@ -255,16 +255,16 @@ public class IndexIntegrationTests extends SingleClusterTest {
         // opendistro_security_user2 -> picard
 
         HttpResponse resc = rh.executeGetRequest("alias*/_search", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("theindex/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("alias3/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("_cat/indices", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
     }
 
@@ -299,43 +299,43 @@ public class IndexIntegrationTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
 
         HttpResponse resc = rh.executeGetRequest("/foo1/_search?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 1"));
 
         resc = rh.executeGetRequest("/foo2/_search?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 2"));
 
         resc = rh.executeGetRequest("/foo/_search?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 3"));
 
         // resc = rh.executeGetRequest("/fooba/z/_search?pretty", encodeBasicHeader("baz", "worf"));
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        // assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/foo1/_doc/1?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"found\" : true"));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 1"));
 
         resc = rh.executeGetRequest("/foo2/_doc/2?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 2"));
         Assert.assertTrue(resc.getBody().contains("\"found\" : true"));
 
         resc = rh.executeGetRequest("/foo/_doc/3?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 3"));
         Assert.assertTrue(resc.getBody().contains("\"found\" : true"));
 
         // resc = rh.executeGetRequest("/fooba/z/4?pretty", encodeBasicHeader("baz", "worf"));
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        // assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // resc = rh.executeGetRequest("/foo*/_search?pretty", encodeBasicHeader("baz", "worf"));
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        // assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/foo*,-fooba/_search?pretty", encodeBasicHeader("baz", "worf"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 1"));
         Assert.assertTrue(resc.getBody().contains("\"content\" : 2"));
     }
@@ -370,135 +370,166 @@ public class IndexIntegrationTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
 
         HttpResponse res = null;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
         // nonexistent index with permissions
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(
+                rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         // existent index without permissions
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/nopermindex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/nopermindex/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
         // nonexistent index without permissions
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/does-not-exist-and-no-perm/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("/does-not-exist-and-no-perm/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         // nonexistent and existent index with permissions
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("/logstash-nonex,logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("/logstash-nonex,logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         // existent index with permissions
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/logstash-1/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
         // nonexistent index with failed login
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("nouser", "nosuer")).getStatusCode()
+            is(rh.executeGetRequest("/logstash-nonex/_search", encodeBasicHeader("nouser", "nosuer")).getStatusCode())
         );
 
         // nonexistent index with no login
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, (res = rh.executeGetRequest("/logstash-nonex/_search")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("/logstash-nonex/_search")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/_all/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/_all/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/*/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/*/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/nopermindex,logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "/nopermindex,logstash-1,nonexist/_search",
+                    encodeBasicHeader("opendistro_security_logstash", "nagilum")
+                ).getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("/logstash-1,nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/nonexist/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("/%3Clogstash-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("/%3Clogstash-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/%3Cnonex-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("/%3Cnonex-%7Bnow%2Fd%7D%3E/_search", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-*/_search",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-*/_search",
+                    encodeBasicHeader("opendistro_security_logstash", "nagilum")
+                ).getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest(
-                "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-1/_search",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executeGetRequest(
+                    "/%3Clogstash-%7Bnow%2Fd%7D%3E,logstash-1/_search",
+                    encodeBasicHeader("opendistro_security_logstash", "nagilum")
+                ).getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            rh.executePutRequest("/logstash-b/_doc/1", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum")).getStatusCode()
+            is(
+                rh.executePutRequest("/logstash-b/_doc/1", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest("/%3Clogstash-cnew-%7Bnow%2Fd%7D%3E", "{}", encodeBasicHeader("opendistro_security_logstash", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "/%3Clogstash-cnew-%7Bnow%2Fd%7D%3E",
+                    "{}",
+                    encodeBasicHeader("opendistro_security_logstash", "nagilum")
+                ).getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            rh.executePutRequest(
-                "/%3Clogstash-new-%7Bnow%2Fd%7D%3E/_doc/1",
-                "{}",
-                encodeBasicHeader("opendistro_security_logstash", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "/%3Clogstash-new-%7Bnow%2Fd%7D%3E/_doc/1",
+                    "{}",
+                    encodeBasicHeader("opendistro_security_logstash", "nagilum")
+                ).getStatusCode()
+            )
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/_cat/indices?v", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("/_cat/indices?v", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         String body = res.getBody();
         Assert.assertTrue(body.contains("logstash-b"));
@@ -554,38 +585,38 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         HttpResponse res = null;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/mysgi/_doc", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executePostRequest("/mysgi/_doc", "{}", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/mysgi/_search?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("/mysgi/_search?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         assertContains(res, "*\"hits\" : {*\"value\" : 0,*\"hits\" : [ ]*");
 
         // add alias to allowed index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest("/logstash-1/_alias/alog1", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePutRequest("/logstash-1/_alias/alog1", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // add alias to not existing (no perm)
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("/nonexitent/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePutRequest("/nonexitent/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // add alias to not existing (with perm)
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executePutRequest("/logstash-nonex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePutRequest("/logstash-nonex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // add alias to not allowed index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("/nopermindex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePutRequest("/nopermindex/_alias/alnp", "", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         String aliasRemoveIndex = "{"
@@ -596,35 +627,35 @@ public class IndexIntegrationTests extends SingleClusterTest {
             + "}";
 
         // remove_index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("/_aliases", aliasRemoveIndex, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePostRequest("/_aliases", aliasRemoveIndex, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // get alias for permitted index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("/logstash-1/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/logstash-1/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // get alias for all indices
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/_alias/alog1", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         // get alias no perm
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("/_alias/nopermalias", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("/_alias/nopermalias", encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
 
         String alias = "{" + "\"aliases\": {" + "\"alias1\": {}" + "}" + "}";
 
         // create alias along with index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("/beats-withalias", alias, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode()
+            is(rh.executePutRequest("/beats-withalias", alias, encodeBasicHeader("aliasmngt", "nagilum")).getStatusCode())
         );
     }
 
@@ -638,7 +669,7 @@ public class IndexIntegrationTests extends SingleClusterTest {
             URLEncoder.encode("_##pdt_data/_search", "UTF-8"),
             encodeBasicHeader("ccsresolv", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         Assert.assertTrue(res.getBody().contains("invalid_index_name_exception"));
     }
 
@@ -655,10 +686,10 @@ public class IndexIntegrationTests extends SingleClusterTest {
 
         // ccsresolv has perm for ?abc*
         HttpResponse res = rh.executeGetRequest("ggg:.abc-6,.abc-6/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         res = rh.executeGetRequest("/*:.abc-6,.abc-6/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         // TODO: Change for 25.0 to be forbidden (possible bug in ES regarding ccs wildcard)
     }
 
@@ -680,50 +711,50 @@ public class IndexIntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse res = rh.executeGetRequest("/*:.abc,.abc/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":1"));
 
         res = rh.executeGetRequest("/ba*bcuzh/_search", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":12"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/*:.abc/_search", encodeBasicHeader("nagilum", "nagilum"));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":1"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/*:xyz,xyz/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":2"));
 
         // res = rh.executeGetRequest("/*noexist/_search", encodeBasicHeader("nagilum", "nagilum"));
-        // Assert.assertEquals(HttpStatus.SC_NOT_FOUND, res.getStatusCode());
+        // assertThat(res.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
 
         res = rh.executeGetRequest("/*:.abc/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":1"));
 
         res = rh.executeGetRequest("/*:xyz/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":2"));
 
         res = rh.executeGetRequest("/.abc/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/xyz/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:.abc,.abc/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:xyz,xyz/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:.abc/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:xyz/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:noperm/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:noperm/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("/*:noexists/_search", encodeBasicHeader("ccsresolv", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -751,7 +782,7 @@ public class IndexIntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         HttpResponse resc = rh.executePostRequest("_msearch", msearchBody, encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"total\":{\"value\":1"));
     }
 
@@ -777,13 +808,13 @@ public class IndexIntegrationTests extends SingleClusterTest {
         Assert.assertFalse(resc.getBody().contains("foo"));
 
         resc = rh.executeGetRequest("/foo-alias/_search", encodeBasicHeader("foo_index", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/foo-index/_search", encodeBasicHeader("foo_index", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
 
         resc = rh.executeGetRequest("/foo-alias/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
 
     }
 
@@ -801,34 +832,34 @@ public class IndexIntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse resc = rh.executeGetRequest("/**/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/*/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/**,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/*,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/*,-*security/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("/*,-*security/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("/*,-*security,-foo*/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("/_all,-*security/_search", encodeBasicHeader("foo_all", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resc = rh.executeGetRequest("/_all,-*security/_search", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
     }
 }

--- a/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
+++ b/src/test/java/org/opensearch/security/IndexTemplateClusterPermissionsCheckTest.java
@@ -12,13 +12,15 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest {
     private RestHelper rh;
@@ -42,8 +44,8 @@ public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest 
 
         // should fail, as user `ds3` doesn't have correct permissions
         HttpResponse response = rh.executePutRequest("/_index_template/sem1234", indexTemplateBody, encodeBasicHeader("ds4", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        assertThat(response.findValueInJson("error.root_cause[0].reason"), is(expectedFailureResponse));
     }
 
     @Test
@@ -54,7 +56,7 @@ public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest 
             indexTemplateBody,
             encodeBasicHeader("sem-user", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -67,8 +69,8 @@ public class IndexTemplateClusterPermissionsCheckTest extends SingleClusterTest 
             indexTemplateBody,
             encodeBasicHeader("sem-user2", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
-        Assert.assertEquals(expectedFailureResponse, response.findValueInJson("error.root_cause[0].reason"));
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
+        assertThat(response.findValueInJson("error.root_cause[0].reason"), is(expectedFailureResponse));
     }
 
 }

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -59,6 +59,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class InitializationIntegrationTests extends SingleClusterTest {
 
     @Test
@@ -76,19 +79,19 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         rh.enableHTTPClientSSL = true;
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = true;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_SERVICE_UNAVAILABLE,
-            rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("___", "")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("___", "")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_SERVICE_UNAVAILABLE,
-            rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode())
         );
 
         rh.keystore = "kirk-keystore.jks";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode())
         );
 
         Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));
@@ -110,13 +113,13 @@ public class InitializationIntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("___", "")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("___", "")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_UNAUTHORIZED,
-            rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode()
+            is(rh.executePutRequest(".opendistro_security/_doc/config", "{}", encodeBasicHeader("___", "")).getStatusCode())
         );
 
     }
@@ -137,10 +140,10 @@ public class InitializationIntegrationTests extends SingleClusterTest {
 
         try (RestHighLevelClient restHighLevelClient = getRestClient(clusterInfo, "spock-keystore.jks", "truststore.jks")) {
             Response whoAmIRes = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "/_plugins/_security/whoami"));
-            Assert.assertEquals(whoAmIRes.getStatusLine().getStatusCode(), 200);
+            assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
             JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper.readTree(whoAmIRes.getEntity().getContent());
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
-            Assert.assertEquals(whoAmIResponsePayload, "CN=spock,OU=client,O=client,L=Test,C=DE", whoAmIResNode.get("dn").asText());
+            assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_admin").asBoolean());
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_node_certificate_request").asBoolean());
         }
@@ -172,7 +175,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         }
 
         try (Client tc = getClient()) {
-            Assert.assertEquals(clusterInfo.numNodes, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(clusterInfo.numNodes));
             tc.index(
                 new IndexRequest(".opendistro_security").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
                     .id("internalusers")
@@ -182,7 +185,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
                 ConfigUpdateAction.INSTANCE,
                 new ConfigUpdateRequest(new String[] { "config", "roles", "rolesmapping", "internalusers", "actiongroups" })
             ).actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
         for (Iterator<TransportAddress> iterator = clusterInfo.httpAdresses.iterator(); iterator.hasNext();) {
@@ -206,7 +209,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         }
 
         try (Client tc = getClient()) {
-            Assert.assertEquals(clusterInfo.numNodes, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(clusterInfo.numNodes));
             tc.index(
                 new IndexRequest(".opendistro_security").setRefreshPolicy(RefreshPolicy.IMMEDIATE)
                     .id("config")
@@ -214,7 +217,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             ).actionGet();
             ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[] { "config" }))
                 .actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
         for (Iterator<TransportAddress> iterator = clusterInfo.httpAdresses.iterator(); iterator.hasNext();) {
@@ -234,7 +237,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             Assert.assertTrue(res.getBody().contains("opendistro_security_anonymous"));
             Assert.assertTrue(res.getBody().contains("name=opendistro_security_anonymous"));
             Assert.assertTrue(res.getBody().contains("roles=[opendistro_security_anonymous_backendrole]"));
-            Assert.assertEquals(200, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(200));
         }
     }
 
@@ -245,9 +248,9 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
         Thread.sleep(10000);
 
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode(), is(HttpStatus.SC_OK));
         HttpResponse res = rh.executeGetRequest("/_cluster/health", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(res.getBody(), HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getBody(), res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -260,9 +263,9 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             setup(Settings.EMPTY, null, settings, false);
             RestHelper rh = nonSslRestHelper();
             Thread.sleep(10000);
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_SERVICE_UNAVAILABLE,
-                rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode()
+                is(rh.executeGetRequest("", encodeBasicHeader("admin", "admin")).getStatusCode())
             );
         } finally {
             ClusterHelper.resetSystemProperties();
@@ -278,25 +281,27 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
 
         HttpResponse resc = rh.executeGetRequest("_search");
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("hits"));
     }
 
     @Test
     public void testDiscoveryWithoutInitialization() throws Exception {
         setup(Settings.EMPTY, null, Settings.EMPTY, false);
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
     }
 

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -58,6 +58,8 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import io.netty.handler.ssl.OpenSsl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.DefaultObjectMapper.readTree;
 
 public class IntegrationTests extends SingleClusterTest {
@@ -79,21 +81,26 @@ public class IntegrationTests extends SingleClusterTest {
 
         // search
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum")))
+                    .getStatusCode()
+            )
         );
 
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
         // search scroll
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/_search/scroll?pretty=true",
-                "{\"scroll_id\" : \"" + scrollid + "\"}",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/_search/scroll?pretty=true",
+                    "{\"scroll_id\" : \"" + scrollid + "\"}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
 
         // search done
@@ -104,14 +111,14 @@ public class IntegrationTests extends SingleClusterTest {
     public void testDnParsingCertAuth() throws Exception {
         Settings settings = Settings.builder().put("username_attribute", "cn").put("roles_attribute", "l").build();
         HTTPClientCertAuthenticator auth = new HTTPClientCertAuthenticator(settings, null);
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("cn=abc,cn=xxx,l=ert,st=zui,c=qwe")).getUsername());
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("cn=abc,l=ert,st=zui,c=qwe")).getUsername());
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("CN=abc,L=ert,st=zui,c=qwe")).getUsername());
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("l=ert,cn=abc,st=zui,c=qwe")).getUsername());
+        assertThat(auth.extractCredentials(null, newThreadContext("cn=abc,cn=xxx,l=ert,st=zui,c=qwe")).getUsername(), is("abc"));
+        assertThat(auth.extractCredentials(null, newThreadContext("cn=abc,l=ert,st=zui,c=qwe")).getUsername(), is("abc"));
+        assertThat(auth.extractCredentials(null, newThreadContext("CN=abc,L=ert,st=zui,c=qwe")).getUsername(), is("abc"));
+        assertThat(auth.extractCredentials(null, newThreadContext("l=ert,cn=abc,st=zui,c=qwe")).getUsername(), is("abc"));
         Assert.assertNull(auth.extractCredentials(null, newThreadContext("L=ert,CN=abc,c,st=zui,c=qwe")));
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("l=ert,st=zui,c=qwe,cn=abc")).getUsername());
-        Assert.assertEquals("abc", auth.extractCredentials(null, newThreadContext("L=ert,st=zui,c=qwe,CN=abc")).getUsername());
-        Assert.assertEquals("L=ert,st=zui,c=qwe", auth.extractCredentials(null, newThreadContext("L=ert,st=zui,c=qwe")).getUsername());
+        assertThat(auth.extractCredentials(null, newThreadContext("l=ert,st=zui,c=qwe,cn=abc")).getUsername(), is("abc"));
+        assertThat(auth.extractCredentials(null, newThreadContext("L=ert,st=zui,c=qwe,CN=abc")).getUsername(), is("abc"));
+        assertThat(auth.extractCredentials(null, newThreadContext("L=ert,st=zui,c=qwe")).getUsername(), is("L=ert,st=zui,c=qwe"));
         Assert.assertArrayEquals(
             new String[] { "ert" },
             auth.extractCredentials(null, newThreadContext("cn=abc,l=ert,st=zui,c=qwe")).getBackendRoles().toArray(new String[0])
@@ -125,9 +132,9 @@ public class IntegrationTests extends SingleClusterTest {
 
         settings = Settings.builder().build();
         auth = new HTTPClientCertAuthenticator(settings, null);
-        Assert.assertEquals(
+        assertThat(
             "cn=abc,l=ert,st=zui,c=qwe",
-            auth.extractCredentials(null, newThreadContext("cn=abc,l=ert,st=zui,c=qwe")).getUsername()
+            is(auth.extractCredentials(null, newThreadContext("cn=abc,l=ert,st=zui,c=qwe")).getUsername())
         );
     }
 
@@ -169,8 +176,8 @@ public class IntegrationTests extends SingleClusterTest {
         setup(tcSettings, new DynamicSecurityConfig(), settings, true);
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode());
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
 
     }
 
@@ -203,8 +210,8 @@ public class IntegrationTests extends SingleClusterTest {
         setup(tcSettings, new DynamicSecurityConfig(), settings, true);
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("").getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode());
+        assertThat(rh.executeGetRequest("").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("worf", "worf")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -244,7 +251,7 @@ public class IntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse resc = rh.executePostRequest("_mget?refresh=true", mgetBody, encodeBasicHeader("picard", "picard"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(resc.getBody().contains("type2"));
 
     }
@@ -269,14 +276,14 @@ public class IntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "knuddel"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resp.getStatusCode());
+        assertThat(resp.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resp = rh.executeGetRequest(
             "/_opendistro/_security/authinfo",
             new BasicHeader("opendistro_security_impersonate_as", "knuddel"),
             encodeBasicHeader("spock", "spock")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resp.getStatusCode());
+        assertThat(resp.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resp.getBody().contains("name=knuddel"));
         Assert.assertFalse(resp.getBody().contains("spock"));
 
@@ -285,14 +292,14 @@ public class IntegrationTests extends SingleClusterTest {
             new BasicHeader("opendistro_security_impersonate_as", "userwhonotexists"),
             encodeBasicHeader("spock", "spock")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resp.getStatusCode());
+        assertThat(resp.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         resp = rh.executeGetRequest(
             "/_opendistro/_security/authinfo",
             new BasicHeader("opendistro_security_impersonate_as", "invalid"),
             encodeBasicHeader("spock", "spock")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resp.getStatusCode());
+        assertThat(resp.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -311,18 +318,18 @@ public class IntegrationTests extends SingleClusterTest {
                 ConfigUpdateAction.INSTANCE,
                 new ConfigUpdateRequest(new String[] { "config", "roles", "rolesmapping", "internalusers", "actiongroups" })
             ).actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
         RestHelper rh = nonSslRestHelper();
         // opendistro_security_shakespeare -> picard
 
         HttpResponse resc = rh.executeGetRequest("shakespeare/_search", encodeBasicHeader("picard", "picard"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"content\":1"));
 
         resc = rh.executeHeadRequest("shakespeare", encodeBasicHeader("picard", "picard"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
     }
 
@@ -332,13 +339,10 @@ public class IntegrationTests extends SingleClusterTest {
         setup();
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("bug.88", "nagilum")).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest("", encodeBasicHeader("a", "b")).getStatusCode());
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("", encodeBasicHeader("\"'+-,;_?*@<>!$%&/()=#", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("", encodeBasicHeader("§ÄÖÜäöüß", "nagilum")).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("bug.88", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("a", "b")).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("", encodeBasicHeader("\"'+-,;_?*@<>!$%&/()=#", "nagilum")).getStatusCode()));
+        assertThat(rh.executeGetRequest("", encodeBasicHeader("§ÄÖÜäöüß", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
 
     }
 
@@ -352,7 +356,7 @@ public class IntegrationTests extends SingleClusterTest {
             new BasicHeader("x-forwarded-for", "10.0.0.7"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody().contains("10.0.0.7"));
     }
 
@@ -377,25 +381,19 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("index*/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()));
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("indexa/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("index*/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("isallowed/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("indexa/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("isallowed/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("special/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("special/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("alsonotallowed/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("alsonotallowed/_search", encodeBasicHeader("rexclude", "nagilum")).getStatusCode())
         );
     }
 
@@ -413,7 +411,7 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertFalse(res.getBody().contains("\"content\":1"));
         Assert.assertFalse(res.getBody().contains("\"content\":2"));
 
@@ -426,11 +424,11 @@ public class IntegrationTests extends SingleClusterTest {
 
             ConfigUpdateResponse cur = tc.execute(ConfigUpdateAction.INSTANCE, new ConfigUpdateRequest(new String[] { "config" }))
                 .actionGet();
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
         }
 
         res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(res.getBody().contains("\"content\":1"));
         Assert.assertTrue(res.getBody().contains("\"content\":2"));
 
@@ -454,13 +452,13 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse res = rh.executeGetRequest("/mindex_1,mindex_2/_search", encodeBasicHeader("mindex12", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
         res = rh.executeGetRequest("/mindex_1,mindex_3/_search", encodeBasicHeader("mindex12", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         res = rh.executeGetRequest("/mindex_1,mindex_4/_search", encodeBasicHeader("mindex12", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
     }
 
@@ -478,11 +476,11 @@ public class IntegrationTests extends SingleClusterTest {
 
         res = rh.executeGetRequest("abc_xyz_2018_05_24/_doc/1", encodeBasicHeader("underscore", "nagilum"));
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"content\":1"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("abc_xyz_2018_05_24/_refresh", encodeBasicHeader("underscore", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("aaa_bbb_2018_05_24/_refresh", encodeBasicHeader("underscore", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -500,13 +498,15 @@ public class IntegrationTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/vulcango*/_delete_by_query?refresh=true&wait_for_completion=true&pretty=true",
-                "{\"query\" : {\"match_all\" : {}}}",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/vulcango*/_delete_by_query?refresh=true&wait_for_completion=true&pretty=true",
+                    "{\"query\" : {\"match_all\" : {}}}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"deleted\" : 3"));
 
@@ -529,7 +529,7 @@ public class IntegrationTests extends SingleClusterTest {
             "{\"doc\" : {\"content\":2}}",
             encodeBasicHeader("user_c", "user_c")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -600,18 +600,18 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse resc;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("permission"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode())
         );
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
@@ -632,22 +632,22 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
         // msearch
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
-        Assert.assertEquals(3, resc.getBody().split("\"status\" : 200").length);
-        Assert.assertEquals(2, resc.getBody().split("\"status\" : 403").length);
+        assertThat(resc.getBody().split("\"status\" : 200").length, is(3));
+        assertThat(resc.getBody().split("\"status\" : 403").length, is(2));
 
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
-        Assert.assertEquals(3, resc.getBody().split("\"status\" : 200").length);
-        Assert.assertEquals(2, resc.getBody().split("\"status\" : 403").length);
+        assertThat(resc.getBody().split("\"status\" : 200").length, is(3));
+        assertThat(resc.getBody().split("\"status\" : 403").length, is(2));
 
         msearchBody = "{\"index\":\"indexc\", \"ignore_unavailable\": true}"
             + System.lineSeparator()
@@ -659,9 +659,9 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
 
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(resc.getBody(), 200, resc.getStatusCode());
-        Assert.assertEquals(resc.getBody(), "security_exception", resc.findValueInJson("responses[0].error.type"));
-        Assert.assertEquals(resc.getBody(), "security_exception", resc.findValueInJson("responses[1].error.type"));
+        assertThat(resc.getBody(), resc.getStatusCode(), is(200));
+        assertThat(resc.getBody(), resc.findValueInJson("responses[0].error.type"), is("security_exception"));
+        assertThat(resc.getBody(), resc.findValueInJson("responses[1].error.type"), is("security_exception"));
 
         String mgetBody = "{"
             + "\"docs\" : ["
@@ -678,7 +678,7 @@ public class IntegrationTests extends SingleClusterTest {
 
         // mget
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("\"content\" : \"indexa\""));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("\"content\" : \"indexb\""));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -698,85 +698,82 @@ public class IntegrationTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(resc.getBody(), 200, resc.getStatusCode());
-        Assert.assertEquals(resc.getBody(), "index_not_found_exception", resc.findValueInJson("docs[0].error.type"));
-        Assert.assertEquals(resc.getBody(), "index_not_found_exception", resc.findValueInJson("docs[1].error.type"));
+        assertThat(resc.getBody(), resc.getStatusCode(), is(200));
+        assertThat(resc.getBody(), resc.findValueInJson("docs[0].error.type"), is("index_not_found_exception"));
+        assertThat(resc.getBody(), resc.findValueInJson("docs[1].error.type"), is("index_not_found_exception"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("permission"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()));
+
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
-        );
-
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("permitnotexistentindex/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("permitnotexistentindex/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("permitnotexistentindex*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("permitnotexistentindex*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         // _all/_mapping/field/*
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("_cat/indices", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("_cat/indices", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
@@ -850,14 +847,14 @@ public class IntegrationTests extends SingleClusterTest {
         }
 
         HttpResponse resc;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b")).getStatusCode()
+            is(rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b")).getStatusCode())
         );
 
         String msearchBody = "{\"index\":\"indexa\", \"ignore_unavailable\": true}"
@@ -870,7 +867,7 @@ public class IntegrationTests extends SingleClusterTest {
             + System.lineSeparator();
         // msearch a
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -878,7 +875,7 @@ public class IntegrationTests extends SingleClusterTest {
 
         // msearch b
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
 
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
@@ -897,13 +894,13 @@ public class IntegrationTests extends SingleClusterTest {
         // msearch b2
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
 
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
         int count = resc.getBody().split("\"status\" : 403").length;
-        Assert.assertEquals(3, count);
+        assertThat(count, is(3));
 
         String mgetBody = "{"
             + "\"docs\" : ["
@@ -919,7 +916,7 @@ public class IntegrationTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("\"content\" : \"indexa\""));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -939,75 +936,72 @@ public class IntegrationTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         count = resc.getBody().split("root_cause").length;
-        Assert.assertEquals(3, count);
+        assertThat(count, is(3));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a")).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode()
+            is(rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf")).getStatusCode())
         );
 
         // _all/_mapping/field/*
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_all/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
         // _mapping/field/*
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
         // */_mapping/field/*
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("*/_mapping/field/*", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
     }
 
@@ -1021,45 +1015,45 @@ public class IntegrationTests extends SingleClusterTest {
             "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         res = rh.executePutRequest(
             "*dis*rit*/_mapping?pretty",
             "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePutRequest(
             "*/_mapping?pretty",
             "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePutRequest(
             "_all/_mapping?pretty",
             "{\"properties\": {\"name\":{\"type\":\"text\"}}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePostRequest(".opendistro_security/_close", "", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executeDeleteRequest(".opendistro_security", encodeBasicHeader("nagilum", "nagilum"));
         res = rh.executeDeleteRequest("_all", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePutRequest(
             ".opendistro_security/_settings",
             "{\"index\" : {\"number_of_replicas\" : 2}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePutRequest(
             ".opendistro_secur*/_settings",
             "{\"index\" : {\"number_of_replicas\" : 2}}",
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         res = rh.executePostRequest(".opendistro_security/_freeze", "", encodeBasicHeader("nagilum", "nagilum"));
-        Assert.assertEquals(400, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(400));
 
         String bulkBody = "{ \"index\" : { \"_index\" : \".opendistro_security\", \"_id\" : \"1\" } }\n"
             + "{ \"field1\" : \"value1\" }\n"
@@ -1071,11 +1065,11 @@ public class IntegrationTests extends SingleClusterTest {
         res = rh.executePostRequest("_bulk?refresh=true&pretty", bulkBody, encodeBasicHeader("nagilum", "nagilum"));
         JsonNode jsonNode = readTree(res.getBody());
 
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        Assert.assertEquals(403, jsonNode.get("items").get(0).get("index").get("status").intValue());
-        Assert.assertEquals(403, jsonNode.get("items").get(1).get("index").get("status").intValue());
-        Assert.assertEquals(201, jsonNode.get("items").get(2).get("index").get("status").intValue());
-        Assert.assertEquals(403, jsonNode.get("items").get(3).get("delete").get("status").intValue());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(jsonNode.get("items").get(0).get("index").get("status").intValue(), is(403));
+        assertThat(jsonNode.get("items").get(1).get("index").get("status").intValue(), is(403));
+        assertThat(jsonNode.get("items").get(2).get("index").get("status").intValue(), is(201));
+        assertThat(jsonNode.get("items").get(3).get("delete").get("status").intValue(), is(403));
     }
 
     @Test
@@ -1084,6 +1078,6 @@ public class IntegrationTests extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig(), Settings.EMPTY);
 
         RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_cat/health", encodeBasicHeader("picard", "picard")).getStatusCode());
+        assertThat(rh.executeGetRequest("_cat/health", encodeBasicHeader("picard", "picard")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 }

--- a/src/test/java/org/opensearch/security/PitIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/PitIntegrationTests.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.Alias;
@@ -25,6 +24,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Integration tests to test point in time APIs permission model
@@ -51,32 +53,32 @@ public class PitIntegrationTests extends SingleClusterTest {
 
         // Create point in time in index should be successful since the user has permission for index
         resc = rh.executePostRequest("/alias/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         String pitId1 = resc.findValueInJson("pit_id");
 
         // Create point in time in index for which the user does not have permission
         resc = rh.executePostRequest("/pit_2/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Create point in time in index for which the user has permission for
         resc = rh.executePostRequest("/pit_2/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         String pitId2 = resc.findValueInJson("pit_id");
         resc = rh.executePostRequest("/pit*/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("all-pit", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         // PIT segments should work since there is atleast one PIT for which user has access for
         resc = rh.executeGetRequest("/_cat/pit_segments", "{\"pit_id\":\"" + pitId1 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         // PIT segments should work since there is atleast one PIT for which user has access for
         resc = rh.executeGetRequest("/_cat/pit_segments", "{\"pit_id\":\"" + pitId1 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         // Should throw error since user does not have access for pitId2
         resc = rh.executeGetRequest("/_cat/pit_segments", "{\"pit_id\":\"" + pitId2 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Should throw error since user does not have access for pitId2
         resc = rh.executeGetRequest(
@@ -84,17 +86,17 @@ public class PitIntegrationTests extends SingleClusterTest {
             "{\"pit_id\":[\"" + pitId1 + "\",\"" + pitId2 + "\"]}",
             encodeBasicHeader("pit-1", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Delete explicit PITs should work for PIT for which user has access for
         resc = rh.executeDeleteRequest("/_search/point_in_time", "{\"pit_id\":\"" + pitId1 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
-        Assert.assertEquals(pitId1, resc.findValueInJson("pits[0].pit_id"));
-        Assert.assertEquals("true", resc.findValueInJson("pits[0].successful"));
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(resc.findValueInJson("pits[0].pit_id"), is(pitId1));
+        assertThat(resc.findValueInJson("pits[0].successful"), is("true"));
 
         // Should throw error since user does not have access for pitId2
         resc = rh.executeDeleteRequest("/_search/point_in_time", "{\"pit_id\":\"" + pitId2 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Should throw error since user does not have access for pitId2
         resc = rh.executeDeleteRequest(
@@ -102,13 +104,13 @@ public class PitIntegrationTests extends SingleClusterTest {
             "{\"pit_id\":[\"" + pitId1 + "\",\"" + pitId2 + "\"]}",
             encodeBasicHeader("pit-1", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Delete explicit PITs should work for PIT for which user has access for
         resc = rh.executeDeleteRequest("/_search/point_in_time", "{\"pit_id\":\"" + pitId2 + "\"}", encodeBasicHeader("pit-2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
-        Assert.assertEquals(pitId2, resc.findValueInJson("pits[0].pit_id"));
-        Assert.assertEquals("true", resc.findValueInJson("pits[0].successful"));
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(resc.findValueInJson("pits[0].pit_id"), is(pitId2));
+        assertThat(resc.findValueInJson("pits[0].successful"), is("true"));
 
     }
 
@@ -135,26 +137,26 @@ public class PitIntegrationTests extends SingleClusterTest {
 
         // Create point in time in index should be successful since the user has permission for index
         resc = rh.executePostRequest("/pit_1/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         String pitId1 = resc.findValueInJson("pit_id");
 
         // Create point in time in index for which the user does not have permission
         resc = rh.executePostRequest("/pit_2/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Create point in time in index for which the user has permission for
         resc = rh.executePostRequest("/pit_2/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         String pitId2 = resc.findValueInJson("pit_id");
 
         // Throw security error if user does not have all index permission
         resc = rh.executeGetRequest("/_search/point_in_time/_all", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // List all PITs should work for user with all index access
         resc = rh.executeGetRequest("/_search/point_in_time/_all", encodeBasicHeader("all-pit", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         List<String> pitList = new ArrayList<>();
         pitList.add(pitId1);
         pitList.add(pitId2);
@@ -163,23 +165,23 @@ public class PitIntegrationTests extends SingleClusterTest {
 
         // Throw security error if user does not have all index permission
         resc = rh.executeGetRequest("/_cat/pit_segments/_all", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // PIT segments should work for user with all index access
         resc = rh.executeGetRequest("/_cat/pit_segments/_all", encodeBasicHeader("all-pit", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         // Throw security error if user does not have all index permission
         resc = rh.executeDeleteRequest("/_search/point_in_time/_all", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Delete all PITs should work for user with all index access
         resc = rh.executeDeleteRequest("/_search/point_in_time/_all", encodeBasicHeader("all-pit", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         pitList.contains(resc.findValueInJson("pits[0].pit_id"));
         pitList.contains(resc.findValueInJson("pits[1].pit_id"));
-        Assert.assertEquals("true", resc.findValueInJson("pits[0].successful"));
-        Assert.assertEquals("true", resc.findValueInJson("pits[1].successful"));
+        assertThat(resc.findValueInJson("pits[0].successful"), is("true"));
+        assertThat(resc.findValueInJson("pits[1].successful"), is("true"));
 
     }
 
@@ -198,24 +200,24 @@ public class PitIntegrationTests extends SingleClusterTest {
         RestHelper.HttpResponse resc;
         // create pit should work since user has permission on data stream
         resc = rh.executePostRequest("/my-data-stream11/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         String pitId1 = resc.findValueInJson("pit_id");
 
         // PIT segments works since the user has access for backing indices
         resc = rh.executeGetRequest("/_cat/pit_segments", "{\"pit_id\":\"" + pitId1 + "\"}", encodeBasicHeader("pit-1", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         // create pit should work since user has permission on data stream
         resc = rh.executePostRequest("/my-data-stream21/_search/point_in_time?keep_alive=100m", "", encodeBasicHeader("pit-2", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         String pitId2 = resc.findValueInJson("pit_id");
 
         // since pit-3 doesn't have permission to backing data stream indices, throw security error
         resc = rh.executeGetRequest("/_cat/pit_segments", "{\"pit_id\":\"" + pitId2 + "\"}", encodeBasicHeader("pit-3", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Delete all PITs should work for user with all index access
         resc = rh.executeDeleteRequest("/_search/point_in_time/_all", encodeBasicHeader("all-pit", "nagilum"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
     }
 }

--- a/src/test/java/org/opensearch/security/PrivilegesEvaluationTest.java
+++ b/src/test/java/org/opensearch/security/PrivilegesEvaluationTest.java
@@ -12,7 +12,6 @@
 package org.opensearch.security;
 
 import com.google.common.collect.ImmutableMap;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -22,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PrivilegesEvaluationTest extends SingleClusterTest {
     @Test
@@ -49,9 +51,9 @@ public class PrivilegesEvaluationTest extends SingleClusterTest {
             "/*hidden_test*/_search?expand_wildcards=all&pretty=true",
             encodeBasicHeader("hidden_test", "nagilum")
         );
-        Assert.assertEquals(httpResponse.getBody(), 403, httpResponse.getStatusCode());
+        assertThat(httpResponse.getBody(), httpResponse.getStatusCode(), is(403));
 
         httpResponse = rh.executeGetRequest("/hidden_test_not_hidden?pretty=true", encodeBasicHeader("hidden_test", "nagilum"));
-        Assert.assertEquals(httpResponse.getBody(), 200, httpResponse.getStatusCode());
+        assertThat(httpResponse.getBody(), httpResponse.getStatusCode(), is(200));
     }
 }

--- a/src/test/java/org/opensearch/security/ResolveAPITests.java
+++ b/src/test/java/org/opensearch/security/ResolveAPITests.java
@@ -18,7 +18,6 @@ package org.opensearch.security;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
@@ -31,6 +30,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class ResolveAPITests extends SingleClusterTest {
 
@@ -47,9 +49,9 @@ public class ResolveAPITests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
         RestHelper.HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -61,9 +63,9 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*xyz*");
         assertContains(res, "*role01_role02*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -77,15 +79,15 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*starfleet_academy*");
         assertContains(res, "*starfleet_library*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
         log.debug(res.getBody());
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertContains(res, "*starfleet*");
@@ -103,9 +105,9 @@ public class ResolveAPITests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
         RestHelper.HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -117,9 +119,9 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*xyz*");
         assertContains(res, "*role01_role02*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -133,9 +135,9 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*starfleet_academy*");
         assertContains(res, "*starfleet_library*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -147,9 +149,9 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*public*");
         assertContains(res, "*xyz*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/starfleet*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
         log.debug(res.getBody());
         assertNotContains(res, "*xception*");
@@ -163,9 +165,9 @@ public class ResolveAPITests extends SingleClusterTest {
         assertContains(res, "*starfleet_academy*");
         assertContains(res, "*starfleet_library*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executeGetRequest("_resolve/index/vulcangov*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((res = rh.executeGetRequest("_resolve/index/vulcangov*?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
         log.debug(res.getBody());
     }

--- a/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
+++ b/src/test/java/org/opensearch/security/RolesInjectorIntegTest.java
@@ -53,6 +53,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Netty4Plugin;
 import org.opensearch.watcher.ResourceWatcherService;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class RolesInjectorIntegTest extends SingleClusterTest {
 
     public static class RolesInjectorPlugin extends Plugin implements ActionPlugin {
@@ -87,18 +90,20 @@ public class RolesInjectorIntegTest extends SingleClusterTest {
     public void testRolesInject() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles("roles.yml"), Settings.EMPTY);
 
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false)

--- a/src/test/java/org/opensearch/security/SecurityAdminIEndpointsTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminIEndpointsTests.java
@@ -12,13 +12,15 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class SecurityAdminIEndpointsTests extends SingleClusterTest {
 
@@ -28,18 +30,22 @@ public class SecurityAdminIEndpointsTests extends SingleClusterTest {
         setup(settings);
         final RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest("_plugins/_security/whoami").getStatusCode());
+        assertThat(rh.executeGetRequest("_plugins/_security/whoami").getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -56,89 +62,102 @@ public class SecurityAdminIEndpointsTests extends SingleClusterTest {
         rh.trustHTTPServerCertificate = true;
         rh.sendAdminCertificate = false;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         RestHelper.HttpResponse res;
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode(), is(HttpStatus.SC_OK));
 
         assertContains(res, "*\"dn\":null*");
 
         rh.sendAdminCertificate = true;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode(), is(HttpStatus.SC_OK));
 
         assertContains(res, "*\"dn\":\"CN=node-0.example.com*");
         assertContains(res, "*\"is_admin\":false*");
         assertContains(res, "*\"is_node_certificate_request\":true*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         rh.keystore = "spock-keystore.jks";
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode(), is(HttpStatus.SC_OK));
 
         assertContains(res, "*\"dn\":\"CN=spock*");
         assertContains(res, "*\"is_admin\":false*");
         assertContains(res, "*\"is_node_certificate_request\":false*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=xxx", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
 
         rh.keystore = "kirk-keystore.jks";
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_plugins/_security/whoami")).getStatusCode(), is(HttpStatus.SC_OK));
 
         assertContains(res, "*\"dn\":\"CN=kirk*");
         assertContains(res, "*\"is_admin\":true*");
         assertContains(res, "*\"is_node_certificate_request\":false*");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "{}", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode());
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "").getStatusCode()
-        );
+        assertThat(rh.executePutRequest("_plugins/_security/configupdate", "").getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
+        assertThat(HttpStatus.SC_OK, is(rh.executePutRequest("_plugins/_security/configupdate?config_types=roles", "").getStatusCode()));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePutRequest(
-                "_plugins/_security/configupdate?config_types=unknown_xxx",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    "_plugins/_security/configupdate?config_types=unknown_xxx",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
         assertContains(res, "*\"successful\":0*failed_node_exception*");
 

--- a/src/test/java/org/opensearch/security/SecurityAdminInvalidConfigsTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminInvalidConfigsTests.java
@@ -40,6 +40,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.tools.SecurityAdmin;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SecurityAdminInvalidConfigsTests extends SingleClusterTest {
 
     @Test
@@ -71,15 +74,12 @@ public class SecurityAdminInvalidConfigsTests extends SingleClusterTest {
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        Assert.assertEquals(
+        assertThat((rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
     }
 
     @Test
@@ -101,19 +101,16 @@ public class SecurityAdminInvalidConfigsTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        Assert.assertEquals(
+        assertThat((rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
     }
 
     @Test
@@ -147,15 +144,12 @@ public class SecurityAdminInvalidConfigsTests extends SingleClusterTest {
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        Assert.assertEquals(
+        assertThat((rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
     }
 
     @Test
@@ -177,18 +171,15 @@ public class SecurityAdminInvalidConfigsTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
-        Assert.assertEquals(
+        assertThat((rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
     }
 }

--- a/src/test/java/org/opensearch/security/SecurityAdminTests.java
+++ b/src/test/java/org/opensearch/security/SecurityAdminTests.java
@@ -38,6 +38,9 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import org.opensearch.security.tools.SecurityAdmin;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SecurityAdminTests extends SingleClusterTest {
 
     @Test
@@ -68,11 +71,11 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -103,11 +106,11 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode());
+        assertThat((rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
@@ -127,9 +130,9 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(-1, returnCode);
+        assertThat(returnCode, is(-1));
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode());
+        assertThat((rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
@@ -148,9 +151,9 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(-1, returnCode);
+        assertThat(returnCode, is(-1));
 
-        Assert.assertEquals(HttpStatus.SC_OK, (rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode());
+        assertThat((rh.executeGetRequest("_plugins/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -185,7 +188,7 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         RestHelper rh = restHelper();
 
-        Assert.assertEquals(HttpStatus.SC_SERVICE_UNAVAILABLE, rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode());
+        assertThat(rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode(), is(HttpStatus.SC_SERVICE_UNAVAILABLE));
     }
 
     @Test
@@ -216,12 +219,12 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
         HttpResponse res;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -258,7 +261,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
@@ -280,7 +283,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-ts");
@@ -302,12 +305,12 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-nhnv");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         RestHelper rh = restHelper();
         HttpResponse res;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -349,7 +352,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         RestHelper rh = restHelper();
         HttpResponse res;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -395,7 +398,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         RestHelper rh = restHelper();
         HttpResponse res;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -418,10 +421,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         rh.keystore = "kirk-keystore.jks";
 
         rh.executePutRequest(".opendistro_security/_doc/roles", FileHelper.loadFile("roles_invalidxcontent.yml"));
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executePutRequest(".opendistro_security/_doc/roles", "{\"roles\":\"dummy\"}").getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executePutRequest(".opendistro_security/_doc/roles", "{\"roles\":\"dummy\"}").getStatusCode()));
 
         final String prefix = getResourceFolder() == null ? "" : getResourceFolder() + "/";
 
@@ -446,7 +446,7 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode());
+        assertThat((res = rh.executeGetRequest("_opendistro/_security/health?pretty")).getStatusCode(), is(HttpStatus.SC_OK));
         assertContains(res, "*UP*");
         assertContains(res, "*strict*");
         assertNotContains(res, "*DOWN*");
@@ -459,7 +459,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-vc");
 
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-f");
@@ -467,7 +467,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-vc");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-f");
@@ -475,7 +475,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-vc");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-f");
@@ -485,7 +485,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-vc");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-f");
@@ -493,7 +493,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("-vc");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         argsAsList.add("-f");
@@ -526,7 +526,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         argsAsList.add("6");
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         argsAsList = new ArrayList<>();
         addDirectoryPath(argsAsList, TEST_RESOURCE_ABSOLUTE_PATH);
@@ -566,7 +566,7 @@ public class SecurityAdminTests extends SingleClusterTest {
 
         // Execute first time to create the index
         int returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         PrintStream ps = new PrintStream(baos);
@@ -574,7 +574,7 @@ public class SecurityAdminTests extends SingleClusterTest {
         System.setOut(ps);
 
         returnCode = SecurityAdmin.execute(argsAsList.toArray(new String[0]));
-        Assert.assertEquals(0, returnCode);
+        assertThat(returnCode, is(0));
 
         System.out.flush();
         System.setOut(old);

--- a/src/test/java/org/opensearch/security/SecurityRolesTests.java
+++ b/src/test/java/org/opensearch/security/SecurityRolesTests.java
@@ -38,6 +38,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SecurityRolesTests extends SingleClusterTest {
 
     @Test
@@ -55,14 +58,14 @@ public class SecurityRolesTests extends SingleClusterTest {
         HttpResponse resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
         Assert.assertTrue(resc.getBody().contains("anonymous"));
         Assert.assertFalse(resc.getBody().contains("xyz_sr"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("sr_user", "nagilum"));
         Assert.assertTrue(resc.getBody().contains("sr_user"));
         Assert.assertTrue(resc.getBody().contains("xyz_sr"));
         Assert.assertFalse(resc.getBody().contains("opendistro_security_kibana_server"));
         Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -92,7 +95,7 @@ public class SecurityRolesTests extends SingleClusterTest {
         Assert.assertFalse(resc.getBody().contains("xyz_sr_hidden"));
 
         Assert.assertTrue(resc.getBody().contains("backend_roles=[abc_ber]"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -116,13 +119,13 @@ public class SecurityRolesTests extends SingleClusterTest {
         Assert.assertFalse(resc.getBody().contains("xyz_sr"));
         Assert.assertTrue(resc.getBody().contains("xyz_impsr"));
         Assert.assertTrue(resc.getBody().contains("backend_roles=[ert_ber]"));
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
 
         resc = rh.executeGetRequest(
             "*/_search?pretty",
             encodeBasicHeader("sr_user", "nagilum"),
             new BasicHeader("opendistro_security_impersonate_as", "sr_impuser")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
     }
 }

--- a/src/test/java/org/opensearch/security/SlowIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/SlowIntegrationTests.java
@@ -51,7 +51,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.transport.Netty4Plugin;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 public class SlowIntegrationTests extends SingleClusterTest {
@@ -67,18 +69,20 @@ public class SlowIntegrationTests extends SingleClusterTest {
             .put("discovery.initial_state_timeout", "8s")
             .build();
         setup(Settings.EMPTY, null, settings, false, ClusterConfiguration.DEFAULT, 5, 1);
-        Assert.assertEquals(
+        assertThat(
             1,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
     }
 
@@ -86,18 +90,20 @@ public class SlowIntegrationTests extends SingleClusterTest {
     @Test
     public void testNodeClientAllowedWithServerCertificate() throws Exception {
         setup();
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false)
@@ -125,9 +131,9 @@ public class SlowIntegrationTests extends SingleClusterTest {
                     .actionGet()
                     .isTimedOut()
             );
-            Assert.assertEquals(
+            assertThat(
                 clusterInfo.numNodes + 1,
-                node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size()
+                is(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size())
             );
         }
     }
@@ -136,18 +142,20 @@ public class SlowIntegrationTests extends SingleClusterTest {
     @Test
     public void testNodeClientDisallowedWithNonServerCertificate() throws Exception {
         setup();
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false)
@@ -170,7 +178,7 @@ public class SlowIntegrationTests extends SingleClusterTest {
                 .start()
         ) {
             Thread.sleep(10000);
-            Assert.assertEquals(1, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(1));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }
@@ -181,18 +189,20 @@ public class SlowIntegrationTests extends SingleClusterTest {
     @Test
     public void testNodeClientDisallowedWithNonServerCertificate2() throws Exception {
         setup();
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false)
@@ -215,7 +225,7 @@ public class SlowIntegrationTests extends SingleClusterTest {
                 .start()
         ) {
             Thread.sleep(10000);
-            Assert.assertEquals(1, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(1));
         } catch (Exception e) {
             Assert.fail(e.toString());
         }

--- a/src/test/java/org/opensearch/security/SnapshotRestoreTests.java
+++ b/src/test/java/org/opensearch/security/SnapshotRestoreTests.java
@@ -52,6 +52,7 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class SnapshotRestoreTests extends SingleClusterTest {
@@ -118,143 +119,164 @@ public class SnapshotRestoreTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // worf not allowed to restore vulcangov index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("worf", "worf")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("worf", "worf")
+                ).getStatusCode()
+            )
         );
         // Try to restore vulcangov index as .opendistro_security index, not possible since Security index is open
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore .opendistro_security index.
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
         // 500 because Security index is open
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore all indices.
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
         // 500 because Security index is open
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
         // Try to restore vulcangov index as .opendistro_security index -> 500 because Security index is open
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index. Delete opendistro_security_copy first, was created
         // in test above
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeDeleteRequest("opendistro_security_copy", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeDeleteRequest("opendistro_security_copy", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore an unknown snapshot
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            rh.executePostRequest(
-                "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // close and restore Security index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(".opendistro_security/_close", "", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executePostRequest(".opendistro_security/_close", "", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(".opendistro_security/_open", "", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executePostRequest(".opendistro_security/_open", "", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
     }
 
@@ -318,121 +340,140 @@ public class SnapshotRestoreTests extends SingleClusterTest {
         }
 
         RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("worf", "worf")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("worf", "worf")
+                ).getStatusCode()
+            )
         );
         // Try to restore vulcangov index as .opendistro_security index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore .opendistro_security index.
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore all indices.
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore an unknown snapshot
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN,
+        // assertThat(HttpStatus.SC_FORBIDDEN,
         // executePostRequest("_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true","{ \"indices\": \"the-unknown-index\" }",
-        // encodeBasicHeader("nagilum", "nagilum"))).getStatusCode());
+        // encois(deBasicHeader("nagilum", "nagilum"))).getStatusCode());
     }
 
     @Test
@@ -495,173 +536,204 @@ public class SnapshotRestoreTests extends SingleClusterTest {
                 new ConfigUpdateRequest(new String[] { "config", "roles", "rolesmapping", "internalusers", "actiongroups" })
             ).actionGet();
             Assert.assertFalse(cur.hasFailures());
-            Assert.assertEquals(currentClusterConfig.getNodes(), cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(currentClusterConfig.getNodes()));
         }
 
         RestHelper rh = nonSslRestHelper();
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/vulcangov/vulcangov_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("worf", "worf")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("worf", "worf")
+                ).getStatusCode()
+            )
         );
         // Try to restore vulcangov index as .opendistro_security index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore .opendistro_security index.
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/.opendistro_security", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executeGetRequest("_snapshot/.opendistro_security/opendistro_security_1", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/.opendistro_security/opendistro_security_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore all indices.
-        Assert.assertEquals(
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
+            is(rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("_snapshot/all/all_1", encodeBasicHeader("nagilum", "nagilum")).getStatusCode()
-        );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
-                .getStatusCode()
+            is(
+                rh.executePostRequest("_snapshot/all/all_1/_restore?wait_for_completion=true", "", encodeBasicHeader("nagilum", "nagilum"))
+                    .getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \"vulcangov\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \".opendistro_security\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         // Try to restore .opendistro_security index as .opendistro_security_copy index
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{ \"indices\": \".opendistro_security\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"opendistro_security_copy\" }",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Try to restore an unknown snapshot
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
-                "",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/unknown-snapshot/_restore?wait_for_completion=true",
+                    "",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         // Tests snapshot with write permissions (OK)
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_restore_1\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_restore_1\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_restore_2a\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_restore_2a\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
 
         // Test snapshot with write permissions (OK)
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_1\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_1\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_2\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_2\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_3\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_3\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_4\" }",
-                encodeBasicHeader("restoreuser", "restoreuser")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/vulcangov/vulcangov_1/_restore?wait_for_completion=true",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"$1_no_restore_4\" }",
+                    encodeBasicHeader("restoreuser", "restoreuser")
+                ).getStatusCode()
+            )
         );
     }
 
@@ -708,21 +780,25 @@ public class SnapshotRestoreTests extends SingleClusterTest {
             + "\"include_global_state\": false"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         putSnapshot = "{"
@@ -731,40 +807,48 @@ public class SnapshotRestoreTests extends SingleClusterTest {
             + "\"include_global_state\": false"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         putSnapshot = "{" + "\"indices\": \"testsnap2\"," + "\"ignore_unavailable\": false," + "\"include_global_state\": true" + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
     }
 
@@ -813,21 +897,25 @@ public class SnapshotRestoreTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{\"indices\": \"b*,-bar\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"wild_first_restored_index_$1\"}",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{\"indices\": \"b*,-bar\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"wild_first_restored_index_$1\"}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePostRequest(
-                "_snapshot/all/all_1/_restore?wait_for_completion=true",
-                "{\"indices\": \"-bar,b*\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"neg_first_restored_index_$1\"}",
-                encodeBasicHeader("nagilum", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/all/all_1/_restore?wait_for_completion=true",
+                    "{\"indices\": \"-bar,b*\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"neg_first_restored_index_$1\"}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                ).getStatusCode()
+            )
         );
         String wild_first_body = rh.executePostRequest(
             "_snapshot/all/all_1/_restore?wait_for_completion=true",
@@ -849,7 +937,6 @@ public class SnapshotRestoreTests extends SingleClusterTest {
 
     @Test
     public void testNoSnapshotRestore() throws Exception {
-
         final Settings settings = Settings.builder()
             .putList("path.repo", repositoryPath.getRoot().getAbsolutePath())
             .put("plugins.security.enable_snapshot_restore_privilege", false)
@@ -893,21 +980,25 @@ public class SnapshotRestoreTests extends SingleClusterTest {
             + "\"include_global_state\": false"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         putSnapshot = "{"
@@ -916,40 +1007,48 @@ public class SnapshotRestoreTests extends SingleClusterTest {
             + "\"include_global_state\": false"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
 
         putSnapshot = "{" + "\"indices\": \"testsnap2\"," + "\"ignore_unavailable\": false," + "\"include_global_state\": true" + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executePutRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
-                putSnapshot,
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePutRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "?wait_for_completion=true&pretty",
+                    putSnapshot,
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            rh.executePostRequest(
-                "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
-                "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
-                encodeBasicHeader("snapresuser", "nagilum")
-            ).getStatusCode()
+            is(
+                rh.executePostRequest(
+                    "_snapshot/bckrepo/" + putSnapshot.hashCode() + "/_restore?wait_for_completion=true&pretty",
+                    "{ \"include_global_state\": true, \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_$1\" }",
+                    encodeBasicHeader("snapresuser", "nagilum")
+                ).getStatusCode()
+            )
         );
     }
 }

--- a/src/test/java/org/opensearch/security/SystemIntegratorsTests.java
+++ b/src/test/java/org/opensearch/security/SystemIntegratorsTests.java
@@ -39,6 +39,9 @@ import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SystemIntegratorsTests extends SingleClusterTest {
 
     @Test
@@ -57,55 +60,55 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, null)
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "|||")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "||127.0.0:80|")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "username||ip|")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "username||ip:port|")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "username||ip:80|")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "username||127.0.x:80|")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "username||127.0.0:80|key1,value1,key2")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         resc = rh.executeGetRequest(
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "||127.0.0:80|key1,value1,key2,value2")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
     }
 
@@ -125,7 +128,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "admin||127.0.0:80|")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=admin, backend_roles=[], requestedTenant=null]"));
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"127.0.0.0:80\""));
         Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[]"));
@@ -135,7 +138,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "admin|role1|127.0.0:80|key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=admin, backend_roles=[role1], requestedTenant=null]"));
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"127.0.0.0:80\""));
         Assert.assertTrue(resc.getBody().contains("\"backend_roles\":[\"role1\"]"));
@@ -145,7 +148,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "admin|role1,role2||key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=admin, backend_roles=[role1, role2], requestedTenant=null]"));
         // remote IP is assigned by XFFResolver
         Assert.assertFalse(resc.getBody().contains("\"remote_address\":null"));
@@ -156,7 +159,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "admin|role1,role2|8.8.8.8:8|key1,value1,key2,value2")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=admin, backend_roles=[role1, role2], requestedTenant=null]"));
         // remote IP is assigned by XFFResolver
         Assert.assertFalse(resc.getBody().contains("\"remote_address\":null"));
@@ -167,7 +170,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "nagilum|role1,role2|8.8.8.8:8|key1,value1,key2,value2")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=nagilum, backend_roles=[role1, role2], requestedTenant=null]"));
         // remote IP is assigned by XFFResolver
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
@@ -180,7 +183,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=myuser, backend_roles=[role1, vulcanadmin], requestedTenant=null]"));
         // remote IP is assigned by XFFResolver
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
@@ -197,7 +200,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
                 "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2|"
             )
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=myuser, backend_roles=[role1, vulcanadmin], requestedTenant=null]"));
         // remote IP is assigned by XFFResolver
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
@@ -213,7 +216,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
                 "myuser|role1,vulcanadmin|8.8.8.8:8|key1,value1,key2,value2|mytenant"
             )
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("User [name=myuser, backend_roles=[role1, vulcanadmin], requestedTenant=mytenant]"));
         // remote IP is assigned by XFFResolver
         Assert.assertTrue(resc.getBody().contains("\"remote_address\":\"8.8.8.8:8\""));
@@ -229,7 +232,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
                 "myuser|role1,vulcanadmin|8.8.8.8:8||mytenant with whitespace"
             )
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(
             resc.getBody().contains("User [name=myuser, backend_roles=[role1, vulcanadmin], requestedTenant=mytenant with whitespace]")
         );
@@ -257,7 +260,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             "_opendistro/_security/authinfo",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "admin|role1|127.0.0:80|key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
     }
 
     @Test
@@ -282,7 +285,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             ".opendistro_security/_search?pretty",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "injectedadmin|role1|127.0.0:80|key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(resc.getBody().contains("\"_id\" : \"config\""));
         Assert.assertTrue(resc.getBody().contains("\"_id\" : \"roles\""));
         Assert.assertTrue(resc.getBody().contains("\"_id\" : \"internalusers\""));
@@ -292,7 +295,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             ".opendistro_security/_search?pretty",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "wrongadmin|role1|127.0.0:80|key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
     }
 
@@ -317,7 +320,7 @@ public class SystemIntegratorsTests extends SingleClusterTest {
             ".opendistro_security/_search?pretty",
             new BasicHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "injectedadmin|role1|127.0.0:80|key1,value1")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertFalse(resc.getBody().contains("\"_id\" : \"config\""));
         Assert.assertFalse(resc.getBody().contains("\"_id\" : \"roles\""));
         Assert.assertFalse(resc.getBody().contains("\"_id\" : \"internalusers\""));

--- a/src/test/java/org/opensearch/security/TaskTests.java
+++ b/src/test/java/org/opensearch/security/TaskTests.java
@@ -29,6 +29,9 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import org.opensearch.tasks.Task;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class TaskTests extends SingleClusterTest {
 
     @Test
@@ -37,13 +40,15 @@ public class TaskTests extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "_tasks?group_by=parents&pretty",
-                encodeBasicHeader("nagilum", "nagilum"),
-                new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "_tasks?group_by=parents&pretty",
+                    encodeBasicHeader("nagilum", "nagilum"),
+                    new BasicHeader(Task.X_OPAQUE_ID, "myOpaqueId12")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().split("X-Opaque-Id").length > 2);
         Assert.assertTrue(!res.getBody().contains("failures"));

--- a/src/test/java/org/opensearch/security/TracingTests.java
+++ b/src/test/java/org/opensearch/security/TracingTests.java
@@ -27,7 +27,6 @@
 package org.opensearch.security;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -47,6 +46,9 @@ import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 @Ignore("subject for manual execution")
 public class TracingTests extends SingleClusterTest {
@@ -389,7 +391,7 @@ public class TracingTests extends SingleClusterTest {
         // end pause1
 
         // search
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")).getStatusCode());
+        assertThat(rh.executeGetRequest("_search", encodeBasicHeader("nagilum", "nagilum")).getStatusCode(), is(HttpStatus.SC_OK));
         // search done
 
         // pause2
@@ -438,21 +440,26 @@ public class TracingTests extends SingleClusterTest {
 
         // search
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("nagilum", "nagilum")))
+                    .getStatusCode()
+            )
         );
 
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
         // search scroll
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/_search/scroll?pretty=true",
-                "{\"scroll_id\" : \"" + scrollid + "\"}",
-                encodeBasicHeader("nagilum", "nagilum")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/_search/scroll?pretty=true",
+                    "{\"scroll_id\" : \"" + scrollid + "\"}",
+                    encodeBasicHeader("nagilum", "nagilum")
+                )).getStatusCode()
+            )
         );
         // search done
     }

--- a/src/test/java/org/opensearch/security/UserServiceUnitTests.java
+++ b/src/test/java/org/opensearch/security/UserServiceUnitTests.java
@@ -20,7 +20,6 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,27 +76,27 @@ public class UserServiceUnitTests {
     public void testServiceUserTypeFilter() {
 
         userService.includeAccountsIfType(config, UserFilterType.SERVICE);
-        Assert.assertEquals(SERVICE_ACCOUNTS_IN_SETTINGS, config.getCEntries().size());
-        Assert.assertEquals(config.getCEntries().containsKey(serviceAccountUsername), true);
-        Assert.assertEquals(config.getCEntries().containsKey(internalAccountUsername), false);
+        assertThat(config.getCEntries().size(), is(SERVICE_ACCOUNTS_IN_SETTINGS));
+        assertThat(true, is(config.getCEntries().containsKey(serviceAccountUsername)));
+        assertThat(false, is(config.getCEntries().containsKey(internalAccountUsername)));
 
     }
 
     @Test
     public void testInternalUserTypeFilter() {
         userService.includeAccountsIfType(config, UserFilterType.INTERNAL);
-        Assert.assertEquals(INTERNAL_ACCOUNTS_IN_SETTINGS, config.getCEntries().size());
-        Assert.assertEquals(config.getCEntries().containsKey(serviceAccountUsername), false);
-        Assert.assertEquals(config.getCEntries().containsKey(internalAccountUsername), true);
+        assertThat(config.getCEntries().size(), is(INTERNAL_ACCOUNTS_IN_SETTINGS));
+        assertThat(false, is(config.getCEntries().containsKey(serviceAccountUsername)));
+        assertThat(true, is(config.getCEntries().containsKey(internalAccountUsername)));
 
     }
 
     @Test
     public void testAnyUserTypeFilter() {
         userService.includeAccountsIfType(config, UserFilterType.ANY);
-        Assert.assertEquals(INTERNAL_ACCOUNTS_IN_SETTINGS + SERVICE_ACCOUNTS_IN_SETTINGS, config.getCEntries().size());
-        Assert.assertEquals(config.getCEntries().containsKey(serviceAccountUsername), true);
-        Assert.assertEquals(config.getCEntries().containsKey(internalAccountUsername), true);
+        assertThat(config.getCEntries().size(), is(INTERNAL_ACCOUNTS_IN_SETTINGS + SERVICE_ACCOUNTS_IN_SETTINGS));
+        assertThat(true, is(config.getCEntries().containsKey(serviceAccountUsername)));
+        assertThat(true, is(config.getCEntries().containsKey(internalAccountUsername)));
     }
 
     private SecurityDynamicConfiguration<?> readConfigFromYml(String file, CType cType) throws Exception {
@@ -109,7 +108,7 @@ public class UserServiceUnitTests {
         int configVersion = 1;
 
         if (jsonNode.get("_meta") != null) {
-            Assert.assertEquals(jsonNode.get("_meta").get("type").asText(), cType.toLCString());
+            assertThat(cType.toLCString(), is(jsonNode.get("_meta").get("type").asText()));
             configVersion = jsonNode.get("_meta").get("config_version").asInt();
         }
         return SecurityDynamicConfiguration.fromNode(jsonNode, cType, configVersion, 0, 0);

--- a/src/test/java/org/opensearch/security/UtilTests.java
+++ b/src/test/java/org/opensearch/security/UtilTests.java
@@ -37,7 +37,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.SecurityUtils;
 import org.opensearch.security.support.WildcardMatcher;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -113,15 +114,15 @@ public class UtilTests {
     @Test
     public void testEnvReplace() {
         Settings settings = Settings.EMPTY;
-        assertEquals("abv${env.MYENV}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV}xyz", settings));
-        assertEquals("abv${envbc.MYENV}xyz", SecurityUtils.replaceEnvVars("abv${envbc.MYENV}xyz", settings));
-        assertEquals("abvtTtxyz", SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz", settings));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV}xyz", settings), is("abv${env.MYENV}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${envbc.MYENV}xyz", settings), is("abv${envbc.MYENV}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz", settings), is("abvtTtxyz"));
         assertTrue(passwordHasher.check("tTt".toCharArray(), SecurityUtils.replaceEnvVars("${envbc.MYENV:-tTt}", settings)));
-        assertEquals("abvtTtxyzxxx", SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}", settings));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}", settings), is("abvtTtxyzxxx"));
         assertTrue(SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${envbc.MYENV:-xxx}", settings).startsWith("abvtTtxyz$2y$"));
-        assertEquals("abv${env.MYENV:tTt}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV:tTt}xyz", settings));
-        assertEquals("abv${env.MYENV-tTt}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV-tTt}xyz", settings));
-        // assertEquals("abvabcdefgxyz", SecurityUtils.replaceEnvVars("abv${envbase64.B64TEST}xyz",settings));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV:tTt}xyz", settings), is("abv${env.MYENV:tTt}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV-tTt}xyz", settings), is("abv${env.MYENV-tTt}xyz"));
+        // assertThat(SecurityUtils.replaceEnvVars("abv${envbase64.B64TEST}xyz",settings), is("abvabcdefgxyz"));
 
         Map<String, String> env = System.getenv();
         assertTrue(env.size() > 0);
@@ -133,14 +134,14 @@ public class UtilTests {
             if (val == null || val.isEmpty()) {
                 continue;
             }
-            assertEquals("abv" + val + "xyz", SecurityUtils.replaceEnvVars("abv${env." + k + "}xyz", settings));
-            assertEquals("abv${" + k + "}xyz", SecurityUtils.replaceEnvVars("abv${" + k + "}xyz", settings));
-            assertEquals("abv" + val + "xyz", SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings));
-            assertEquals(
-                "abv" + val + "xyzabv" + val + "xyz",
-                SecurityUtils.replaceEnvVars("abv${env." + k + "}xyzabv${env." + k + "}xyz", settings)
+            assertThat(SecurityUtils.replaceEnvVars("abv${env." + k + "}xyz", settings), is("abv" + val + "xyz"));
+            assertThat(SecurityUtils.replaceEnvVars("abv${" + k + "}xyz", settings), is("abv${" + k + "}xyz"));
+            assertThat(SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings), is("abv" + val + "xyz"));
+            assertThat(
+                SecurityUtils.replaceEnvVars("abv${env." + k + "}xyzabv${env." + k + "}xyz", settings),
+                is("abv" + val + "xyzabv" + val + "xyz")
             );
-            assertEquals("abv" + val + "xyz", SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings));
+            assertThat(SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings), is("abv" + val + "xyz"));
             assertTrue(passwordHasher.check(val.toCharArray(), SecurityUtils.replaceEnvVars("${envbc." + k + "}", settings)));
             checked = true;
         }
@@ -151,33 +152,33 @@ public class UtilTests {
     @Test
     public void testNoEnvReplace() {
         Settings settings = Settings.builder().put(ConfigConstants.SECURITY_DISABLE_ENVVAR_REPLACEMENT, true).build();
-        assertEquals("abv${env.MYENV}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV}xyz", settings));
-        assertEquals("abv${envbc.MYENV}xyz", SecurityUtils.replaceEnvVars("abv${envbc.MYENV}xyz", settings));
-        assertEquals("abv${env.MYENV:-tTt}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz", settings));
-        assertEquals(
-            "abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}",
-            SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}", settings)
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV}xyz", settings), is("abv${env.MYENV}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${envbc.MYENV}xyz", settings), is("abv${envbc.MYENV}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz", settings), is("abv${env.MYENV:-tTt}xyz"));
+        assertThat(
+            SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}", settings),
+            is("abv${env.MYENV:-tTt}xyz${env.MYENV:-xxx}")
         );
         assertFalse(SecurityUtils.replaceEnvVars("abv${env.MYENV:-tTt}xyz${envbc.MYENV:-xxx}", settings).startsWith("abvtTtxyz$2y$"));
-        assertEquals("abv${env.MYENV:tTt}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV:tTt}xyz", settings));
-        assertEquals("abv${env.MYENV-tTt}xyz", SecurityUtils.replaceEnvVars("abv${env.MYENV-tTt}xyz", settings));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV:tTt}xyz", settings), is("abv${env.MYENV:tTt}xyz"));
+        assertThat(SecurityUtils.replaceEnvVars("abv${env.MYENV-tTt}xyz", settings), is("abv${env.MYENV-tTt}xyz"));
         Map<String, String> env = System.getenv();
         assertTrue(env.size() > 0);
 
         for (String k : env.keySet()) {
-            assertEquals("abv${env." + k + "}xyz", SecurityUtils.replaceEnvVars("abv${env." + k + "}xyz", settings));
-            assertEquals("abv${" + k + "}xyz", SecurityUtils.replaceEnvVars("abv${" + k + "}xyz", settings));
-            assertEquals(
-                "abv${env." + k + ":-k182765ggh}xyz",
-                SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings)
+            assertThat(SecurityUtils.replaceEnvVars("abv${env." + k + "}xyz", settings), is("abv${env." + k + "}xyz"));
+            assertThat(SecurityUtils.replaceEnvVars("abv${" + k + "}xyz", settings), is("abv${" + k + "}xyz"));
+            assertThat(
+                SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings),
+                is("abv${env." + k + ":-k182765ggh}xyz")
             );
-            assertEquals(
-                "abv${env." + k + "}xyzabv${env." + k + "}xyz",
-                SecurityUtils.replaceEnvVars("abv${env." + k + "}xyzabv${env." + k + "}xyz", settings)
+            assertThat(
+                SecurityUtils.replaceEnvVars("abv${env." + k + "}xyzabv${env." + k + "}xyz", settings),
+                is("abv${env." + k + "}xyzabv${env." + k + "}xyz")
             );
-            assertEquals(
-                "abv${env." + k + ":-k182765ggh}xyz",
-                SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings)
+            assertThat(
+                SecurityUtils.replaceEnvVars("abv${env." + k + ":-k182765ggh}xyz", settings),
+                is("abv${env." + k + ":-k182765ggh}xyz")
             );
         }
     }

--- a/src/test/java/org/opensearch/security/auditlog/AuditTestUtils.java
+++ b/src/test/java/org/opensearch/security/auditlog/AuditTestUtils.java
@@ -27,7 +27,8 @@ import org.opensearch.security.auditlog.impl.AuditLogImpl;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.threadpool.ThreadPool;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class AuditTestUtils {
     public static void updateAuditConfig(final RestHelper rh, final Settings settings) throws Exception {
@@ -40,7 +41,7 @@ public class AuditTestUtils {
         rh.sendAdminCertificate = true;
         rh.keystore = "auditlog/kirk-keystore.jks";
         RestHelper.HttpResponse response = rh.executePutRequest("_opendistro/_security/api/audit/config", payload);
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         rh.sendAdminCertificate = sendAdminCertificate;
         rh.keystore = keystore;
     }

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -44,6 +44,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -89,7 +90,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         final AuditMessage message = TestAuditlogImpl.doThenWaitForMessage(() -> {
             final HttpResponse response = rh.executePostRequest("_search?pretty", search, encodeBasicHeader("admin", "admin"));
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         });
 
         assertThat(message.getCategory(), equalTo(AuditCategory.COMPLIANCE_DOC_READ));
@@ -229,7 +230,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             HttpResponse response = rh.executePostRequest("_msearch?pretty", search, encodeBasicHeader("admin", "admin"));
             assertNotContains(response, "*exception*");
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         }, 2);
 
         final AuditMessage desginationMsg = messages.stream()
@@ -333,7 +334,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             }
 
             final HttpResponse response = rh.executeGetRequest("_search?pretty", encodeBasicHeader("admin", "admin"));
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         }, 4);
 
         // Record the updated config, and then for each node record that the config was updated
@@ -380,7 +381,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                     body,
                     encodeBasicHeader("admin", "admin")
                 );
-                Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+                assertThat(response.getStatusCode(), is(HttpStatus.SC_CREATED));
             });
         });
         assertThat(ex1.getMissingCount(), equalTo(1));
@@ -393,7 +394,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                     body,
                     encodeBasicHeader("admin", "admin")
                 );
-                Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+                assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
             });
         });
         assertThat(ex2.getMissingCount(), equalTo(1));
@@ -427,7 +428,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 body,
                 encodeBasicHeader("admin", "admin")
             );
-            Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_CREATED));
         });
         Assert.assertTrue(TestAuditlogImpl.sb.toString().split(".*audit_compliance_diff_content.*replace.*").length == 1);
 
@@ -438,7 +439,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 body,
                 encodeBasicHeader("admin", "admin")
             );
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         });
         Assert.assertTrue(TestAuditlogImpl.sb.toString().split(".*audit_compliance_diff_content.*replace.*").length == 1);
     }

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceConfigTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceConfigTest.java
@@ -31,7 +31,7 @@ import org.mockito.Mockito;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -57,8 +57,8 @@ public class ComplianceConfigTest {
         assertFalse(complianceConfig.shouldLogReadMetadataOnly());
         assertFalse(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(defaultIgnoredUserMatcher, complianceConfig.getIgnoredComplianceUsersForWriteMatcher());
+        assertThat(complianceConfig.getIgnoredComplianceUsersForReadMatcher(), is(defaultIgnoredUserMatcher));
+        assertThat(complianceConfig.getIgnoredComplianceUsersForWriteMatcher(), is(defaultIgnoredUserMatcher));
     }
 
     @Test
@@ -92,13 +92,13 @@ public class ComplianceConfigTest {
         assertTrue(complianceConfig.shouldLogReadMetadataOnly());
         assertTrue(complianceConfig.shouldLogWriteMetadataOnly());
         assertFalse(complianceConfig.shouldLogDiffsForWrite());
-        assertEquals(
-            WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")),
-            complianceConfig.getIgnoredComplianceUsersForReadMatcher()
+        assertThat(
+            complianceConfig.getIgnoredComplianceUsersForReadMatcher(),
+            is(WildcardMatcher.from(ImmutableSet.of("test-user-1", "test-user-2")))
         );
-        assertEquals(
-            WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")),
-            complianceConfig.getIgnoredComplianceUsersForWriteMatcher()
+        assertThat(
+            complianceConfig.getIgnoredComplianceUsersForWriteMatcher(),
+            is(WildcardMatcher.from(ImmutableSet.of("test-user-3", "test-user-4")))
         );
 
         // test write history

--- a/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/RestApiComplianceAuditlogTest.java
@@ -30,6 +30,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
@@ -56,7 +57,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 body,
                 encodeBasicHeader("admin", "admin")
             );
-            Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_CREATED));
         });
         validateMsgs(List.of(message));
 
@@ -87,7 +88,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
 
         final AuditMessage message = TestAuditlogImpl.doThenWaitForMessage(() -> {
             HttpResponse response = rh.executePutRequest("_opendistro/_security/api/internalusers/compuser?pretty", body);
-            Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_CREATED));
         });
         validateMsgs(List.of(message));
         assertThat(message.toString(), containsString("COMPLIANCE_INTERNAL_CONFIG_WRITE"));
@@ -115,7 +116,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         rh.keystore = "kirk-keystore.jks";
         final AuditMessage message = TestAuditlogImpl.doThenWaitForMessage(() -> {
             HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/rolesmapping/opendistro_security_all_access?pretty");
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         });
         validateMsgs(List.of(message));
         assertThat(message.toString(), containsString("audit_request_effective_user"));
@@ -167,7 +168,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
                 body,
                 encodeBasicHeader("admin", "admin")
             );
-            Assert.assertEquals(response.getBody(), HttpStatus.SC_CREATED, response.getStatusCode());
+            assertThat(response.getBody(), response.getStatusCode(), is(HttpStatus.SC_CREATED));
         });
         validateMsgs(List.of(message));
         assertThat(message.toString(), containsString("audit_request_effective_user"));
@@ -199,7 +200,7 @@ public class RestApiComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         final AuditMessage message = TestAuditlogImpl.doThenWaitForMessage(() -> {
             HttpResponse response = rh.executeGetRequest("_opendistro/_security/api/internalusers/admin?pretty");
             String auditLogImpl = TestAuditlogImpl.sb.toString();
-            Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
             Assert.assertTrue(auditLogImpl.contains("COMPLIANCE_INTERNAL_CONFIG_READ"));
         });
         validateMsgs(List.of(message));

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -28,13 +28,13 @@ import org.opensearch.security.support.WildcardMatcher;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
 import static org.opensearch.security.auditlog.impl.AuditCategory.BAD_HEADERS;
 import static org.opensearch.security.auditlog.impl.AuditCategory.FAILED_LOGIN;
 import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
 import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVILEGES;
 import static org.opensearch.security.auditlog.impl.AuditCategory.SSL_EXCEPTION;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -56,10 +56,10 @@ public class AuditConfigFilterTest {
         assertFalse(auditConfigFilter.shouldResolveBulkRequests());
         assertTrue(auditConfigFilter.shouldExcludeSensitiveHeaders());
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredAuditRequestsMatcher());
-        assertEquals(defaultIgnoredUserMatcher, auditConfigFilter.getIgnoredAuditUsersMatcher());
+        assertThat(auditConfigFilter.getIgnoredAuditUsersMatcher(), is(defaultIgnoredUserMatcher));
         assertSame(WildcardMatcher.NONE, auditConfigFilter.getIgnoredCustomHeadersMatcher());
-        assertEquals(auditConfigFilter.getDisabledRestCategories(), defaultDisabledCategories);
-        assertEquals(auditConfigFilter.getDisabledTransportCategories(), defaultDisabledCategories);
+        assertThat(defaultDisabledCategories, is(auditConfigFilter.getDisabledRestCategories()));
+        assertThat(defaultDisabledCategories, is(auditConfigFilter.getDisabledTransportCategories()));
     }
 
     @Test
@@ -95,11 +95,11 @@ public class AuditConfigFilterTest {
         assertFalse(auditConfigFilter.shouldResolveIndices());
         assertTrue(auditConfigFilter.shouldResolveBulkRequests());
         assertFalse(auditConfigFilter.shouldExcludeSensitiveHeaders());
-        assertEquals(WildcardMatcher.from(Collections.singleton("test-user")), auditConfigFilter.getIgnoredAuditUsersMatcher());
-        assertEquals(WildcardMatcher.from(Collections.singleton("test-request")), auditConfigFilter.getIgnoredAuditRequestsMatcher());
-        assertEquals(WildcardMatcher.from(Collections.singleton("test-header")), auditConfigFilter.getIgnoredCustomHeadersMatcher());
-        assertEquals(auditConfigFilter.getDisabledRestCategories(), EnumSet.of(BAD_HEADERS, SSL_EXCEPTION));
-        assertEquals(auditConfigFilter.getDisabledTransportCategories(), EnumSet.of(FAILED_LOGIN, MISSING_PRIVILEGES));
+        assertThat(auditConfigFilter.getIgnoredAuditUsersMatcher(), is(WildcardMatcher.from(Collections.singleton("test-user"))));
+        assertThat(auditConfigFilter.getIgnoredAuditRequestsMatcher(), is(WildcardMatcher.from(Collections.singleton("test-request"))));
+        assertThat(auditConfigFilter.getIgnoredCustomHeadersMatcher(), is(WildcardMatcher.from(Collections.singleton("test-header"))));
+        assertThat(EnumSet.of(BAD_HEADERS, SSL_EXCEPTION), is(auditConfigFilter.getDisabledRestCategories()));
+        assertThat(EnumSet.of(FAILED_LOGIN, MISSING_PRIVILEGES), is(auditConfigFilter.getDisabledTransportCategories()));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -32,9 +32,10 @@ import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
 import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -100,23 +101,23 @@ public class AuditConfigSerializeTest {
         final ComplianceConfig compliance = auditConfig.getCompliance();
         // assert
         assertTrue(audit.isRestApiAuditEnabled());
-        assertEquals(audit.getDisabledRestCategories(), EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES));
+        assertThat(audit.getDisabledRestCategories(), is(EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES)));
         assertTrue(audit.isTransportApiAuditEnabled());
-        assertEquals(audit.getDisabledTransportCategories(), EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES));
+        assertThat(audit.getDisabledTransportCategories(), is(EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES)));
         assertFalse(audit.shouldResolveBulkRequests());
         assertTrue(audit.shouldLogRequestBody());
         assertTrue(audit.shouldResolveIndices());
         assertTrue(audit.shouldExcludeSensitiveHeaders());
         assertSame(WildcardMatcher.NONE, audit.getIgnoredAuditRequestsMatcher());
-        assertEquals(DEFAULT_IGNORED_USER, audit.getIgnoredAuditUsersMatcher());
-        assertEquals(WildcardMatcher.NONE, audit.getIgnoredCustomHeadersMatcher());
+        assertThat(audit.getIgnoredAuditUsersMatcher(), is(DEFAULT_IGNORED_USER));
+        assertThat(audit.getIgnoredCustomHeadersMatcher(), is(WildcardMatcher.NONE));
         assertFalse(compliance.shouldLogExternalConfig());
         assertFalse(compliance.shouldLogInternalConfig());
         assertFalse(compliance.shouldLogReadMetadataOnly());
-        assertEquals(DEFAULT_IGNORED_USER, compliance.getIgnoredComplianceUsersForReadMatcher());
+        assertThat(compliance.getIgnoredComplianceUsersForReadMatcher(), is(DEFAULT_IGNORED_USER));
         assertFalse(compliance.shouldLogWriteMetadataOnly());
         assertFalse(compliance.shouldLogDiffsForWrite());
-        assertEquals(DEFAULT_IGNORED_USER, compliance.getIgnoredComplianceUsersForWriteMatcher());
+        assertThat(compliance.getIgnoredComplianceUsersForWriteMatcher(), is(DEFAULT_IGNORED_USER));
     }
 
     @Test
@@ -160,33 +161,33 @@ public class AuditConfigSerializeTest {
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
         // assert
         assertTrue(audit.isRestApiAuditEnabled());
-        assertEquals(audit.getDisabledRestCategories(), EnumSet.of(AuditCategory.AUTHENTICATED));
+        assertThat(EnumSet.of(AuditCategory.AUTHENTICATED), is(audit.getDisabledRestCategories()));
         assertTrue(audit.isTransportApiAuditEnabled());
-        assertEquals(audit.getDisabledTransportCategories(), EnumSet.of(AuditCategory.SSL_EXCEPTION));
+        assertThat(EnumSet.of(AuditCategory.SSL_EXCEPTION), is(audit.getDisabledTransportCategories()));
         assertTrue(audit.shouldResolveBulkRequests());
         assertTrue(audit.shouldLogRequestBody());
         assertTrue(audit.shouldResolveIndices());
         assertTrue(audit.shouldExcludeSensitiveHeaders());
         assertTrue(configCompliance.shouldLogExternalConfig());
         assertTrue(configCompliance.shouldLogInternalConfig());
-        assertEquals(WildcardMatcher.from(Collections.singleton("test-user-1")), audit.getIgnoredAuditUsersMatcher());
-        assertEquals(WildcardMatcher.from(Collections.singleton("test-request")), audit.getIgnoredAuditRequestsMatcher());
+        assertThat(audit.getIgnoredAuditUsersMatcher(), is(WildcardMatcher.from(Collections.singleton("test-user-1"))));
+        assertThat(audit.getIgnoredAuditRequestsMatcher(), is(WildcardMatcher.from(Collections.singleton("test-request"))));
         assertTrue(configCompliance.shouldLogReadMetadataOnly());
-        assertEquals(
+        assertThat(
             WildcardMatcher.from(Collections.singleton("test-user-2")),
-            configCompliance.getIgnoredComplianceUsersForReadMatcher()
+            is(configCompliance.getIgnoredComplianceUsersForReadMatcher())
         );
-        assertEquals(
+        assertThat(
             Collections.singletonMap(WildcardMatcher.from("test-read-watch-field"), Collections.singleton("test-field-1")),
-            configCompliance.getReadEnabledFields()
+            is(configCompliance.getReadEnabledFields())
         );
         assertTrue(configCompliance.shouldLogWriteMetadataOnly());
         assertFalse(configCompliance.shouldLogDiffsForWrite());
-        assertEquals(
+        assertThat(
             WildcardMatcher.from(Collections.singleton("test-user-3")),
-            configCompliance.getIgnoredComplianceUsersForWriteMatcher()
+            is(configCompliance.getIgnoredComplianceUsersForWriteMatcher())
         );
-        assertEquals(WildcardMatcher.from("test-write-watch-index"), configCompliance.getWatchedWriteIndicesMatcher());
+        assertThat(configCompliance.getWatchedWriteIndicesMatcher(), is(WildcardMatcher.from("test-write-watch-index")));
     }
 
     @Test
@@ -313,15 +314,15 @@ public class AuditConfigSerializeTest {
         // assert
         final AuditConfig.Filter audit = auditConfig.getFilter();
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
-        assertEquals(audit.getDisabledRestCategories(), EnumSet.of(GRANTED_PRIVILEGES, AUTHENTICATED));
-        assertEquals(audit.getDisabledTransportCategories(), EnumSet.of(GRANTED_PRIVILEGES, AUTHENTICATED));
-        assertEquals(DEFAULT_IGNORED_USER, audit.getIgnoredAuditUsersMatcher());
-        assertEquals(WildcardMatcher.NONE, audit.getIgnoredAuditRequestsMatcher());
-        assertEquals(DEFAULT_IGNORED_USER, configCompliance.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(DEFAULT_IGNORED_USER, configCompliance.getIgnoredComplianceUsersForWriteMatcher());
+        assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledRestCategories()));
+        assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledTransportCategories()));
+        assertThat(audit.getIgnoredAuditUsersMatcher(), is(DEFAULT_IGNORED_USER));
+        assertThat(audit.getIgnoredAuditRequestsMatcher(), is(WildcardMatcher.NONE));
+        assertThat(configCompliance.getIgnoredComplianceUsersForReadMatcher(), is(DEFAULT_IGNORED_USER));
+        assertThat(configCompliance.getIgnoredComplianceUsersForWriteMatcher(), is(DEFAULT_IGNORED_USER));
         assertTrue(configCompliance.getReadEnabledFields().isEmpty());
-        assertEquals(WildcardMatcher.NONE, configCompliance.getWatchedWriteIndicesMatcher());
-        assertEquals(".opendistro_security", configCompliance.getSecurityIndex());
+        assertThat(configCompliance.getWatchedWriteIndicesMatcher(), is(WildcardMatcher.NONE));
+        assertThat(configCompliance.getSecurityIndex(), is(".opendistro_security"));
     }
 
     @Test
@@ -368,16 +369,16 @@ public class AuditConfigSerializeTest {
         // assert
         final AuditConfig.Filter audit = auditConfig.getFilter();
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
-        assertEquals(audit.getDisabledRestCategories(), EnumSet.of(GRANTED_PRIVILEGES, AUTHENTICATED));
-        assertEquals(audit.getDisabledTransportCategories(), EnumSet.of(GRANTED_PRIVILEGES, AUTHENTICATED));
-        assertEquals(DEFAULT_IGNORED_USER, audit.getIgnoredAuditUsersMatcher());
-        assertEquals(WildcardMatcher.NONE, audit.getIgnoredAuditRequestsMatcher());
-        assertEquals(DEFAULT_IGNORED_USER, configCompliance.getIgnoredComplianceUsersForReadMatcher());
-        assertEquals(DEFAULT_IGNORED_USER, configCompliance.getIgnoredComplianceUsersForWriteMatcher());
+        assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledRestCategories()));
+        assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledTransportCategories()));
+        assertThat(audit.getIgnoredAuditUsersMatcher(), is(DEFAULT_IGNORED_USER));
+        assertThat(audit.getIgnoredAuditRequestsMatcher(), is(WildcardMatcher.NONE));
+        assertThat(configCompliance.getIgnoredComplianceUsersForReadMatcher(), is(DEFAULT_IGNORED_USER));
+        assertThat(configCompliance.getIgnoredComplianceUsersForWriteMatcher(), is(DEFAULT_IGNORED_USER));
         assertTrue(configCompliance.getReadEnabledFields().isEmpty());
-        assertEquals(WildcardMatcher.NONE, configCompliance.getWatchedWriteIndicesMatcher());
-        assertEquals("test-security-index", configCompliance.getSecurityIndex());
-        assertEquals("test-auditlog-index", configCompliance.getAuditLogIndex());
+        assertThat(configCompliance.getWatchedWriteIndicesMatcher(), is(WildcardMatcher.NONE));
+        assertThat(configCompliance.getSecurityIndex(), is("test-security-index"));
+        assertThat(configCompliance.getAuditLogIndex(), is("test-auditlog-index"));
     }
 
     private boolean compareJson(final String json1, final String json2) throws JsonProcessingException {

--- a/src/test/java/org/opensearch/security/auditlog/config/ThreadPoolConfigTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/ThreadPoolConfigTest.java
@@ -17,7 +17,8 @@ import org.junit.rules.ExpectedException;
 
 import org.opensearch.common.settings.Settings;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class ThreadPoolConfigTest {
 
@@ -66,8 +67,8 @@ public class ThreadPoolConfigTest {
         ThreadPoolConfig config = new ThreadPoolConfig(5, 200);
 
         // assert
-        assertEquals(5, config.getThreadPoolSize());
-        assertEquals(200, config.getThreadPoolMaxQueueLen());
+        assertThat(config.getThreadPoolSize(), is(5));
+        assertThat(config.getThreadPoolMaxQueueLen(), is(200));
     }
 
     @Test
@@ -80,7 +81,7 @@ public class ThreadPoolConfigTest {
 
         // assert
         ThreadPoolConfig config = ThreadPoolConfig.getConfig(settings);
-        assertEquals(8, config.getThreadPoolSize());
-        assertEquals(50, config.getThreadPoolMaxQueueLen());
+        assertThat(config.getThreadPoolSize(), is(8));
+        assertThat(config.getThreadPoolMaxQueueLen(), is(50));
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditCategoryTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditCategoryTest.java
@@ -17,12 +17,13 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
 import static org.opensearch.security.auditlog.impl.AuditCategory.BAD_HEADERS;
 
@@ -73,7 +74,7 @@ public class AuditCategoryTest {
         @Test
         public void testAuditCategoryEnumSetGenerationWhenEmpty() {
             Set<AuditCategory> categories = AuditCategory.parse(input);
-            Assert.assertEquals(categories, expected);
+            assertThat(expected, is(categories));
         }
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
@@ -38,7 +38,8 @@ import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityRequestFactory;
 import org.opensearch.security.securityconf.impl.CType;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -85,14 +86,14 @@ public class AuditMessageTest {
     public void testAuthorizationRestHeadersAreFiltered() {
         when(auditConfig.getFilter().shouldExcludeHeader("test-header")).thenReturn(false);
         message.addRestHeaders(TEST_REST_HEADERS, true, auditConfig.getFilter());
-        assertEquals(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), ImmutableMap.of("test-header", ImmutableList.of("test-4")));
+        assertThat(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), is(ImmutableMap.of("test-header", ImmutableList.of("test-4"))));
     }
 
     @Test
     public void testCustomRestHeadersAreFiltered() {
         when(auditConfig.getFilter().shouldExcludeHeader("test-header")).thenReturn(true);
         message.addRestHeaders(TEST_REST_HEADERS, true, auditConfig.getFilter());
-        assertEquals(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), Map.of());
+        assertThat(Map.of(), is(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS)));
     }
 
     @Test
@@ -107,7 +108,7 @@ public class AuditMessageTest {
     public void testRestHeadersAreNotFiltered() {
         when(auditConfig.getFilter().shouldExcludeHeader("test-header")).thenReturn(false);
         message.addRestHeaders(TEST_REST_HEADERS, false, null);
-        assertEquals(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS), TEST_REST_HEADERS);
+        assertThat(TEST_REST_HEADERS, is(message.getAsMap().get(AuditMessage.REST_REQUEST_HEADERS)));
     }
 
     @Test
@@ -121,13 +122,13 @@ public class AuditMessageTest {
     @Test
     public void testTransportHeadersAreFiltered() {
         message.addTransportHeaders(TEST_TRANSPORT_HEADERS, true);
-        assertEquals(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS), ImmutableMap.of("test-header", "test-4"));
+        assertThat(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS), is(ImmutableMap.of("test-header", "test-4")));
     }
 
     @Test
     public void testTransportHeadersAreNotFiltered() {
         message.addTransportHeaders(TEST_TRANSPORT_HEADERS, false);
-        assertEquals(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS), TEST_TRANSPORT_HEADERS);
+        assertThat(TEST_TRANSPORT_HEADERS, is(message.getAsMap().get(AuditMessage.TRANSPORT_REQUEST_HEADERS)));
     }
 
     @Test
@@ -138,29 +139,29 @@ public class AuditMessageTest {
 
         // does not perform redaction for non-internal user doc
         message.addSecurityConfigContentToRequestBody(hash1, "test-doc");
-        assertEquals(hash1, message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is(hash1));
 
         // test hash redaction
         message.addSecurityConfigContentToRequestBody(hash1, internalUsersDocId);
-        assertEquals("__HASH__", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("__HASH__"));
 
         // test hash redaction in string
         message.addSecurityConfigContentToRequestBody("Hash " + hash2 + " is redacted", internalUsersDocId);
-        assertEquals("Hash __HASH__ is redacted", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("Hash __HASH__ is redacted"));
 
         // test hash redaction inline without spaces
         message.addSecurityConfigContentToRequestBody("Inline hash" + hash2 + "is redacted", internalUsersDocId);
-        assertEquals("Inline hash__HASH__is redacted", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("Inline hash__HASH__is redacted"));
 
         // test map redaction
         message.addSecurityConfigWriteDiffSource("Diff is " + hash2, internalUsersDocId);
-        assertEquals("Diff is __HASH__", message.getAsMap().get(AuditMessage.COMPLIANCE_DIFF_CONTENT));
+        assertThat(message.getAsMap().get(AuditMessage.COMPLIANCE_DIFF_CONTENT), is("Diff is __HASH__"));
 
         // test tuple redaction
         final ByteBuffer[] byteBuffers = new ByteBuffer[] { ByteBuffer.wrap(("Hash in tuple is " + hash1).getBytes()) };
         BytesReference ref = BytesReference.fromByteBuffers(byteBuffers);
         message.addSecurityConfigTupleToRequestBody(new Tuple<>(XContentType.JSON, ref), internalUsersDocId);
-        assertEquals("Hash in tuple is __HASH__", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("Hash in tuple is __HASH__"));
     }
 
     @Test
@@ -187,7 +188,7 @@ public class AuditMessageTest {
         request = SecurityRequestFactory.from(restRequest);
 
         message.addRestRequestInfo(request, auditConfig.getFilter());
-        assertEquals("ERROR: Unable to generate request body", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("ERROR: Unable to generate request body"));
 
         // No content, source parameter present but Invalid source-content-type parameter
         when(httpRequest.uri()).thenReturn("/aaaa?source=request_body");
@@ -197,6 +198,6 @@ public class AuditMessageTest {
         request = SecurityRequestFactory.from(restRequest);
 
         message.addRestRequestInfo(request, auditConfig.getFilter());
-        assertEquals("ERROR: Unable to generate request body", message.getAsMap().get(AuditMessage.REQUEST_BODY));
+        assertThat(message.getAsMap().get(AuditMessage.REQUEST_BODY), is("ERROR: Unable to generate request body"));
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
@@ -29,6 +29,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.AbstractSecurityUnitTest;
 import org.opensearch.transport.TransportRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +57,7 @@ public class AuditlogTest {
         AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", new ClusterHealthRequest(), null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
     }
 
     @Test
@@ -71,7 +73,7 @@ public class AuditlogTest {
         AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
     }
 
     @Test
@@ -87,7 +89,7 @@ public class AuditlogTest {
         TestAuditlogImpl.clear();
         al.logSSLException(null, new Exception("test rest"));
         al.logSSLException(null, new Exception("test rest"), null, null);
-        Assert.assertEquals(2, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(2));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/auditlog/impl/DelegateTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/DelegateTest.java
@@ -40,7 +40,7 @@ public class DelegateTest {
         auditLog.close();
         // if (expectedClass != null) {
         // Assert.assertNotNull("delegate is null for type: "+type,auditLog.delegate);
-        // Assert.assertEquals(expectedClass, auditLog.delegate.getClass());
+        // assertThat(auditLog.delegate.getClass(), is(expectedClass));
         // } else {
         // Assert.assertNull(auditLog.delegate);
         // }

--- a/src/test/java/org/opensearch/security/auditlog/impl/IgnoreAuditUsersTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/IgnoreAuditUsersTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.auditlog.impl;
 
 import java.net.InetSocketAddress;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,6 +29,8 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,7 +79,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(0, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(0));
     }
 
     @Test
@@ -99,7 +100,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
     }
 
     @Test
@@ -159,7 +160,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(0, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(0));
 
         settings = Settings.builder()
             .put("plugins.security.audit.type", TestAuditlogImpl.class.getName())
@@ -184,7 +185,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
 
         settings = Settings.builder()
             .put("plugins.security.audit.type", TestAuditlogImpl.class.getName())
@@ -211,7 +212,7 @@ public class IgnoreAuditUsersTest {
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
         al.logSecurityIndexAttempt(sr, "indices:data/read/search", null);
         al.logMissingPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(TestAuditlogImpl.messages.toString(), 0, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.toString(), TestAuditlogImpl.messages.size(), is(0));
 
         settings = Settings.builder()
             .put("plugins.security.audit.type", TestAuditlogImpl.class.getName())
@@ -236,7 +237,7 @@ public class IgnoreAuditUsersTest {
         );
         TestAuditlogImpl.clear();
         al.logGrantedPrivileges("indices:data/read/search", sr, null);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
     }
 
     private static ThreadPool newThreadPool(Object... transients) {

--- a/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/TracingTests.java
@@ -32,6 +32,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class TracingTests extends SingleClusterTest {
 
     @Override
@@ -282,7 +285,7 @@ public class TracingTests extends SingleClusterTest {
         // end pause1
 
         // search
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")).getStatusCode());
+        assertThat(rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin")).getStatusCode(), is(HttpStatus.SC_OK));
         // search done
 
         // pause2
@@ -331,21 +334,23 @@ public class TracingTests extends SingleClusterTest {
 
         // search
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
 
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
         // search scroll
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/_search/scroll?pretty=true",
-                "{\"scroll_id\" : \"" + scrollid + "\"}",
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/_search/scroll?pretty=true",
+                    "{\"scroll_id\" : \"" + scrollid + "\"}",
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
 
         // search done
@@ -452,27 +457,27 @@ public class TracingTests extends SingleClusterTest {
         String data1 = FileHelper.loadFile("auditlog/data1.json");
         String data2 = FileHelper.loadFile("auditlog/data1mod.json");
         HttpResponse res = rh.executePutRequest("myindex1/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(201, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(201));
         res = rh.executePutRequest("myindex1/_doc/1?refresh", data2, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(409, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(409));
         res = rh.executeDeleteRequest("myindex1/_doc/1?refresh", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(403, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(403));
         res = rh.executeGetRequest("myindex1/_doc/1", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(200, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(200));
         Assert.assertFalse(res.getBody().contains("city"));
         Assert.assertTrue(res.getBody().contains("\"found\":true,"));
 
         // immutable 2
         res = rh.executePutRequest("myindex2/_doc/1?refresh", data1, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(201, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(201));
         res = rh.executePutRequest("myindex2/_doc/1?refresh", data2, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(200, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(200));
         res = rh.executeGetRequest("myindex2/_doc/1", encodeBasicHeader("admin", "admin"));
         Assert.assertTrue(res.getBody().contains("city"));
         res = rh.executeDeleteRequest("myindex2/_doc/1?refresh", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(200, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(200));
         res = rh.executeGetRequest("myindex2/_doc/1", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(404, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(404));
     }
 
 }

--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -43,6 +43,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.rest.RestRequest.Method.DELETE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.PATCH;
@@ -85,7 +86,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         // assert no auditing
         TestAuditlogImpl.clear();
         rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(0, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(0));
     }
 
     @Test
@@ -141,12 +142,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
                 RuntimeException.class,
                 () -> nonSslRestHelper().executeGetRequest("_search", encodeBasicHeader("admin", "admin"))
             );
-            Assert.assertEquals("org.apache.http.NoHttpResponseException", ex.getCause().getClass().getName());
+            assertThat(ex.getCause().getClass().getName(), is("org.apache.http.NoHttpResponseException"));
         }, 1);
 
         // All of the messages should be the same as the http client is attempting multiple times.
         messages.stream().forEach((message) -> {
-            Assert.assertEquals(AuditCategory.SSL_EXCEPTION, message.getCategory());
+            assertThat(message.getCategory(), is(AuditCategory.SSL_EXCEPTION));
             Assert.assertTrue(message.getExceptionStackTrace().contains("not an SSL/TLS record"));
         });
         validateMsgs(messages);
@@ -166,7 +167,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse response = rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         Thread.sleep(1500);
         String auditLogImpl = TestAuditlogImpl.sb.toString();
@@ -178,9 +179,9 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         Assert.assertTrue(auditLogImpl.contains("\"audit_request_effective_user\" : \"admin\""));
         Assert.assertTrue(auditLogImpl.contains("REST"));
         Assert.assertFalse(auditLogImpl.toLowerCase().contains("authorization"));
-        Assert.assertEquals(
+        assertThat(
             TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID),
-            TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID)
+            is(TestAuditlogImpl.messages.get(1).getAsMap().get(AuditMessage.TASK_ID))
         );
         validateMsgs(TestAuditlogImpl.messages);
     }
@@ -199,11 +200,11 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse response = rh.executeGetRequest("_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         Thread.sleep(1500);
         String auditLogImpl = TestAuditlogImpl.sb.toString();
-        Assert.assertEquals(2, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(2));
         Assert.assertTrue(auditLogImpl.contains("GRANTED_PRIVILEGES"));
         Assert.assertTrue(auditLogImpl.contains("AUTHENTICATED"));
         Assert.assertTrue(auditLogImpl.contains("indices:data/read/search"));
@@ -245,9 +246,9 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
     private void testPrivilegeRest(final int expectedStatus, final String endpoint, final AuditCategory category) throws Exception {
         TestAuditlogImpl.clear();
         final HttpResponse response = rh.executeGetRequest(endpoint, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         final String auditlog = TestAuditlogImpl.sb.toString();
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         Assert.assertTrue(auditlog.contains("\"audit_category\" : \"" + category + "\""));
         Assert.assertTrue(auditlog.contains("\"audit_rest_request_path\" : \"" + endpoint + "\""));
         Assert.assertTrue(auditlog.contains("\"audit_request_effective_user\" : \"admin\""));
@@ -310,25 +311,25 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
     public void testWrongUser() throws Exception {
 
         HttpResponse response = rh.executeGetRequest("", encodeBasicHeader("wronguser", "admin"));
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Thread.sleep(500);
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("FAILED_LOGIN"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("wronguser"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertFalse(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
     public void testUnknownAuthorization() throws Exception {
 
         HttpResponse response = rh.executeGetRequest("", encodeBasicHeader("unknown", "unknown"));
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("FAILED_LOGIN"));
         Assert.assertFalse(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("Basic dW5rbm93bjp1bmtub3du"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
@@ -336,9 +337,9 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         /// testUnauthenticated
         HttpResponse response = rh.executeGetRequest("_search");
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Thread.sleep(1500);
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl.contains("FAILED_LOGIN"));
         Assert.assertTrue(auditLogImpl.contains("<NONE>"));
@@ -351,21 +352,21 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
     public void testJustAuthenticated() throws Exception {
         HttpResponse response = rh.executeGetRequest("", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        Assert.assertEquals(0, TestAuditlogImpl.messages.size());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(TestAuditlogImpl.messages.size(), is(0));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
     public void testSecurityIndexAttempt() throws Exception {
 
         HttpResponse response = rh.executePutRequest(".opendistro_security/_doc/0", "{}", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("MISSING_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("OPENDISTRO_SECURITY_INDEX_ATTEMPT"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("admin"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertEquals(2, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(2));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
@@ -376,25 +377,25 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             new BasicHeader("_opendistro_security_bad", "bad"),
             encodeBasicHeader("admin", "admin")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertFalse(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("BAD_HEADERS"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("_opendistro_security_bad"));
-        Assert.assertEquals(TestAuditlogImpl.sb.toString(), 1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
     public void testMissingPriv() throws Exception {
 
         HttpResponse response = rh.executeGetRequest("sf/_search", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("MISSING_PRIVILEGES"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("indices:data/read/search"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("worf"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains("\"sf\""));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertFalse(TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
@@ -411,13 +412,13 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         // msaerch
         HttpResponse response = rh.executePostRequest("_msearch?pretty", msearch, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(response.getStatusReason(), HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusReason(), response.getStatusCode(), is(HttpStatus.SC_OK));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl, auditLogImpl.contains("indices:data/read/msearch"));
         Assert.assertTrue(auditLogImpl, auditLogImpl.contains("indices:data/read/search"));
         Assert.assertTrue(auditLogImpl, auditLogImpl.contains("match_all"));
         Assert.assertTrue(auditLogImpl.contains("audit_trace_task_id"));
-        Assert.assertEquals(auditLogImpl, 4, TestAuditlogImpl.messages.size());
+        assertThat(auditLogImpl, TestAuditlogImpl.messages.size(), is(4));
         Assert.assertFalse(auditLogImpl.toLowerCase().contains("authorization"));
         validateMsgs(TestAuditlogImpl.messages);
     }
@@ -447,7 +448,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             + System.lineSeparator();
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"errors\":false"));
         Assert.assertTrue(response.getBody().contains("\"status\":201"));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
@@ -486,7 +487,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("worf", "worf"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("\"errors\":true"));
         Assert.assertTrue(response.getBody().contains("\"status\":200"));
         Assert.assertTrue(response.getBody().contains("\"status\":403"));
@@ -514,7 +515,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             "{\\\"persistent_settings\\\":{\\\"indices\\\":{\\\"recovery\\\":{\\\"*\\\":null}}},\\\"transient_settings\\\":{\\\"indices\\\":{\\\"recovery\\\":{\\\"*\\\":null}}}}";
 
         HttpResponse response = rh.executePutRequest("_cluster/settings", json, encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl.contains("AUTHENTICATED"));
         Assert.assertTrue(auditLogImpl.contains("cluster:admin/settings/update"));
@@ -613,13 +614,13 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse response = rh.executeGetRequest("sf/_search?pretty", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl.contains("starfleet_academy"));
         Assert.assertTrue(auditLogImpl.contains("starfleet_library"));
         Assert.assertTrue(auditLogImpl.contains("starfleet"));
         Assert.assertTrue(auditLogImpl.contains("sf"));
-        Assert.assertEquals(2, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(2));
         validateMsgs(TestAuditlogImpl.messages);
     }
 
@@ -646,36 +647,40 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         int start = res.getBody().indexOf("_scroll_id") + 15;
         String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/_search/scroll?pretty=true",
-                "{\"scroll_id\" : \"" + scrollid + "\"}",
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/_search/scroll?pretty=true",
+                    "{\"scroll_id\" : \"" + scrollid + "\"}",
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
-        Assert.assertEquals(4, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(4));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("vulcangov/_search?scroll=1m&pretty=true", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         start = res.getBody().indexOf("_scroll_id") + 15;
         scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
         TestAuditlogImpl.clear();
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePostRequest(
-                "/_search/scroll?pretty=true",
-                "{\"scroll_id\" : \"" + scrollid + "\"}",
-                encodeBasicHeader("admin2", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/_search/scroll?pretty=true",
+                    "{\"scroll_id\" : \"" + scrollid + "\"}",
+                    encodeBasicHeader("admin2", "admin")
+                )).getStatusCode()
+            )
         );
         Thread.sleep(1000);
         String auditLogImpl = TestAuditlogImpl.sb.toString();
@@ -712,12 +717,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         TestAuditlogImpl.clear();
         HttpResponse response = rh.executeGetRequest("thealias/_search?pretty", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl.contains("thealias"));
         Assert.assertTrue(auditLogImpl.contains("audit_trace_resolved_indices"));
         Assert.assertTrue(auditLogImpl.contains("vulcangov"));
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
         TestAuditlogImpl.clear();
     }
@@ -741,12 +746,12 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             new BasicHeader("_opendistro_security_user", "xxx"),
             encodeBasicHeader("admin", "admin")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertFalse(auditLogImpl.contains("YWRtaW46YWRtaW4"));
         Assert.assertTrue(auditLogImpl.contains("BAD_HEADERS"));
         Assert.assertTrue(auditLogImpl.contains("xxx"));
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
         TestAuditlogImpl.clear();
     }
@@ -773,9 +778,9 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse response = rh.executeDeleteRequest("index1?pretty", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executePostRequest("index2/_close?pretty", "", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         String auditLogImpl = TestAuditlogImpl.sb.toString();
         Assert.assertTrue(auditLogImpl.contains("indices:admin/close"));
         Assert.assertTrue(auditLogImpl.contains("indices:admin/delete"));
@@ -806,13 +811,15 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         TestAuditlogImpl.clear();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "/vulcango*/_delete_by_query?refresh=true&wait_for_completion=true&pretty=true",
-                "{\"query\" : {\"match_all\" : {}}}",
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/vulcango*/_delete_by_query?refresh=true&wait_for_completion=true&pretty=true",
+                    "{\"query\" : {\"match_all\" : {}}}",
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         assertContains(res, "*\"deleted\" : 3,*");
         String auditlogContents = TestAuditlogImpl.sb.toString();
@@ -894,23 +901,23 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
 
         // test GET
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executeGetRequest("test", adminHeader); }, 1);
-        Assert.assertEquals(GET, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getRequestMethod(), is(GET));
 
         // test PUT
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executePutRequest("test/_doc/0", "{}", adminHeader); }, 1);
-        Assert.assertEquals(PUT, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getRequestMethod(), is(PUT));
 
         // test DELETE
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executeDeleteRequest("test", adminHeader); }, 1);
-        Assert.assertEquals(DELETE, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getRequestMethod(), is(DELETE));
 
         // test POST
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executePostRequest("test/_doc", "{}", adminHeader); }, 1);
-        Assert.assertEquals(POST, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getRequestMethod(), is(POST));
 
         // test PATCH
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executePatchRequest("/_opendistro/_security/api/audit", "[]"); }, 1);
-        Assert.assertEquals(PATCH, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getRequestMethod(), is(PATCH));
 
         // test MISSING_PRIVILEGES
         // admin does not have REST role here
@@ -919,31 +926,31 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             2
         );
         // The intital request is authenicated
-        Assert.assertEquals(PATCH, messages.get(0).getRequestMethod());
-        Assert.assertEquals(AuditCategory.AUTHENTICATED, messages.get(0).getCategory());
+        assertThat(messages.get(0).getRequestMethod(), is(PATCH));
+        assertThat(messages.get(0).getCategory(), is(AuditCategory.AUTHENTICATED));
         // The secondary request does not have permissions
-        Assert.assertEquals(PATCH, messages.get(1).getRequestMethod());
-        Assert.assertEquals(AuditCategory.MISSING_PRIVILEGES, messages.get(1).getCategory());
+        assertThat(messages.get(1).getRequestMethod(), is(PATCH));
+        assertThat(messages.get(1).getCategory(), is(AuditCategory.MISSING_PRIVILEGES));
 
         // test AUTHENTICATED
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> { rh.executeGetRequest("test", adminHeader); }, 1);
-        Assert.assertEquals(AuditCategory.AUTHENTICATED, messages.get(0).getCategory());
-        Assert.assertEquals(GET, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getCategory(), is(AuditCategory.AUTHENTICATED));
+        assertThat(messages.get(0).getRequestMethod(), is(GET));
 
         // test FAILED_LOGIN
         messages = TestAuditlogImpl.doThenWaitForMessages(
             () -> { rh.executeGetRequest("test", encodeBasicHeader("random", "random")); },
             1
         );
-        Assert.assertEquals(AuditCategory.FAILED_LOGIN, messages.get(0).getCategory());
-        Assert.assertEquals(GET, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getCategory(), is(AuditCategory.FAILED_LOGIN));
+        assertThat(messages.get(0).getRequestMethod(), is(GET));
 
         // test BAD_HEADERS
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             rh.executeGetRequest("test", new BasicHeader("_opendistro_security_user", "xxx"));
         }, 1);
-        Assert.assertEquals(AuditCategory.BAD_HEADERS, messages.get(0).getCategory());
-        Assert.assertEquals(GET, messages.get(0).getRequestMethod());
+        assertThat(messages.get(0).getCategory(), is(AuditCategory.BAD_HEADERS));
+        assertThat(messages.get(0).getRequestMethod(), is(GET));
     }
 
     @Test
@@ -961,7 +968,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
         // test PUT accounts API
         TestAuditlogImpl.clear();
         rh.executePutRequest("/_opendistro/_security/api/account", "{\"password\":\"new-pass\", \"current_password\":\"curr-passs\"}");
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
 
         // test PUT internal users API
@@ -970,7 +977,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             "/_opendistro/_security/api/internalusers/test1",
             "{\"password\":\"new-pass\", \"backend_roles\":[], \"attributes\": {}}"
         );
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
 
         // test PATCH internal users API
@@ -979,7 +986,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             "/_opendistro/_security/api/internalusers/test1",
             "[{\"op\":\"add\", \"path\":\"/password\", \"value\": \"test-pass\"}]"
         );
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
 
         // test PUT users API
@@ -988,7 +995,7 @@ public class BasicAuditlogTest extends AbstractAuditlogiUnitTest {
             "/_opendistro/_security/api/user/test2",
             "{\"password\":\"new-pass\", \"backend_roles\":[], \"attributes\": {}}"
         );
-        Assert.assertEquals(1, TestAuditlogImpl.messages.size());
+        assertThat(TestAuditlogImpl.messages.size(), is(1));
         Assert.assertTrue(TestAuditlogImpl.sb.toString().contains(expectedRequestBody));
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/SSLAuditlogTest.java
@@ -27,6 +27,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
 
     private ClusterInfo monitoringClusterInfo;
@@ -100,12 +103,12 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         HttpResponse response = rh.executeGetRequest("_search");
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Thread.sleep(5000);
         response = rhMon.executeGetRequest("security-auditlog*/_refresh", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }
@@ -144,12 +147,12 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         HttpResponse response = rh.executeGetRequest("_search");
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Thread.sleep(5000);
         response = rhMon.executeGetRequest("security-auditlog*/_refresh", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rhMon.executeGetRequest("security-auditlog*/_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }
@@ -183,12 +186,12 @@ public class SSLAuditlogTest extends AbstractAuditlogiUnitTest {
 
         setup(additionalSettings);
         HttpResponse response = rh.executeGetRequest("_search");
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
         Thread.sleep(5000);
         response = rhMon.executeGetRequest("security-auditlog*/_refresh", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rhMon.executeGetRequest("security-auditlog-*/_search", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         assertNotContains(response, "*\"hits\":{\"total\":0,*");
         assertContains(response, "*\"failed\":0},\"hits\":*");
     }

--- a/src/test/java/org/opensearch/security/auditlog/routing/FallbackTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/routing/FallbackTest.java
@@ -30,6 +30,9 @@ import org.opensearch.security.auditlog.sink.AuditLogSink;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FallbackTest extends AbstractAuditlogiUnitTest {
 
     @Test
@@ -48,28 +51,28 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
 
         // endpoint 1 is failing, endoint2 and default work
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
-        Assert.assertEquals(3, sinks.size());
+        assertThat(sinks.size(), is(3));
         // this sink has failed, message must be logged to fallback sink
         AuditLogSink sink = sinks.get(0);
-        Assert.assertEquals("endpoint1", sink.getName());
-        Assert.assertEquals(FailingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("endpoint1"));
+        assertThat(sink.getClass(), is(FailingSink.class));
         sink = sink.getFallbackSink();
-        Assert.assertEquals("fallback", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("fallback"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         LoggingSink loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.get(0), is(msg));
         // this sink succeeds
         sink = sinks.get(1);
-        Assert.assertEquals("endpoint2", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("endpoint2"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.get(0), is(msg));
         // default sink also succeeds
         sink = sinks.get(2);
-        Assert.assertEquals("default", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("default"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.get(0), is(msg));
 
         // has only one end point which fails
         router = createMessageRouterComplianceEnabled(settings);
@@ -77,13 +80,13 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
         router.route(msg);
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
         sink = sinks.get(0);
-        Assert.assertEquals("endpoint3", sink.getName());
-        Assert.assertEquals(FailingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("endpoint3"));
+        assertThat(sink.getClass(), is(FailingSink.class));
         sink = sink.getFallbackSink();
-        Assert.assertEquals("fallback", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("fallback"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.get(0), is(msg));
 
         // has only default which succeeds
         router = createMessageRouterComplianceEnabled(settings);
@@ -91,17 +94,17 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
         router.route(msg);
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
         sink = sinks.get(0);
-        Assert.assertEquals("default", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("default"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(1, loggingSkin.messages.size());
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.size(), is(1));
+        assertThat(loggingSkin.messages.get(0), is(msg));
         // fallback must be empty
         sink = sink.getFallbackSink();
-        Assert.assertEquals("fallback", sink.getName());
-        Assert.assertEquals(LoggingSink.class, sink.getClass());
+        assertThat(sink.getName(), is("fallback"));
+        assertThat(sink.getClass(), is(LoggingSink.class));
         loggingSkin = (LoggingSink) sink;
-        Assert.assertEquals(0, loggingSkin.messages.size());
+        assertThat(loggingSkin.messages.size(), is(0));
 
         // test non configured categories, must be logged to default only
         router = createMessageRouterComplianceEnabled(settings);
@@ -109,8 +112,8 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
         router.route(msg);
         Assert.assertNull(router.categorySinks.get(AuditCategory.FAILED_LOGIN));
         loggingSkin = (LoggingSink) router.defaultSink;
-        Assert.assertEquals(1, loggingSkin.messages.size());
-        Assert.assertEquals(msg, loggingSkin.messages.get(0));
+        assertThat(loggingSkin.messages.size(), is(1));
+        assertThat(loggingSkin.messages.get(0), is(msg));
         // all others must be empty
         assertLoggingSinksEmpty(router);
 
@@ -123,7 +126,7 @@ public class FallbackTest extends AbstractAuditlogiUnitTest {
         allSinks.removeAll(Collections.singleton(router.defaultSink));
         for (AuditLogSink sink : allSinks) {
             LoggingSink loggingSink = (LoggingSink) sink;
-            Assert.assertEquals(0, loggingSink.messages.size());
+            assertThat(loggingSink.messages.size(), is(0));
         }
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/routing/RouterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/routing/RouterTest.java
@@ -31,6 +31,9 @@ import org.opensearch.security.auditlog.sink.InternalOpenSearchSink;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class RouterTest extends AbstractAuditlogiUnitTest {
 
     @Test
@@ -40,24 +43,24 @@ public class RouterTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         // default
-        Assert.assertEquals("default", router.defaultSink.getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, router.defaultSink.getClass());
+        assertThat(router.defaultSink.getName(), is("default"));
+        assertThat(router.defaultSink.getClass(), is(ExternalOpenSearchSink.class));
         // test category sinks
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
         Assert.assertNotNull(sinks);
         // 3, since we include default as well
-        Assert.assertEquals(3, sinks.size());
-        Assert.assertEquals("endpoint1", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint2", sinks.get(1).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(1).getClass());
-        Assert.assertEquals("default", sinks.get(2).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(2).getClass());
+        assertThat(sinks.size(), is(3));
+        assertThat(sinks.get(0).getName(), is("endpoint1"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint2"));
+        assertThat(sinks.get(1).getClass(), is(ExternalOpenSearchSink.class));
+        assertThat(sinks.get(2).getName(), is("default"));
+        assertThat(sinks.get(2).getClass(), is(ExternalOpenSearchSink.class));
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
         // 1, since we do not include default
-        Assert.assertEquals(1, sinks.size());
-        Assert.assertEquals("endpoint3", sinks.get(0).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
+        assertThat(sinks.size(), is(1));
+        assertThat(sinks.get(0).getName(), is("endpoint3"));
+        assertThat(sinks.get(0).getClass(), is(DebugSink.class));
     }
 
     @Test
@@ -113,8 +116,8 @@ public class RouterTest extends AbstractAuditlogiUnitTest {
                 // each sink must contain our message
                 for (AuditLogSink sink : sinks) {
                     LoggingSink logSink = (LoggingSink) sink;
-                    Assert.assertEquals(1, logSink.messages.size());
-                    Assert.assertEquals(msg, logSink.messages.get(0));
+                    assertThat(logSink.messages.size(), is(1));
+                    assertThat(logSink.messages.get(0), is(msg));
                     Assert.assertTrue(logSink.sb.length() > 0);
                     Assert.assertTrue(Arrays.stream(sinkNames).anyMatch(sink.getName()::equals));
                 }
@@ -126,7 +129,7 @@ public class RouterTest extends AbstractAuditlogiUnitTest {
                         continue;
                     }
                     LoggingSink logSink = (LoggingSink) sink;
-                    Assert.assertEquals(0, logSink.messages.size());
+                    assertThat(logSink.messages.size(), is(0));
                     Assert.assertTrue(logSink.sb.length() == 0);
                 }
             }

--- a/src/test/java/org/opensearch/security/auditlog/routing/RoutingConfigurationTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/routing/RoutingConfigurationTest.java
@@ -28,6 +28,10 @@ import org.opensearch.security.auditlog.sink.ExternalOpenSearchSink;
 import org.opensearch.security.auditlog.sink.InternalOpenSearchSink;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
 public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
 
     @Test
@@ -37,24 +41,24 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         // default
-        Assert.assertEquals("default", router.defaultSink.getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, router.defaultSink.getClass());
+        assertThat(router.defaultSink.getName(), is("default"));
+        assertThat(router.defaultSink.getClass(), is(ExternalOpenSearchSink.class));
         // test category sinks
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
         Assert.assertNotNull(sinks);
         // 3, since we include default as well
-        Assert.assertEquals(3, sinks.size());
-        Assert.assertEquals("endpoint1", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint2", sinks.get(1).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(1).getClass());
-        Assert.assertEquals("default", sinks.get(2).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(2).getClass());
+        assertThat(sinks.size(), is(3));
+        assertThat(sinks.get(0).getName(), is("endpoint1"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint2"));
+        assertThat(sinks.get(1).getClass(), is(ExternalOpenSearchSink.class));
+        assertThat(sinks.get(2).getName(), is("default"));
+        assertThat(sinks.get(2).getClass(), is(ExternalOpenSearchSink.class));
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ);
         // 1, since we do not include default
-        Assert.assertEquals(1, sinks.size());
-        Assert.assertEquals("endpoint3", sinks.get(0).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
+        assertThat(sinks.size(), is(1));
+        assertThat(sinks.get(0).getName(), is("endpoint3"));
+        assertThat(sinks.get(0).getClass(), is(DebugSink.class));
     }
 
     @Test
@@ -68,9 +72,9 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = new AuditMessageRouter(settings, null, null, null);
         // no default sink, audit log not enabled
-        Assert.assertEquals(false, router.isEnabled());
-        Assert.assertEquals(null, router.defaultSink);
-        Assert.assertEquals(null, router.categorySinks);
+        assertThat(router.isEnabled(), is(false));
+        assertThat(router.defaultSink, is(nullValue()));
+        assertThat(router.categorySinks, is(nullValue()));
         // make sure no exception is thrown
         router.route(MockAuditMessageFactory.validAuditMessage());
     }
@@ -82,20 +86,20 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         // fallback to debug sink if no default is given
-        Assert.assertEquals(InternalOpenSearchSink.class, router.defaultSink.getClass());
+        assertThat(router.defaultSink.getClass(), is(InternalOpenSearchSink.class));
         // missing configuration for endpoint2 / External ES. Fallback to
         // localhost
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
         // 2 valid endpoints
-        Assert.assertEquals(2, sinks.size());
-        Assert.assertEquals("endpoint1", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint3", sinks.get(1).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(1).getClass());
+        assertThat(sinks.size(), is(2));
+        assertThat(sinks.get(0).getName(), is("endpoint1"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint3"));
+        assertThat(sinks.get(1).getClass(), is(DebugSink.class));
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
-        Assert.assertEquals(1, sinks.size());
-        Assert.assertEquals("default", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
+        assertThat(sinks.size(), is(1));
+        assertThat(sinks.get(0).getName(), is("default"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
         // no valid end points for category, must use default
         Assert.assertNull(router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ));
     }
@@ -107,31 +111,31 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         // no default sink, we fall back to debug sink
-        Assert.assertEquals(DebugSink.class, router.defaultSink.getClass());
+        assertThat(router.defaultSink.getClass(), is(DebugSink.class));
 
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
         // 3, since default is not valid but replaced with Debug
-        Assert.assertEquals(3, sinks.size());
-        Assert.assertEquals("default", sinks.get(0).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint1", sinks.get(1).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(1).getClass());
-        Assert.assertEquals("endpoint2", sinks.get(2).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(2).getClass());
+        assertThat(sinks.size(), is(3));
+        assertThat(sinks.get(0).getName(), is("default"));
+        assertThat(sinks.get(0).getClass(), is(DebugSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint1"));
+        assertThat(sinks.get(1).getClass(), is(InternalOpenSearchSink.class));
+        assertThat(sinks.get(2).getName(), is("endpoint2"));
+        assertThat(sinks.get(2).getClass(), is(ExternalOpenSearchSink.class));
 
         sinks = router.categorySinks.get(AuditCategory.GRANTED_PRIVILEGES);
-        Assert.assertEquals(3, sinks.size());
-        Assert.assertEquals("endpoint1", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint3", sinks.get(1).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(1).getClass());
-        Assert.assertEquals("default", sinks.get(2).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(2).getClass());
+        assertThat(sinks.size(), is(3));
+        assertThat(sinks.get(0).getName(), is("endpoint1"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint3"));
+        assertThat(sinks.get(1).getClass(), is(DebugSink.class));
+        assertThat(sinks.get(2).getName(), is("default"));
+        assertThat(sinks.get(2).getClass(), is(DebugSink.class));
 
         sinks = router.categorySinks.get(AuditCategory.AUTHENTICATED);
-        Assert.assertEquals(1, sinks.size());
-        Assert.assertEquals("endpoint1", sinks.get(0).getName());
-        Assert.assertEquals(InternalOpenSearchSink.class, sinks.get(0).getClass());
+        assertThat(sinks.size(), is(1));
+        assertThat(sinks.get(0).getName(), is("endpoint1"));
+        assertThat(sinks.get(0).getClass(), is(InternalOpenSearchSink.class));
 
         // bad headers has no valid endpoint, so we use default
         Assert.assertNull(router.categorySinks.get(AuditCategory.BAD_HEADERS));
@@ -148,22 +152,22 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         // debug sink not valid, fallback to debug
-        Assert.assertEquals(DebugSink.class, router.defaultSink.getClass());
+        assertThat(router.defaultSink.getClass(), is(DebugSink.class));
 
         List<AuditLogSink> sinks = router.categorySinks.get(AuditCategory.MISSING_PRIVILEGES);
         // 2 valid endpoints in config, default falls back to debug
-        Assert.assertEquals(3, sinks.size());
-        Assert.assertEquals("endpoint2", sinks.get(0).getName());
-        Assert.assertEquals(ExternalOpenSearchSink.class, sinks.get(0).getClass());
-        Assert.assertEquals("endpoint3", sinks.get(1).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(1).getClass());
-        Assert.assertEquals("default", sinks.get(2).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(2).getClass());
+        assertThat(sinks.size(), is(3));
+        assertThat(sinks.get(0).getName(), is("endpoint2"));
+        assertThat(sinks.get(0).getClass(), is(ExternalOpenSearchSink.class));
+        assertThat(sinks.get(1).getName(), is("endpoint3"));
+        assertThat(sinks.get(1).getClass(), is(DebugSink.class));
+        assertThat(sinks.get(2).getName(), is("default"));
+        assertThat(sinks.get(2).getClass(), is(DebugSink.class));
 
         sinks = router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_WRITE);
-        Assert.assertEquals(1, sinks.size());
-        Assert.assertEquals("default", sinks.get(0).getName());
-        Assert.assertEquals(DebugSink.class, sinks.get(0).getClass());
+        assertThat(sinks.size(), is(1));
+        assertThat(sinks.get(0).getName(), is("default"));
+        assertThat(sinks.get(0).getClass(), is(DebugSink.class));
 
         // no valid endpoints for category, must fallback to default
         Assert.assertNull(router.categorySinks.get(AuditCategory.COMPLIANCE_DOC_READ));
@@ -176,7 +180,7 @@ public class RoutingConfigurationTest extends AbstractAuditlogiUnitTest {
             .build();
         AuditMessageRouter router = createMessageRouterComplianceEnabled(settings);
         ThreadPoolConfig config = router.storagePool.getConfig();
-        Assert.assertEquals(5, config.getThreadPoolSize());
-        Assert.assertEquals(200000, config.getThreadPoolMaxQueueLen());
+        assertThat(config.getThreadPoolSize(), is(5));
+        assertThat(config.getThreadPoolMaxQueueLen(), is(200000));
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/sink/KafkaSinkTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/KafkaSinkTest.java
@@ -32,6 +32,9 @@ import org.opensearch.security.test.helper.file.FileHelper;
 
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
 
     @ClassRule
@@ -64,11 +67,11 @@ public class KafkaSinkTest extends AbstractAuditlogiUnitTest {
             SinkProvider provider = new SinkProvider(settings, null, null, null);
             AuditLogSink sink = provider.getDefaultSink();
             try {
-                Assert.assertEquals(KafkaSink.class, sink.getClass());
+                assertThat(sink.getClass(), is(KafkaSink.class));
                 boolean success = sink.doStore(MockAuditMessageFactory.validAuditMessage(AuditCategory.MISSING_PRIVILEGES));
                 Assert.assertTrue(success);
                 ConsumerRecords<Long, String> records = consumer.poll(Duration.ofSeconds(10));
-                Assert.assertEquals(1, records.count());
+                assertThat(records.count(), is(1));
             } finally {
                 sink.close();
             }

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -35,6 +35,9 @@ import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class SinkProviderTLSTest {
 
     protected HttpServer server = null;
@@ -90,7 +93,7 @@ public class SinkProviderTLSTest {
 
         SinkProvider provider = new SinkProvider(builder.build(), null, null, null);
         WebhookSink defaultSink = (WebhookSink) provider.defaultSink;
-        Assert.assertEquals(true, defaultSink.verifySSL);
+        assertThat(defaultSink.verifySSL, is(true));
 
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         provider.allSinks.get("endpoint1").store(msg);

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTest.java
@@ -12,11 +12,14 @@
 package org.opensearch.security.auditlog.sink;
 
 import org.apache.logging.log4j.Level;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.test.helper.file.FileHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 public class SinkProviderTest {
 
@@ -29,70 +32,70 @@ public class SinkProviderTest {
         SinkProvider provider = new SinkProvider(settings, null, null, null);
 
         // make sure we have a debug sink as fallback
-        Assert.assertEquals(DebugSink.class, provider.fallbackSink.getClass());
+        assertThat(provider.fallbackSink.getClass(), is(DebugSink.class));
 
         AuditLogSink sink = provider.getSink("DefaULT");
-        Assert.assertEquals(sink.getClass(), DebugSink.class);
+        assertThat(DebugSink.class, is(sink.getClass()));
 
         sink = provider.getSink("endpoint1");
-        Assert.assertEquals(InternalOpenSearchSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(InternalOpenSearchSink.class));
 
         sink = provider.getSink("endpoint2");
-        Assert.assertEquals(ExternalOpenSearchSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(ExternalOpenSearchSink.class));
         // todo: sink does not work
 
         sink = provider.getSink("endpoinT3");
-        Assert.assertEquals(DebugSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(DebugSink.class));
 
         // no valid type
         sink = provider.getSink("endpoint4");
-        Assert.assertEquals(null, sink);
+        assertThat(sink, is(nullValue()));
 
         sink = provider.getSink("endpoint2");
-        Assert.assertEquals(ExternalOpenSearchSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(ExternalOpenSearchSink.class));
         // todo: sink does not work, no valid config
 
         // no valid type
         sink = provider.getSink("endpoint6");
-        Assert.assertEquals(null, sink);
+        assertThat(sink, is(nullValue()));
 
         // no valid type
         sink = provider.getSink("endpoint7");
-        Assert.assertEquals(null, sink);
+        assertThat(sink, is(nullValue()));
 
         sink = provider.getSink("endpoint8");
-        Assert.assertEquals(DebugSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(DebugSink.class));
 
         // wrong type in config
         sink = provider.getSink("endpoint9");
-        Assert.assertEquals(ExternalOpenSearchSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(ExternalOpenSearchSink.class));
 
         // log4j, valid configuration
         sink = provider.getSink("endpoint10");
-        Assert.assertEquals(Log4JSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(Log4JSink.class));
         Log4JSink lsink = (Log4JSink) sink;
-        Assert.assertEquals("loggername", lsink.loggerName);
-        Assert.assertEquals(Level.WARN, lsink.logLevel);
+        assertThat(lsink.loggerName, is("loggername"));
+        assertThat(lsink.logLevel, is(Level.WARN));
 
         // log4j, no level, fallback to default
         sink = provider.getSink("endpoint11");
-        Assert.assertEquals(Log4JSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(Log4JSink.class));
         lsink = (Log4JSink) sink;
-        Assert.assertEquals("loggername", lsink.loggerName);
-        Assert.assertEquals(Level.INFO, lsink.logLevel);
+        assertThat(lsink.loggerName, is("loggername"));
+        assertThat(lsink.logLevel, is(Level.INFO));
 
         // log4j, wrong level, fallback to log4j default
         sink = provider.getSink("endpoint12");
-        Assert.assertEquals(Log4JSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(Log4JSink.class));
         lsink = (Log4JSink) sink;
-        Assert.assertEquals("loggername", lsink.loggerName);
-        Assert.assertEquals(Level.DEBUG, lsink.logLevel);
+        assertThat(lsink.loggerName, is("loggername"));
+        assertThat(lsink.logLevel, is(Level.DEBUG));
 
         sink = provider.getSink("endpoint13");
-        Assert.assertEquals(Log4JSink.class, sink.getClass());
+        assertThat(sink.getClass(), is(Log4JSink.class));
         lsink = (Log4JSink) sink;
-        Assert.assertEquals("audit", lsink.loggerName);
-        Assert.assertEquals(Level.INFO, lsink.logLevel);
+        assertThat(lsink.loggerName, is("audit"));
+        assertThat(lsink.logLevel, is(Level.INFO));
 
     }
 
@@ -103,8 +106,8 @@ public class SinkProviderTest {
             .build();
         SinkProvider provider = new SinkProvider(settings, null, null, null);
         InternalOpenSearchSink sink = (InternalOpenSearchSink) provider.defaultSink;
-        Assert.assertEquals("myownindex", sink.index);
-        Assert.assertEquals("auditevents", sink.type);
+        assertThat(sink.index, is("myownindex"));
+        assertThat(sink.type, is("auditevents"));
     }
 
 }

--- a/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -43,6 +43,9 @@ import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class WebhookAuditLogTest {
 
     protected HttpServer server = null;
@@ -77,8 +80,8 @@ public class WebhookAuditLogTest {
         // Webhook sink has failed ...
         Assert.assertNull(auditlog.webhookFormat);
         // ... so message must be stored in fallback
-        Assert.assertEquals(1, fallback.messages.size());
-        Assert.assertEquals(msg, fallback.messages.get(0));
+        assertThat(fallback.messages.size(), is(1));
+        assertThat(fallback.messages.get(0), is(msg));
 
     }
 
@@ -101,8 +104,8 @@ public class WebhookAuditLogTest {
 
         MockWebhookAuditLog auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
-        Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
+        assertThat(auditlog.webhookFormat, is(WebhookFormat.TEXT));
+        assertThat(auditlog.webhookFormat.getContentType(), is(ContentType.TEXT_PLAIN));
         Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
 
         // provide faulty format, defaults to TEXT
@@ -117,8 +120,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
-        Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
+        assertThat(auditlog.webhookFormat, is(WebhookFormat.TEXT));
+        assertThat(auditlog.webhookFormat.getContentType(), is(ContentType.TEXT_PLAIN));
         Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         auditlog.close();
 
@@ -134,8 +137,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        Assert.assertEquals(WebhookFormat.TEXT, auditlog.webhookFormat);
-        Assert.assertEquals(ContentType.TEXT_PLAIN, auditlog.webhookFormat.getContentType());
+        assertThat(auditlog.webhookFormat, is(WebhookFormat.TEXT));
+        assertThat(auditlog.webhookFormat.getContentType(), is(ContentType.TEXT_PLAIN));
         Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains("audit_request_remote_address"));
@@ -152,8 +155,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        Assert.assertEquals(WebhookFormat.JSON, auditlog.webhookFormat);
-        Assert.assertEquals(ContentType.APPLICATION_JSON, auditlog.webhookFormat.getContentType());
+        assertThat(auditlog.webhookFormat, is(WebhookFormat.JSON));
+        assertThat(auditlog.webhookFormat.getContentType(), is(ContentType.APPLICATION_JSON));
         Assert.assertFalse(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains("audit_request_remote_address"));
@@ -170,8 +173,8 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new MockWebhookAuditLog(settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null);
         auditlog.store(msg);
-        Assert.assertEquals(WebhookFormat.SLACK, auditlog.webhookFormat);
-        Assert.assertEquals(ContentType.APPLICATION_JSON, auditlog.webhookFormat.getContentType());
+        assertThat(auditlog.webhookFormat, is(WebhookFormat.SLACK));
+        assertThat(auditlog.webhookFormat.getContentType(), is(ContentType.APPLICATION_JSON));
         Assert.assertTrue(auditlog.payload, auditlog.payload.startsWith("{\"text\":"));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains(AuditMessage.UTC_TIMESTAMP));
         Assert.assertTrue(auditlog.payload, auditlog.payload.contains("audit_request_remote_address"));
@@ -199,8 +202,8 @@ public class WebhookAuditLogTest {
         Assert.assertNull(auditlog.payload);
         Assert.assertNull(auditlog.webhookUrl);
         // message must be stored in fallback
-        Assert.assertEquals(1, fallback.messages.size());
-        Assert.assertEquals(msg, fallback.messages.get(0));
+        assertThat(fallback.messages.size(), is(1));
+        assertThat(fallback.messages.get(0), is(msg));
     }
 
     @Test
@@ -222,10 +225,10 @@ public class WebhookAuditLogTest {
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
         // can't connect, no server running ...
-        Assert.assertEquals("http://localhost:8080/endpoint", auditlog.webhookUrl);
+        assertThat(auditlog.webhookUrl, is("http://localhost:8080/endpoint"));
         // ... message must be stored in fallback
-        Assert.assertEquals(1, fallback.messages.size());
-        Assert.assertEquals(msg, fallback.messages.get(0));
+        assertThat(fallback.messages.size(), is(1));
+        assertThat(fallback.messages.get(0), is(msg));
     }
 
     @Test
@@ -254,12 +257,12 @@ public class WebhookAuditLogTest {
         WebhookSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         AuditMessage msg = MockAuditMessageFactory.validAuditMessage();
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.startsWith("{\"text\":"));
         assertStringContainsAllKeysAndValues(handler.body);
         // no message stored on fallback
-        Assert.assertEquals(0, fallback.messages.size());
+        assertThat(fallback.messages.size(), is(0));
         handler.reset();
 
         // TEXT
@@ -275,7 +278,7 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertFalse(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -294,7 +297,7 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -313,8 +316,8 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
-        Assert.assertEquals("", handler.body);
+        assertThat(handler.method, is("POST"));
+        assertThat(handler.body, is(""));
         Assert.assertFalse(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(URLDecoder.decode(handler.uri, StandardCharsets.UTF_8.displayName()));
         handler.reset();
@@ -332,7 +335,7 @@ public class WebhookAuditLogTest {
 
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("GET", handler.method);
+        assertThat(handler.method, is("GET"));
         Assert.assertNull(handler.body);
         assertStringContainsAllKeysAndValues(URLDecoder.decode(handler.uri, StandardCharsets.UTF_8.displayName()));
         server.shutdown(3l, TimeUnit.SECONDS);
@@ -368,8 +371,8 @@ public class WebhookAuditLogTest {
         Assert.assertNull(handler.body);
         Assert.assertNull(handler.uri);
         // ... so message must be stored in fallback
-        Assert.assertEquals(1, fallback.messages.size());
-        Assert.assertEquals(msg, fallback.messages.get(0));
+        assertThat(fallback.messages.size(), is(1));
+        assertThat(fallback.messages.get(0), is(msg));
         server.shutdown(3l, TimeUnit.SECONDS);
     }
 
@@ -404,8 +407,8 @@ public class WebhookAuditLogTest {
         Assert.assertNull(handler.method);
         Assert.assertNull(handler.body);
         // message must be stored in fallback
-        Assert.assertEquals(1, fallback.messages.size());
-        Assert.assertEquals(msg, fallback.messages.get(0));
+        assertThat(fallback.messages.size(), is(1));
+        assertThat(fallback.messages.get(0), is(msg));
 
         // disable ssl verification, no ca, call must succeed
         handler.reset();
@@ -417,7 +420,7 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -436,7 +439,7 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -493,7 +496,7 @@ public class WebhookAuditLogTest {
             .build();
         AuditLogSink auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -512,7 +515,7 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT, null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -622,7 +625,7 @@ public class WebhookAuditLogTest {
             .build();
         AuditLogSink auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -641,7 +644,7 @@ public class WebhookAuditLogTest {
             .build();
         auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);
@@ -730,7 +733,7 @@ public class WebhookAuditLogTest {
 
         AuditLogSink auditlog = new WebhookSink("name", settings, "plugins.security.audit.endpoints.endpoint1.config", null, fallback);
         auditlog.store(msg);
-        Assert.assertEquals("POST", handler.method);
+        assertThat(handler.method, is("POST"));
         Assert.assertNotNull(handler.body);
         Assert.assertTrue(handler.body.contains("{"));
         assertStringContainsAllKeysAndValues(handler.body);

--- a/src/test/java/org/opensearch/security/auth/RolesInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/RolesInjectorTest.java
@@ -30,8 +30,10 @@ import org.opensearch.security.user.User;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class RolesInjectorTest {
@@ -52,9 +54,9 @@ public class RolesInjectorTest {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         RolesInjector rolesInjector = new RolesInjector(auditLog);
         Set<String> roles = rolesInjector.injectUserAndRoles(transportRequest, "action0", task, threadContext);
-        assertEquals(null, roles);
+        assertThat(roles, is(nullValue()));
         User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-        assertEquals(null, user);
+        assertThat(user, is(nullValue()));
     }
 
     @Test
@@ -66,11 +68,11 @@ public class RolesInjectorTest {
         Set<String> roles = rolesInjector.injectUserAndRoles(transportRequest, "action0", task, threadContext);
 
         User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-        assertEquals("user1", user.getName());
-        assertEquals(0, user.getRoles().size());
-        assertEquals(2, roles.size());
-        assertEquals(true, roles.contains("role_1"));
-        assertEquals(true, roles.contains("role_2"));
+        assertThat(user.getName(), is("user1"));
+        assertThat(user.getRoles().size(), is(0));
+        assertThat(roles.size(), is(2));
+        assertThat(roles.contains("role_1"), is(true));
+        assertThat(roles.contains("role_2"), is(true));
     }
 
     @Test
@@ -84,9 +86,9 @@ public class RolesInjectorTest {
             RolesInjector rolesInjector = new RolesInjector(auditLog);
             Set<String> roles = rolesInjector.injectUserAndRoles(transportRequest, "action0", task, threadContext);
 
-            assertEquals(null, roles);
+            assertThat(roles, is(nullValue()));
             User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-            assertEquals(null, user);
+            assertThat(user, is(nullValue()));
         });
     }
 }

--- a/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
+++ b/src/test/java/org/opensearch/security/auth/UserInjectorTest.java
@@ -30,7 +30,8 @@ import org.opensearch.transport.TransportRequest;
 
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -60,8 +61,8 @@ public class UserInjectorTest {
         roles.addAll(Arrays.asList("role1", "role2"));
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2");
         User injectedUser = userInjector.getInjectedUser();
-        assertEquals(injectedUser.getName(), "user");
-        assertEquals(injectedUser.getRoles(), roles);
+        assertThat("user", is(injectedUser.getName()));
+        assertThat(roles, is(injectedUser.getRoles()));
     }
 
     @Test
@@ -73,9 +74,9 @@ public class UserInjectorTest {
             "user|role1,role2|2001:db8:3333:4444:5555:6666:7777:8888:9200"
         );
         UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
-        assertEquals("user", injectedUser.getName());
-        assertEquals(9200, injectedUser.getTransportAddress().getPort());
-        assertEquals("2001:db8:3333:4444:5555:6666:7777:8888", injectedUser.getTransportAddress().getAddress());
+        assertThat(injectedUser.getName(), is("user"));
+        assertThat(injectedUser.getTransportAddress().getPort(), is(9200));
+        assertThat(injectedUser.getTransportAddress().getAddress(), is("2001:db8:3333:4444:5555:6666:7777:8888"));
     }
 
     @Test
@@ -84,9 +85,9 @@ public class UserInjectorTest {
         roles.addAll(Arrays.asList("role1", "role2"));
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER, "user|role1,role2|2001:db8::1:9200");
         UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
-        assertEquals("user", injectedUser.getName());
-        assertEquals(9200, injectedUser.getTransportAddress().getPort());
-        assertEquals("2001:db8::1", injectedUser.getTransportAddress().getAddress());
+        assertThat(injectedUser.getName(), is("user"));
+        assertThat(injectedUser.getTransportAddress().getPort(), is(9200));
+        assertThat(injectedUser.getTransportAddress().getAddress(), is("2001:db8::1"));
     }
 
     @Test
@@ -110,10 +111,10 @@ public class UserInjectorTest {
             "user|role1,role2|[2001:db8:3333:4444:5555:6666:7777:8888]:9200"
         );
         UserInjector.InjectedUser injectedUser = userInjector.getInjectedUser();
-        assertEquals("user", injectedUser.getName());
-        assertEquals(roles, injectedUser.getRoles());
-        assertEquals(9200, injectedUser.getTransportAddress().getPort());
-        assertEquals("2001:db8:3333:4444:5555:6666:7777:8888", injectedUser.getTransportAddress().getAddress());
+        assertThat(injectedUser.getName(), is("user"));
+        assertThat(injectedUser.getRoles(), is(roles));
+        assertThat(injectedUser.getTransportAddress().getPort(), is(9200));
+        assertThat(injectedUser.getTransportAddress().getAddress(), is("2001:db8:3333:4444:5555:6666:7777:8888"));
     }
 
     @Test
@@ -144,19 +145,19 @@ public class UserInjectorTest {
 
         map = userInjector.mapFromArray("key", "value");
         assertNotNull(map);
-        assertEquals(1, map.size());
-        assertEquals("value", map.get("key"));
+        assertThat(map.size(), is(1));
+        assertThat(map.get("key"), is("value"));
 
         map = userInjector.mapFromArray("key", "value", "key", "value");
         assertNotNull(map);
-        assertEquals(1, map.size());
-        assertEquals("value", map.get("key"));
+        assertThat(map.size(), is(1));
+        assertThat(map.get("key"), is("value"));
 
         map = userInjector.mapFromArray("key1", "value1", "key2", "value2");
         assertNotNull(map);
-        assertEquals(2, map.size());
-        assertEquals("value1", map.get("key1"));
-        assertEquals("value2", map.get("key2"));
+        assertThat(map.size(), is(2));
+        assertThat(map.get("key1"), is("value1"));
+        assertThat(map.get("key2"), is("value2"));
 
     }
 

--- a/src/test/java/org/opensearch/security/authtoken/jwt/EncryptionDecryptionUtilsTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/EncryptionDecryptionUtilsTest.java
@@ -16,6 +16,9 @@ import java.util.Base64;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class EncryptionDecryptionUtilsTest {
 
     @Test
@@ -28,7 +31,7 @@ public class EncryptionDecryptionUtilsTest {
         String encryptedString = util.encrypt(data);
         String decryptedString = util.decrypt(encryptedString);
 
-        Assert.assertEquals(data, decryptedString);
+        assertThat(decryptedString, is(data));
     }
 
     @Test
@@ -43,7 +46,7 @@ public class EncryptionDecryptionUtilsTest {
         EncryptionDecryptionUtil util2 = new EncryptionDecryptionUtil(secret2);
         RuntimeException ex = Assert.assertThrows(RuntimeException.class, () -> util2.decrypt(encryptedString));
 
-        Assert.assertEquals("Error processing data with cipher", ex.getMessage());
+        assertThat(ex.getMessage(), is("Error processing data with cipher"));
     }
 
     @Test
@@ -54,7 +57,7 @@ public class EncryptionDecryptionUtilsTest {
         EncryptionDecryptionUtil util = new EncryptionDecryptionUtil(secret);
         RuntimeException ex = Assert.assertThrows(RuntimeException.class, () -> util.decrypt(corruptedEncryptedString));
 
-        Assert.assertEquals("Last unit does not have enough valid bits", ex.getMessage());
+        assertThat(ex.getMessage(), is("Last unit does not have enough valid bits"));
     }
 
     @Test
@@ -66,7 +69,7 @@ public class EncryptionDecryptionUtilsTest {
         String encryptedString = util.encrypt(data);
         String decryptedString = util.decrypt(encryptedString);
 
-        Assert.assertEquals(data, decryptedString);
+        assertThat(decryptedString, is(data));
     }
 
     @Test(expected = NullPointerException.class)

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNull.notNullValue;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -65,8 +64,8 @@ public class JwtVendorTest {
         final Settings settings = Settings.builder().put("signing_key", signingKeyB64Encoded).build();
 
         final Tuple<JWK, JWSSigner> jwk = JwtVendor.createJwkFromSettings(settings);
-        Assert.assertEquals("HS512", jwk.v1().getAlgorithm().getName());
-        Assert.assertEquals("sig", jwk.v1().getKeyUse().toString());
+        assertThat(jwk.v1().getAlgorithm().getName(), is("HS512"));
+        assertThat(jwk.v1().getKeyUse().toString(), is("sig"));
         Assert.assertTrue(jwk.v1().toOctetSequenceKey().getKeyValue().decodeToString().startsWith(signingKey));
     }
 
@@ -173,7 +172,7 @@ public class JwtVendorTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals("java.lang.IllegalArgumentException: The expiration time should be a positive integer", exception.getMessage());
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: The expiration time should be a positive integer"));
     }
 
     @Test
@@ -212,7 +211,7 @@ public class JwtVendorTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals("java.lang.IllegalArgumentException: encryption_key cannot be null", exception.getMessage());
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: encryption_key cannot be null"));
     }
 
     @Test
@@ -233,7 +232,7 @@ public class JwtVendorTest {
                 throw new RuntimeException(e);
             }
         });
-        assertEquals("java.lang.IllegalArgumentException: Roles cannot be null", exception.getMessage());
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: Roles cannot be null"));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtilTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/KeyPaddingUtilTest.java
@@ -15,7 +15,8 @@ import org.junit.Test;
 
 import com.nimbusds.jose.JWSAlgorithm;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class KeyPaddingUtilTest {
 
@@ -28,7 +29,7 @@ public class KeyPaddingUtilTest {
 
         // For HS256, HMAC using SHA-256, typical key length is 256 bits or 32 bytes
         int expectedLength = 32;
-        assertEquals(expectedLength, paddedKey.length());
+        assertThat(paddedKey.length(), is(expectedLength));
     }
 
     @Test
@@ -38,6 +39,6 @@ public class KeyPaddingUtilTest {
 
         // For HS384, HMAC using SHA-384, typical key length is 384 bits or 48 bytes
         int expectedLength = 48;
-        assertEquals(expectedLength, paddedKey.length());
+        assertThat(paddedKey.length(), is(expectedLength));
     }
 }

--- a/src/test/java/org/opensearch/security/cache/CachingTest.java
+++ b/src/test/java/org/opensearch/security/cache/CachingTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.cache;
 
 import org.apache.http.HttpStatus;
 import org.apache.http.message.BasicHeader;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,6 +21,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class CachingTest extends SingleClusterTest {
 
@@ -43,16 +45,16 @@ public class CachingTest extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig(), Settings.EMPTY);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
-        Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
-        Assert.assertEquals(1, DummyAuthorizer.getCount());
-        Assert.assertEquals(3, DummyAuthenticationBackend.getAuthCount());
-        Assert.assertEquals(0, DummyAuthenticationBackend.getExistsCount());
+        assertThat(DummyHTTPAuthenticator.getCount(), is(3L));
+        assertThat(DummyAuthorizer.getCount(), is(1L));
+        assertThat(DummyAuthenticationBackend.getAuthCount(), is(3L));
+        assertThat(DummyAuthenticationBackend.getExistsCount(), is(0L));
     }
 
     @Test
@@ -61,16 +63,16 @@ public class CachingTest extends SingleClusterTest {
         setup(Settings.EMPTY, new DynamicSecurityConfig(), settings);
         final RestHelper rh = nonSslRestHelper();
         HttpResponse res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest("_opendistro/_security/authinfo?pretty");
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
-        Assert.assertEquals(3, DummyHTTPAuthenticator.getCount());
-        Assert.assertEquals(3, DummyAuthorizer.getCount());
-        Assert.assertEquals(3, DummyAuthenticationBackend.getAuthCount());
-        Assert.assertEquals(0, DummyAuthenticationBackend.getExistsCount());
+        assertThat(DummyHTTPAuthenticator.getCount(), is(3L));
+        assertThat(DummyAuthorizer.getCount(), is(3L));
+        assertThat(DummyAuthenticationBackend.getAuthCount(), is(3L));
+        assertThat(DummyAuthenticationBackend.getExistsCount(), is(0L));
     }
 
     @Test
@@ -82,26 +84,26 @@ public class CachingTest extends SingleClusterTest {
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         res = rh.executeGetRequest(
             "_opendistro/_security/authinfo?pretty",
             new BasicHeader("opendistro_security_impersonate_as", "impuser2")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
 
-        Assert.assertEquals(4, DummyHTTPAuthenticator.getCount());
-        Assert.assertEquals(3, DummyAuthorizer.getCount());
-        Assert.assertEquals(4, DummyAuthenticationBackend.getAuthCount());
-        Assert.assertEquals(2, DummyAuthenticationBackend.getExistsCount());
+        assertThat(DummyHTTPAuthenticator.getCount(), is(4L));
+        assertThat(DummyAuthorizer.getCount(), is(3L));
+        assertThat(DummyAuthenticationBackend.getAuthCount(), is(4L));
+        assertThat(DummyAuthenticationBackend.getExistsCount(), is(2L));
     }
 }

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -65,6 +65,7 @@ import org.opensearch.transport.Netty4Plugin;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
@@ -131,7 +132,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         String json = "{" + "\"persistent\" : {" + "\"cluster.remote.cross_cluster_two.seeds\" : [\"" + seed + "\"]" + "}" + "}";
 
         HttpResponse response = rh1.executePutRequest("_cluster/settings", json, encodeBasicHeader("sarek", "sarek"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     private Tuple<ClusterInfo, RestHelper> setupCluster(
@@ -204,7 +205,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
@@ -215,7 +216,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             encodeBasicHeader("nagilum", "nagilum")
         );
         // TODO fix exception nesting
-        // Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, ccs.getStatusCode());
+        // assertThat(ccs.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         // Assert.assertTrue(ccs.getBody().contains("Can not filter indices; index cross_cluster_two:xx exists but there is also a remote
         // cluster named: cross_cluster_two"));
 
@@ -224,7 +225,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:abcnonext/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         Assert.assertTrue(ccs.getBody().contains("index_not_found_exception"));
 
         // query 6
@@ -232,7 +233,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertTrue(ccs.getBody().contains("crl1"));
@@ -299,34 +300,34 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // query 2
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         // query 3
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // query 4
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
@@ -335,7 +336,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twutter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // query 6
         String msearchBody = "{}"
@@ -348,7 +349,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         // query 7
         msearchBody = "{}"
@@ -361,135 +362,135 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_all/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth*/_search",
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E,%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="
                 + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         // Alias both
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "notexist,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         // TODO Fix for 25.0 to resolve coordalias (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("crusherw", "crusherw")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -551,7 +552,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
@@ -560,14 +561,14 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twit*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         // query 3
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter,twutter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("twutter"));
 
         // query 4
@@ -575,7 +576,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
@@ -584,7 +585,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twutter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // query 6
         String msearchBody = "{}"
@@ -597,7 +598,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         // query 7
         msearchBody = "{}"
@@ -610,43 +611,43 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             msearchBody,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_all/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:*,*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("crl1_"));
         Assert.assertTrue(ccs.getBody().contains("crl2_"));
 
@@ -655,103 +656,103 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "*cross*:*twit*,*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter,t*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:*/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "hfghgtdhfhuth*/_search",
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(":*/_search", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("\"hits\":[]")); // TODO: Change for 25.0 to be forbidden (Indices options)
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "*:/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:%3Clogstash-%7Bnow%2Fd%7D%3E,%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty&ccs_minimize_roundtrips="
                 + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:remotealias,coordalias/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
 
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executeGetRequest(
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("crusherw", "crusherw")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -785,7 +786,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             "cross_cluster_two:twitter/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertFalse(ccs.getBody().contains("crl1"));
@@ -839,7 +840,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertFalse(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("coordinating"));
@@ -850,7 +851,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertFalse(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertFalse(ccs.getBody().contains("coordinating"));
@@ -861,13 +862,13 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:remo*,coo*/_search?pretty",
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("remote"));
@@ -878,7 +879,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("remote"));
@@ -889,7 +890,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("remote"));
@@ -900,7 +901,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("remote"));
@@ -911,7 +912,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("remote"));
@@ -976,7 +977,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertFalse(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
@@ -990,7 +991,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertFalse(ccs.getBody().contains("cross_cluster_two"));
         Assert.assertFalse(ccs.getBody().contains("twitter"));
@@ -1004,7 +1005,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two:analytics"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
@@ -1016,13 +1017,13 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:ana*,twi*/_search?pretty",
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two:analytics"));
         Assert.assertTrue(ccs.getBody().contains("twitter"));
@@ -1034,7 +1035,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two:analytics"));
         Assert.assertFalse(ccs.getBody().contains("twitter"));
@@ -1046,13 +1047,13 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:*/_search?pretty",
             dashboardsIndicesAgg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("cross_cluster_two:analytics"));
         Assert.assertFalse(ccs.getBody().contains("twitter"));
@@ -1107,7 +1108,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertTrue(ccs.getBody().contains("crl1"));
@@ -1119,7 +1120,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertTrue(ccs.getBody().contains("crl1"));
@@ -1131,7 +1132,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertFalse(ccs.getBody().contains("crl1"));
@@ -1143,37 +1144,40 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:*,notfound/_search?pretty",
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfound,notfound/_search?pretty",
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfou*,*/_search?pretty",
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());// TODO: Change for 25.0 to be forbidden (Indices options)
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));// TODO: Change for 25.0 to be forbidden (Indices options,
+                                                              // is(HttpStatus.SC_OK))
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:*,notfou*/_search?pretty",
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());// TODO: Change for 25.0 to be forbidden (Indices options)
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));// TODO: Change for 25.0 to be forbidden (Indices options,
+                                                              // is(HttpStatus.SC_OK))
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:not*,notf*/_search?pretty",
             agg,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());// TODO: Change for 25.0 to be forbidden (Indices options)
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));// TODO: Change for 25.0 to be forbidden (Indices options,
+                                                              // is(HttpStatus.SC_OK))
     }
 
     @Test
@@ -1233,13 +1237,13 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfound*,*/_search?pretty",
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("security_exception"));
         Assert.assertTrue(ccs.getBody().contains("\"timed_out\" : false"));
         Assert.assertTrue(ccs.getBody().contains("crl1"));
@@ -1251,31 +1255,31 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfound,notfound/_search?pretty",
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:notfou*,*/_search?pretty",
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:*,notfou*/_search?pretty",
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         ccs = new RestHelper(cl1Info, false, false, getResourceFolder()).executePostRequest(
             "cross_cluster_two:not*,notf*/_search?pretty",
             agg,
             encodeBasicHeader("twitter", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     private ClusterTransportClientSettings getBaseSettingsWithDifferentCert() {
@@ -1411,22 +1415,22 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
     public void testCcsWithRoleInjection() throws Exception {
         setupCcs(new DynamicSecurityConfig().setSecurityRoles("roles.yml"));
 
-        Assert.assertEquals(
+        assertThat(
             cl1Info.numNodes,
-            cl1.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes()
+            is(cl1.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes())
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            cl1.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(cl1.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
-        Assert.assertEquals(
+        assertThat(
             cl2Info.numNodes,
-            cl2.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes()
+            is(cl2.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getNumberOfNodes())
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            cl2.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(cl2.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         try (Client tc = cl2.nodeClient()) {
@@ -1469,7 +1473,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             getReq.refresh(true);
 
             GetResponse getRes = remoteClient.get(getReq).actionGet();
-            Assert.assertEquals(getRes.getId(), "0");
+            assertThat("0", is(getRes.getId()));
         } catch (OpenSearchSecurityException ex) {
             exception = ex;
             log.warn(ex.toString());
@@ -1494,7 +1498,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
             getReq.refresh(true);
 
             GetResponse getRes = remoteClient.get(getReq).actionGet();
-            Assert.assertEquals(getRes.getId(), "0");
+            assertThat("0", is(getRes.getId()));
         } catch (OpenSearchSecurityException ex) {
             Assert.assertNull(ex);
             log.warn(ex.toString());

--- a/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
@@ -44,6 +44,9 @@ import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class RemoteReindexTests extends AbstractSecurityUnitTest {
 
     private final ClusterHelper cl1 = new ClusterHelper(
@@ -134,7 +137,7 @@ public class RemoteReindexTests extends AbstractSecurityUnitTest {
             reindex,
             encodeBasicHeader("nagilum", "nagilum")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("created\" : 1"));
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -53,7 +53,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
@@ -282,7 +281,7 @@ public class ConfigurationRepositoryTest {
 
     void assertClusterState(final ArgumentCaptor<ClusterStateUpdateTask> clusterStateUpdateTaskCaptor) throws Exception {
         final var initializedStateUpdate = clusterStateUpdateTaskCaptor.getValue();
-        assertEquals(Priority.IMMEDIATE, initializedStateUpdate.priority());
+        assertThat(initializedStateUpdate.priority(), is(Priority.IMMEDIATE));
         var clusterState = initializedStateUpdate.execute(ClusterState.EMPTY_STATE);
         SecurityMetadata securityMetadata = clusterState.custom(SecurityMetadata.TYPE);
         assertNotNull(securityMetadata.created());

--- a/src/test/java/org/opensearch/security/configuration/SaltTest.java
+++ b/src/test/java/org/opensearch/security/configuration/SaltTest.java
@@ -21,9 +21,10 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.ConfigConstants;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.configuration.Salt.SALT_SIZE;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 public class SaltTest {
 
@@ -36,7 +37,7 @@ public class SaltTest {
         final Salt salt = Salt.from(Settings.EMPTY);
 
         // assert
-        assertEquals(SALT_SIZE, salt.getSalt16().length);
+        assertThat(salt.getSalt16().length, is(SALT_SIZE));
         assertArrayEquals(ConfigConstants.SECURITY_COMPLIANCE_SALT_DEFAULT.getBytes(StandardCharsets.UTF_8), salt.getSalt16());
     }
 
@@ -51,7 +52,7 @@ public class SaltTest {
 
         // assert
         assertArrayEquals(testSalt.getBytes(StandardCharsets.UTF_8), salt.getSalt16());
-        assertEquals(SALT_SIZE, salt.getSalt16().length);
+        assertThat(salt.getSalt16().length, is(SALT_SIZE));
     }
 
     @Test
@@ -63,7 +64,7 @@ public class SaltTest {
         final Salt salt = Salt.from(settings);
 
         // assert
-        assertEquals(SALT_SIZE, salt.getSalt16().length);
+        assertThat(salt.getSalt16().length, is(SALT_SIZE));
         assertArrayEquals(testSalt.substring(0, SALT_SIZE).getBytes(StandardCharsets.UTF_8), salt.getSalt16());
     }
 

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/AbstractDlsFlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/AbstractDlsFlsTest.java
@@ -15,8 +15,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.Assert;
-
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.search.MultiSearchResponse;
@@ -32,6 +30,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public abstract class AbstractDlsFlsTest extends SingleClusterTest {
 
@@ -67,7 +68,7 @@ public abstract class AbstractDlsFlsTest extends SingleClusterTest {
 
     protected SearchResponse executeSearch(String indexName, String user, String password) throws Exception {
         HttpResponse response = rh.executeGetRequest("/" + indexName + "/_search?from=0&size=50&pretty", encodeBasicHeader(user, password));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         return SearchResponse.fromXContent(xcp);
@@ -89,7 +90,7 @@ public abstract class AbstractDlsFlsTest extends SingleClusterTest {
         }
 
         HttpResponse response = rh.executePostRequest("/_msearch?pretty", body.toString(), encodeBasicHeader(user, password));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         return MultiSearchResponse.fromXContext(xcp);
@@ -104,7 +105,7 @@ public abstract class AbstractDlsFlsTest extends SingleClusterTest {
         String body = "{ \"docs\": [" + String.join(",", indexAndIdJson) + "] }";
 
         HttpResponse response = rh.executePostRequest("/_mget?pretty", body, encodeBasicHeader(user, password));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         return MultiGetResponse.fromXContent(xcp);

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CCReplicationTest.java
@@ -68,6 +68,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Netty4Plugin;
 import org.opensearch.transport.TransportService;
 import org.opensearch.watcher.ResourceWatcherService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 // CS-ENFORCE-SINGLE
 
 public class CCReplicationTest extends AbstractDlsFlsTest {
@@ -200,18 +203,20 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
     public void testReplication() throws Exception {
         setup(Settings.EMPTY, new DynamicSecurityConfig().setSecurityRoles("roles_ccreplication.yml"), Settings.EMPTY);
 
-        Assert.assertEquals(
+        assertThat(
             clusterInfo.numNodes,
-            clusterHelper.nodeClient()
-                .admin()
-                .cluster()
-                .health(new ClusterHealthRequest().waitForGreenStatus())
-                .actionGet()
-                .getNumberOfNodes()
+            is(
+                clusterHelper.nodeClient()
+                    .admin()
+                    .cluster()
+                    .health(new ClusterHealthRequest().waitForGreenStatus())
+                    .actionGet()
+                    .getNumberOfNodes()
+            )
         );
-        Assert.assertEquals(
+        assertThat(
             ClusterHealthStatus.GREEN,
-            clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus()
+            is(clusterHelper.nodeClient().admin().cluster().health(new ClusterHealthRequest().waitForGreenStatus()).actionGet().getStatus())
         );
 
         final Settings tcSettings = AbstractSecurityUnitTest.nodeRolesSettings(Settings.builder(), false, false)
@@ -243,7 +248,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             Assert.assertTrue(
                 ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated")
             );
-            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
+            assertThat(RestStatus.FORBIDDEN, is(ex.status()));
         }
 
         try (
@@ -261,7 +266,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             Assert.assertTrue(
                 ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated")
             );
-            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
+            assertThat(RestStatus.FORBIDDEN, is(ex.status()));
         }
 
         try (
@@ -279,7 +284,7 @@ public class CCReplicationTest extends AbstractDlsFlsTest {
             Assert.assertTrue(
                 ex.getMessage().contains("Cross Cluster Replication is not supported when FLS or DLS or Fieldmasking is activated")
             );
-            Assert.assertEquals(ex.status(), RestStatus.FORBIDDEN);
+            assertThat(RestStatus.FORBIDDEN, is(ex.status()));
         }
 
         try (

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedComplexMappingTest.java
@@ -25,6 +25,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
 
     @Override
@@ -61,9 +64,9 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
 
         Assert.assertTrue(res.getBody().contains("win 8"));
@@ -84,19 +87,23 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("c1f04335d9f41"));
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc1", "password"))
-                    .getStatusCode()
+                is(
+                    rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc1", "password"))
+                        .getStatusCode()
+                )
             );
         }
 
         for (int i = 0; i < 10; i++) {
 
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc", "password")))
-                    .getStatusCode()
+                is(
+                    (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("user_masked_nowc", "password")))
+                        .getStatusCode()
+                )
             );
 
             Assert.assertFalse(res.getBody().contains("\"aaa"));
@@ -118,17 +125,17 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
             Assert.assertFalse(res.getBody().contains("osx"));
             Assert.assertFalse(res.getBody().contains("win 7"));
 
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin")).getStatusCode()
+                is(rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin")).getStatusCode())
             );
 
         }
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+                is((res = rh.executePostRequest("/logs/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
             );
             Assert.assertTrue(res.getBody().contains("win 8"));
             Assert.assertTrue(res.getBody().contains("win xp"));
@@ -157,9 +164,9 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertFalse(
             res.getBody()
@@ -187,10 +194,12 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
 
         for (int i = 0; i < 10; i++) {
 
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("user_masked_nowc", "password")))
-                    .getStatusCode()
+                is(
+                    (res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("user_masked_nowc", "password")))
+                        .getStatusCode()
+                )
             );
             Assert.assertTrue(
                 res.getBody()
@@ -217,9 +226,9 @@ public class CustomFieldMaskedComplexMappingTest extends AbstractDlsFlsTest {
             Assert.assertFalse(res.getBody().contains("\"timestamp\" : \"2018-07-22T20:45:16.163Z"));
         }
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logs/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertFalse(
             res.getBody()

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/CustomFieldMaskedTest.java
@@ -23,6 +23,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -64,9 +67,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
 
         String query;
         HttpResponse res;
-        // Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty&size=0", query,
+        // assertThat(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty&size=0", query,
         // encodeBasicHeader("admin", "admin"))).getStatusCode());
-        // Assert.assertTrue(res.getBody().contains("100.100"));
+        // Asseis(rt.assertTrue(res.getBody().contains("100.100"));)
 
         query = "{"
             + "\"query\" : {"
@@ -82,7 +85,7 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}"
             + "}";
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
         Assert.assertTrue(res.getBody().contains("XXX"));
@@ -105,7 +108,7 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
         Assert.assertTrue(res.getBody().contains("XXX"));
@@ -128,7 +131,7 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password"));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("***"));
         Assert.assertTrue(res.getBody().contains("XXX"));
@@ -146,9 +149,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("200.100"));
@@ -157,10 +160,12 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("***"));
         Assert.assertFalse(res.getBody().contains("XXX"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked_custom", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"doc_count\" : 31"));
         Assert.assertTrue(res.getBody().contains("\"doc_count\" : 1"));
@@ -170,9 +175,12 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("***.100.2.XXX"));
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+                is(
+                    (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin")))
+                        .getStatusCode()
+                )
             );
             Assert.assertTrue(res.getBody().contains("100.100"));
             Assert.assertTrue(res.getBody().contains("200.100"));
@@ -191,9 +199,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -210,10 +218,12 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("***"));
         Assert.assertFalse(res.getBody().contains("XXX"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked_custom", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked_custom", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -238,9 +248,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -256,9 +266,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("***"));
         Assert.assertFalse(res.getBody().contains("XXX"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked_custom", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked_custom", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertFalse(res.getBody().contains("cust1"));
@@ -283,9 +293,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -301,9 +311,9 @@ public class CustomFieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("***"));
         Assert.assertFalse(res.getBody().contains("XXX"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked_custom", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked_custom", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertFalse(res.getBody().contains("cust1"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DateMathTest.java
@@ -26,6 +26,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.support.SecurityUtils;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DateMathTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -62,9 +65,12 @@ public class DateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty", encodeBasicHeader("admin", "admin")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -73,12 +79,14 @@ public class DateMathTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty",
-                encodeBasicHeader("opendistro_security_logstash", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "%3Clogstash-%7Bnow%2Fd%7D%3E/_search?pretty",
+                    encodeBasicHeader("opendistro_security_logstash", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -95,21 +103,27 @@ public class DateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty",
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty",
-                encodeBasicHeader("opendistro_security_logstash", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "%3Clogstash-%7Bnow%2Fd%7D%3E/_field_caps?fields=*&pretty",
+                    encodeBasicHeader("opendistro_security_logstash", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
@@ -123,9 +137,9 @@ public class DateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -134,10 +148,12 @@ public class DateMathTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("logstash-*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -154,9 +170,12 @@ public class DateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -165,9 +184,12 @@ public class DateMathTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("logstash-1-*,logstash-20*/_search?pretty", encodeBasicHeader("regex", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DfmOverwritesAllTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DfmOverwritesAllTest.java
@@ -23,6 +23,9 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 /**
  * Tests that the dfm_empty_overwrites_all flag works correctly.
  * Per default, if a user has a role that adds restrictions to an index
@@ -94,7 +97,7 @@ public class DfmOverwritesAllTest extends AbstractDlsFlsTest {
         HttpResponse response;
 
         response = rh.executeGetRequest("/index1-*/_search?pretty", encodeBasicHeader("admin", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
 
         // the only document in index1-1 is filtered by DLS query, so normally no hit in index-1-1
         Assert.assertTrue(response.getBody().contains("index1-1"));
@@ -136,7 +139,7 @@ public class DfmOverwritesAllTest extends AbstractDlsFlsTest {
         HttpResponse response;
 
         response = rh.executeGetRequest("/index1-*/_search?pretty", encodeBasicHeader("dfm_restricted_role", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
 
         // the only document in index1-1 is filtered by DLS query, so no hit in index-1-1
         Assert.assertFalse(response.getBody().contains("index1-1"));
@@ -188,7 +191,7 @@ public class DfmOverwritesAllTest extends AbstractDlsFlsTest {
             "/index1-*/_search?pretty",
             encodeBasicHeader("dfm_restricted_and_unrestricted_all_indices_role", "password")
         );
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
 
         // the only document in index1-1 is filtered by DLS query, so normally no hit in index-1-1
         Assert.assertTrue(response.getBody().contains("index1-1"));
@@ -239,7 +242,7 @@ public class DfmOverwritesAllTest extends AbstractDlsFlsTest {
             "/index1-*/_search?pretty",
             encodeBasicHeader("dfm_restricted_and_unrestricted_one_index_role", "password")
         );
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
 
         // we have a role that places no restrictions on index-1-1, lifting the DLS from the restricted role
         Assert.assertTrue(response.getBody().contains("index1-1"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsDateMathTest.java
@@ -27,6 +27,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsDateMathTest extends AbstractDlsFlsTest {
 
     @Override
@@ -61,16 +64,16 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -82,16 +85,16 @@ public class DlsDateMathTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_BAD_REQUEST,
-            (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("date_math", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("'now' is not allowed in DLS queries"));
         Assert.assertTrue(res.getBody().contains("error"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsFlsCrossClusterSearchTest.java
@@ -29,6 +29,9 @@ import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
 
     private final ClusterHelper cl1 = new ClusterHelper(
@@ -151,7 +154,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
             encodeBasicHeader("human_resources_trainee", "password")
         );
         String body = ccs.getBody();
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(body.contains("crl1"));
         Assert.assertTrue(body.contains("crl2"));
         Assert.assertTrue(body.contains("\"value\" : 1,\n      \"relation"));
@@ -164,7 +167,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
         Assert.assertFalse(body.contains("secret1"));
         Assert.assertFalse(body.contains("AnotherSecredField"));
         Assert.assertFalse(body.contains("xxx1"));
-        Assert.assertEquals(ccs.getHeaders().toString(), 1, ccs.getHeaders().size());
+        assertThat(ccs.getHeaders().toString(), ccs.getHeaders().size(), is(1));
     }
 
     @Test
@@ -237,7 +240,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
             "cross_cluster_two:humanresources/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("human_resources_trainee", "password")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
         Assert.assertTrue(ccs.getBody().contains("\"value\" : 1,\n      \"relation"));
@@ -250,7 +253,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
         Assert.assertTrue(ccs.getBody().contains("__fn__crl2"));
         Assert.assertFalse(ccs.getBody().contains("secret1"));
         Assert.assertFalse(ccs.getBody().contains("AnotherSecredField"));
-        Assert.assertEquals(ccs.getHeaders().toString(), 1, ccs.getHeaders().size());
+        assertThat(ccs.getHeaders().toString(), ccs.getHeaders().size(), is(1));
     }
 
     @Test
@@ -365,7 +368,7 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
             "cross_cluster_two:humanresources,humanresources/_search?pretty&ccs_minimize_roundtrips=" + ccsMinimizeRoundtrips(),
             encodeBasicHeader("human_resources_trainee", "password")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, ccs.getStatusCode());
+        assertThat(ccs.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(ccs.getBody().contains("crl1"));
         Assert.assertTrue(ccs.getBody().contains("crl2"));
         Assert.assertTrue(ccs.getBody().contains("\"value\" : 2,\n      \"relation"));
@@ -380,6 +383,6 @@ public class DlsFlsCrossClusterSearchTest extends AbstractSecurityUnitTest {
         Assert.assertFalse(ccs.getBody().contains("secret1"));
         Assert.assertFalse(ccs.getBody().contains("AnotherSecredField"));
         Assert.assertTrue(ccs.getBody().contains("someoneelse"));
-        Assert.assertEquals(ccs.getHeaders().toString(), 1, ccs.getHeaders().size());
+        assertThat(ccs.getHeaders().toString(), ccs.getHeaders().size(), is(1));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsNestedTest.java
@@ -23,6 +23,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsNestedTest extends AbstractDlsFlsTest {
 
     @Override
@@ -84,16 +87,16 @@ public class DlsNestedTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"my_nested_object\" : {"));
         Assert.assertTrue(res.getBody().contains("\"field\" : \"my_nested_object\","));
         Assert.assertTrue(res.getBody().contains("\"offset\" : 0"));
 
-        // Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin",
+        // assertThat(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin",
         // "admin"))).getStatusCode());
         // Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n \"relation"));
         // Assert.assertTrue(res.getBody().contains("\"value\" : 1510.0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsPropsReplaceTest.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsPropsReplaceTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -62,23 +65,27 @@ public class DlsPropsReplaceTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 5,\n      \"relation"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/prop1,prop2/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/prop-mapped/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/prop-mapped/_search?pretty&size=100", encodeBasicHeader("prop_replace", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"amount\" : 6060"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsScrollTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsScrollTest.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsScrollTest extends AbstractDlsFlsTest {
 
     @Override
@@ -55,10 +58,12 @@ public class DlsScrollTest extends AbstractDlsFlsTest {
         setup();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?scroll=1m&pretty=true&size=5", encodeBasicHeader("dept_manager", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?scroll=1m&pretty=true&size=5", encodeBasicHeader("dept_manager", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 101,"));
 
@@ -67,13 +72,15 @@ public class DlsScrollTest extends AbstractDlsFlsTest {
         while (true) {
             int start = res.getBody().indexOf("_scroll_id") + 15;
             String scrollid = res.getBody().substring(start, res.getBody().indexOf("\"", start + 1));
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest(
-                    "/_search/scroll?pretty=true",
-                    "{\"scroll\" : \"1m\", \"scroll_id\" : \"" + scrollid + "\"}",
-                    encodeBasicHeader("dept_manager", "password")
-                )).getStatusCode()
+                is(
+                    (res = rh.executePostRequest(
+                        "/_search/scroll?pretty=true",
+                        "{\"scroll\" : \"1m\", \"scroll_id\" : \"" + scrollid + "\"}",
+                        encodeBasicHeader("dept_manager", "password")
+                    )).getStatusCode()
+                )
             );
             Assert.assertTrue(res.getBody().contains("\"value\" : 101,"));
             Assert.assertFalse(res.getBody().contains("\"amount\" : 3"));
@@ -86,6 +93,6 @@ public class DlsScrollTest extends AbstractDlsFlsTest {
             }
         }
 
-        Assert.assertEquals(21, c);
+        assertThat(c, is(21));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTermLookupQueryTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTermLookupQueryTest.java
@@ -50,6 +50,8 @@ import org.opensearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.dlic.dlsfls.DlsTermsLookupAsserts.assertAccessCodesMatch;
 
 public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
@@ -231,12 +233,12 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         );
 
         HttpResponse response = rh.executeGetRequest("/tlqdocuments/_search?pretty", encodeBasicHeader("tlq_1337", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
         // 10 docs, all need to have access code 1337
-        Assert.assertEquals(searchResponse.toString(), 10, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(10L));
         // fields need to have 1337 access code
         assertAccessCodesMatch(searchResponse.getHits().getHits(), new Integer[] { 1337 });
     }
@@ -252,13 +254,13 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         );
 
         HttpResponse response = rh.executeGetRequest("/tlqdocuments/_search?pretty", encodeBasicHeader("tlq_42", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
 
         // 10 docs, all need to have access code 42
-        Assert.assertEquals(searchResponse.toString(), 10, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(10L));
         // fields need to have 42 access code
         assertAccessCodesMatch(searchResponse.getHits().getHits(), new Integer[] { 42 });
 
@@ -275,13 +277,13 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         );
 
         HttpResponse response = rh.executeGetRequest("/tlqdocuments/_search?pretty", encodeBasicHeader("tlq_1337_42", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
 
         // 15 docs, all need to have either access code 1337 or 42
-        Assert.assertEquals(searchResponse.toString(), 15, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(15L));
         // fields need to have 42 or 1337 access code
         assertAccessCodesMatch(searchResponse.getHits().getHits(), new Integer[] { 42, 1337 });
 
@@ -298,12 +300,12 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         );
 
         HttpResponse response = rh.executeGetRequest("/tlqdocuments/_search?pretty", encodeBasicHeader("tlq_999", "password"));
-        Assert.assertEquals(200, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(200));
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
 
-        Assert.assertEquals(searchResponse.toString(), 0, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(0L));
     }
 
     @Test
@@ -316,7 +318,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
                 .setSecurityRolesMapping("roles_mapping_tlq.yml")
         );
         SearchResponse searchResponse = executeSearch("tlqdocuments", "tlq_empty_access_codes", "password");
-        Assert.assertEquals(searchResponse.toString(), 0, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(0L));
     }
 
     @Test
@@ -330,7 +332,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         );
         SearchResponse searchResponse = executeSearch("tlqdocuments", "tlq_no_codes", "password");
 
-        Assert.assertEquals(searchResponse.toString(), 0, searchResponse.getHits().getTotalHits().value);
+        assertThat(searchResponse.toString(), searchResponse.getHits().getTotalHits().value, is(0L));
     }
 
     @Test
@@ -354,7 +356,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdummy"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 5, tlqdummyHits.size());
+        assertThat(searchResponse.toString(), tlqdummyHits.size(), is(5));
 
         // check 10 hits with code 1337 from tlqdocuments index. All other documents
         // must be filtered
@@ -362,7 +364,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdocuments"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 10, tlqdocumentHits.size());
+        assertThat(searchResponse.toString(), tlqdocumentHits.size(), is(10));
         assertAccessCodesMatch(tlqdocumentHits, new Integer[] { 1337 });
 
         // check no access to user_access_codes index
@@ -370,7 +372,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("user_access_codes"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 0, userAccessCodesHits.size());
+        assertThat(searchResponse.toString(), userAccessCodesHits.size(), is(0));
     }
 
     @Test
@@ -395,7 +397,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdummy"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 5, tlqdummyHits.size());
+        assertThat(searchResponse.toString(), tlqdummyHits.size(), is(5));
 
         // check 10 hits with code 1337 from tlqdocuments index. All other documents
         // must be filtered
@@ -403,7 +405,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdocuments"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 10, tlqdocumentHits.size());
+        assertThat(searchResponse.toString(), tlqdocumentHits.size(), is(10));
         assertAccessCodesMatch(tlqdocumentHits, new Integer[] { 1337 });
 
         // check no access to user_access_codes index
@@ -411,7 +413,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("user_access_codes"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 0, userAccessCodesHits.size());
+        assertThat(searchResponse.toString(), userAccessCodesHits.size(), is(0));
     }
 
     @Test
@@ -436,7 +438,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdummy"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 5, tlqdummyHits.size());
+        assertThat(searchResponse.toString(), tlqdummyHits.size(), is(5));
 
         // check 10 hits with code 1337 from tlqdocuments index. All other documents
         // must be filtered
@@ -444,7 +446,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdocuments"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 10, tlqdocumentHits.size());
+        assertThat(searchResponse.toString(), tlqdocumentHits.size(), is(10));
         assertAccessCodesMatch(tlqdocumentHits, new Integer[] { 1337 });
 
         // check no access to user_access_codes index
@@ -452,7 +454,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("user_access_codes"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 0, userAccessCodesHits.size());
+        assertThat(searchResponse.toString(), userAccessCodesHits.size(), is(0));
 
     }
 
@@ -477,7 +479,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdummy"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 5, tlqdummyHits.size());
+        assertThat(searchResponse.toString(), tlqdummyHits.size(), is(5));
 
         // ccheck 10 hits with code 1337 from tlqdocuments index. All other documents
         // must be filtered
@@ -485,7 +487,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
             .stream()
             .filter((h) -> h.getIndex().equals("tlqdocuments"))
             .collect(Collectors.toSet());
-        Assert.assertEquals(searchResponse.toString(), 10, tlqdocumentHits.size());
+        assertThat(searchResponse.toString(), tlqdocumentHits.size(), is(10));
         assertAccessCodesMatch(tlqdocumentHits, new Integer[] { 1337 });
     }
 
@@ -513,12 +515,12 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
 
         // check all 5 tlqdummy entries present
         List<SearchHit> tlqdummyHits = Arrays.asList(responseItems[0].getResponse().getHits().getHits());
-        Assert.assertEquals(searchResponse.toString(), 5, tlqdummyHits.size());
+        assertThat(searchResponse.toString(), tlqdummyHits.size(), is(5));
 
         // check 10 hits with code 1337 from tlqdocuments index. All other documents
         // must be filtered
         List<SearchHit> tlqdocumentHits = Arrays.asList(responseItems[1].getResponse().getHits().getHits());
-        Assert.assertEquals(searchResponse.toString(), 10, tlqdocumentHits.size());
+        assertThat(searchResponse.toString(), tlqdocumentHits.size(), is(10));
         assertAccessCodesMatch(tlqdocumentHits, new Integer[] { 1337 });
 
         // check no access to user_access_codes index, just two indices in the response
@@ -647,7 +649,7 @@ public class DlsTermLookupQueryTest extends AbstractDlsFlsTest {
         // we expect a security exception here, user has no direct access to
         // user_access_codes index
         HttpResponse response = rh.executeGetRequest("/user_access_codes/_doc/tlq_1337", encodeBasicHeader("tlq_1337", "password"));
-        Assert.assertEquals(403, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(403));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/DlsTest.java
@@ -23,6 +23,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class DlsTest extends AbstractDlsFlsTest {
 
     @Override
@@ -66,17 +69,17 @@ public class DlsTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1500.0"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1510.0"));
@@ -103,31 +106,32 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
-        Assert.assertEquals(res.getHeaders().toString(), 1, res.getHeaders().size());
 
-        Assert.assertEquals(
+        assertThat(res.getHeaders().toString(), res.getHeaders().size(), is(1));
+
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -146,9 +150,9 @@ public class DlsTest extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -167,23 +171,26 @@ public class DlsTest extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -197,16 +204,16 @@ public class DlsTest extends AbstractDlsFlsTest {
         res = rh.executeGetRequest("/deals/_doc/1?pretty", encodeBasicHeader("dept_manager", "password"));
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 2,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 1,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -222,9 +229,9 @@ public class DlsTest extends AbstractDlsFlsTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_dls_query"));
         Assert.assertFalse(res.getBody().contains("_opendistro_security_fls_fields"));
@@ -244,9 +251,9 @@ public class DlsTest extends AbstractDlsFlsTest {
             + "]"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_dls_query"));
         Assert.assertFalse(res.getBody().contains("_opendistro_security_fls_fields"));
@@ -262,22 +269,22 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/terms/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/terms/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
-        Assert.assertEquals(res.getTextFromJsonBody("/hits/total/value"), "1");
-        Assert.assertEquals(res.getTextFromJsonBody("/_shards/failed"), "0");
+        assertThat("1", is(res.getTextFromJsonBody("/hits/total/value")));
+        assertThat("0", is(res.getTextFromJsonBody("/_shards/failed")));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/terms/_doc/0", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/terms/_doc/0", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
-        Assert.assertEquals(res.getTextFromJsonBody("/_source/foo"), "bar");
+        assertThat("bar", is(res.getTextFromJsonBody("/_source/foo")));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            rh.executeGetRequest("/terms/_doc/1", encodeBasicHeader("dept_manager", "password")).getStatusCode()
+            is(rh.executeGetRequest("/terms/_doc/1", encodeBasicHeader("dept_manager", "password")).getStatusCode())
         );
     }
 
@@ -302,9 +309,9 @@ public class DlsTest extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -317,16 +324,16 @@ public class DlsTest extends AbstractDlsFlsTest {
         setup();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -398,7 +405,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response1 = rh.executePostRequest("logs*/_search", query1, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response1.getStatusCode());
+        assertThat(response1.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         Assert.assertTrue(response1.getBody(), response1.getBody().contains("min_doc_count 0 is not supported when DLS is activated"));
 
         // Non-admin user without setting "min_doc_count". Expected to only have access to buckets for dept_manager excluding E with 0
@@ -429,7 +436,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response2 = rh.executePostRequest("logs*/_search", query2, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response2.getStatusCode());
+        assertThat(response2.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response2.getBody(), response2.getBody().contains("\"key\":\"A\""));
         Assert.assertFalse(response2.getBody(), response2.getBody().contains("\"key\":\"B\""));
         Assert.assertFalse(response2.getBody(), response2.getBody().contains("\"key\":\"C\""));
@@ -439,7 +446,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin with setting "min_doc_count":0. Expected to have access to all buckets".
         HttpResponse response3 = rh.executePostRequest("logs*/_search", query1, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response3.getStatusCode());
+        assertThat(response3.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response3.getBody(), response3.getBody().contains("\"key\":\"A\""));
         Assert.assertTrue(response3.getBody(), response3.getBody().contains("\"key\":\"B\""));
         Assert.assertTrue(response3.getBody(), response3.getBody().contains("\"key\":\"C\""));
@@ -449,7 +456,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin without setting "min_doc_count". Expected to have access to all buckets excluding E with 0 doc_count".
         HttpResponse response4 = rh.executePostRequest("logs*/_search", query2, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response4.getStatusCode());
+        assertThat(response4.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response4.getBody(), response4.getBody().contains("\"key\":\"A\""));
         Assert.assertTrue(response4.getBody(), response4.getBody().contains("\"key\":\"B\""));
         Assert.assertTrue(response4.getBody(), response4.getBody().contains("\"key\":\"C\""));
@@ -462,7 +469,7 @@ public class DlsTest extends AbstractDlsFlsTest {
             "{\"size\":100,\"aggregations\":{\"significant_termX\":{\"significant_terms\":{\"field\":\"termX.keyword\",\"min_doc_count\":0}}}}";
         HttpResponse response5 = rh.executePostRequest("logs*/_search", query3, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response5.getStatusCode());
+        assertThat(response5.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response5.getBody(), response5.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response5.getBody(), response5.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response5.getBody(), response5.getBody().contains("\"termX\":\"C\""));
@@ -474,7 +481,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response6 = rh.executePostRequest("logs*/_search", query4, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response6.getStatusCode());
+        assertThat(response6.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response6.getBody(), response6.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response6.getBody(), response6.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response6.getBody(), response6.getBody().contains("\"termX\":\"C\""));
@@ -484,7 +491,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin with setting "min_doc_count":0. Expected to have access to all buckets".
         HttpResponse response7 = rh.executePostRequest("logs*/_search", query3, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response7.getStatusCode());
+        assertThat(response7.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response7.getBody(), response7.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response7.getBody(), response7.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response7.getBody(), response7.getBody().contains("\"termX\":\"C\""));
@@ -494,7 +501,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin without setting "min_doc_count". Expected to have access to all buckets".
         HttpResponse response8 = rh.executePostRequest("logs*/_search", query4, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response8.getStatusCode());
+        assertThat(response8.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response8.getBody(), response8.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response8.getBody(), response8.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response8.getBody(), response8.getBody().contains("\"termX\":\"C\""));
@@ -507,7 +514,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response9 = rh.executePostRequest("logs*/_search", query5, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response9.getStatusCode());
+        assertThat(response9.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response9.getBody(), response9.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response9.getBody(), response9.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response9.getBody(), response9.getBody().contains("\"termX\":\"C\""));
@@ -519,7 +526,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response10 = rh.executePostRequest("logs*/_search", query6, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response10.getStatusCode());
+        assertThat(response10.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response10.getBody(), response10.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response10.getBody(), response10.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response10.getBody(), response10.getBody().contains("\"termX\":\"C\""));
@@ -529,7 +536,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin with setting "min_doc_count":0. Expected to have access to all buckets".
         HttpResponse response11 = rh.executePostRequest("logs*/_search", query5, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response11.getStatusCode());
+        assertThat(response11.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response11.getBody(), response11.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response11.getBody(), response11.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response11.getBody(), response11.getBody().contains("\"termX\":\"C\""));
@@ -539,7 +546,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin without setting "min_doc_count". Expected to have access to all buckets".
         HttpResponse response12 = rh.executePostRequest("logs*/_search", query6, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response12.getStatusCode());
+        assertThat(response12.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response12.getBody(), response12.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response12.getBody(), response12.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response12.getBody(), response12.getBody().contains("\"termX\":\"C\""));
@@ -553,7 +560,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response13 = rh.executePostRequest("logs*/_search", query7, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response13.getStatusCode());
+        assertThat(response13.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response13.getBody(), response13.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response13.getBody(), response13.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response13.getBody(), response13.getBody().contains("\"termX\":\"C\""));
@@ -566,7 +573,7 @@ public class DlsTest extends AbstractDlsFlsTest {
 
         HttpResponse response14 = rh.executePostRequest("logs*/_search", query8, encodeBasicHeader("dept_manager", "password"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response14.getStatusCode());
+        assertThat(response14.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response14.getBody(), response14.getBody().contains("\"termX\":\"A\""));
         Assert.assertFalse(response14.getBody(), response14.getBody().contains("\"termX\":\"B\""));
         Assert.assertFalse(response14.getBody(), response14.getBody().contains("\"termX\":\"C\""));
@@ -576,7 +583,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin with setting "min_doc_count":0. Expected to have access to all buckets".
         HttpResponse response15 = rh.executePostRequest("logs*/_search", query7, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response15.getStatusCode());
+        assertThat(response15.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response15.getBody(), response15.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response15.getBody(), response15.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response15.getBody(), response15.getBody().contains("\"termX\":\"C\""));
@@ -586,7 +593,7 @@ public class DlsTest extends AbstractDlsFlsTest {
         // Admin without setting "min_doc_count". Expected to have access to all buckets".
         HttpResponse response16 = rh.executePostRequest("logs*/_search", query8, encodeBasicHeader("admin", "admin"));
 
-        Assert.assertEquals(HttpStatus.SC_OK, response16.getStatusCode());
+        assertThat(response16.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response16.getBody(), response16.getBody().contains("\"termX\":\"A\""));
         Assert.assertTrue(response16.getBody(), response16.getBody().contains("\"termX\":\"B\""));
         Assert.assertTrue(response16.getBody(), response16.getBody().contains("\"termX\":\"C\""));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FieldMaskedTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FieldMaskedTest.java
@@ -24,6 +24,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FieldMaskedTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -74,14 +77,16 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
             + "}"
             + "}";
 
-        // Assert.assertEquals(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty&size=0", query,
+        // assertThat(HttpStatus.SC_OK, (res = rh.executePostRequest("/deals/_search?pretty&size=0", query,
         // encodeBasicHeader("admin", "admin"))).getStatusCode());
-        // Assert.assertTrue(res.getBody().contains("100.100"));
+        // Asseis(rt.assertTrue(res.getBody().contains("100.100"));)
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("100.100"));
 
@@ -102,10 +107,12 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
             + "}"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("100.100"));
 
@@ -126,10 +133,12 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
             + "}"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("100.100"));
     }
@@ -146,9 +155,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("100.100"));
         Assert.assertTrue(res.getBody().contains("200.100"));
@@ -158,10 +167,12 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("26a8671e57fefc13504f8c61ced67ac98338261ace1e5bf462038b2f2caae16e"));
         Assert.assertFalse(res.getBody().contains("87873bdb698e5f0f60e0b02b76dad1ec11b2787c628edbc95b7ff0e82274b140"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("user_masked", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"doc_count\" : 30"));
         Assert.assertTrue(res.getBody().contains("\"doc_count\" : 1"));
@@ -172,9 +183,12 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("87873bdb698e5f0f60e0b02b76dad1ec11b2787c628edbc95b7ff0e82274b140"));
 
         for (int i = 0; i < 10; i++) {
-            Assert.assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+                is(
+                    (res = rh.executePostRequest("/deals/_search?pretty&size=0", query, encodeBasicHeader("admin", "admin")))
+                        .getStatusCode()
+                )
             );
             Assert.assertTrue(res.getBody().contains("100.100"));
             Assert.assertTrue(res.getBody().contains("200.100"));
@@ -194,9 +208,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -206,9 +220,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("100.100.2.2"));
         Assert.assertFalse(res.getBody().contains("87873bdb698e5f0f60e0b02b76dad1ec11b2787c628edbc95b7ff0e82274b140"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -228,9 +242,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -241,9 +255,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("87873bdb698e5f0f60e0b02b76dad1ec11b2787c628edbc95b7ff0e82274b140"));
         Assert.assertFalse(res.getBody().contains(DigestUtils.sha512Hex("100.100.1.1")));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=100", encodeBasicHeader("user_masked", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 32,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -263,9 +277,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -274,9 +288,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("100.100.2.2"));
         Assert.assertFalse(res.getBody().contains("87873bdb698e5f0f60e0b02b76dad1ec11b2787c628edbc95b7ff0e82274b140"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -294,9 +308,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -307,9 +321,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains(DigestUtils.sha3_224Hex("100.100.1.1")));
         Assert.assertFalse(res.getBody().contains(DigestUtils.sha512Hex("100.100.1.1")));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode())
         );
 
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
@@ -330,9 +344,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -343,9 +357,9 @@ public class FieldMaskedTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains(DigestUtils.sha3_224Hex("100.100.1.1")));
         Assert.assertFalse(res.getBody().contains(DigestUtils.sha512Hex("100.100.1.1")));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("user_masked", "password"))).getStatusCode())
         );
 
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/Fls983Test.java
@@ -22,6 +22,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class Fls983Test extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -38,10 +41,12 @@ public class Fls983Test extends AbstractDlsFlsTest {
 
         String doc = "{\"doc\" : {" + "\"x\" : \"y\"" + "}}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/.kibana/_update/0?pretty", doc, encodeBasicHeader("human_resources_trainee", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/.kibana/_update/0?pretty", doc, encodeBasicHeader("human_resources_trainee", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("updated"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestAB.java
@@ -23,6 +23,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsDlsTestAB extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -75,9 +78,9 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -91,9 +94,9 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("f3_b"));
         Assert.assertFalse(res.getBody().contains("f1_b"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_aaa", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -107,9 +110,9 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("f3_b"));
         Assert.assertFalse(res.getBody().contains("f1_b"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/aaa,bbb/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -123,9 +126,9 @@ public class FlsDlsTestAB extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("f3_b"));
         Assert.assertTrue(res.getBody().contains("f1_b"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/abalias/_search?pretty", encodeBasicHeader("user_bbb", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestForbiddenField.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -56,18 +59,20 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 0"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1510.0"));
@@ -80,17 +85,19 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
         setup();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager_fls_dls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager_fls_dls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -109,10 +116,12 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -131,25 +140,29 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_fls_dls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager_fls_dls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager_fls_dls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 0,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -166,16 +179,16 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
         res = rh.executeGetRequest("/deals/_doc/1?pretty", encodeBasicHeader("dept_manager_fls_dls", "password"));
         Assert.assertTrue(res.getBody().contains("\"found\" : false"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 2,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager_fls_dls", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager_fls_dls", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 0,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -188,9 +201,9 @@ public class FlsDlsTestForbiddenField extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("user_combined", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("user_combined", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestMulti.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsDlsTestMulti.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsDlsTestMulti extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -66,18 +69,20 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 1710.0"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"value\" : 21711.0"));
@@ -91,25 +96,27 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("ctype"));
         Assert.assertFalse(res.getBody().contains("secret"));
         Assert.assertTrue(res.getBody().contains("zip"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 3,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=0", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -128,10 +135,12 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -150,25 +159,29 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
                 + "}"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?q=amount:10&pretty", encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -182,16 +195,16 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
         res = rh.executeGetRequest("/deals/_doc/1?pretty", encodeBasicHeader("dept_manager_multi", "password"));
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 4,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_count?pretty", encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"count\" : 3,"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -205,10 +218,12 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
         // "{\"index\":\".opendistro_security\", \"type\":\"_doc\", \"ignore_unavailable\": true}"+System.lineSeparator()+
         // "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"+System.lineSeparator();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody(), res.getBody().contains("\"value\" : 3,\n          \"relation"));
         Assert.assertFalse(res.getBody().contains("_opendistro_security_dls_query"));
@@ -240,9 +255,9 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
             + "]"
             + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_multi", "password"))).getStatusCode())
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_dls_query"));
         Assert.assertFalse(res.getBody().contains("_opendistro_security_fls_fields"));
@@ -281,16 +296,18 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
                 + "  }"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("thesuggestion"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("thesuggestion"));
     }
@@ -314,16 +331,18 @@ public class FlsDlsTestMulti extends AbstractDlsFlsTest {
                 + "  }"
                 + "}";
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("thesuggestion"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("dept_manager_multi", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("thesuggestion"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
@@ -22,6 +22,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -105,9 +108,9 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
             + "}";
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));
@@ -116,9 +119,9 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
 
         // only see's - timestamp and host field
         // therefore non-existing does not exist so we expect c-missing2-0 to be returned
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("fls_exists", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/data/_search?pretty", query, encodeBasicHeader("fls_exists", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("a-normal-0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsFieldsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsFieldsTest.java
@@ -25,6 +25,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsFieldsTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -56,18 +59,18 @@ public class FlsFieldsTest extends AbstractDlsFlsTest {
         String query = FileHelper.loadFile("dlsfls/flsquery.json");
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("secret"));
         Assert.assertTrue(res.getBody().contains("@timestamp"));
         Assert.assertTrue(res.getBody().contains("\"timestamp"));
         Assert.assertTrue(res.getBody().contains("numfield5"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields", "password"))).getStatusCode())
         );
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("secret"));
@@ -82,17 +85,20 @@ public class FlsFieldsTest extends AbstractDlsFlsTest {
         String query = FileHelper.loadFile("dlsfls/flsquery2.json");
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty=true", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty=true", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("secret"));
         Assert.assertTrue(res.getBody().contains("@timestamp"));
         Assert.assertTrue(res.getBody().contains("\"timestamp"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty=true", query, encodeBasicHeader("fls_fields", "password"))).getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty=true", query, encodeBasicHeader("fls_fields", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("secret"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsFieldsWcTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsFieldsWcTest.java
@@ -25,6 +25,9 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsFieldsWcTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -56,17 +59,20 @@ public class FlsFieldsWcTest extends AbstractDlsFlsTest {
         String query = FileHelper.loadFile("dlsfls/flsquery.json");
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("secret"));
         Assert.assertTrue(res.getBody().contains("@timestamp"));
         Assert.assertTrue(res.getBody().contains("\"timestamp"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields_wc", "password"))).getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields_wc", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("secret"));
@@ -81,17 +87,20 @@ public class FlsFieldsWcTest extends AbstractDlsFlsTest {
         String query = FileHelper.loadFile("dlsfls/flsquery2.json");
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("secret"));
         Assert.assertTrue(res.getBody().contains("@timestamp"));
         Assert.assertTrue(res.getBody().contains("\"timestamp"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields_wc", "password"))).getStatusCode()
+            is(
+                (res = rh.executePostRequest("/deals/_search?pretty", query, encodeBasicHeader("fls_fields_wc", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("secret"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsPerfTest.java
@@ -29,6 +29,9 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 @Ignore
 public class FlsPerfTest extends AbstractDlsFlsTest {
 
@@ -90,9 +93,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         StopWatch sw = new StopWatch("testFlsPerfNamed");
         sw.start("non fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()))
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -101,10 +104,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field997\""));
 
         sw.start("with fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
         Assert.assertFalse(res.getBody().contains("field1\""));
@@ -114,10 +119,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 2 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
 
@@ -128,10 +135,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 3 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_only", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
 
@@ -150,9 +159,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         StopWatch sw = new StopWatch("testFlsPerfWcEx");
         sw.start("non fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()))
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -161,9 +170,14 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field997\""));
 
         sw.start("with fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password"))).getStatusCode()
+            is(
+                is(
+                    (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password")))
+                        .getStatusCode()
+                )
+            )
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -173,9 +187,14 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 2 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password"))).getStatusCode()
+            is(
+                is(
+                    (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password")))
+                        .getStatusCode()
+                )
+            )
         );
         sw.stop();
 
@@ -186,9 +205,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 3 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_ex", "password"))).getStatusCode())
         );
         sw.stop();
 
@@ -207,9 +226,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         StopWatch sw = new StopWatch("testFlsPerfNamedEx");
         sw.start("non fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -218,9 +237,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field997\""));
 
         sw.start("with fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -230,9 +252,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 2 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
 
@@ -243,9 +268,12 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 3 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_named_ex", "password")))
+                    .getStatusCode()
+            )
         );
         sw.stop();
 
@@ -264,9 +292,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         StopWatch sw = new StopWatch("testFlsWcIn");
         sw.start("non fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         sw.stop();
         Assert.assertTrue(res.getBody().contains("field1\""));
@@ -275,9 +303,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("field997\""));
 
         sw.start("with fls");
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode())
         );
         sw.stop();
         Assert.assertFalse(res.getBody().contains("field0\""));
@@ -286,9 +314,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 2 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode())
         );
         sw.stop();
 
@@ -298,9 +326,9 @@ public class FlsPerfTest extends AbstractDlsFlsTest {
 
         sw.start("with fls 3 after warmup");
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty&size=1000", encodeBasicHeader("perf_wc_in", "password"))).getStatusCode())
         );
         sw.stop();
 

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsTest.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class FlsTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -47,9 +50,9 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertTrue(res.getBody().contains("customer.name"));
@@ -58,10 +61,12 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("amount"));
         Assert.assertTrue(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_field_caps?fields=*&pretty", encodeBasicHeader("dept_manager_fls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_field_caps?fields=*&pretty", encodeBasicHeader("dept_manager_fls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertTrue(res.getBody().contains("customer.name"));
@@ -70,12 +75,14 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("amount"));
         Assert.assertFalse(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "/deals/_field_caps?fields=*&pretty",
-                encodeBasicHeader("dept_manager_fls_reversed_fields", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "/deals/_field_caps?fields=*&pretty",
+                    encodeBasicHeader("dept_manager_fls_reversed_fields", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("customer.name"));
@@ -92,9 +99,9 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertTrue(res.getBody().contains("name"));
@@ -103,9 +110,9 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("amount"));
         Assert.assertTrue(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertTrue(res.getBody().contains("name"));
@@ -114,10 +121,12 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("amount"));
         Assert.assertFalse(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_mapping?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("customer"));
         Assert.assertFalse(res.getBody().contains("name"));
@@ -134,9 +143,9 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -147,9 +156,9 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("amount"));
         Assert.assertTrue(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -160,10 +169,12 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("amount"));
         Assert.assertFalse(res.getBody().contains("secret"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_search?pretty", encodeBasicHeader("dept_manager_fls_reversed_fields", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -182,9 +193,9 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -193,9 +204,9 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("ctype"));
         Assert.assertTrue(res.getBody().contains("amount"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/deals/_doc/0?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -204,10 +215,12 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("ctype"));
         Assert.assertFalse(res.getBody().contains("amount"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/deals/_doc/0?realtime=true&pretty", encodeBasicHeader("dept_manager_fls", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/deals/_doc/0?realtime=true&pretty", encodeBasicHeader("dept_manager_fls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertTrue(res.getBody().contains("cust1"));
@@ -216,12 +229,14 @@ public class FlsTest extends AbstractDlsFlsTest {
         Assert.assertFalse(res.getBody().contains("ctype"));
         Assert.assertFalse(res.getBody().contains("amount"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "/deals/_doc/0?realtime=true&pretty",
-                encodeBasicHeader("dept_manager_fls_reversed_fields", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "/deals/_doc/0?realtime=true&pretty",
+                    encodeBasicHeader("dept_manager_fls_reversed_fields", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));
         Assert.assertFalse(res.getBody().contains("cust1"));
@@ -239,21 +254,28 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("/deals/_update/0?pretty", "{\"doc\": {\"zip\": \"98765\"}}", encodeBasicHeader("admin", "admin")))
-                .getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/deals/_update/0?pretty",
+                    "{\"doc\": {\"zip\": \"98765\"}}",
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"_version\" : 2"));
         Assert.assertFalse(res.getBody(), res.getBody().contains("\"successful\" : 0"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            (res = rh.executePostRequest(
-                "/deals/_update/0?pretty",
-                "{\"doc\": {\"zip\": \"98765000\"}}",
-                encodeBasicHeader("dept_manager_fls", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/deals/_update/0?pretty",
+                    "{\"doc\": {\"zip\": \"98765000\"}}",
+                    encodeBasicHeader("dept_manager_fls", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("Update is not supported"));
     }
@@ -265,13 +287,15 @@ public class FlsTest extends AbstractDlsFlsTest {
 
         HttpResponse res = null;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_INTERNAL_SERVER_ERROR,
-            (res = rh.executePostRequest(
-                "/deals/_update/0?pretty",
-                "{\"doc\": {\"zip\": \"98765000\"}}",
-                encodeBasicHeader("dept_manager_fls", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "/deals/_update/0?pretty",
+                    "{\"doc\": {\"zip\": \"98765000\"}}",
+                    encodeBasicHeader("dept_manager_fls", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("Update is not supported"));
     }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/IndexPatternTest.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class IndexPatternTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -50,9 +53,9 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -61,10 +64,12 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/logstash-2016/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 1,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -81,20 +86,25 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-2016/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/logstash-2016/_field_caps?fields=*&pretty", encodeBasicHeader("admin", "admin")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("ipaddr"));
         Assert.assertTrue(res.getBody().contains("message"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                "/logstash-2016/_field_caps?fields=*&pretty",
-                encodeBasicHeader("opendistro_security_logstash", "password")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    "/logstash-2016/_field_caps?fields=*&pretty",
+                    encodeBasicHeader("opendistro_security_logstash", "password")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("ipaddr"));
         Assert.assertFalse(res.getBody().contains("message"));
@@ -108,9 +118,9 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -119,10 +129,12 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
-                .getStatusCode()
+            is(
+                (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("opendistro_security_logstash", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -139,9 +151,9 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
 
         HttpResponse res;
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("admin", "admin"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 4,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -150,9 +162,9 @@ public class IndexPatternTest extends AbstractDlsFlsTest {
         Assert.assertTrue(res.getBody().contains("mymsg"));
         Assert.assertTrue(res.getBody().contains("msgid"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode()
+            is((res = rh.executeGetRequest("/logstash-20*/_search?pretty", encodeBasicHeader("regex", "password"))).getStatusCode())
         );
         Assert.assertTrue(res.getBody().contains("\"value\" : 2,\n      \"relation"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/MFlsTest.java
@@ -21,6 +21,9 @@ import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class MFlsTest extends AbstractDlsFlsTest {
 
     protected void populateData(Client tc) {
@@ -51,9 +54,12 @@ public class MFlsTest extends AbstractDlsFlsTest {
         HttpResponse res;
 
         // normal search
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("deals,finance/_search?pretty", encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest("deals,finance/_search?pretty", encodeBasicHeader("dept_manager_fls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -76,9 +82,12 @@ public class MFlsTest extends AbstractDlsFlsTest {
             + System.lineSeparator();
 
         // msearch
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is(
+                (res = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("dept_manager_fls", "password")))
+                    .getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"failed\" : 0"));
@@ -103,9 +112,9 @@ public class MFlsTest extends AbstractDlsFlsTest {
             + "}";
 
         // mget
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode()
+            is((res = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("dept_manager_fls", "password"))).getStatusCode())
         );
         Assert.assertFalse(res.getBody().contains("_opendistro_security_"));
         Assert.assertTrue(res.getBody().contains("\"found\" : true"));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
@@ -37,7 +37,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -112,13 +113,13 @@ public abstract class AbstractApiActionValidationTest {
         }.createEndpointValidator();
 
         var result = defaultPessimisticValidator.onConfigChange(SecurityConfiguration.of(null, configuration));
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
 
         result = defaultPessimisticValidator.onConfigDelete(SecurityConfiguration.of(null, configuration));
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
 
         result = defaultPessimisticValidator.onConfigLoad(SecurityConfiguration.of(null, configuration));
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
 
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -32,6 +32,8 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
 
 public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
@@ -115,7 +117,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         boolean sendAdminCertificate = rh.sendAdminCertificate;
         rh.sendAdminCertificate = true;
         HttpResponse response = rh.executeDeleteRequest("/_opendistro/_security/api/internalusers/" + username, new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
@@ -131,7 +133,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
             "{\"password\": \"" + password + "\"}",
             new Header[0]
         );
-        Assert.assertEquals(status, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
         if (Objects.nonNull(message)) {
             Assert.assertTrue(response.getBody().contains(message));
@@ -150,7 +152,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         }
         payload += "]}";
         HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, payload, new Header[0]);
-        Assert.assertEquals(response.getBody(), status, response.getStatusCode());
+        assertThat(response.getBody(), response.getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
@@ -166,7 +168,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         }
         payload += "]}";
         HttpResponse response = rh.executePutRequest("/_opendistro/_security/api/internalusers/" + username, payload, new Header[0]);
-        Assert.assertEquals(status, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
@@ -182,7 +184,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
             "{\"hash\": \"" + hash + "\"}",
             new Header[0]
         );
-        Assert.assertEquals(status, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
@@ -194,14 +196,14 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
             "{\"hash\": \"" + hash + "\", \"password\": \"" + password + "\"}",
             new Header[0]
         );
-        Assert.assertEquals(status, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
     protected void checkGeneralAccess(int status, String username, String password) throws Exception {
         boolean sendAdminCertificate = rh.sendAdminCertificate;
         rh.sendAdminCertificate = false;
-        Assert.assertEquals(status, rh.executeGetRequest("", encodeBasicHeader(username, password)).getStatusCode());
+        assertThat(rh.executeGetRequest("", encodeBasicHeader(username, password)).getStatusCode(), is(status));
         rh.sendAdminCertificate = sendAdminCertificate;
     }
 
@@ -211,7 +213,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         String action = indexName + "/" + actionType + "/" + id;
         HttpResponse response = rh.executeGetRequest(action, encodeBasicHeader(username, password));
         int returnedStatus = response.getStatusCode();
-        Assert.assertEquals(status, returnedStatus);
+        assertThat(returnedStatus, is(status));
         return response.getBody();
 
     }
@@ -223,7 +225,7 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         String payload = "{\"value\" : \"true\"}";
         HttpResponse response = rh.executePutRequest(action, payload, encodeBasicHeader(username, password));
         int returnedStatus = response.getStatusCode();
-        Assert.assertEquals(status, returnedStatus);
+        assertThat(response.getBody(), returnedStatus, is(status));
         return response.getBody();
     }
 
@@ -237,15 +239,12 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
     }
 
     protected void assertHealthy() throws Exception {
-        Assert.assertEquals(HttpStatus.SC_OK, rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode());
-        Assert.assertEquals(
+        assertThat(rh.executeGetRequest("_opendistro/_security/health?pretty").getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             HttpStatus.SC_OK,
-            rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("admin", "admin")).getStatusCode()
+            is(rh.executeGetRequest("_opendistro/_security/authinfo?pretty", encodeBasicHeader("admin", "admin")).getStatusCode())
         );
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("admin", "admin")).getStatusCode()
-        );
+        assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("admin", "admin")).getStatusCode()));
     }
 
     String createRestAdminPermissionsPayload(String... additionPerms) throws JsonProcessingException {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiActionValidationTest.java
@@ -18,7 +18,8 @@ import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,7 +46,7 @@ public class ActionGroupsApiActionValidationTest extends AbstractApiActionValida
             SecurityConfiguration.of("ag", configuration)
         );
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -62,7 +63,7 @@ public class ActionGroupsApiActionValidationTest extends AbstractApiActionValida
             SecurityConfiguration.of("ag", configuration)
         );
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -78,8 +79,8 @@ public class ActionGroupsApiActionValidationTest extends AbstractApiActionValida
 
         final var result = actionGroupsApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of(ag,"kibana_read_only", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
-        assertEquals("kibana_read_only is an existing role. A action group cannot be named with an existing role name.", xContentToJsonNode(result.errorMessage()).get("message").asText());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(xContentToJsonNode(result.errorMessage()).get("message").asText(), is("kibana_read_only is an existing role. A action group cannot be named with an existing role name."));
     }
 
     @Test
@@ -96,8 +97,8 @@ public class ActionGroupsApiActionValidationTest extends AbstractApiActionValida
         final var result = actionGroupsApiActionEndpointValidator
                 .onConfigChange(SecurityConfiguration.of(ag,"ag", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
-        assertEquals("ag cannot be an allowed_action of itself", xContentToJsonNode(result.errorMessage()).get("message").asText());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(xContentToJsonNode(result.errorMessage()).get("message").asText(), is("ag cannot be an allowed_action of itself"));
     }
 
     @Test
@@ -114,8 +115,8 @@ public class ActionGroupsApiActionValidationTest extends AbstractApiActionValida
         final var result = actionGroupsApiActionEndpointValidator
                 .onConfigChange(SecurityConfiguration.of(ag,"ag", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
-        assertEquals("Invalid action group type: some_type_we_know_nothing_about. Supported types are: cluster, index.", xContentToJsonNode(result.errorMessage()).get("message").asText());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
+        assertThat(xContentToJsonNode(result.errorMessage()).get("message").asText(), is("Invalid action group type: some_type_we_know_nothing_about. Supported types are: cluster, index."));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
@@ -34,8 +34,8 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -70,9 +70,9 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
         assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
             // Note: the response has no whitespaces, so the .json file does not have whitespaces
-            Assert.assertEquals(
+            assertThat(
                 FileHelper.loadFile("restapi/whitelist_response_success.json"),
-                FileHelper.loadFile("restapi/whitelist_response_success.json")
+                is(FileHelper.loadFile("restapi/whitelist_response_success.json"))
             );
         }
         // FORBIDDEN FOR NON SUPER ADMIN
@@ -97,7 +97,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
 
         rh.sendAdminCertificate = true;
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(response.getHeaders().contains("_meta"));
     }
 
@@ -111,7 +111,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
             ENDPOINT,
             "{ \"unknownkey\": true, \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"GET\"] }}"
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         assertTrue(response.getBody().contains("invalid_keys"));
         assertHealthy();
     }
@@ -125,7 +125,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
             ENDPOINT,
             "{ \"invalid\"::{{ [\"*\"], \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"GET\"] }}"
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         assertHealthy();
     }
 
@@ -140,9 +140,9 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
 
         rh.sendAdminCertificate = true;
         response = rh.executePutRequest(ENDPOINT, "", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         JsonNode settings = DefaultObjectMapper.readTree(response.getBody());
-        Assert.assertEquals(RequestContentValidator.ValidationError.PAYLOAD_MANDATORY.message(), settings.get("reason").asText());
+        assertThat(settings.get("reason").asText(), is(RequestContentValidator.ValidationError.PAYLOAD_MANDATORY.message()));
     }
 
     /**
@@ -257,11 +257,11 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config\", \"value\": {\"enabled\": true, \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"PUT\"] }}}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
-        assertEquals(
+        assertThat(
             response.getBody(),
-            "{\"config\":{\"enabled\":true,\"requests\":{\"/_cat/nodes\":[\"GET\"],\"/_cat/indices\":[\"PUT\"]}}}"
+            is("{\"config\":{\"enabled\":true,\"requests\":{\"/_cat/nodes\":[\"GET\"],\"/_cat/indices\":[\"PUT\"]}}}")
         );
 
         // PATCH just requests
@@ -270,7 +270,7 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config/requests\", \"value\": {\"/_cat/nodes\": [\"GET\"]}}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
         assertTrue(response.getBody().contains("\"requests\":{\"/_cat/nodes\":[\"GET\"]}"));
 
@@ -280,19 +280,19 @@ public class AllowlistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config/enabled\", \"value\": false}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":false"));
 
         // PATCH just enabled using "add" operation when it is currently false - works correctly
         response = rh.executePatchRequest(ENDPOINT, "[{ \"op\": \"add\", \"path\": \"/config/enabled\", \"value\": true}]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":true"));
 
         // PATCH just enabled using "add" operation when it is currently true - works correctly
         response = rh.executePatchRequest(ENDPOINT, "[{ \"op\": \"add\", \"path\": \"/config/enabled\", \"value\": false}]", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
         response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":false"));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
@@ -28,7 +28,8 @@ import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.util.FakeRestRequest;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 
 public class AuditApiActionRequestContentValidatorTest extends AbstractApiActionValidationTest {
@@ -53,7 +54,7 @@ public class AuditApiActionRequestContentValidatorTest extends AbstractApiAction
         final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
         var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
         assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
     }
 
     @Test
@@ -76,6 +77,6 @@ public class AuditApiActionRequestContentValidatorTest extends AbstractApiAction
         final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
         var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
         assertFalse(result.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, result.status());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
@@ -13,10 +13,8 @@ package org.opensearch.security.dlic.rest.api;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
@@ -41,10 +39,12 @@ import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.DefaultObjectMapper.readTree;
 import static org.opensearch.security.DefaultObjectMapper.writeValueAsString;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class AuditApiActionTest extends AbstractRestApiUnitTest {
@@ -87,19 +87,19 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
 
         // should have /config for put request
         response = rh.executePutRequest(ENDPOINT, "{\"xxx\": 1}");
-        assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_METHOD_NOT_ALLOWED));
 
         // no post supported
         response = rh.executePostRequest(ENDPOINT, "{\"xxx\": 1}");
-        assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_METHOD_NOT_ALLOWED));
 
         // should have /config for patch request
         response = rh.executePatchRequest(ENDPOINT, "{\"xxx\": 1}");
-        assertEquals(response.getBody(), HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getBody(), response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
         // no delete supported
         response = rh.executeDeleteRequest(ENDPOINT);
-        assertEquals(HttpStatus.SC_METHOD_NOT_ALLOWED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_METHOD_NOT_ALLOWED));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         List<String> actual = Streams.stream(readTree(response.getBody()).at("/config/audit/disabled_rest_categories").iterator())
             .map(JsonNode::textValue)
             .collect(Collectors.toList());
-        assertEquals(testCategories, actual);
+        assertThat(actual, is(testCategories));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         );
         ObjectNode json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
         RestHelper.HttpResponse response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
         // test success for REST disabled categories
         auditConfig = new AuditConfig(
@@ -157,7 +157,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         );
         json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // test bad request for transport disabled categories
         auditConfig = new AuditConfig(
@@ -169,7 +169,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         );
         json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
         // test success for transport disabled categories
         auditConfig = new AuditConfig(
@@ -193,7 +193,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         );
         json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
@@ -211,11 +211,11 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
 
         // test get
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         List<String> actual = Streams.stream(readTree(response.getBody()).get("_readonly").iterator())
             .map(JsonNode::textValue)
             .collect(Collectors.toList());
-        assertEquals(readonlyFields, actual);
+        assertThat(actual, is(readonlyFields));
 
         // test config
         final AuditConfig auditConfig = AuditConfig.from(Settings.EMPTY);
@@ -261,7 +261,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         throws Exception {
         rh.sendAdminCertificate = sendAdminCertificate;
         RestHelper.HttpResponse response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false), header);
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
     }
 
     private void testReadonlyBoolean(final ObjectNode json, final String config, final String resource) throws Exception {
@@ -345,7 +345,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + resourcePath + "\",\"value\": " + writeValueAsString(testMap, false) + "}]",
             adminCredsHeader
         );
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         assertTrue(response.getBody().contains("No updates required"));
     }
 
@@ -397,12 +397,12 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             ENDPOINT,
             "[{\"op\": \"add\",\"path\": \"" + "/config/audit/disabled_rest_categories" + "\",\"value\": " + jsonValue + "}]"
         );
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         response = rh.executePatchRequest(
             ENDPOINT,
             "[{\"op\": \"add\",\"path\": \"" + "/config/audit/disabled_transport_categories" + "\",\"value\": " + jsonValue + "}]"
         );
-        assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
     }
 
     @Test
@@ -438,17 +438,17 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
 
     private void testPutAction(final String payload, final int expectedStatus, final Header... headers) throws Exception {
         RestHelper.HttpResponse response = rh.executePutRequest(CONFIG_ENDPOINT, payload, headers);
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
 
         if (expectedStatus == HttpStatus.SC_OK) {
             response = rh.executeGetRequest(ENDPOINT, headers);
-            assertEquals(readTree(payload), readTree(response.getBody()).get("config"));
+            assertThat(readTree(response.getBody()).get("config"), is(readTree(payload)));
         }
     }
 
     private void testGetAction(final int expectedStatus, final Header... headers) throws Exception {
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT, headers);
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
             JsonNode jsonNode = readTree(response.getBody());
 
@@ -518,9 +518,9 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": " + value + "}]",
             headers
         );
-        assertEquals(expected, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expected));
         if (expected == HttpStatus.SC_OK) {
-            assertEquals(value, readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).asBoolean());
+            assertThat(readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).asBoolean(), is(value));
         }
     }
 
@@ -545,9 +545,9 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": []}]",
             headers
         );
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
-            assertEquals(0, readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size());
+            assertThat(readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size(), is(0));
         }
 
         // add value
@@ -556,7 +556,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": " + jsonValue + "}]",
             headers
         );
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
             final JsonNode responseJson = readTree(rh.executeGetRequest(ENDPOINT, headers).getBody());
             final List<String> actualList = DefaultObjectMapper.readValue(
@@ -564,15 +564,15 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
                 new TypeReference<List<String>>() {
                 }
             );
-            assertEquals(expectedList.size(), actualList.size());
+            assertThat(actualList.size(), is(expectedList.size()));
             assertTrue(actualList.containsAll(expectedList));
         }
 
         // check null
         response = rh.executePatchRequest(ENDPOINT, "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": []}]", headers);
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
-            assertEquals(0, readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size());
+            assertThat(readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size(), is(0));
         }
     }
 
@@ -590,11 +590,9 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": {}}]",
             headers
         );
-        Set<Integer> expectedSet = new HashSet<>(List.of(expectedStatus));
-        expectedSet.add(HttpStatus.SC_BAD_REQUEST);
-        assertTrue(expectedSet.contains(response.getStatusCode()));
+        assertThat(response.getStatusCode(), anyOf(is(expectedStatus), is(HttpStatus.SC_BAD_REQUEST)));
         if (expectedStatus == HttpStatus.SC_OK) {
-            assertEquals(0, readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size());
+            assertThat(readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size(), is(0));
         }
 
         // add value
@@ -603,7 +601,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": " + jsonValue + "}]",
             headers
         );
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
             final JsonNode responseJson = readTree(rh.executeGetRequest(ENDPOINT, headers).getBody());
             final Map<String, List<String>> actualMap = DefaultObjectMapper.readValue(
@@ -611,14 +609,14 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
                 new TypeReference<Map<String, List<String>>>() {
                 }
             );
-            assertEquals(actualMap, expectedMap);
+            assertThat(expectedMap, is(actualMap));
         }
 
         // check null
         response = rh.executePatchRequest(ENDPOINT, "[{\"op\": \"add\",\"path\": \"" + patchResource + "\",\"value\": null}]", headers);
-        assertEquals(expectedStatus, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
-            assertEquals(0, readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size());
+            assertThat(readTree(rh.executeGetRequest(ENDPOINT, headers).getBody()).at(patchResource).size(), is(0));
         }
     }
 
@@ -665,26 +663,26 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
 
         // update config
         RestHelper.HttpResponse response = rh.executePutRequest(CONFIG_ENDPOINT, payload);
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // make patch request
         response = rh.executePatchRequest(ENDPOINT, "[{\"op\": \"add\",\"path\": \"" + "/config/enabled" + "\",\"value\": " + false + "}]");
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePatchRequest(ENDPOINT, "[{\"op\": \"add\",\"path\": \"" + "/config/enabled" + "\",\"value\": " + true + "}]");
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePatchRequest(ENDPOINT, "[{\"op\": \"add\",\"path\": \"" + "/config/enabled" + "\",\"value\": " + true + "}]");
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         assertTrue(response.getBody().contains("No updates required"));
 
         // get config
         response = rh.executeGetRequest(ENDPOINT);
-        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         final JsonNode configNode = readTree(response.getBody()).get("config");
 
         // verify configs are same
-        assertEquals(readTree(payload), configNode);
+        assertThat(configNode, is(readTree(payload)));
     }
 
     private String getTestPayload() {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
@@ -22,7 +22,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.util.FakeRestRequest;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -37,7 +38,7 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
         for (final var m : RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS) {
             final var result = auditApiAction.withEnabledAuditApi(FakeRestRequest.builder().withMethod(m).build());
             assertFalse(result.isValid());
-            assertEquals(RestStatus.NOT_IMPLEMENTED, result.status());
+            assertThat(result.status(), is(RestStatus.NOT_IMPLEMENTED));
         }
     }
 
@@ -84,6 +85,6 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
             SecurityConfiguration.of(objectMapper.valueToTree(AuditConfig.from(Settings.EMPTY)), "config", dynamicConfiguration)
         );
         assertFalse(result.isValid());
-        assertEquals(RestStatus.CONFLICT, result.status());
+        assertThat(result.status(), is(RestStatus.CONFLICT));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -21,6 +21,8 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
@@ -47,38 +49,38 @@ public class GetConfigurationApiTest extends AbstractRestApiUnitTest {
         // test that every config is accessible
         // config
         response = rh.executeGetRequest(ENDPOINT + "/securityconfig");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.getAsBoolean("config.dynamic.authc.authentication_domain_basic_internal.http_enabled", false), true);
+        assertThat(true, is(settings.getAsBoolean("config.dynamic.authc.authentication_domain_basic_internal.http_enabled", false)));
         Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 
         // internalusers
         response = rh.executeGetRequest(ENDPOINT + "/internalusers");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.get("admin.hash"));
-        Assert.assertEquals("", settings.get("other.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
+        assertThat(settings.get("other.hash"), is(""));
         Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 
         // roles
         response = rh.executeGetRequest(ENDPOINT + "/roles");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         JsonNode jnode = DefaultObjectMapper.readTree(response.getBody());
-        Assert.assertEquals(jnode.get("opendistro_security_all_access").get("cluster_permissions").get(0).asText(), "cluster:*");
+        assertThat("cluster:*", is(jnode.get("opendistro_security_all_access").get("cluster_permissions").get(0).asText()));
         Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 
         // roles
         response = rh.executeGetRequest(ENDPOINT + "/rolesmapping");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.getAsList("opendistro_security_role_starfleet.backend_roles").get(0), "starfleet");
+        assertThat("starfleet", is(settings.getAsList("opendistro_security_role_starfleet.backend_roles").get(0)));
         Assert.assertNull(settings.get("_opendistro_security_meta.type"));
 
         // action groups
         response = rh.executeGetRequest(ENDPOINT + "/actiongroups");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(settings.getAsList("ALL.allowed_actions").get(0), "indices:*");
+        assertThat("indices:*", is(settings.getAsList("ALL.allowed_actions").get(0)));
         Assert.assertTrue(settings.hasValue("INTERNAL.allowed_actions"));
         Assert.assertNull(settings.get("_opendistro_security_meta.type"));
     }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/IndexMissingTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.dlic.rest.api;
 
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.security.DefaultObjectMapper;
@@ -21,6 +20,8 @@ import org.opensearch.security.support.SecurityJsonNode;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class IndexMissingTest extends AbstractRestApiUnitTest {
@@ -52,33 +53,33 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
 
         // GET configuration
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/roles");
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         String errorString = response.getBody();
-        Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
+        assertThat(errorString, is("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}"));
 
         // GET roles
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         errorString = response.getBody();
-        Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
+        assertThat(errorString, is("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}"));
 
         // GET rolesmapping
         response = rh.executeGetRequest(ENDPOINT + "/rolesmapping/opendistro_security_role_starfleet", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         errorString = response.getBody();
-        Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
+        assertThat(errorString, is("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}"));
 
         // GET actiongroups
         response = rh.executeGetRequest(ENDPOINT + "/actiongroups/READ");
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         errorString = response.getBody();
-        Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
+        assertThat(errorString, is("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}"));
 
         // GET internalusers
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/picard");
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
         errorString = response.getBody();
-        Assert.assertEquals("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}", errorString);
+        assertThat(errorString, is("{\"status\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Security index not initialized\"}"));
 
         // PUT request
         response = rh.executePutRequest(
@@ -86,22 +87,22 @@ public class IndexMissingTest extends AbstractRestApiUnitTest {
             FileHelper.loadFile("restapi/actiongroup_read.json"),
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
         // DELETE request
         response = rh.executeDeleteRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_INTERNAL_SERVER_ERROR));
 
         // setup index now
         initialize(this.clusterHelper, this.clusterInfo);
 
         // GET configuration
         response = rh.executeGetRequest(ENDPOINT + "/roles");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         SecurityJsonNode securityJsonNode = new SecurityJsonNode(DefaultObjectMapper.readTree(response.getBody()));
-        Assert.assertEquals(
+        assertThat(
             "OPENDISTRO_SECURITY_CLUSTER_ALL",
-            securityJsonNode.get("opendistro_security_admin").get("cluster_permissions").get(0).asString()
+            is(securityJsonNode.get("opendistro_security_admin").get("cluster_permissions").get(0).asString())
         );
 
     }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -95,7 +95,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
             configuration
         );
         final var result = internalUsersApiActionEndpointValidator.onConfigChange(securityConfiguration);
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
         assertFalse(securityConfiguration.requestContent().has("password"));
         assertTrue(securityConfiguration.requestContent().has("hash"));
         assertTrue(passwordHasher.check("aaaaaa".toCharArray(), securityConfiguration.requestContent().get("hash").asText()));
@@ -112,7 +112,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
                 .build()
         );
         assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_IMPLEMENTED, result.status());
+        assertThat(result.status(), is(RestStatus.NOT_IMPLEMENTED));
 
         result = internalUsersApiAction.withAuthTokenPath(
             FakeRestRequest.builder()
@@ -122,7 +122,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
                 .build()
         );
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
             SecurityConfiguration.of(objectMapper.createObjectNode(), "aaaa", configuration)
         );
         assertFalse(result.isValid());
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, result.status());
+        assertThat(result.status(), is(RestStatus.INTERNAL_SERVER_ERROR));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiActionValidationTest.java
@@ -15,7 +15,8 @@ import org.junit.Test;
 
 import org.opensearch.core.rest.RestStatus;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 
 public class NodesDnApiActionValidationTest extends AbstractApiActionValidationTest {
@@ -31,7 +32,7 @@ public class NodesDnApiActionValidationTest extends AbstractApiActionValidationT
         );
 
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
     }
 
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -36,6 +35,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 
@@ -123,8 +123,8 @@ public class NodesDnApiTest extends AbstractRestApiUnitTest {
         String body = FileHelper.loadFile("restapi/nodesdn_null_array_element.json");
         HttpResponse response = rh.executePutRequest(ENDPOINT + "/nodesdn/cluster1", body, headers);
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
-        Assert.assertEquals(RequestContentValidator.ValidationError.NULL_ARRAY_ELEMENT.message(), settings.get("reason"));
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
+        assertThat(settings.get("reason"), is(RequestContentValidator.ValidationError.NULL_ARRAY_ELEMENT.message()));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RequestHandlersBuilderTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RequestHandlersBuilderTest.java
@@ -31,7 +31,8 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.reset;
@@ -73,9 +74,9 @@ public class RequestHandlersBuilderTest {
             final var responseBytes = responseArgumentCaptor.getValue();
             final var json = DefaultObjectMapper.readTree(responseBytes.content().utf8ToString());
             if (method == RestRequest.Method.POST) {
-                assertEquals(RestStatus.NOT_IMPLEMENTED.name(), json.get("status").asText());
+                assertThat(json.get("status").asText(), is(RestStatus.NOT_IMPLEMENTED.name()));
             } else {
-                assertEquals(RestStatus.FORBIDDEN.name(), json.get("status").asText());
+                assertThat(json.get("status").asText(), is(RestStatus.FORBIDDEN.name()));
             }
             reset(channel);
         }
@@ -116,12 +117,12 @@ public class RequestHandlersBuilderTest {
             .withSaveOrUpdateConfigurationHandler((client, configuration, indexResponseOnSucessActionListener) -> {})
             .build();
 
-        assertEquals(
+        assertThat(
             RequestHandler.RequestHandlersBuilder.SUPPORTED_METHODS.stream().sorted().collect(Collectors.toList()),
-            requestHandlers.keySet().stream().sorted().collect(Collectors.toList())
+            is(requestHandlers.keySet().stream().sorted().collect(Collectors.toList()))
         );
         requestHandlers.forEach(
-            ((method, requestOperationHandler) -> assertEquals(RequestHandler.methodNotImplementedHandler, requestOperationHandler))
+            ((method, requestOperationHandler) -> assertThat(requestOperationHandler, is(RequestHandler.methodNotImplementedHandler)))
         );
     }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RoleBasedAccessTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RoleBasedAccessTest.java
@@ -22,6 +22,8 @@ import org.opensearch.security.support.SecurityJsonNode;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
@@ -50,134 +52,136 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
         // legacy user API, accessible for worf, single user
         HttpResponse response = rh.executeGetRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Settings settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertTrue(settings.get("admin.hash") != null);
-        Assert.assertEquals("", settings.get("admin.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
 
         // new user API, accessible for worf, single user
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertTrue(settings.get("admin.hash") != null);
 
         // legacy user API, accessible for worf, get complete config
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.get("admin.hash"));
-        Assert.assertEquals("", settings.get("sarek.hash"));
-        Assert.assertEquals("", settings.get("worf.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
+        assertThat(settings.get("sarek.hash"), is(""));
+        assertThat(settings.get("worf.hash"), is(""));
 
         // new user API, accessible for worf
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.get("admin.hash"));
-        Assert.assertEquals("", settings.get("sarek.hash"));
-        Assert.assertEquals("", settings.get("worf.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
+        assertThat(settings.get("sarek.hash"), is(""));
+        assertThat(settings.get("worf.hash"), is(""));
 
         // legacy user API, accessible for worf, get complete config, no trailing slash
         response = rh.executeGetRequest(ENDPOINT + "/internalusers", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.get("admin.hash"));
-        Assert.assertEquals("", settings.get("sarek.hash"));
-        Assert.assertEquals("", settings.get("worf.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
+        assertThat(settings.get("sarek.hash"), is(""));
+        assertThat(settings.get("worf.hash"), is(""));
 
         // new user API, accessible for worf, get complete config, no trailing slash
         response = rh.executeGetRequest(ENDPOINT + "/internalusers", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.get("admin.hash"));
-        Assert.assertEquals("", settings.get("sarek.hash"));
-        Assert.assertEquals("", settings.get("worf.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
+        assertThat(settings.get("sarek.hash"), is(""));
+        assertThat(settings.get("worf.hash"), is(""));
 
         // roles API, GET accessible for worf
         response = rh.executeGetRequest(ENDPOINT + "/rolesmapping", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        Assert.assertEquals("", settings.getAsList("opendistro_security_all_access.users").get(0), "nagilum");
-        Assert.assertEquals("", settings.getAsList("opendistro_security_role_starfleet_library.backend_roles").get(0), "starfleet*");
-        Assert.assertEquals("", settings.getAsList("opendistro_security_zdummy_all.users").get(0), "bug108");
+        assertThat("", "nagilum", is(settings.getAsList("opendistro_security_all_access.users").get(0)));
+        assertThat("", "starfleet*", is(settings.getAsList("opendistro_security_role_starfleet_library.backend_roles").get(0)));
+        assertThat("", "bug108", is(settings.getAsList("opendistro_security_zdummy_all.users").get(0)));
 
         // Deprecated get configuration API, acessible for sarek
         // response = rh.executeGetRequest("_opendistro/_security/api/configuration/internalusers", encodeBasicHeader("sarek", "sarek"));
         // settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        // Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        // Assert.assertEquals("", settings.get("admin.hash"));
-        // Assert.assertEquals("", settings.get("sarek.hash"));
-        // Assert.assertEquals("", settings.get("worf.hash"));
+        // assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        // assertThat(settings.get("admin.hash"), is(""));
+        // assertThat(settings.get("sarek.hash"), is(""));
+        // assertThat(settings.get("worf.hash"), is(""));
 
         // Deprecated get configuration API, acessible for sarek
         // response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("sarek", "sarek"));
         // settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
-        // Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        // Assert.assertEquals("", settings.getAsList("ALL").get(0), "indices:*");
-        // Assert.assertEquals("", settings.getAsList("OPENDISTRO_SECURITY_CLUSTER_MONITOR").get(0), "cluster:monitor/*");
+        // assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        // assertThat("indices:*", is("", settings.getAsList("ALL").get(0)));
+        // assertThat("cluster:monitor/*", is("", settings.getAsList("OPENDISTRO_SECURITY_CLUSTER_MONITOR").get(0)));
         // new format for action groups
-        // Assert.assertEquals("", settings.getAsList("CRUD.permissions").get(0), "READ_UT");
+        // assertThat("READ_UT", is("", settings.getAsList("CRUD.permissions").get(0)));
 
         // configuration API, not accessible for worf
         // response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("worf", "worf"));
-        // Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        // assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         // Assert.assertTrue(response.getBody().contains("does not have any access to endpoint CONFIGURATION"));
 
         // cache API, not accessible for worf since it's disabled globally
         response = rh.executeDeleteRequest("_opendistro/_security/api/cache", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any access to endpoint CACHE"));
 
         // cache API, not accessible for sarek since it's disabled globally
         response = rh.executeDeleteRequest("_opendistro/_security/api/cache", encodeBasicHeader("sarek", "sarek"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any access to endpoint CACHE"));
 
         // Admin user has no eligible role at all
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any role privileged for admin access"));
 
         // Admin user has no eligible role at all
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any role privileged for admin access"));
 
         // Admin user has no eligible role at all
         response = rh.executeGetRequest(ENDPOINT + "/internalusers", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any role privileged for admin access"));
 
         // Admin user has no eligible role at all
         response = rh.executeGetRequest(ENDPOINT + "/roles", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any role privileged for admin access"));
 
         // --- DELETE ---
 
         // Admin user has no eligible role at all
         response = rh.executeDeleteRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("admin", "admin"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertTrue(response.getBody().contains("does not have any role privileged for admin access"));
 
         // Worf, has access to internalusers API, able to delete
         response = rh.executeDeleteRequest(ENDPOINT + "/internalusers/other", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("'other' deleted"));
 
         // Worf, has access to internalusers API, user "other" deleted now
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/other", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         Assert.assertTrue(response.getBody().contains("'other' not found"));
 
         // Worf, has access to roles API, get captains role
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        Assert.assertEquals(
-            new SecurityJsonNode(DefaultObjectMapper.readTree(response.getBody())).getDotted(
-                "opendistro_security_role_starfleet_captains.cluster_permissions"
-            ).get(0).asString(),
-            "cluster:monitor*"
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
+            "cluster:monitor*",
+            is(
+                new SecurityJsonNode(DefaultObjectMapper.readTree(response.getBody())).getDotted(
+                    "opendistro_security_role_starfleet_captains.cluster_permissions"
+                ).get(0).asString()
+            )
         );
 
         // Worf, has access to roles API, able to delete
@@ -185,21 +189,21 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
             ENDPOINT + "/roles/opendistro_security_role_starfleet_captains",
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("'opendistro_security_role_starfleet_captains' deleted"));
 
         // Worf, has access to roles API, captains role deleted now
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
         Assert.assertTrue(response.getBody().contains("'opendistro_security_role_starfleet_captains' not found"));
 
         // Worf, has no DELETE access to rolemappings API
         response = rh.executeDeleteRequest(ENDPOINT + "/rolesmapping/opendistro_security_unittest_1", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // Worf, has no DELETE access to rolemappings API, legacy endpoint
         response = rh.executeDeleteRequest(ENDPOINT + "/rolesmapping/opendistro_security_unittest_1", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // --- PUT ---
 
@@ -209,7 +213,7 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
             FileHelper.loadFile("restapi/roles_captains_tenants.json"),
             encodeBasicHeader("admin", "admin")
         );
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // worf, restore role starfleet captains
         response = rh.executePutRequest(
@@ -217,17 +221,17 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
             FileHelper.loadFile("restapi/roles_captains_different_content.json"),
             encodeBasicHeader("worf", "worf")
         );
-        Assert.assertEquals(HttpStatus.SC_CREATED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_CREATED));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
 
         // starfleet role present again
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", encodeBasicHeader("worf", "worf"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
-        Assert.assertEquals(
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(
             new SecurityJsonNode(DefaultObjectMapper.readTree(response.getBody())).getDotted(
                 "opendistro_security_role_starfleet_captains.index_permissions"
             ).get(0).get("allowed_actions").get(0).asString(),
-            "blafasel"
+            is("blafasel")
         );
 
         // Try the same, but now with admin certificate
@@ -235,18 +239,18 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
         // admin
         response = rh.executeGetRequest(ENDPOINT + "/internalusers/admin", encodeBasicHeader("la", "lu"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         settings = Settings.builder().loadFromSource(response.getBody(), XContentType.JSON).build();
         Assert.assertTrue(settings.get("admin.hash") != null);
-        Assert.assertEquals("", settings.get("admin.hash"));
+        assertThat(settings.get("admin.hash"), is(""));
 
         // worf and config
         // response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("bla", "fasel"));
-        // Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        // assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // cache
         response = rh.executeDeleteRequest("_opendistro/_security/api/cache", encodeBasicHeader("wrong", "wrong"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // -- test user, does not have any endpoints disabled, but has access to API, i.e. full access
 
@@ -254,14 +258,14 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
 
         // GET actiongroups
         // response = rh.executeGetRequest("_opendistro/_security/api/configuration/actiongroups", encodeBasicHeader("test", "test"));
-        // Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        // assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executeGetRequest("_opendistro/_security/api/actiongroups", encodeBasicHeader("test", "test"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // clear cache - globally disabled, has to fail
         response = rh.executeDeleteRequest("_opendistro/_security/api/cache", encodeBasicHeader("test", "test"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // PUT roles
         response = rh.executePutRequest(
@@ -269,23 +273,23 @@ public class RoleBasedAccessTest extends AbstractRestApiUnitTest {
             FileHelper.loadFile("restapi/roles_captains_different_content.json"),
             encodeBasicHeader("test", "test")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // GET captions role
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", encodeBasicHeader("test", "test"));
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         // Delete captions role
         response = rh.executeDeleteRequest(
             ENDPOINT + "/roles/opendistro_security_role_starfleet_captains",
             encodeBasicHeader("test", "test")
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertTrue(response.getBody().contains("'opendistro_security_role_starfleet_captains' deleted"));
 
         // GET captions role
         response = rh.executeGetRequest(ENDPOINT + "/roles/opendistro_security_role_starfleet_captains", encodeBasicHeader("test", "test"));
-        Assert.assertEquals(HttpStatus.SC_NOT_FOUND, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
 
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionValidationTest.java
@@ -18,7 +18,8 @@ import org.opensearch.security.securityconf.impl.v7.RoleV7;
 
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -52,7 +53,7 @@ public class RolesApiActionValidationTest extends AbstractApiActionValidationTes
         final var result = rolesApiActionEndpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("sss", configuration));
 
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
     }
 
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesMappingApiActionValidationTest.java
@@ -20,7 +20,8 @@ import org.junit.Test;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.securityconf.impl.CType;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +55,7 @@ public class RolesMappingApiActionValidationTest extends AbstractApiActionValida
                  SecurityConfiguration.of("rest_api_admin_role", configuration));
 
          assertFalse(result.isValid());
-         assertEquals(RestStatus.FORBIDDEN, result.status());
+         assertThat(result.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -69,7 +70,7 @@ public class RolesMappingApiActionValidationTest extends AbstractApiActionValida
         // no role
         var result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("aaa", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_FOUND, result.status());
+        assertThat(result.status(), is(RestStatus.NOT_FOUND));
         //static role is ok
         result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("all_access", configuration));
         assertTrue(result.isValid());
@@ -82,7 +83,7 @@ public class RolesMappingApiActionValidationTest extends AbstractApiActionValida
         //hidden role is not ok
         result = rolesApiActionEndpointValidator.onConfigChange(SecurityConfiguration.of("some_hidden_role", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_FOUND, result.status());
+        assertThat(result.status(), is(RestStatus.NOT_FOUND));
     }
 
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityApiAccessTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityApiAccessTest.java
@@ -12,9 +12,10 @@
 package org.opensearch.security.dlic.rest.api;
 
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class SecurityApiAccessTest extends AbstractRestApiUnitTest {
@@ -34,14 +35,14 @@ public class SecurityApiAccessTest extends AbstractRestApiUnitTest {
         setup();
 
         // test with no cert, must fail
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest(ENDPOINT).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin")).getStatusCode());
+        assertThat(rh.executeGetRequest(ENDPOINT).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
         // test with non-admin cert, must fail
         rh.keystore = "restapi/node-0-keystore.jks";
         rh.sendAdminCertificate = true;
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, rh.executeGetRequest(ENDPOINT).getStatusCode());
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin")).getStatusCode());
+        assertThat(rh.executeGetRequest(ENDPOINT).getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
+        assertThat(rh.executeGetRequest(ENDPOINT, encodeBasicHeader("admin", "admin")).getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
 
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigurationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigurationTest.java
@@ -22,7 +22,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -57,25 +58,25 @@ public class SecurityConfigurationTest {
     public void testNewOrUpdatedEntity() {
         var securityConfiguration = SecurityConfiguration.of("security_rest_api_access", configuration);
         assertTrue(securityConfiguration.entityExists());
-        assertEquals("security_rest_api_access", securityConfiguration.entityName());
+        assertThat(securityConfiguration.entityName(), is("security_rest_api_access"));
 
         securityConfiguration = SecurityConfiguration.of("security_rest_api_access_v2", configuration);
         assertFalse(securityConfiguration.entityExists());
-        assertEquals("security_rest_api_access_v2", securityConfiguration.entityName());
+        assertThat(securityConfiguration.entityName(), is("security_rest_api_access_v2"));
 
         final var newRole = new RoleV7();
         newRole.setCluster_permissions(List.of("cluster:admin/opendistro/alerting/alerts/get"));
         configuration.putCObject("security_rest_api_access_v2", newRole);
         assertTrue(configuration.exists("security_rest_api_access_v2"));
         assertFalse(securityConfiguration.entityExists());
-        assertEquals("security_rest_api_access_v2", securityConfiguration.entityName());
+        assertThat(securityConfiguration.entityName(), is("security_rest_api_access_v2"));
     }
 
     @Test
     public void testNoEntityNameConfiguration() {
         final var securityConfiguration = SecurityConfiguration.of(null, configuration);
         assertFalse(securityConfiguration.entityExists());
-        assertEquals("empty", securityConfiguration.entityName());
+        assertThat(securityConfiguration.entityName(), is("empty"));
     }
 
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecuritySSLCertsApiActionValidationTest.java
@@ -17,9 +17,10 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.util.FakeRestRequest;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RELOAD_CERTS_ACTION;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
@@ -37,7 +38,7 @@ public class SecuritySSLCertsApiActionValidationTest extends AbstractApiActionVa
         );
         final var result = securitySSLCertsApiAction.withSecurityKeyStore();
         assertFalse(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/TenantInfoActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/TenantInfoActionTest.java
@@ -13,13 +13,14 @@ package org.opensearch.security.dlic.rest.api;
 
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 
 public class TenantInfoActionTest extends AbstractRestApiUnitTest {
@@ -48,15 +49,15 @@ public class TenantInfoActionTest extends AbstractRestApiUnitTest {
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendAdminCertificate = true;
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         rh.sendAdminCertificate = false;
         response = rh.executeGetRequest(ENDPOINT);
-        Assert.assertEquals(HttpStatus.SC_UNAUTHORIZED, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
         rh.sendHTTPClientCredentials = true;
         response = rh.executeGetRequest(ENDPOINT);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test
@@ -76,13 +77,13 @@ public class TenantInfoActionTest extends AbstractRestApiUnitTest {
             "[{\"op\": \"add\",\"path\": \"/config/dynamic/kibana/opendistro_role\"," + "\"value\": \"opendistro_security_internal\"}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         response = rh.executePutRequest(BASE_ENDPOINT + "/api/rolesmapping/opendistro_security_internal", payload, new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
         rh.sendAdminCertificate = false;
         response = rh.executeGetRequest(ENDPOINT);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 }

--- a/src/test/java/org/opensearch/security/dlic/rest/api/WhitelistApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/WhitelistApiTest.java
@@ -34,8 +34,8 @@ import org.opensearch.security.test.helper.rest.RestHelper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -77,9 +77,9 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
         assertThat(response.getBody(), response.getStatusCode(), equalTo(expectedStatus));
         if (expectedStatus == HttpStatus.SC_OK) {
             // Note: the response has no whitespaces, so the .json file does not have whitespaces
-            Assert.assertEquals(
+            assertThat(
                 FileHelper.loadFile("restapi/whitelist_response_success.json"),
-                FileHelper.loadFile("restapi/whitelist_response_success.json")
+                is(FileHelper.loadFile("restapi/whitelist_response_success.json"))
             );
         }
         // FORBIDDEN FOR NON SUPER ADMIN
@@ -104,7 +104,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
 
         rh.sendAdminCertificate = true;
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT + "/whitelist");
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         Assert.assertFalse(response.getBody().contains("_meta"));
     }
 
@@ -118,7 +118,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             ENDPOINT + "/whitelist",
             "{ \"unknownkey\": true, \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"GET\"] }}"
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         assertTrue(response.getBody().contains("invalid_keys"));
         assertHealthy();
     }
@@ -132,7 +132,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             ENDPOINT + "/whitelist",
             "{ \"invalid\"::{{ [\"*\"], \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"GET\"] }}"
         );
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         assertHealthy();
     }
 
@@ -147,9 +147,9 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
 
         rh.sendAdminCertificate = true;
         response = rh.executePutRequest(ENDPOINT + "/whitelist", "", new Header[0]);
-        Assert.assertEquals(HttpStatus.SC_BAD_REQUEST, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
         JsonNode settings = DefaultObjectMapper.readTree(response.getBody());
-        Assert.assertEquals(RequestContentValidator.ValidationError.PAYLOAD_MANDATORY.message(), settings.get("reason").asText());
+        assertThat(settings.get("reason").asText(), is(RequestContentValidator.ValidationError.PAYLOAD_MANDATORY.message()));
     }
 
     /**
@@ -241,11 +241,11 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config\", \"value\": {\"enabled\": true, \"requests\": {\"/_cat/nodes\": [\"GET\"],\"/_cat/indices\": [\"PUT\"] }}}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
-        assertEquals(
+        assertThat(
             response.getBody(),
-            "{\"config\":{\"enabled\":true,\"requests\":{\"/_cat/nodes\":[\"GET\"],\"/_cat/indices\":[\"PUT\"]}}}"
+            is("{\"config\":{\"enabled\":true,\"requests\":{\"/_cat/nodes\":[\"GET\"],\"/_cat/indices\":[\"PUT\"]}}}")
         );
 
         // PATCH just requests
@@ -254,7 +254,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config/requests\", \"value\": {\"/_cat/nodes\": [\"GET\"]}}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
         assertTrue(response.getBody().contains("\"requests\":{\"/_cat/nodes\":[\"GET\"]}"));
 
@@ -264,7 +264,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"replace\", \"path\": \"/config/enabled\", \"value\": false}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":false"));
 
@@ -274,7 +274,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"add\", \"path\": \"/config/enabled\", \"value\": true}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":true"));
 
@@ -284,7 +284,7 @@ public class WhitelistApiTest extends AbstractRestApiUnitTest {
             "[{ \"op\": \"add\", \"path\": \"/config/enabled\", \"value\": false}]",
             new Header[0]
         );
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
         response = rh.executeGetRequest(ENDPOINT + "/whitelist", adminCredsHeader);
         assertTrue(response.getBody().contains("\"enabled\":false"));

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
@@ -33,7 +33,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -74,11 +75,11 @@ public class EndpointValidatorTest {
     public void requiredEntityName() {
         var validationResult = endpointValidator.withRequiredEntityName(null);
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.BAD_REQUEST, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.BAD_REQUEST));
 
         validationResult = endpointValidator.withRequiredEntityName("a");
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -86,7 +87,7 @@ public class EndpointValidatorTest {
         when(configuration.exists("some_role")).thenReturn(false);
         final var validationResult = endpointValidator.entityExists(SecurityConfiguration.of("some_role", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.NOT_FOUND, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.NOT_FOUND));
     }
 
     @Test
@@ -94,7 +95,7 @@ public class EndpointValidatorTest {
         when(configuration.exists("some_role")).thenReturn(true);
         final var validationResult = endpointValidator.entityExists(SecurityConfiguration.of("some_role", configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -102,7 +103,7 @@ public class EndpointValidatorTest {
         when(configuration.exists(null)).thenReturn(false);
         final var validationResult = endpointValidator.entityExists(SecurityConfiguration.of(null, configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -110,7 +111,7 @@ public class EndpointValidatorTest {
         when(configuration.isHidden("some_entity")).thenReturn(true);
         final var validationResult = endpointValidator.entityHidden( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.NOT_FOUND, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.NOT_FOUND));
     }
 
     @Test
@@ -118,7 +119,7 @@ public class EndpointValidatorTest {
         when(configuration.isHidden("some_entity")).thenReturn(false);
         final var validationResult = endpointValidator.entityHidden( SecurityConfiguration.of("some_entity", configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class EndpointValidatorTest {
         when(configuration.isReserved("some_entity")).thenReturn(true);
         final var validationResult = endpointValidator.entityReserved( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -134,7 +135,7 @@ public class EndpointValidatorTest {
         when(configuration.isReserved("some_entity")).thenReturn(false);
         final var validationResult = endpointValidator.entityReserved( SecurityConfiguration.of("some_entity", configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -142,7 +143,7 @@ public class EndpointValidatorTest {
         when(configuration.isStatic("some_entity")).thenReturn(true);
         final var validationResult = endpointValidator.entityStatic( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -150,7 +151,7 @@ public class EndpointValidatorTest {
         when(configuration.isStatic("some_entity")).thenReturn(false);
         final var validationResult = endpointValidator.entityStatic( SecurityConfiguration.of("some_entity", configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -159,7 +160,7 @@ public class EndpointValidatorTest {
 
         var validationResult = endpointValidator.entityImmutable( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.NOT_FOUND, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.NOT_FOUND));
     }
 
     @Test
@@ -168,7 +169,7 @@ public class EndpointValidatorTest {
         when(configuration.isStatic("some_entity")).thenReturn(true);
         final var validationResult = endpointValidator.entityImmutable( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -178,7 +179,7 @@ public class EndpointValidatorTest {
         when(configuration.isReserved("some_entity")).thenReturn(true);
         final var validationResult = endpointValidator.entityImmutable( SecurityConfiguration.of("some_entity", configuration));
         assertFalse(validationResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -186,19 +187,19 @@ public class EndpointValidatorTest {
         configImmutableEntities(false);
         var result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("hidden_entity", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_FOUND, result.status());
+        assertThat(result.status(), is(RestStatus.NOT_FOUND));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("static_entity", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("reserved_entity", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.FORBIDDEN, result.status());
+        assertThat(result.status(), is(RestStatus.FORBIDDEN));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("just_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -207,19 +208,19 @@ public class EndpointValidatorTest {
 
         var result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("hidden_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("static_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("reserved_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
 
         result = endpointValidator.isAllowedToChangeImmutableEntity(SecurityConfiguration.of("just_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -228,11 +229,11 @@ public class EndpointValidatorTest {
 
         var result = endpointValidator.isAllowedToLoadOrChangeHiddenEntity(SecurityConfiguration.of("hidden_entity", configuration));
         assertFalse(result.isValid());
-        assertEquals(RestStatus.NOT_FOUND, result.status());
+        assertThat(result.status(), is(RestStatus.NOT_FOUND));
 
         result = endpointValidator.isAllowedToLoadOrChangeHiddenEntity(SecurityConfiguration.of("just_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -241,11 +242,11 @@ public class EndpointValidatorTest {
 
         var result = endpointValidator.isAllowedToLoadOrChangeHiddenEntity(SecurityConfiguration.of("hidden_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
 
         result = endpointValidator.isAllowedToLoadOrChangeHiddenEntity(SecurityConfiguration.of("just_entity", configuration));
         assertTrue(result.isValid());
-        assertEquals(RestStatus.OK, result.status());
+        assertThat(result.status(), is(RestStatus.OK));
     }
 
     private void configImmutableEntities(final boolean isAdmin) {
@@ -267,7 +268,7 @@ public class EndpointValidatorTest {
 
         var validationResult = endpointValidator.entityImmutable( SecurityConfiguration.of("some_entity", configuration));
         assertTrue(validationResult.isValid());
-        assertEquals(RestStatus.OK, validationResult.status());
+        assertThat(validationResult.status(), is(RestStatus.OK));
     }
 
     @Test
@@ -283,8 +284,8 @@ public class EndpointValidatorTest {
 
         for (final var roleWithExpectedResults : expectedResultForRoles) {
             final var validationResult = endpointValidator.validateRoles(List.of(roleWithExpectedResults.getLeft()), configuration);
-            assertEquals(roleWithExpectedResults.getMiddle(), validationResult.isValid());
-            assertEquals(roleWithExpectedResults.getRight(), validationResult.status());
+            assertThat(validationResult.isValid(), is(roleWithExpectedResults.getMiddle()));
+            assertThat(validationResult.status(), is(roleWithExpectedResults.getRight()));
         }
 
     }
@@ -302,8 +303,8 @@ public class EndpointValidatorTest {
 
         for (final var roleWithExpectedResults : expectedResultForRoles) {
             final var validationResult = endpointValidator.validateRoles(List.of(roleWithExpectedResults.getLeft()), configuration);
-            assertEquals(roleWithExpectedResults.getMiddle(), validationResult.isValid());
-            assertEquals(roleWithExpectedResults.getRight(), validationResult.status());
+            assertThat(validationResult.isValid(), is(roleWithExpectedResults.getMiddle()));
+            assertThat(validationResult.status(), is(roleWithExpectedResults.getRight()));
         }
 
     }
@@ -338,7 +339,7 @@ public class EndpointValidatorTest {
             SecurityConfiguration.of("some_role", configuration)
         );
         assertFalse(roleCheckResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, roleCheckResult.status());
+        assertThat(roleCheckResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -359,7 +360,7 @@ public class EndpointValidatorTest {
             SecurityConfiguration.of(objectMapper.createObjectNode().set("cluster_permissions", array), "some_role", configuration)
         );
         assertFalse(roleCheckResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, roleCheckResult.status());
+        assertThat(roleCheckResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -372,7 +373,7 @@ public class EndpointValidatorTest {
             SecurityConfiguration.of("some_ag", configuration)
         );
         assertFalse(agCheckResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, agCheckResult.status());
+        assertThat(agCheckResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     @Test
@@ -391,7 +392,7 @@ public class EndpointValidatorTest {
                 SecurityConfiguration.of(objectMapper.createObjectNode().set("allowed_actions", array), "some_ag", configuration)
         );
         assertFalse(agCheckResult.isValid());
-        assertEquals(RestStatus.FORBIDDEN, agCheckResult.status());
+        assertThat(agCheckResult.status(), is(RestStatus.FORBIDDEN));
     }
 
     private List<String> restAdminPermissions() {

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/PasswordValidatorTest.java
@@ -18,10 +18,11 @@ import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_MIN_LENGTH;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX;
-import static org.junit.Assert.assertEquals;
 
 public class PasswordValidatorTest {
 
@@ -69,7 +70,7 @@ public class PasswordValidatorTest {
         final RequestContentValidator.ValidationError expectedValidationResult
     ) {
         for (final String password : WEAK_PASSWORDS)
-            assertEquals(password, expectedValidationResult, passwordValidator.validate("some_user_name", password));
+            assertThat(password, passwordValidator.validate("some_user_name", password), is(expectedValidationResult));
 
     }
 
@@ -78,7 +79,7 @@ public class PasswordValidatorTest {
         final RequestContentValidator.ValidationError expectedValidationResult
     ) {
         for (final String password : FAIR_PASSWORDS)
-            assertEquals(password, expectedValidationResult, passwordValidator.validate("some_user_name", password));
+            assertThat(password, passwordValidator.validate("some_user_name", password), is(expectedValidationResult));
 
     }
 
@@ -87,7 +88,7 @@ public class PasswordValidatorTest {
         final RequestContentValidator.ValidationError expectedValidationResult
     ) {
         for (final String password : GOOD_PASSWORDS)
-            assertEquals(password, expectedValidationResult, passwordValidator.validate("some_user_name", password));
+            assertThat(password, passwordValidator.validate("some_user_name", password), is(expectedValidationResult));
 
     }
 
@@ -96,7 +97,7 @@ public class PasswordValidatorTest {
         final RequestContentValidator.ValidationError expectedValidationResult
     ) {
         for (final String password : STRONG_PASSWORDS)
-            assertEquals(password, expectedValidationResult, passwordValidator.validate("some_user_name", password));
+            assertThat(password, passwordValidator.validate("some_user_name", password), is(expectedValidationResult));
 
     }
 
@@ -105,16 +106,16 @@ public class PasswordValidatorTest {
         final RequestContentValidator.ValidationError expectedValidationResult
     ) {
         for (final String password : VERY_STRONG_PASSWORDS)
-            assertEquals(password, expectedValidationResult, passwordValidator.validate("some_user_name", password));
+            assertThat(password, passwordValidator.validate("some_user_name", password), is(expectedValidationResult));
 
     }
 
     public void verifySimilarPasswords(final PasswordValidator passwordValidator) {
         for (final String password : SIMILAR_PASSWORDS)
-            assertEquals(
+            assertThat(
                 password,
-                RequestContentValidator.ValidationError.SIMILAR_PASSWORD,
-                passwordValidator.validate("some_user_name", password)
+                passwordValidator.validate("some_user_name", password),
+                is(RequestContentValidator.ValidationError.SIMILAR_PASSWORD)
             );
 
     }
@@ -129,16 +130,16 @@ public class PasswordValidatorTest {
         verifyWeakPasswords(passwordValidator, RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX);
         verifyFairPasswords(passwordValidator, RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX);
         for (final String password : GOOD_PASSWORDS.subList(0, GOOD_PASSWORDS.size() - 2))
-            assertEquals(
+            assertThat(
                 password,
-                RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX,
-                passwordValidator.validate("some_user_name", password)
+                passwordValidator.validate("some_user_name", password),
+                is(RequestContentValidator.ValidationError.INVALID_PASSWORD_INVALID_REGEX)
             );
         for (final String password : GOOD_PASSWORDS.subList(GOOD_PASSWORDS.size() - 2, GOOD_PASSWORDS.size()))
-            assertEquals(
+            assertThat(
                 password,
-                RequestContentValidator.ValidationError.WEAK_PASSWORD,
-                passwordValidator.validate("some_user_name", password)
+                passwordValidator.validate("some_user_name", password),
+                is(RequestContentValidator.ValidationError.WEAK_PASSWORD)
             );
         verifyStrongPasswords(passwordValidator, RequestContentValidator.ValidationError.NONE);
         verifyVeryStrongPasswords(passwordValidator, RequestContentValidator.ValidationError.NONE);
@@ -151,9 +152,9 @@ public class PasswordValidatorTest {
             Settings.builder().put(SECURITY_RESTAPI_PASSWORD_MIN_LENGTH, 15).build()
         );
         for (final String password : STRONG_PASSWORDS) {
-            assertEquals(
+            assertThat(
                 RequestContentValidator.ValidationError.INVALID_PASSWORD_TOO_SHORT,
-                passwordValidator.validate(password, "some_user_name")
+                is(passwordValidator.validate(password, "some_user_name"))
             );
         }
 

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
@@ -38,7 +38,8 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -155,9 +156,9 @@ public class RequestContentValidatorTest {
         assertFalse(validationResult.isValid());
         assertErrorMessage(errorMessage, RequestContentValidator.ValidationError.WRONG_DATATYPE);
 
-        assertEquals("String expected", errorMessage.get("a").asText());
-        assertEquals("Object expected", errorMessage.get("b").asText());
-        assertEquals("Array expected", errorMessage.get("c").asText());
+        assertThat(errorMessage.get("a").asText(), is("String expected"));
+        assertThat(errorMessage.get("b").asText(), is("Object expected"));
+        assertThat(errorMessage.get("c").asText(), is("Array expected"));
     }
 
     @Test
@@ -190,8 +191,8 @@ public class RequestContentValidatorTest {
         final JsonNode errorMessage = xContentToJsonNode(validationResult.errorMessage());
         assertErrorMessage(errorMessage, RequestContentValidator.ValidationError.INVALID_CONFIGURATION);
 
-        assertEquals("{\"keys\":\"c,d\"}", errorMessage.get("invalid_keys").toString());
-        assertEquals("{\"keys\":\"a\"}", errorMessage.get("missing_mandatory_keys").toString());
+        assertThat(errorMessage.get("invalid_keys").toString(), is("{\"keys\":\"c,d\"}"));
+        assertThat(errorMessage.get("missing_mandatory_keys").toString(), is("{\"keys\":\"a\"}"));
     }
 
     @Test
@@ -313,8 +314,8 @@ public class RequestContentValidatorTest {
     }
 
     private void assertErrorMessage(final JsonNode jsonNode, final RequestContentValidator.ValidationError expectedValidationError) {
-        assertEquals("error", jsonNode.get("status").asText());
-        assertEquals(expectedValidationError.message(), jsonNode.get("reason").asText());
+        assertThat(jsonNode.get("status").asText(), is("error"));
+        assertThat(jsonNode.get("reason").asText(), is(expectedValidationError.message()));
     }
 
 }

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -49,14 +49,14 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import org.mockito.ArgumentCaptor;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.rest.RestRequest.Method.PUT;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -93,7 +93,7 @@ public class OnBehalfOfAuthenticatorTest {
     public void testGetTypeReturnsExpectedType() {
         OnBehalfOfAuthenticator authenticator = new OnBehalfOfAuthenticator(defaultSettings(), clusterName);
         String type = authenticator.getType();
-        assertEquals("onbehalfof_jwt", type);
+        assertThat(type, is("onbehalfof_jwt"));
     }
 
     @Test
@@ -285,9 +285,9 @@ public class OnBehalfOfAuthenticatorTest {
         );
 
         assertNotNull(credentials);
-        assertEquals("Leonard McCoy", credentials.getUsername());
-        assertEquals(0, credentials.getSecurityRoles().size());
-        assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getSecurityRoles().size(), is(0));
+        assertThat(credentials.getBackendRoles().size(), is(0));
         assertThat(credentials.getAttributes(), equalTo(expectedAttributes));
     }
 
@@ -413,9 +413,9 @@ public class OnBehalfOfAuthenticatorTest {
         );
 
         assertNotNull(credentials);
-        assertEquals("Leonard McCoy", credentials.getUsername());
-        assertEquals(2, credentials.getSecurityRoles().size());
-        assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getSecurityRoles().size(), is(2));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -465,8 +465,8 @@ public class OnBehalfOfAuthenticatorTest {
         );
 
         assertNotNull(credentials);
-        assertEquals("Leonard McCoy", credentials.getUsername());
-        assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -480,8 +480,8 @@ public class OnBehalfOfAuthenticatorTest {
         );
 
         assertNotNull(credentials);
-        assertEquals("Leonard McCoy", credentials.getUsername());
-        assertEquals(1, credentials.getSecurityRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getSecurityRoles().size(), is(1));
         assertTrue(credentials.getSecurityRoles().contains("123"));
     }
 
@@ -496,9 +496,9 @@ public class OnBehalfOfAuthenticatorTest {
         );
 
         assertNotNull(credentials);
-        assertEquals("Leonard McCoy", credentials.getUsername());
-        assertEquals(0, credentials.getSecurityRoles().size());
-        assertEquals(0, credentials.getBackendRoles().size());
+        assertThat(credentials.getUsername(), is("Leonard McCoy"));
+        assertThat(credentials.getSecurityRoles().size(), is(0));
+        assertThat(credentials.getBackendRoles().size(), is(0));
     }
 
     @Test
@@ -570,8 +570,8 @@ public class OnBehalfOfAuthenticatorTest {
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(signingKeyB64Encoded, claimsEncryptionKey, builder, true);
 
         assertNotNull(credentials);
-        assertEquals("Cluster_0", credentials.getUsername());
-        assertEquals(3, credentials.getSecurityRoles().size());
+        assertThat(credentials.getUsername(), is("Cluster_0"));
+        assertThat(credentials.getSecurityRoles().size(), is(3));
         assertTrue(credentials.getSecurityRoles().contains("a"));
         assertTrue(credentials.getSecurityRoles().contains("b"));
         assertTrue(credentials.getSecurityRoles().contains("3rd"));

--- a/src/test/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/proxy/HTTPExtendedProxyAuthenticatorTest.java
@@ -52,7 +52,8 @@ import org.opensearch.security.filter.SecurityRequestFactory;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.AuthCredentials;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -73,7 +74,7 @@ public class HTTPExtendedProxyAuthenticatorTest {
 
     @Test
     public void testGetType() {
-        assertEquals("extended-proxy", authenticator.getType());
+        assertThat(authenticator.getType(), is("extended-proxy"));
     }
 
     @Test(expected = OpenSearchSecurityException.class)
@@ -109,9 +110,9 @@ public class HTTPExtendedProxyAuthenticatorTest {
         authenticator = new HTTPExtendedProxyAuthenticator(settings, null);
         AuthCredentials creds = authenticator.extractCredentials(new TestRestRequest(headers).asSecurityRequest(), context);
         assertNotNull(creds);
-        assertEquals("aValidUser", creds.getUsername());
-        assertEquals("123,456", creds.getAttributes().get("attr.proxy.uid"));
-        assertEquals("someothervalue", creds.getAttributes().get("attr.proxy.other"));
+        assertThat(creds.getUsername(), is("aValidUser"));
+        assertThat(creds.getAttributes().get("attr.proxy.uid"), is("123,456"));
+        assertThat(creds.getAttributes().get("attr.proxy.other"), is("someothervalue"));
         assertTrue(creds.isComplete());
     }
 
@@ -126,8 +127,8 @@ public class HTTPExtendedProxyAuthenticatorTest {
         authenticator = new HTTPExtendedProxyAuthenticator(settings, null);
         AuthCredentials creds = authenticator.extractCredentials(new TestRestRequest(headers).asSecurityRequest(), context);
         assertNotNull(creds);
-        assertEquals("aValidUser", creds.getUsername());
-        assertEquals(ImmutableSet.of("role1", "role2"), creds.getBackendRoles());
+        assertThat(creds.getUsername(), is("aValidUser"));
+        assertThat(creds.getBackendRoles(), is(ImmutableSet.of("role1", "role2")));
         assertTrue(creds.isComplete());
     }
 

--- a/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
+++ b/src/test/java/org/opensearch/security/multitenancy/test/MultitenancyTests.java
@@ -38,6 +38,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class MultitenancyTests extends SingleClusterTest {
 
@@ -114,14 +115,14 @@ public class MultitenancyTests extends SingleClusterTest {
         }
 
         HttpResponse resc;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexa,indexb/_search?pretty", encodeBasicHeader("user_b", "user_b"))).getStatusCode())
         );
 
         String msearchBody = "{\"index\":\"indexa\", \"ignore_unavailable\": true}"
@@ -134,7 +135,7 @@ public class MultitenancyTests extends SingleClusterTest {
             + System.lineSeparator();
         // msearch a
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_a", "user_a"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -142,7 +143,7 @@ public class MultitenancyTests extends SingleClusterTest {
 
         // msearch b
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexa"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -159,13 +160,13 @@ public class MultitenancyTests extends SingleClusterTest {
 
         // msearch b2
         resc = rh.executePostRequest("_msearch?pretty", msearchBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexc"));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("indexd"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("permission"));
         int count = resc.getBody().split("\"status\" : 403").length;
-        Assert.assertEquals(3, count);
+        assertThat(count, is(3));
 
         String mgetBody = "{"
             + "\"docs\" : ["
@@ -181,7 +182,7 @@ public class MultitenancyTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertFalse(resc.getBody(), resc.getBody().contains("\"content\" : \"indexa\""));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("indexb"));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
@@ -201,59 +202,59 @@ public class MultitenancyTests extends SingleClusterTest {
             + "}";
 
         resc = rh.executePostRequest("_mget?pretty", mgetBody, encodeBasicHeader("user_b", "user_b"));
-        Assert.assertEquals(200, resc.getStatusCode());
+        assertThat(resc.getStatusCode(), is(200));
         Assert.assertTrue(resc.getBody(), resc.getBody().contains("exception"));
         count = resc.getBody().split("root_cause").length;
-        Assert.assertEquals(3, count);
+        assertThat(count, is(3));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("index*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexa/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexb/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("_all/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("notexists/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_NOT_FOUND,
-            (resc = rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("indexanbh,indexabb*/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode()
+            is((resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("user_a", "user_a"))).getStatusCode())
         );
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode()
+            is((resc = rh.executeGetRequest("starfleet/_search?pretty", encodeBasicHeader("worf", "worf"))).getStatusCode())
         );
 
     }
@@ -266,52 +267,63 @@ public class MultitenancyTests extends SingleClusterTest {
 
         HttpResponse res;
         String body = "{\"buildNum\": 15460, \"defaultIndex\": \"humanresources\", \"tenant\": \"human_resources\"}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePutRequest(
-                ".kibana/_doc/5.6.0?pretty",
-                body,
-                new BasicHeader("securitytenant", "blafasel"),
-                encodeBasicHeader("hr_employee", "hr_employee")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    ".kibana/_doc/5.6.0?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "blafasel"),
+                    encodeBasicHeader("hr_employee", "hr_employee")
+                )).getStatusCode()
+            )
         );
 
         body = "{\"buildNum\": 15460, \"defaultIndex\": \"humanresources\", \"tenant\": \"human_resources\"}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_FORBIDDEN,
-            (res = rh.executePutRequest(
-                ".kibana/_doc/5.6.0?pretty",
-                body,
-                new BasicHeader("securitytenant", "business_intelligence"),
-                encodeBasicHeader("hr_employee", "hr_employee")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    ".kibana/_doc/5.6.0?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "business_intelligence"),
+                    encodeBasicHeader("hr_employee", "hr_employee")
+                )).getStatusCode()
+            )
         );
 
         body = "{\"buildNum\": 15460, \"defaultIndex\": \"humanresources\", \"tenant\": \"human_resources\"}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            (res = rh.executePutRequest(
-                ".kibana/_doc/5.6.0?pretty",
-                body,
-                new BasicHeader("securitytenant", "human_resources"),
-                encodeBasicHeader("hr_employee", "hr_employee")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    ".kibana/_doc/5.6.0?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "human_resources"),
+                    encodeBasicHeader("hr_employee", "hr_employee")
+                )).getStatusCode()
+            )
         );
-        Assert.assertEquals(".kibana_1592542611_humanresources_1", DefaultObjectMapper.readTree(res.getBody()).get("_index").asText());
+        assertThat(DefaultObjectMapper.readTree(res.getBody()).get("_index").asText(), is(".kibana_1592542611_humanresources_1"));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                ".kibana/_doc/5.6.0?pretty",
-                new BasicHeader("securitytenant", "human_resources"),
-                encodeBasicHeader("hr_employee", "hr_employee")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    ".kibana/_doc/5.6.0?pretty",
+                    new BasicHeader("securitytenant", "human_resources"),
+                    encodeBasicHeader("hr_employee", "hr_employee")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(WildcardMatcher.from("*human_resources*").test(res.getBody()));
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(".kibana_1592542611_humanresources_1/_alias", encodeBasicHeader("admin", "admin"))).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(".kibana_1592542611_humanresources_1/_alias", encodeBasicHeader("admin", "admin")))
+                    .getStatusCode()
+            )
         );
         Assert.assertNotNull(
             DefaultObjectMapper.readTree(res.getBody())
@@ -355,14 +367,16 @@ public class MultitenancyTests extends SingleClusterTest {
         // search
         HttpResponse res;
         String body = "{\"query\" : {\"term\" : { \"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}}}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                ".kibana/_search/?pretty",
-                body,
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    ".kibana/_search/?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
@@ -375,14 +389,16 @@ public class MultitenancyTests extends SingleClusterTest {
             + "{\"size\":10, \"query\":{\"bool\":{\"must\":{\"match_all\":{}}}}}"
             + System.lineSeparator();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "_msearch/?pretty",
-                body,
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "_msearch/?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
@@ -390,13 +406,15 @@ public class MultitenancyTests extends SingleClusterTest {
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
         // get
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                ".kibana/_doc/index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b?pretty",
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    ".kibana/_doc/index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b?pretty",
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
@@ -405,14 +423,16 @@ public class MultitenancyTests extends SingleClusterTest {
 
         // mget
         body = "{\"docs\" : [{\"_index\" : \".kibana\",\"_id\" : \"index-pattern:9fbbd1a0-c3c5-11e8-a13f-71b8ea5a4f7b\"}]}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePostRequest(
-                "_mget/?pretty",
-                body,
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePostRequest(
+                    "_mget/?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("humanresources"));
@@ -425,14 +445,16 @@ public class MultitenancyTests extends SingleClusterTest {
             + "\"index-pattern\" : {"
             + "\"title\" : \"xyz\""
             + "}}";
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_CREATED,
-            (res = rh.executePutRequest(
-                ".kibana/_doc/abc?pretty",
-                body,
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    ".kibana/_doc/abc?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains("\"result\" : \"created\""));
@@ -448,25 +470,24 @@ public class MultitenancyTests extends SingleClusterTest {
             + "{ \"field2\" : \"value2\" }"
             + System.lineSeparator();
 
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executePutRequest(
-                "_bulk?pretty",
-                body,
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("admin", "admin")
-            )).getStatusCode()
+            is(
+                (res = rh.executePutRequest(
+                    "_bulk?pretty",
+                    body,
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("admin", "admin")
+                )).getStatusCode()
+            )
         );
         Assert.assertFalse(res.getBody().contains("exception"));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
         Assert.assertTrue(res.getBody().contains("\"errors\" : false"));
         Assert.assertTrue(res.getBody().contains("\"result\" : \"created\""));
 
-        Assert.assertEquals(
-            HttpStatus.SC_OK,
-            (res = rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin"))).getStatusCode()
-        );
-        Assert.assertEquals(2, res.getBody().split(".kibana").length);
+        assertThat(HttpStatus.SC_OK, is((res = rh.executeGetRequest("_cat/indices", encodeBasicHeader("admin", "admin"))).getStatusCode()));
+        assertThat(res.getBody().split(".kibana").length, is(2));
         Assert.assertTrue(res.getBody().contains(dashboardsIndex));
 
     }
@@ -493,13 +514,13 @@ public class MultitenancyTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(".kibana-6/_doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode()
+            is((res = rh.executeGetRequest(".kibana-6/_doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode())
         );
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(".kibana/_doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode()
+            is((res = rh.executeGetRequest(".kibana/_doc/6.2.2?pretty", encodeBasicHeader("kibanaro", "kibanaro"))).getStatusCode())
         );
 
     }
@@ -532,13 +553,15 @@ public class MultitenancyTests extends SingleClusterTest {
         final RestHelper rh = nonSslRestHelper();
 
         HttpResponse res;
-        Assert.assertEquals(
+        assertThat(
             HttpStatus.SC_OK,
-            (res = rh.executeGetRequest(
-                ".kibana/_doc/6.2.2?pretty",
-                new BasicHeader("securitytenant", "__user__"),
-                encodeBasicHeader("kibanaro", "kibanaro")
-            )).getStatusCode()
+            is(
+                (res = rh.executeGetRequest(
+                    ".kibana/_doc/6.2.2?pretty",
+                    new BasicHeader("securitytenant", "__user__"),
+                    encodeBasicHeader("kibanaro", "kibanaro")
+                )).getStatusCode()
+            )
         );
         Assert.assertTrue(res.getBody().contains(".kibana_-900636979_kibanaro"));
     }
@@ -615,12 +638,12 @@ public class MultitenancyTests extends SingleClusterTest {
 
         /* The anonymous user has access to its tenant */
         res = rh.executeGetRequest(url, new BasicHeader("securitytenant", anonymousTenant));
-        Assert.assertEquals(HttpStatus.SC_OK, res.getStatusCode());
-        Assert.assertEquals(anonymousTenant, res.findValueInJson("_source.tenant"));
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_OK));
+        assertThat(res.findValueInJson("_source.tenant"), is(anonymousTenant));
 
         /* No access to other tenants */
         res = rh.executeGetRequest(url, new BasicHeader("securitytenant", "human_resources"));
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, res.getStatusCode());
+        assertThat(res.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.privileges;
 
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +20,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class PrivilegesEvaluatorTest extends SingleClusterTest {
     private static final Header NegativeLookaheadUserHeader = encodeBasicHeader("negative_lookahead_user", "negative_lookahead_user");
@@ -44,17 +46,17 @@ public class PrivilegesEvaluatorTest extends SingleClusterTest {
 
         RestHelper rh = nonSslRestHelper();
         RestHelper.HttpResponse response = rh.executeGetRequest("*/_search", NegativeLookaheadUserHeader);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         response = rh.executeGetRequest("r*/_search", NegativeLookaheadUserHeader);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 
     @Test
     public void testRegexPattern() throws Exception {
         RestHelper rh = nonSslRestHelper();
         RestHelper.HttpResponse response = rh.executeGetRequest("*/_search", NegatedRegexUserHeader);
-        Assert.assertEquals(HttpStatus.SC_FORBIDDEN, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         response = rh.executeGetRequest("r*/_search", NegatedRegexUserHeader);
-        Assert.assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
 }

--- a/src/test/java/org/opensearch/security/protected_indices/ProtectedIndicesTests.java
+++ b/src/test/java/org/opensearch/security/protected_indices/ProtectedIndicesTests.java
@@ -54,8 +54,9 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
 
 public class ProtectedIndicesTests extends SingleClusterTest {
 
@@ -887,41 +888,49 @@ public class ProtectedIndicesTests extends SingleClusterTest {
         RestHelper rh = nonSslRestHelper();
 
         for (String index : listOfIndexesToTest) {
-            assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executeGetRequest("_snapshot/" + index + "/" + index + "_1", protectedIndexUserHeader).getStatusCode()
+                is(rh.executeGetRequest("_snapshot/" + index + "/" + index + "_1", protectedIndexUserHeader).getStatusCode())
             );
-            assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePostRequest(
-                    "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
-                    "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
-                    protectedIndexUserHeader
-                ).getStatusCode()
+                is(
+                    rh.executePostRequest(
+                        "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
+                        "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
+                        protectedIndexUserHeader
+                    ).getStatusCode()
+                )
             );
-            assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePostRequest(
-                    "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
-                    "",
-                    protectedIndexUserHeader
-                ).getStatusCode()
+                is(
+                    rh.executePostRequest(
+                        "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
+                        "",
+                        protectedIndexUserHeader
+                    ).getStatusCode()
+                )
             );
-            assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePostRequest(
-                    "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
-                    "{ \"indices\": \"" + index + "\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"" + index + "_1\" }",
-                    protectedIndexUserHeader
-                ).getStatusCode()
+                is(
+                    rh.executePostRequest(
+                        "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
+                        "{ \"indices\": \"" + index + "\", \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"" + index + "_1\" }",
+                        protectedIndexUserHeader
+                    ).getStatusCode()
+                )
             );
-            assertEquals(
+            assertThat(
                 HttpStatus.SC_OK,
-                rh.executePutRequest(
-                    "_snapshot/" + index + "/" + index + "_2?wait_for_completion=true",
-                    String.format(putSnapshot, index),
-                    protectedIndexUserHeader
-                ).getStatusCode()
+                is(
+                    rh.executePutRequest(
+                        "_snapshot/" + index + "/" + index + "_2?wait_for_completion=true",
+                        String.format(putSnapshot, index),
+                        protectedIndexUserHeader
+                    ).getStatusCode()
+                )
             );
         }
     }

--- a/src/test/java/org/opensearch/security/securityconf/FlattenedActionGroupsTest.java
+++ b/src/test/java/org/opensearch/security/securityconf/FlattenedActionGroupsTest.java
@@ -18,12 +18,14 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import org.junit.Assert;
 import org.junit.Test;
 
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class FlattenedActionGroupsTest {
     @Test
@@ -42,11 +44,11 @@ public class FlattenedActionGroupsTest {
 
         FlattenedActionGroups actionGroups = new FlattenedActionGroups(config);
 
-        Assert.assertEquals(
+        assertThat(
             ImmutableSet.of("C", "A", "A1", "A2", "A3", "C1", "B", "B1", "B2", "B3", "Z"),
-            actionGroups.resolve(ImmutableSet.of("Z"))
+            is(actionGroups.resolve(ImmutableSet.of("Z")))
         );
-        Assert.assertEquals(ImmutableSet.of("A", "A1", "A2", "A3"), actionGroups.resolve(ImmutableSet.of("A")));
+        assertThat(actionGroups.resolve(ImmutableSet.of("A")), is(ImmutableSet.of("A", "A1", "A2", "A3")));
     }
 
     /**
@@ -70,9 +72,9 @@ public class FlattenedActionGroupsTest {
 
         FlattenedActionGroups actionGroups = new FlattenedActionGroups(config);
 
-        Assert.assertEquals(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1"), actionGroups.resolve(ImmutableSet.of("A")));
-        Assert.assertEquals(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1"), actionGroups.resolve(ImmutableSet.of("C")));
-        Assert.assertEquals(ImmutableSet.of("D", "D1"), actionGroups.resolve(ImmutableSet.of("D")));
+        assertThat(actionGroups.resolve(ImmutableSet.of("A")), is(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1")));
+        assertThat(actionGroups.resolve(ImmutableSet.of("C")), is(ImmutableSet.of("A", "A1", "B", "B1", "C", "C1", "D", "D1")));
+        assertThat(actionGroups.resolve(ImmutableSet.of("D")), is(ImmutableSet.of("D", "D1")));
     }
 
     private static class TestActionGroups {

--- a/src/test/java/org/opensearch/security/securityconf/impl/v6/ConfigV6Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v6/ConfigV6Test.java
@@ -34,52 +34,52 @@ public class ConfigV6Test {
     }
 
     public void assertEquals(ConfigV6.Kibana expected, JsonNode node) {
-        Assert.assertEquals(expected.multitenancy_enabled, node.get("multitenancy_enabled").asBoolean());
+        assertThat(node.get("multitenancy_enabled").asBoolean(), is(expected.multitenancy_enabled));
         assertThat(node.get("sign_in_options").isArray(), is(true));
         assertThat(node.get("sign_in_options").toString(), containsString(expected.sign_in_options.get(0).toString()));
 
         if (expected.server_username == null) {
             Assert.assertNull(node.get("server_username"));
         } else {
-            Assert.assertEquals(expected.server_username, node.get("server_username").asText());
+            assertThat(node.get("server_username").asText(), is(expected.server_username));
         }
         if (expected.index == null) {
             // null is not persisted
             Assert.assertNull(node.get("index"));
         } else {
-            Assert.assertEquals(expected.index, node.get("index").asText());
+            assertThat(node.get("index").asText(), is(expected.index));
         }
         if (expected.opendistro_role == null) {
             Assert.assertNull(node.get("opendistro_role"));
         } else {
-            Assert.assertEquals(expected.opendistro_role, node.get("opendistro_role").asText());
+            assertThat(node.get("opendistro_role").asText(), is(expected.opendistro_role));
         }
         if (omitDefaults && !expected.do_not_fail_on_forbidden) {
             // false (default) is not persisted
             Assert.assertNull(node.get("do_not_fail_on_forbidden"));
         } else {
-            Assert.assertEquals(expected.do_not_fail_on_forbidden, node.get("do_not_fail_on_forbidden").asBoolean());
+            assertThat(node.get("do_not_fail_on_forbidden").asBoolean(), is(expected.do_not_fail_on_forbidden));
         }
     }
 
     private void assertEquals(ConfigV6.Kibana expected, ConfigV6.Kibana actual) {
-        Assert.assertEquals(expected.multitenancy_enabled, actual.multitenancy_enabled);
+        assertThat(actual.multitenancy_enabled, is(expected.multitenancy_enabled));
         assertThat(expected.sign_in_options, is(actual.sign_in_options));
         if (expected.server_username == null) {
             // null is restored to default instead of null
-            Assert.assertEquals(new ConfigV6.Kibana().server_username, actual.server_username);
+            assertThat(actual.server_username, is(new ConfigV6.Kibana().server_username));
         } else {
-            Assert.assertEquals(expected.server_username, actual.server_username);
+            assertThat(actual.server_username, is(expected.server_username));
         }
         // null is restored to default (which is null).
-        Assert.assertEquals(expected.opendistro_role, actual.opendistro_role);
+        assertThat(actual.opendistro_role, is(expected.opendistro_role));
         if (expected.index == null) {
             // null is restored to default instead of null
-            Assert.assertEquals(new ConfigV6.Kibana().index, actual.index);
+            assertThat(actual.index, is(new ConfigV6.Kibana().index));
         } else {
-            Assert.assertEquals(expected.index, actual.index);
+            assertThat(actual.index, is(expected.index));
         }
-        Assert.assertEquals(expected.do_not_fail_on_forbidden, actual.do_not_fail_on_forbidden);
+        assertThat(actual.do_not_fail_on_forbidden, is(expected.do_not_fail_on_forbidden));
     }
 
     public ConfigV6Test(boolean omitDefaults) {
@@ -120,7 +120,7 @@ public class ConfigV6Test {
         ConfigV6.OnBehalfOfSettings oboSettings;
 
         oboSettings = new ConfigV6.OnBehalfOfSettings();
-        Assert.assertEquals(oboSettings.getOboEnabled(), Boolean.FALSE);
+        assertThat(Boolean.FALSE, is(oboSettings.getOboEnabled()));
         Assert.assertNull(oboSettings.getSigningKey());
         Assert.assertNull(oboSettings.getEncryptionKey());
     }

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
@@ -34,44 +34,44 @@ public class ConfigV7Test {
     }
 
     public void assertEquals(ConfigV7.Kibana expected, JsonNode node) {
-        Assert.assertEquals(expected.multitenancy_enabled, node.get("multitenancy_enabled").asBoolean());
+        assertThat(node.get("multitenancy_enabled").asBoolean(), is(expected.multitenancy_enabled));
         assertThat(node.get("sign_in_options").isArray(), is(true));
         assertThat(node.get("sign_in_options").toString(), containsString(expected.sign_in_options.get(0).toString()));
 
         if (expected.server_username == null) {
             Assert.assertNull(node.get("server_username"));
         } else {
-            Assert.assertEquals(expected.server_username, node.get("server_username").asText());
+            assertThat(node.get("server_username").asText(), is(expected.server_username));
         }
         if (expected.index == null) {
             // null is not persisted
             Assert.assertNull(node.get("index"));
         } else {
-            Assert.assertEquals(expected.index, node.get("index").asText());
+            assertThat(node.get("index").asText(), is(expected.index));
         }
         if (expected.opendistro_role == null) {
             Assert.assertNull(node.get("opendistro_role"));
         } else {
-            Assert.assertEquals(expected.opendistro_role, node.get("opendistro_role").asText());
+            assertThat(node.get("opendistro_role").asText(), is(expected.opendistro_role));
         }
     }
 
     private void assertEquals(ConfigV7.Kibana expected, ConfigV7.Kibana actual) {
-        Assert.assertEquals(expected.multitenancy_enabled, actual.multitenancy_enabled);
+        assertThat(actual.multitenancy_enabled, is(expected.multitenancy_enabled));
         assertThat(expected.sign_in_options, is(actual.sign_in_options));
         if (expected.server_username == null) {
             // null is restored to default instead of null
-            Assert.assertEquals(new ConfigV7.Kibana().server_username, actual.server_username);
+            assertThat(actual.server_username, is(new ConfigV7.Kibana().server_username));
         } else {
-            Assert.assertEquals(expected.server_username, actual.server_username);
+            assertThat(actual.server_username, is(expected.server_username));
         }
         // null is restored to default (which is null).
-        Assert.assertEquals(expected.opendistro_role, actual.opendistro_role);
+        assertThat(actual.opendistro_role, is(expected.opendistro_role));
         if (expected.index == null) {
             // null is restored to default instead of null
-            Assert.assertEquals(new ConfigV7.Kibana().index, actual.index);
+            assertThat(actual.index, is(new ConfigV7.Kibana().index));
         } else {
-            Assert.assertEquals(expected.index, actual.index);
+            assertThat(actual.index, is(expected.index));
         }
     }
 
@@ -111,7 +111,7 @@ public class ConfigV7Test {
         ConfigV7.OnBehalfOfSettings oboSettings;
 
         oboSettings = new ConfigV7.OnBehalfOfSettings();
-        Assert.assertEquals(oboSettings.getOboEnabled(), Boolean.FALSE);
+        assertThat(Boolean.FALSE, is(oboSettings.getOboEnabled()));
         Assert.assertNull(oboSettings.getSigningKey());
         Assert.assertNull(oboSettings.getEncryptionKey());
     }

--- a/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
@@ -40,6 +40,9 @@ import org.opensearch.security.ssl.util.CertificateValidator;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CertificateValidatorTest {
 
     public static final Date CRL_DATE = new Date(1525546426000L);
@@ -54,7 +57,7 @@ public class CertificateValidatorTest {
             crls = CertificateFactory.getInstance("X.509").generateCRLs(crlin);
         }
 
-        Assert.assertEquals(crls.size(), 1);
+        assertThat(1, is(crls.size()));
 
         // trust chain incl intermediate certificates (root + intermediates)
         Collection<? extends Certificate> rootCas;
@@ -63,7 +66,7 @@ public class CertificateValidatorTest {
             rootCas = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(rootCas.size(), 2);
+        assertThat(2, is(rootCas.size()));
 
         // certificate chain to validate (client cert + intermediates but without root)
         Collection<? extends Certificate> certsToValidate;
@@ -72,7 +75,7 @@ public class CertificateValidatorTest {
             certsToValidate = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(certsToValidate.size(), 2);
+        assertThat(2, is(certsToValidate.size()));
 
         CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), crls);
         validator.setDate(CRL_DATE);
@@ -93,7 +96,7 @@ public class CertificateValidatorTest {
             crls = CertificateFactory.getInstance("X.509").generateCRLs(crlin);
         }
 
-        Assert.assertEquals(crls.size(), 1);
+        assertThat(1, is(crls.size()));
 
         // trust chain incl intermediate certificates (root + intermediates)
         Collection<? extends Certificate> rootCas;
@@ -102,7 +105,7 @@ public class CertificateValidatorTest {
             rootCas = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(rootCas.size(), 2);
+        assertThat(2, is(rootCas.size()));
 
         // certificate chain to validate (client cert + intermediates but without root)
         Collection<? extends Certificate> certsToValidate;
@@ -111,7 +114,7 @@ public class CertificateValidatorTest {
             certsToValidate = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(certsToValidate.size(), 3);
+        assertThat(3, is(certsToValidate.size()));
 
         CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), crls);
         validator.setDate(CRL_DATE);
@@ -132,7 +135,7 @@ public class CertificateValidatorTest {
             rootCas = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(rootCas.size(), 2);
+        assertThat(2, is(rootCas.size()));
 
         // certificate chain to validate (client cert + intermediates but without root)
         Collection<? extends Certificate> certsToValidate;
@@ -141,7 +144,7 @@ public class CertificateValidatorTest {
             certsToValidate = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(certsToValidate.size(), 2);
+        assertThat(2, is(certsToValidate.size()));
 
         CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), Collections.emptyList());
         validator.setDate(CRL_DATE);
@@ -164,7 +167,7 @@ public class CertificateValidatorTest {
             rootCas = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(rootCas.size(), 1);
+        assertThat(1, is(rootCas.size()));
 
         // certificate chain to validate (client cert + intermediates but without root)
         Collection<? extends Certificate> certsToValidate;
@@ -174,7 +177,7 @@ public class CertificateValidatorTest {
             certsToValidate = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509").generateCertificates(trin);
         }
 
-        Assert.assertEquals(certsToValidate.size(), 2);
+        assertThat(2, is(certsToValidate.size()));
 
         CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), Collections.emptyList());
         validator.setEnableCRLDP(true);

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -47,6 +47,9 @@ import org.opensearch.transport.Netty4Plugin;
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.util.internal.PlatformDependent;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class OpenSSLTest extends SSLTest {
     private static final String USE_NETTY_DEFAULT_ALLOCATOR_PROPERTY = "opensearch.unsafe.use_netty_default_allocator";
     private static String USE_NETTY_DEFAULT_ALLOCATOR;
@@ -218,8 +221,8 @@ public class OpenSSLTest extends SSLTest {
                 .health(new ClusterHealthRequest().waitForNodes("4").timeout(TimeValue.timeValueSeconds(5)))
                 .actionGet();
             Assert.assertFalse(res.isTimedOut());
-            Assert.assertEquals(4, res.getNumberOfNodes());
-            Assert.assertEquals(4, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(res.getNumberOfNodes(), is(4));
+            assertThat(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(4));
         }
 
         Assert.assertFalse(rh.executeSimpleRequest("_nodes/stats?pretty").contains("\"tx_size_in_bytes\" : 0"));

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -64,6 +64,8 @@ import org.opensearch.transport.Netty4Plugin;
 
 import io.netty.util.internal.PlatformDependent;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_KEYPASSWORD;
@@ -161,15 +163,15 @@ public class SSLTest extends SingleClusterTest {
             String[] enabledProtocols = new DefaultSecurityKeyStore(settings, Paths.get(".")).createHTTPSSLEngine().getEnabledProtocols();
 
             if (allowOpenSSL) {
-                Assert.assertEquals(2, enabledProtocols.length); // SSLv2Hello is always enabled when using openssl
+                assertThat(enabledProtocols.length, is(2)); // SSLv2Hello is always enabled when using openssl
                 Assert.assertTrue("Check SSLv3", "SSLv3".equals(enabledProtocols[0]) || "SSLv3".equals(enabledProtocols[1]));
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("TLS_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("TLS_RSA_EXPORT_WITH_RC4_40_MD5"));
             } else {
-                Assert.assertEquals(1, enabledProtocols.length);
-                Assert.assertEquals("SSLv3", enabledProtocols[0]);
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("SSL_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledProtocols.length, is(1));
+                assertThat(enabledProtocols[0], is("SSLv3"));
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("SSL_RSA_EXPORT_WITH_RC4_40_MD5"));
             }
 
             settings = Settings.builder()
@@ -198,15 +200,15 @@ public class SSLTest extends SingleClusterTest {
             enabledProtocols = new DefaultSecurityKeyStore(settings, Paths.get(".")).createServerTransportSSLEngine().getEnabledProtocols();
 
             if (allowOpenSSL) {
-                Assert.assertEquals(2, enabledProtocols.length); // SSLv2Hello is always enabled when using openssl
+                assertThat(enabledProtocols.length, is(2)); // SSLv2Hello is always enabled when using openssl
                 Assert.assertTrue("Check SSLv3", "SSLv3".equals(enabledProtocols[0]) || "SSLv3".equals(enabledProtocols[1]));
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("TLS_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("TLS_RSA_EXPORT_WITH_RC4_40_MD5"));
             } else {
-                Assert.assertEquals(1, enabledProtocols.length);
-                Assert.assertEquals("SSLv3", enabledProtocols[0]);
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("SSL_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledProtocols.length, is(1));
+                assertThat(enabledProtocols[0], is("SSLv3"));
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("SSL_RSA_EXPORT_WITH_RC4_40_MD5"));
             }
             enabledCiphers = new DefaultSecurityKeyStore(settings, Paths.get(".")).createClientTransportSSLEngine(null, -1)
                 .getEnabledCipherSuites();
@@ -214,15 +216,15 @@ public class SSLTest extends SingleClusterTest {
                 .getEnabledProtocols();
 
             if (allowOpenSSL) {
-                Assert.assertEquals(2, enabledProtocols.length); // SSLv2Hello is always enabled when using openssl
+                assertThat(enabledProtocols.length, is(2)); // SSLv2Hello is always enabled when using openssl
                 Assert.assertTrue("Check SSLv3", "SSLv3".equals(enabledProtocols[0]) || "SSLv3".equals(enabledProtocols[1]));
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("TLS_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("TLS_RSA_EXPORT_WITH_RC4_40_MD5"));
             } else {
-                Assert.assertEquals(1, enabledProtocols.length);
-                Assert.assertEquals("SSLv3", enabledProtocols[0]);
-                Assert.assertEquals(1, enabledCiphers.length);
-                Assert.assertEquals("SSL_RSA_EXPORT_WITH_RC4_40_MD5", enabledCiphers[0]);
+                assertThat(enabledProtocols.length, is(1));
+                assertThat(enabledProtocols[0], is("SSLv3"));
+                assertThat(enabledCiphers.length, is(1));
+                assertThat(enabledCiphers[0], is("SSL_RSA_EXPORT_WITH_RC4_40_MD5"));
             }
         } catch (OpenSearchSecurityException e) {
             Assert.assertTrue(
@@ -757,8 +759,8 @@ public class SSLTest extends SingleClusterTest {
                 .health(new ClusterHealthRequest().waitForNodes("4").timeout(TimeValue.timeValueSeconds(15)))
                 .actionGet();
             Assert.assertFalse(res.isTimedOut());
-            Assert.assertEquals(4, res.getNumberOfNodes());
-            Assert.assertEquals(4, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(res.getNumberOfNodes(), is(4));
+            assertThat(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(4));
         }
 
         String res = rh.executeSimpleRequest("_nodes/stats?pretty");
@@ -788,7 +790,7 @@ public class SSLTest extends SingleClusterTest {
     @Test
     public void testUnmodifieableCipherProtocolConfig() throws Exception {
         SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0] = "bogus";
-        Assert.assertEquals("TLSv1.3", SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0]);
+        assertThat(SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0], is("TLSv1.3"));
 
         try {
             SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false).set(0, "bogus");
@@ -849,21 +851,23 @@ public class SSLTest extends SingleClusterTest {
 
             log.debug("Client built, connect now to {}:{}", clusterInfo.nodeHost, clusterInfo.httpPort);
 
-            Assert.assertEquals(3, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(3));
             log.debug("Client connected");
             TestPrincipalExtractor.reset();
-            Assert.assertEquals(
+            assertThat(
                 "test",
-                tc.index(new IndexRequest("test").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"a\":5}", XContentType.JSON))
-                    .actionGet()
-                    .getIndex()
+                is(
+                    tc.index(new IndexRequest("test").setRefreshPolicy(RefreshPolicy.IMMEDIATE).source("{\"a\":5}", XContentType.JSON))
+                        .actionGet()
+                        .getIndex()
+                )
             );
             log.debug("Index created");
-            Assert.assertEquals(1L, tc.search(new SearchRequest("test")).actionGet().getHits().getTotalHits().value);
+            assertThat(tc.search(new SearchRequest("test")).actionGet().getHits().getTotalHits().value, is(1L));
             log.debug("Search done");
-            Assert.assertEquals(3, tc.admin().cluster().health(new ClusterHealthRequest("test")).actionGet().getNumberOfNodes());
+            assertThat(tc.admin().cluster().health(new ClusterHealthRequest("test")).actionGet().getNumberOfNodes(), is(3));
             log.debug("ClusterHealth done");
-            Assert.assertEquals(3, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(3));
             log.debug("NodesInfoRequest asserted");
         }
 
@@ -1005,8 +1009,8 @@ public class SSLTest extends SingleClusterTest {
                 .health(new ClusterHealthRequest().waitForNodes("4").timeout(TimeValue.timeValueSeconds(5)))
                 .actionGet();
             Assert.assertFalse(res.isTimedOut());
-            Assert.assertEquals(4, res.getNumberOfNodes());
-            Assert.assertEquals(4, node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(res.getNumberOfNodes(), is(4));
+            assertThat(node.client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(4));
         }
 
         String res = rh.executeSimpleRequest("_nodes/stats?pretty");

--- a/src/test/java/org/opensearch/security/ssl/SecureSSLSettingsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SecureSSLSettingsTest.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 import org.opensearch.common.settings.MockSecureSettings;
 import org.opensearch.common.settings.Settings;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
 
 public class SecureSSLSettingsTest {
@@ -26,14 +28,14 @@ public class SecureSSLSettingsTest {
         mockSecureSettings.setString(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.propertyName, "test-password");
         final var settings = Settings.builder().setSecureSettings(mockSecureSettings).build();
         final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        Assert.assertEquals("test-password", password);
+        assertThat(password, is("test-password"));
     }
 
     @Test
     public void testGetInsecureSetting() {
         final var settings = Settings.builder().put(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.insecurePropertyName, "test-password").build();
         final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        Assert.assertEquals("test-password", password);
+        assertThat(password, is("test-password"));
     }
 
     @Test
@@ -45,6 +47,6 @@ public class SecureSSLSettingsTest {
             .put(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.insecurePropertyName, "insecure-password")
             .build();
         final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        Assert.assertEquals("secure-password", password);
+        assertThat(password, is("secure-password"));
     }
 }

--- a/src/test/java/org/opensearch/security/ssl/util/CertFromFileTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/CertFromFileTests.java
@@ -18,6 +18,9 @@ import org.junit.Test;
 
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CertFromFileTests {
 
     @Test
@@ -31,7 +34,7 @@ public class CertFromFileTests {
 
         CertFromFile cert = new CertFromFile(certProps);
 
-        Assert.assertEquals(1, cert.getCerts().length);
+        assertThat(cert.getCerts().length, is(1));
         Assert.assertNotNull(cert.getClientPemCert());
         Assert.assertNotNull(cert.getClientPemKey());
         Assert.assertNotNull(cert.getClientTrustedCas());
@@ -80,7 +83,7 @@ public class CertFromFileTests {
 
         CertFromFile cert = new CertFromFile(clientCertProps, servertCertProps);
 
-        Assert.assertEquals(2, cert.getCerts().length);
+        assertThat(cert.getCerts().length, is(2));
     }
 
 }

--- a/src/test/java/org/opensearch/security/ssl/util/CertFromKeystoreTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/CertFromKeystoreTests.java
@@ -22,6 +22,9 @@ import org.junit.Test;
 
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CertFromKeystoreTests {
 
     @Test
@@ -36,7 +39,7 @@ public class CertFromKeystoreTests {
         CertFromKeystore cert = new CertFromKeystore(props, "node-0", "changeit");
 
         // second cert is Signing cert
-        Assert.assertEquals(2, cert.getCerts().length);
+        assertThat(cert.getCerts().length, is(2));
         Assert.assertTrue(cert.getCerts()[0].getSubjectDN().getName().contains("node-0"));
 
         Assert.assertNotNull(cert.getServerKey());
@@ -55,7 +58,7 @@ public class CertFromKeystoreTests {
         CertFromKeystore cert = new CertFromKeystore(props, null, "changeit");
 
         // second cert is Signing cert
-        Assert.assertEquals(2, cert.getCerts().length);
+        assertThat(cert.getCerts().length, is(2));
         Assert.assertTrue(cert.getCerts()[0].getSubjectDN().getName().contains("node-0"));
     }
 
@@ -70,7 +73,7 @@ public class CertFromKeystoreTests {
 
         CertFromKeystore cert = new CertFromKeystore(props, "node-0-server", "node-0-client", "changeit", "changeit");
 
-        Assert.assertEquals(4, cert.getCerts().length);
+        assertThat(cert.getCerts().length, is(4));
 
         Assert.assertTrue(cert.getClientCert()[0].getSubjectDN().getName().contains("node-client"));
         Assert.assertTrue(cert.getServerCert()[0].getSubjectDN().getName().contains("node-server"));

--- a/src/test/java/org/opensearch/security/ssl/util/CertFromTruststoreTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/CertFromTruststoreTests.java
@@ -21,6 +21,9 @@ import org.junit.Test;
 
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class CertFromTruststoreTests {
 
     @Test
@@ -34,7 +37,7 @@ public class CertFromTruststoreTests {
 
         CertFromTruststore cert = new CertFromTruststore(props, "root-ca");
 
-        Assert.assertEquals(1, cert.getClientTrustedCerts().length);
+        assertThat(cert.getClientTrustedCerts().length, is(1));
         Assert.assertTrue(cert.getClientTrustedCerts().equals(cert.getServerTrustedCerts()));
     }
 
@@ -48,7 +51,7 @@ public class CertFromTruststoreTests {
 
         CertFromTruststore cert = new CertFromTruststore(props, null);
 
-        Assert.assertEquals(1, cert.getClientTrustedCerts().length);
+        assertThat(cert.getClientTrustedCerts().length, is(1));
     }
 
     public void testLoadDifferentCertsForClientServerUsage() throws CertificateException, NoSuchAlgorithmException, KeyStoreException,
@@ -61,8 +64,8 @@ public class CertFromTruststoreTests {
 
         CertFromTruststore cert = new CertFromTruststore(props, "root-ca", "root-ca");
 
-        Assert.assertEquals(1, cert.getClientTrustedCerts().length);
-        Assert.assertEquals(1, cert.getServerTrustedCerts().length);
+        assertThat(cert.getClientTrustedCerts().length, is(1));
+        assertThat(cert.getServerTrustedCerts().length, is(1));
         // we are loading same cert twice
         Assert.assertFalse(cert.getClientTrustedCerts().equals(cert.getServerTrustedCerts()));
     }

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConnectionTestUtilTests.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConnectionTestUtilTests.java
@@ -17,12 +17,14 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
 
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class SSLConnectionTestUtilTests {
     private Socket socket;
@@ -64,7 +66,7 @@ public class SSLConnectionTestUtilTests {
 
         verifyClientHelloSend();
         Mockito.verify(socket, Mockito.times(1)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_AVAILABLE, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.SSL_AVAILABLE));
     }
 
     @Test
@@ -85,7 +87,7 @@ public class SSLConnectionTestUtilTests {
         verifyClientHelloSend();
         verifyOpenSearchPingSend();
         Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.SSL_NOT_AVAILABLE));
     }
 
     @Test
@@ -107,7 +109,7 @@ public class SSLConnectionTestUtilTests {
         Mockito.verifyNoInteractions(inputStreamReader);
         verifyOpenSearchPingSend();
         Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.SSL_NOT_AVAILABLE, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.SSL_NOT_AVAILABLE));
     }
 
     @Test
@@ -131,7 +133,7 @@ public class SSLConnectionTestUtilTests {
         verifyClientHelloSend();
         verifyOpenSearchPingSend();
         Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.OPENSEARCH_PING_FAILED));
     }
 
     @Test
@@ -161,7 +163,7 @@ public class SSLConnectionTestUtilTests {
         verifyClientHelloSend();
         verifyOpenSearchPingSend();
         Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.OPENSEARCH_PING_FAILED));
     }
 
     @Test
@@ -185,7 +187,7 @@ public class SSLConnectionTestUtilTests {
         verifyOpenSearchPingSend();
         Mockito.verifyNoInteractions(inputStream);
         Mockito.verify(socket, Mockito.times(2)).close();
-        Assert.assertEquals("Unexpected result for testConnection invocation", SSLConnectionTestResult.OPENSEARCH_PING_FAILED, result);
+        assertThat("Unexpected result for testConnection invocation", result, is(SSLConnectionTestResult.OPENSEARCH_PING_FAILED));
     }
 
     private void verifyClientHelloSend() throws IOException {
@@ -193,7 +195,7 @@ public class SSLConnectionTestUtilTests {
         Mockito.verify(outputStreamWriter, Mockito.times(1)).write(clientHelloMsgArgCaptor.capture());
         String msgWritten = clientHelloMsgArgCaptor.getValue();
         String expectedMsg = "DUALCM";
-        Assert.assertEquals("Unexpected Dual SSL Client Hello message written to socket", expectedMsg, msgWritten);
+        assertThat("Unexpected Dual SSL Client Hello message written to socket", msgWritten, is(expectedMsg));
     }
 
     private void verifyOpenSearchPingSend() throws IOException {
@@ -202,7 +204,7 @@ public class SSLConnectionTestUtilTests {
         byte[] bytesWritten = argumentCaptor.getValue();
         byte[] expectedBytes = new byte[] { 'E', 'S', (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF };
         for (int i = 0; i < bytesWritten.length; i++) {
-            Assert.assertEquals("Unexpected OpenSearch Ping bytes written to socket", expectedBytes[i], bytesWritten[i]);
+            assertThat("Unexpected OpenSearch Ping bytes written to socket", bytesWritten[i], is(expectedBytes[i]));
         }
     }
 

--- a/src/test/java/org/opensearch/security/state/SecurityMetadataSerializationTestCase.java
+++ b/src/test/java/org/opensearch/security/state/SecurityMetadataSerializationTestCase.java
@@ -35,7 +35,8 @@ import org.opensearch.core.common.io.stream.Writeable;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.test.DiffableTestUtils;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotSame;
 
 @RunWith(RandomizedRunner.class)
@@ -102,8 +103,8 @@ public class SecurityMetadataSerializationTestCase extends RandomizedTest {
 
     void assertEqualInstances(ClusterState.Custom expectedInstance, ClusterState.Custom newInstance) {
         assertNotSame(newInstance, expectedInstance);
-        assertEquals(expectedInstance, newInstance);
-        assertEquals(expectedInstance.hashCode(), newInstance.hashCode());
+        assertThat(newInstance, is(expectedInstance));
+        assertThat(newInstance.hashCode(), is(expectedInstance.hashCode()));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/support/Base64CustomHelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64CustomHelperTest.java
@@ -31,6 +31,8 @@ import org.opensearch.security.user.User;
 import com.amazon.dlic.auth.ldap.LdapUser;
 import org.ldaptive.LdapEntry;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.support.Base64CustomHelper.deserializeObject;
 import static org.opensearch.security.support.Base64CustomHelper.serializeObject;
 
@@ -54,37 +56,37 @@ public class Base64CustomHelperTest {
     @Test
     public void testString() {
         String string = "string";
-        Assert.assertEquals(string, ds(string));
+        assertThat(ds(string), is(string));
     }
 
     @Test
     public void testInteger() {
         Integer integer = 0;
-        Assert.assertEquals(integer, ds(integer));
+        assertThat(ds(integer), is(integer));
     }
 
     @Test
     public void testDouble() {
         Double number = 0.;
-        Assert.assertEquals(number, ds(number));
+        assertThat(ds(number), is(number));
     }
 
     @Test
     public void testInetSocketAddress() {
         InetSocketAddress inetSocketAddress = new InetSocketAddress(0);
-        Assert.assertEquals(inetSocketAddress, ds(inetSocketAddress));
+        assertThat(ds(inetSocketAddress), is(inetSocketAddress));
     }
 
     @Test
     public void testUser() {
         User user = new User("user");
-        Assert.assertEquals(user, ds(user));
+        assertThat(ds(user), is(user));
     }
 
     @Test
     public void testSourceFieldsContext() {
         SourceFieldsContext sourceFieldsContext = new SourceFieldsContext(new SearchRequest(""));
-        Assert.assertEquals(sourceFieldsContext.toString(), ds(sourceFieldsContext).toString());
+        assertThat(ds(sourceFieldsContext).toString(), is(sourceFieldsContext.toString()));
     }
 
     @Test
@@ -94,7 +96,7 @@ public class Base64CustomHelperTest {
                 put("key", "value");
             }
         };
-        Assert.assertEquals(map, ds(map));
+        assertThat(ds(map), is(map));
     }
 
     @Test
@@ -104,7 +106,7 @@ public class Base64CustomHelperTest {
                 add("value");
             }
         };
-        Assert.assertEquals(list, ds(list));
+        assertThat(ds(list), is(list));
     }
 
     @Test
@@ -117,17 +119,17 @@ public class Base64CustomHelperTest {
             34,
             WildcardMatcher.ANY
         );
-        Assert.assertEquals(ldapUser, ds(ldapUser));
+        assertThat(ds(ldapUser), is(ldapUser));
     }
 
     @Test
     public void testGetWriteableClassID() {
         // a need to make a change in this test signifies a breaking change in security plugin's custom serialization
         // format
-        Assert.assertEquals(Integer.valueOf(1), Base64CustomHelper.getWriteableClassID(User.class));
-        Assert.assertEquals(Integer.valueOf(2), Base64CustomHelper.getWriteableClassID(LdapUser.class));
-        Assert.assertEquals(Integer.valueOf(3), Base64CustomHelper.getWriteableClassID(UserInjector.InjectedUser.class));
-        Assert.assertEquals(Integer.valueOf(4), Base64CustomHelper.getWriteableClassID(SourceFieldsContext.class));
+        assertThat(Base64CustomHelper.getWriteableClassID(User.class), is(Integer.valueOf(1)));
+        assertThat(Base64CustomHelper.getWriteableClassID(LdapUser.class), is(Integer.valueOf(2)));
+        assertThat(Base64CustomHelper.getWriteableClassID(UserInjector.InjectedUser.class), is(Integer.valueOf(3)));
+        assertThat(Base64CustomHelper.getWriteableClassID(SourceFieldsContext.class), is(Integer.valueOf(4)));
     }
 
     @Test
@@ -136,7 +138,7 @@ public class Base64CustomHelperTest {
 
         // for custom serialization, we expect InjectedUser to be returned on deserialization
         UserInjector.InjectedUser deserializedInjecteduser = (UserInjector.InjectedUser) ds(injectedUser);
-        Assert.assertEquals(injectedUser, deserializedInjecteduser);
+        assertThat(deserializedInjecteduser, is(injectedUser));
         Assert.assertTrue(deserializedInjecteduser.isInjected());
     }
 

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -14,14 +14,13 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.stream.IntStream;
 
-import org.junit.Assert;
 import org.junit.Test;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.support.Base64Helper.deserializeObject;
 import static org.opensearch.security.support.Base64Helper.serializeObject;
-import static org.junit.Assert.assertThat;
 
 public class Base64HelperTest {
 
@@ -41,8 +40,8 @@ public class Base64HelperTest {
     @Test
     public void testSerde() {
         String test = "string";
-        Assert.assertEquals(test, ds(test));
-        Assert.assertEquals(test, dsJDK(test));
+        assertThat(ds(test), is(test));
+        assertThat(dsJDK(test), is(test));
     }
 
     @Test
@@ -50,8 +49,8 @@ public class Base64HelperTest {
         String test = "string";
         String jdkSerialized = Base64Helper.serializeObject(test, true);
         String customSerialized = Base64Helper.serializeObject(test, false);
-        Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(jdkSerialized));
-        Assert.assertEquals(jdkSerialized, Base64Helper.ensureJDKSerialized(customSerialized));
+        assertThat(Base64Helper.ensureJDKSerialized(jdkSerialized), is(jdkSerialized));
+        assertThat(Base64Helper.ensureJDKSerialized(customSerialized), is(jdkSerialized));
     }
 
     @Test
@@ -65,9 +64,9 @@ public class Base64HelperTest {
         final var customSerialized = Base64Helper.serializeObject(largeObject, false);
         final var customSerializedOnlyHashMap = Base64Helper.serializeObject(hm, false);
 
-        assertThat(jdkSerialized.length(), equalTo(3832));
+        assertThat(jdkSerialized.length(), is(3832));
         // The custom serializer is ~50x larger than the jdk serialized version
-        assertThat(customSerialized.length(), equalTo(184792));
+        assertThat(customSerialized.length(), is(184792));
         // Show that the majority of the size of the custom serialized large object is the map duplicated ~100 times
         assertThat((double) customSerializedOnlyHashMap.length(), closeTo(customSerialized.length() / 100, 70d));
     }

--- a/src/test/java/org/opensearch/security/support/Base64JDKHelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64JDKHelperTest.java
@@ -33,6 +33,7 @@ import org.ldaptive.LdapEntry;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
 public class Base64JDKHelperTest {
@@ -47,51 +48,51 @@ public class Base64JDKHelperTest {
     @Test
     public void testString() {
         String string = "string";
-        Assert.assertEquals(string, ds(string));
+        assertThat(ds(string), is(string));
     }
 
     @Test
     public void testInteger() {
         Integer integer = 0;
-        Assert.assertEquals(integer, ds(integer));
+        assertThat(ds(integer), is(integer));
     }
 
     @Test
     public void testDouble() {
         Double number = 0.0;
-        Assert.assertEquals(number, ds(number));
+        assertThat(ds(number), is(number));
     }
 
     @Test
     public void testInetSocketAddress() {
         InetSocketAddress inetSocketAddress = new InetSocketAddress(0);
-        Assert.assertEquals(inetSocketAddress, ds(inetSocketAddress));
+        assertThat(ds(inetSocketAddress), is(inetSocketAddress));
     }
 
     @Test
     public void testUser() {
         User user = new User("user");
-        Assert.assertEquals(user, ds(user));
+        assertThat(ds(user), is(user));
     }
 
     @Test
     public void testSourceFieldsContext() {
         SourceFieldsContext sourceFieldsContext = new SourceFieldsContext(new SearchRequest(""));
-        Assert.assertEquals(sourceFieldsContext.toString(), ds(sourceFieldsContext).toString());
+        assertThat(ds(sourceFieldsContext).toString(), is(sourceFieldsContext.toString()));
     }
 
     @Test
     public void testHashMap() {
         HashMap<String, String> map = new HashMap<>();
         map.put("key", "value");
-        Assert.assertEquals(map, ds(map));
+        assertThat(ds(map), is(map));
     }
 
     @Test
     public void testArrayList() {
         ArrayList<String> list = new ArrayList<>();
         list.add("value");
-        Assert.assertEquals(list, ds(list));
+        assertThat(ds(list), is(list));
     }
 
     @Test
@@ -126,7 +127,7 @@ public class Base64JDKHelperTest {
             34,
             WildcardMatcher.ANY
         );
-        Assert.assertEquals(ldapUser, ds(ldapUser));
+        assertThat(ds(ldapUser), is(ldapUser));
     }
 
     @Test
@@ -136,7 +137,7 @@ public class Base64JDKHelperTest {
         // we expect to get User object when deserializing InjectedUser via JDK serialization
         User user = new User("username");
         User deserializedUser = (User) ds(injectedUser);
-        Assert.assertEquals(user, deserializedUser);
+        assertThat(deserializedUser, is(user));
         Assert.assertTrue(deserializedUser.isInjected());
     }
 }

--- a/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
+++ b/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
@@ -21,8 +21,9 @@ import org.junit.rules.TemporaryFolder;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.securityconf.impl.CType;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -54,8 +55,8 @@ public class ConfigReaderTest {
                 assertTrue(emptyYaml.has("_meta"));
 
                 final var meta = emptyYaml.get("_meta");
-                assertEquals(cType.toLCString(), meta.get("type").asText());
-                assertEquals(DEFAULT_CONFIG_VERSION, meta.get("config_version").asInt());
+                assertThat(meta.get("type").asText(), is(cType.toLCString()));
+                assertThat(meta.get("config_version").asInt(), is(DEFAULT_CONFIG_VERSION));
             }
         }
     }

--- a/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
+++ b/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
@@ -58,9 +58,9 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.configuration.ConfigurationRepository.DEFAULT_CONFIG_VERSION;
 import static org.opensearch.security.support.YamlConfigReader.emptyYamlConfigFor;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -172,19 +172,19 @@ public class SecurityIndexHandlerTest {
         verify(indicesAdminClient).create(requestCaptor.capture(), any());
 
         final var createRequest = requestCaptor.getValue();
-        assertEquals(INDEX_NAME, createRequest.index());
+        assertThat(createRequest.index(), is(INDEX_NAME));
         for (final var setting : SecurityIndexHandler.INDEX_SETTINGS.entrySet())
-            assertEquals(setting.getValue().toString(), createRequest.settings().get(setting.getKey()));
+            assertThat(createRequest.settings().get(setting.getKey()), is(setting.getValue().toString()));
 
-        assertEquals(ActiveShardCount.ONE, createRequest.waitForActiveShards());
+        assertThat(createRequest.waitForActiveShards(), is(ActiveShardCount.ONE));
     }
 
     @Test
     public void testCreateIndex_shouldReturnSecurityExceptionIfItCanNotCreateIndex() {
 
         final var listener = spy(ActionListener.<Boolean>wrap(r -> fail("Unexpected behave"), e -> {
-            assertEquals(SecurityException.class, e.getClass());
-            assertEquals("Couldn't create security index " + INDEX_NAME, e.getMessage());
+            assertThat(e.getClass(), is(SecurityException.class));
+            assertThat(e.getMessage(), is("Couldn't create security index " + INDEX_NAME));
         }));
 
         doAnswer(invocation -> {
@@ -202,7 +202,7 @@ public class SecurityIndexHandlerTest {
     @Test
     public void testUploadDefaultConfiguration_shouldFailIfRequiredConfigFilesAreMissing() {
         final var listener = spy(ActionListener.<Set<SecurityConfig>>wrap(r -> fail("Unexpected behave"), e -> {
-            assertEquals(SecurityException.class, e.getClass());
+            assertThat(e.getClass(), is(SecurityException.class));
             assertThat(e.getMessage(), containsString("Couldn't find configuration file"));
         }));
         securityIndexHandler.uploadDefaultConfiguration(configFolder, listener);
@@ -218,8 +218,8 @@ public class SecurityIndexHandlerTest {
             100L
         );
         final var listener = spy(ActionListener.<Set<SecurityConfig>>wrap(r -> fail("Unexpected behave"), e -> {
-            assertEquals(SecurityException.class, e.getClass());
-            assertEquals(e.getMessage(), failedBulkResponse.buildFailureMessage());
+            assertThat(e.getClass(), is(SecurityException.class));
+            assertThat(failedBulkResponse.buildFailureMessage(), is(e.getMessage()));
         }));
         doAnswer(invocation -> {
             ActionListener<BulkResponse> actionListener = invocation.getArgument(1);
@@ -268,8 +268,8 @@ public class SecurityIndexHandlerTest {
         final var bulkRequest = bulkRequestCaptor.getValue();
         for (final var r : bulkRequest.requests()) {
             final var indexRequest = (IndexRequest) r;
-            assertEquals(INDEX_NAME, r.index());
-            assertEquals(DocWriteRequest.OpType.INDEX, indexRequest.opType());
+            assertThat(r.index(), is(INDEX_NAME));
+            assertThat(indexRequest.opType(), is(DocWriteRequest.OpType.INDEX));
         }
         verify(listener).onResponse(any());
     }
@@ -337,7 +337,7 @@ public class SecurityIndexHandlerTest {
         final var listener = spy(
             ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
                 r -> fail("Unexpected behave"),
-                e -> assertEquals(SecurityException.class, e.getClass())
+                e -> assertThat(e.getClass(), is(SecurityException.class))
             )
         );
 
@@ -361,7 +361,7 @@ public class SecurityIndexHandlerTest {
         final var listener = spy(
             ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
                 r -> fail("Unexpected behave"),
-                e -> assertEquals("Missing required configuration for type: CONFIG", e.getMessage())
+                e -> assertThat(e.getMessage(), is("Missing required configuration for type: CONFIG"))
             )
         );
         doAnswer(invocation -> {
@@ -384,7 +384,7 @@ public class SecurityIndexHandlerTest {
         final var listener = spy(
             ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
                 r -> fail("Unexpected behave"),
-                e -> assertEquals("Version 1 is not supported for CONFIG", e.getMessage())
+                e -> assertThat(e.getMessage(), is("Version 1 is not supported for CONFIG"))
             )
         );
         doAnswer(invocation -> {
@@ -417,7 +417,7 @@ public class SecurityIndexHandlerTest {
         final var listener = spy(
             ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(
                 r -> fail("Unexpected behave"),
-                e -> assertEquals("Couldn't parse content for CONFIG", e.getMessage())
+                e -> assertThat(e.getMessage(), is("Couldn't parse content for CONFIG"))
             )
         );
         doAnswer(invocation -> {
@@ -451,7 +451,7 @@ public class SecurityIndexHandlerTest {
     @Test
     public void testLoadConfiguration_shouldBuildSecurityConfig() {
         final var listener = spy(ActionListener.<Map<CType, SecurityDynamicConfiguration<?>>>wrap(config -> {
-            assertEquals(CType.values().length, config.keySet().size());
+            assertThat(config.keySet().size(), is(CType.values().length));
             for (final var c : CType.values()) {
                 assertTrue(c.toLCString(), config.containsKey(c));
             }

--- a/src/test/java/org/opensearch/security/support/StreamableRegistryTest.java
+++ b/src/test/java/org/opensearch/security/support/StreamableRegistryTest.java
@@ -18,13 +18,16 @@ import org.junit.Test;
 
 import org.opensearch.OpenSearchException;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 public class StreamableRegistryTest {
 
     StreamableRegistry streamableRegistry = StreamableRegistry.getInstance();
 
     @Test
     public void testStreamableTypeIDs() {
-        Assert.assertEquals(1, streamableRegistry.getStreamableID(InetSocketAddress.class));
+        assertThat(streamableRegistry.getStreamableID(InetSocketAddress.class), is(1));
         Assert.assertThrows(OpenSearchException.class, () -> streamableRegistry.getStreamableID(String.class));
     }
 }

--- a/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/AbstractSystemIndicesTests.java
@@ -37,7 +37,8 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  *  Test for opendistro system indices, to restrict configured indices access to adminDn
@@ -165,15 +166,15 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
     }
 
     void validateSearchResponse(RestHelper.HttpResponse response, int expectedHits) throws IOException {
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
         XContentParser xcp = XContentType.JSON.xContent()
             .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, response.getBody());
         SearchResponse searchResponse = SearchResponse.fromXContent(xcp);
-        assertEquals(RestStatus.OK, searchResponse.status());
-        assertEquals(expectedHits, searchResponse.getHits().getHits().length);
-        assertEquals(0, searchResponse.getFailedShards());
-        assertEquals(5, searchResponse.getSuccessfulShards());
+        assertThat(searchResponse.status(), is(RestStatus.OK));
+        assertThat(searchResponse.getHits().getHits().length, is(expectedHits));
+        assertThat(searchResponse.getFailedShards(), is(0));
+        assertThat(searchResponse.getSuccessfulShards(), is(5));
     }
 
     String permissionExceptionMessage(String action, String username) {
@@ -185,7 +186,7 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
     }
 
     void validateForbiddenResponse(RestHelper.HttpResponse response, String action, String user) {
-        assertEquals(RestStatus.FORBIDDEN.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.FORBIDDEN.getStatus()));
         MatcherAssert.assertThat(response.getBody(), Matchers.containsStringIgnoringCase(permissionExceptionMessage(action, user)));
     }
 
@@ -196,7 +197,7 @@ public abstract class AbstractSystemIndicesTests extends SingleClusterTest {
         if (isSecurityIndexRequest || isRequestingAccessToNonAuthorizedSystemIndex) {
             validateForbiddenResponse(response, isSecurityIndexRequest ? "" : action, user);
         } else {
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexDisabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexDisabledTests.java
@@ -23,7 +23,8 @@ import org.opensearch.client.Client;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -53,7 +54,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
     }
 
     @Test
@@ -69,7 +70,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery, allAccessUserHeader);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         assertTrue(response.getBody().contains(SYSTEM_INDICES.get(0)));
         assertFalse(response.getBody().contains(ACCESSIBLE_ONLY_BY_SUPER_ADMIN));
     }
@@ -100,7 +101,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", "", header);
-        assertEquals(RestStatus.FORBIDDEN.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.FORBIDDEN.getStatus()));
         validateForbiddenResponse(response, "indices:data/read/search", user);
     }
 
@@ -113,10 +114,10 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseDoc = restHelper.executeDeleteRequest(index + "/_doc/document1");
-            assertEquals(RestStatus.OK.getStatus(), responseDoc.getStatusCode());
+            assertThat(responseDoc.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseIndex = restHelper.executeDeleteRequest(index);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -161,10 +162,10 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseClose = restHelper.executePostRequest(index + "/_close", "");
-            assertEquals(RestStatus.OK.getStatus(), responseClose.getStatusCode());
+            assertThat(responseClose.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseOpen = restHelper.executePostRequest(index + "/_open", "");
-            assertEquals(RestStatus.OK.getStatus(), responseOpen.getStatusCode());
+            assertThat(responseOpen.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -178,7 +179,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
             // User can open the index but cannot close it
             response = restHelper.executePostRequest(index + "/_open", "", allAccessUserHeader);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -204,7 +205,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
             if (index.equals(ACCESSIBLE_ONLY_BY_SUPER_ADMIN) || index.equals(SYSTEM_INDEX_WITH_NO_ASSOCIATED_ROLE_PERMISSIONS)) {
                 validateForbiddenResponse(response, "indices:admin/open", user);
             } else {
-                assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+                assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
             }
         }
     }
@@ -218,10 +219,10 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse responseIndex = restHelper.executePutRequest(index, createIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}");
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -245,10 +246,10 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index, createIndexSettings, header);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}", header);
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -261,10 +262,10 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index + "/_settings", updateIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePutRequest(index + "/_mapping", newMappings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -310,22 +311,22 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
         }
 
         for (String index : SYSTEM_INDICES) {
-            assertEquals(HttpStatus.SC_OK, restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode());
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
         }
     }
@@ -344,7 +345,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
         for (String index : SYSTEM_INDICES) {
             String snapshotRequest = "_snapshot/" + index + "/" + index + "_1";
             RestHelper.HttpResponse res = restHelper.executeGetRequest(snapshotRequest);
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest(snapshotRequest + "/_restore?wait_for_completion=true", "", allAccessUserHeader);
             shouldBeAllowedOnlyForAuthorizedIndices(index, res, "", allAccessUser);
@@ -381,7 +382,7 @@ public class SystemIndexDisabledTests extends AbstractSystemIndicesTests {
         for (String index : SYSTEM_INDICES) {
             String snapshotRequest = "_snapshot/" + index + "/" + index + "_1";
             RestHelper.HttpResponse res = restHelper.executeGetRequest(snapshotRequest);
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             String action = index.equals(ACCESSIBLE_ONLY_BY_SUPER_ADMIN) ? "" : "indices:data/write/index, indices:admin/create";
 

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionDisabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionDisabledTests.java
@@ -23,7 +23,8 @@ import org.opensearch.client.Client;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 
 /**
@@ -52,7 +53,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
     }
 
     @Test
@@ -67,7 +68,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery, allAccessUserHeader);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         assertFalse(response.getBody().contains(SYSTEM_INDICES.get(0)));
         assertFalse(response.getBody().contains(ACCESSIBLE_ONLY_BY_SUPER_ADMIN));
     }
@@ -99,7 +100,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", "", header);
-        assertEquals(RestStatus.FORBIDDEN.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.FORBIDDEN.getStatus()));
         validateForbiddenResponse(response, "indices:data/read/search", user);
     }
 
@@ -112,10 +113,10 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseDoc = restHelper.executeDeleteRequest(index + "/_doc/document1");
-            assertEquals(RestStatus.OK.getStatus(), responseDoc.getStatusCode());
+            assertThat(responseDoc.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseIndex = restHelper.executeDeleteRequest(index);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -155,10 +156,10 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseClose = restHelper.executePostRequest(index + "/_close", "");
-            assertEquals(RestStatus.OK.getStatus(), responseClose.getStatusCode());
+            assertThat(responseClose.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseOpen = restHelper.executePostRequest(index + "/_open", "");
-            assertEquals(RestStatus.OK.getStatus(), responseOpen.getStatusCode());
+            assertThat(responseOpen.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -172,7 +173,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
             // admin cannot close any system index but can open them
             response = restHelper.executePostRequest(index + "/_open", "", allAccessUserHeader);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -196,7 +197,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
             // normal user cannot open or close security index
             response = restHelper.executePostRequest(index + "/_open", "", header);
             if (index.startsWith(".system")) {
-                assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+                assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
             } else {
                 validateForbiddenResponse(response, "indices:admin/open", user);
             }
@@ -213,10 +214,10 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse responseIndex = restHelper.executePutRequest(index, createIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}");
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -240,10 +241,10 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index, createIndexSettings, header);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}", header);
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -256,10 +257,10 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index + "/_settings", updateIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePutRequest(index + "/_mapping", newMappings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -305,22 +306,22 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
         }
 
         for (String index : SYSTEM_INDICES) {
-            assertEquals(HttpStatus.SC_OK, restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode());
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
         }
     }
@@ -338,7 +339,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse res = restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1");
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest(
                 "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
@@ -378,7 +379,7 @@ public class SystemIndexPermissionDisabledTests extends AbstractSystemIndicesTes
         RestHelper restHelper = sslRestHelper();
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse res = restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1");
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest("_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true", "", header);
             validateForbiddenResponse(res, "", user);

--- a/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
+++ b/src/test/java/org/opensearch/security/system_indices/SystemIndexPermissionEnabledTests.java
@@ -21,7 +21,8 @@ import org.opensearch.client.Client;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.test.helper.rest.RestHelper;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 
 public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTests {
@@ -47,7 +48,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
     }
 
     @Test
@@ -63,7 +64,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", matchAllQuery, allAccessUserHeader);
-        assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         assertFalse(response.getBody().contains(SYSTEM_INDICES.get(0)));
         assertFalse(response.getBody().contains(ACCESSIBLE_ONLY_BY_SUPER_ADMIN));
     }
@@ -86,7 +87,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", "", normalUserHeader);
-        assertEquals(RestStatus.FORBIDDEN.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.FORBIDDEN.getStatus()));
         validateForbiddenResponse(response, "indices:data/read/search", normalUser);
     }
 
@@ -102,7 +103,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         // search all indices
         RestHelper.HttpResponse response = restHelper.executePostRequest("/_search", "", normalUserWithoutSystemIndexHeader);
-        assertEquals(RestStatus.FORBIDDEN.getStatus(), response.getStatusCode());
+        assertThat(response.getStatusCode(), is(RestStatus.FORBIDDEN.getStatus()));
         validateForbiddenResponse(response, "indices:data/read/search", normalUserWithoutSystemIndex);
     }
 
@@ -137,10 +138,10 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseDoc = restHelper.executeDeleteRequest(index + "/_doc/document1");
-            assertEquals(RestStatus.OK.getStatus(), responseDoc.getStatusCode());
+            assertThat(responseDoc.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseIndex = restHelper.executeDeleteRequest(index);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -198,10 +199,10 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse responseClose = restHelper.executePostRequest(index + "/_close", "");
-            assertEquals(RestStatus.OK.getStatus(), responseClose.getStatusCode());
+            assertThat(responseClose.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse responseOpen = restHelper.executePostRequest(index + "/_open", "");
-            assertEquals(RestStatus.OK.getStatus(), responseOpen.getStatusCode());
+            assertThat(responseOpen.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -252,10 +253,10 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse responseIndex = restHelper.executePutRequest(index, createIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), responseIndex.getStatusCode());
+            assertThat(responseIndex.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             RestHelper.HttpResponse response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}");
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -279,10 +280,10 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : INDICES_FOR_CREATE_REQUEST) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index, createIndexSettings, header);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePostRequest(index + "/_doc", "{\"foo\": \"bar\"}", header);
-            assertEquals(RestStatus.CREATED.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.CREATED.getStatus()));
         }
     }
 
@@ -295,10 +296,10 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse response = restHelper.executePutRequest(index + "/_settings", updateIndexSettings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
 
             response = restHelper.executePutRequest(index + "/_mapping", newMappings);
-            assertEquals(RestStatus.OK.getStatus(), response.getStatusCode());
+            assertThat(response.getStatusCode(), is(RestStatus.OK.getStatus()));
         }
     }
 
@@ -352,22 +353,22 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
         }
 
         for (String index : SYSTEM_INDICES) {
-            assertEquals(HttpStatus.SC_OK, restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode());
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1").getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
-            assertEquals(
-                HttpStatus.SC_OK,
+            assertThat(
                 restHelper.executePostRequest(
                     "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
                     "{ \"rename_pattern\": \"(.+)\", \"rename_replacement\": \"restored_index_with_global_state_$1\" }",
                     allAccessUserHeader
-                ).getStatusCode()
+                ).getStatusCode(),
+                is(HttpStatus.SC_OK)
             );
         }
     }
@@ -385,7 +386,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
 
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse res = restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1");
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest(
                 "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
@@ -416,7 +417,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
         RestHelper restHelper = sslRestHelper();
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse res = restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1");
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest(
                 "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",
@@ -449,7 +450,7 @@ public class SystemIndexPermissionEnabledTests extends AbstractSystemIndicesTest
         RestHelper restHelper = sslRestHelper();
         for (String index : SYSTEM_INDICES) {
             RestHelper.HttpResponse res = restHelper.executeGetRequest("_snapshot/" + index + "/" + index + "_1");
-            assertEquals(HttpStatus.SC_UNAUTHORIZED, res.getStatusCode());
+            assertThat(res.getStatusCode(), is(HttpStatus.SC_UNAUTHORIZED));
 
             res = restHelper.executePostRequest(
                 "_snapshot/" + index + "/" + index + "_1/_restore?wait_for_completion=true",

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -87,6 +87,9 @@ import org.opensearch.threadpool.ThreadPool;
 
 import io.netty.handler.ssl.OpenSsl;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 /*
  * There are real thread leaks during test execution, not all threads are
  * properly waited on or interrupted.  While this normally doesn't create test
@@ -237,7 +240,7 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
     protected void initialize(ClusterHelper clusterHelper, ClusterInfo clusterInfo, DynamicSecurityConfig securityConfig)
         throws IOException {
         try (Client tc = clusterHelper.nodeClient()) {
-            Assert.assertEquals(clusterInfo.numNodes, tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size());
+            assertThat(tc.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet().getNodes().size(), is(clusterInfo.numNodes));
 
             try {
                 tc.admin().indices().create(new CreateIndexRequest(".opendistro_security")).actionGet();
@@ -255,7 +258,7 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
                 new ConfigUpdateRequest(CType.lcStringValues().toArray(new String[0]))
             ).actionGet();
             Assert.assertFalse(cur.failures().toString(), cur.hasFailures());
-            Assert.assertEquals(clusterInfo.numNodes, cur.getNodes().size());
+            assertThat(cur.getNodes().size(), is(clusterInfo.numNodes));
 
             SearchResponse sr = tc.search(new SearchRequest(".opendistro_security")).actionGet();
             sr = tc.search(new SearchRequest(".opendistro_security")).actionGet();

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -71,6 +71,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration.NodeSettings;
 import org.opensearch.security.test.helper.network.SocketUtils;
 import org.opensearch.transport.TransportInfo;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 // CS-ENFORCE-SINGLE
 
 public final class ClusterHelper {
@@ -380,7 +383,7 @@ public final class ClusterHelper {
                 log.debug("... cluster state ok {} with {} nodes", healthResponse.getStatus().name(), healthResponse.getNumberOfNodes());
             }
 
-            org.junit.Assert.assertEquals(expectedNodeCount, healthResponse.getNumberOfNodes());
+            assertThat(healthResponse.getNumberOfNodes(), is(expectedNodeCount));
 
             final NodesInfoResponse res = client.admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet();
 

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -54,7 +54,8 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static java.util.Collections.emptySet;
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -208,7 +209,7 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 String serializedUserHeader = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
-                assertEquals(serializedUserHeader, Base64Helper.serializeObject(user, true));
+                assertThat(serializedUserHeader, is(Base64Helper.serializeObject(user, true)));
                 senderLatch.get().countDown();
             }
         };
@@ -223,7 +224,7 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 User transientUser = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-                assertEquals(transientUser, user);
+                assertThat(user, is(transientUser));
                 senderLatch.get().countDown();
             }
         };
@@ -238,7 +239,7 @@ public class SecurityInterceptorTests {
     final void verifyOriginalContext(User user) {
 
         User transientUser = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
-        assertEquals(transientUser, user);
+        assertThat(user, is(transientUser));
         assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER));
     }
 


### PR DESCRIPTION
### Description
As per this issue: https://github.com/opensearch-project/security/issues/1832, changed all occurrences of Assert.assertEquals to assertThat, additionally changed imports accordingly.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Enhancement

* Why these changes are required?
Refer to: https://github.com/opensearch-project/security/issues/1832

* What is the old behavior before changes and new behavior after changes?
Nothing ideally.

### Issues Resolved
https://github.com/opensearch-project/security/issues/3680
https://github.com/opensearch-project/security/issues/1832

Is this a backport? If so, please add backport PR # and/or commits #
Yes

### Testing
N/A, changed tests

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
