### PR TITLE
Fixed READ_ACTIONS required by TermsAggregationEvaluator

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/TermsAggregationEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/TermsAggregationEvaluator.java
@@ -53,9 +53,7 @@ public class TermsAggregationEvaluator {
         "indices:data/read/mget",
         "indices:data/read/get",
         "indices:data/read/search",
-        "indices:data/read/field_caps*"
-        // "indices:admin/mappings/fields/get*"
-    };
+        "indices:data/read/field_caps" };
 
     private static final QueryBuilder NONE_QUERY = new MatchNoneQueryBuilder();
 


### PR DESCRIPTION
The READ_ACTIONS array is passed by TermsAggregationEvaluator to securityRoles.getAllPermittedIndicesForDashboards() which checks whether privileges are available for all actions specified in READ_ACTIONS. READ_ACTIONS also contained the string "indices:data/read/field_caps*", which is actually wrong, because it is not an action but looks like pattern. However, the code behind securityRoles.getAllPermittedIndicesForDashboards() will never treat these strings as patterns. The "*" is only considered a normal, bare character. Patterns (via WildcardMatcher class) will be only applied to these strings.

This had the effect that a bare privilege "indices:data/read/field_caps" was not sufficient to fulfill the requirement. It was necessary to have either "indices:data/read/field_caps*" in ones roles.yml or something broader like "indices:data/read/*". The latter is the most likely case, which is the reason why in most cases this gets unnoticed.

Observed while working on #3870 and decoupled from #4380.

### Description
[Describe what this change achieves]
* Category:  Bug fix
* Why these changes are required? - The code created an impression that patterns were supported at the particular place, while they were actually not supported.
* What is the old behavior before changes and new behavior after changes? - No significant changes. It will be sufficient to specify the privilege "indices:data/read/field_caps" instead of ""indices:data/read/field_caps*" to have field caps on indices properly working, but in practice this seems to be a rare case.

### Issues Resolved

Contributes to #3870

### Testing

Integration testing via existing tests

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
