### PR TITLE
Update backport section of PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 ### Issues Resolved
 [List any issues this PR will resolve]
 
-Is this a backport? If so, please add backport PR # and/or commits #
+Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
 
 Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
 


### PR DESCRIPTION
### Description
Updates template to notify user to remove `backport-failed` label from source PR when back-porting it manually

* Category : Maintenance
* Why these changes are required?
* To maintain a clean usage of `backport-failed` label to allow release-managers to track missing/failed backports correctly.


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
