### PR TITLE
Pass set to SystemIndexRegistry.matchesSystemIndexPattern

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
@@ -179,7 +179,7 @@ public class SystemIndexAccessEvaluator {
             .collect(Collectors.toSet());
         if (isSystemIndexEnabled) {
             systemIndices.addAll(systemIndexMatcher.getMatchAny(requestedResolved.getAllIndices(), Collectors.toList()));
-            systemIndices.addAll(SystemIndexRegistry.matchesSystemIndexPattern(requestedResolved.getAllIndices().toArray(String[]::new)));
+            systemIndices.addAll(SystemIndexRegistry.matchesSystemIndexPattern(requestedResolved.getAllIndices()));
         }
         return systemIndices;
     }


### PR DESCRIPTION
### Description

This PR fixes a compilation error after merge of https://github.com/opensearch-project/OpenSearch/pull/14750 in core which changes the method signature to SystemIndexRegistry.matchesSystemIndexPattern to accept a set to prevent having to convert between a set and array in SystemIndexAccessEvaluator.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
