### PR TITLE
Addresses a bug with `plugins.security.allow_unsafe_democertificates` setting

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -378,6 +378,13 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         demoCertHashes.add("a2ce3f577a5031398c1b4f58761444d837b031d0aff7614f8b9b5e4a9d59dbd1"); // esnode
         demoCertHashes.add("cd708e8dc707ae065f7ad8582979764b497f062e273d478054ab2f49c5469c6"); // root-ca
 
+        // updates correct sha256sum
+        demoCertHashes.add("a3556d6bb61f7bd63cb19b1c8d0078d30c12739dedb0455c5792ac8627782042"); // kirk
+        demoCertHashes.add("25e34a9a5d4f1dceed1666eb624397bf3fe5787a7133cd32838ace0381bce1f7"); // kirk-key
+        demoCertHashes.add("a2ce3f577a5031398c1b4f58761444d837b031d0aff7614f8b9b5e4a9d59dbd1"); // esnode
+        demoCertHashes.add("ba9c5a61065f7f6115188128ffbdaa18fca34562b78b811f082439e2bef1d282"); // esnode-key
+        demoCertHashes.add("bcd708e8dc707ae065f7ad8582979764b497f062e273d478054ab2f49c5469c6"); // root-ca
+
         final SecurityManager sm = System.getSecurityManager();
 
         if (sm != null) {

--- a/src/main/java/org/opensearch/security/tools/democonfig/Certificates.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Certificates.java
@@ -48,7 +48,7 @@ public enum Certificates {
                 "KRVHWCFiR7bZhHGLq3br8hSu0hwjb3oGa1ZI8dui6ujyZt6nm6BoEkau3G/6+zq9",
                 "E6vX3+8Fj4HKCAL6i0SwfGmEpTNp5WUhqibK/fMhhmMT4Mx6MxkT+OFnIjdUU0S/",
                 "e3kgnG8qjficUr38CyEli1U0M7koIXUZI7r+LQ==",
-                "-----END CERTIFICATE-----"
+                "-----END CERTIFICATE-----\n"
             )
         )
     ),
@@ -83,7 +83,7 @@ public enum Certificates {
                 "mQGwy8vIqMjAdHGLrCS35sVYBXG13knS52LJHvbVee39AbD5/LlWvjJGlQMzCLrw",
                 "F7oILW5kXxhb8S73GWcuMbuQMFVHFONbZAZgn+C9FW4l7XyRdkrbR1MRZ2km8YMs",
                 "/AHmo368d4PSNRMMzLHw8Q==",
-                "-----END PRIVATE KEY-----"
+                "-----END PRIVATE KEY-----\n"
             )
         )
     ),
@@ -115,7 +115,7 @@ public enum Certificates {
                 "hUBqIEAYly1EqH/y45APiRt3Nor1yF6zEI4TnL0yNrHw6LyQkUNCHIGMJLfnJQ9L",
                 "camMGIXOx60kXNMTigF9oXXwixWAnDM9y3QT8QXA7hej/4zkbO+vIeV/7lGUdkyg",
                 "PAi92EvyxmsliEMyMR0VINl8emyobvfwa7oMeWMR+hg=",
-                "-----END CERTIFICATE-----"
+                "-----END CERTIFICATE-----\n"
             )
         )
     ),
@@ -150,7 +150,7 @@ public enum Certificates {
                 "tu49A/0KZu4PBjrFMYTSEWGNJez3Fb2VsJwylVl6HivwbP61FhlYfyksCzQQFU71",
                 "+x7Nmybp7PmpEBECr3deoZKQ/acNHn0iwb0It+YqV5+TquQebqgwK6WCLsMuiYKT",
                 "bg/ch9Rhxbq22yrVgWHh6epp",
-                "-----END PRIVATE KEY-----"
+                "-----END PRIVATE KEY-----\n"
             )
         )
     ),
@@ -185,7 +185,7 @@ public enum Certificates {
                 "1yVJon6RkUGtqBqKIuLksKwEr//ELnjmXit4LQKSnqKr0FTCB7seIrKJNyb35Qnq",
                 "qy9a/Unhokrmdda1tr6MbqU8l7HmxLuSd/Ky+L0eDNtYv6YfMewtjg0TtAnFyQov",
                 "rdXmeq1dy9HLo3Ds4AFz3Gx9076TxcRS/iI=",
-                "-----END CERTIFICATE-----"
+                "-----END CERTIFICATE-----\n"
             )
         )
     );

--- a/src/test/java/org/opensearch/security/tools/democonfig/CertificateGeneratorTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/CertificateGeneratorTests.java
@@ -165,7 +165,7 @@ public class CertificateGeneratorTests {
         try (BufferedReader reader = new BufferedReader(new FileReader(pemFilePath))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                pemContent.append(line).append("\n");
+                pemContent.append(line);
             }
         }
         return pemContent.toString();


### PR DESCRIPTION
### Description
This PR addresses a bug where mismatching demo certificate hashes caused the setting `plugins.security.allow_unsafe_democertificates` to not work as expected.

* Category : Bug fix

* Why these changes are required?
Without this PR, the setting `plugins.security.allow_unsafe_democertificates` will not work.

* What is the old behavior before changes and new behavior after changes?
* Before: Cluster fails to not boot up when setting is set to true
* After: Cluster fails to boot up

### Issues Resolved
- Resolves #4599 

### Testing
Unit testing, Manual Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
