### PR TITLE
Fixes authtoken endpoint

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
@@ -90,6 +90,17 @@ public class CertificatesRestApiIntegrationTest extends AbstractApiIntegrationTe
         withUser(REST_API_ADMIN_SSL_INFO, this::verifySSLCertsInfo);
     }
 
+    @Test
+    public void timeoutTest() throws Exception {
+        withUser(REST_ADMIN_USER, this::verifyTimeoutRequest);
+    }
+
+    private void verifyTimeoutRequest(final TestRestClient client) throws Exception {
+        TestRestClient.HttpResponse response = ok(() -> client.get(sslCertsPath() + "?timeout=0"));
+        final var body = response.bodyAsJsonNode();
+        assertThat(body.get("nodes").size(), is(0));
+    }
+
     private void verifySSLCertsInfo(final TestRestClient client) throws Exception {
         assertSSLCertsInfo(
             localCluster.nodes(),

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
@@ -441,6 +441,18 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
     }
 
     @Test
+    public void verifyPOSTOnlyForAuthTokenEndpoint() throws Exception {
+        withUser(ADMIN_USER_NAME, client -> {
+            badRequest(() -> client.post(apiPath(ADMIN_USER_NAME, "authtoken")));
+            ok(() -> client.post(apiPath(SERVICE_ACCOUNT_USER, "authtoken")));
+            /*
+              should be notImplement but the call doesn't reach {@link org.opensearch.security.dlic.rest.api.InternalUsersApiAction#withAuthTokenPath(RestRequest)}
+             */
+            methodNotAllowed(() -> client.post(apiPath("randomPath")));
+        });
+    }
+
+    @Test
     public void userApiWithDotsInName() throws Exception {
         withUser(ADMIN_USER_NAME, client -> {
             for (final var dottedUserName : List.of(".my.dotuser0", ".my.dot.user0")) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/CertificatesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/CertificatesApiAction.java
@@ -71,6 +71,7 @@ public class CertificatesApiAction extends AbstractApiAction {
     protected void consumeParameters(RestRequest request) {
         request.param("nodeId");
         request.param("cert_type");
+        request.param("timeout");
     }
 
     private void securitySSLCertsRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -160,10 +160,10 @@ public class InternalUsersApiAction extends AbstractApiAction {
     ValidationResult<String> withAuthTokenPath(final RestRequest request) throws IOException {
         return endpointValidator.withRequiredEntityName(nameParam(request)).map(username -> {
             // Handle auth token fetching
-            if (!(request.uri().contains("/internalusers/" + username + "/authtoken") && request.uri().endsWith("/authtoken"))) {
-                return ValidationResult.error(RestStatus.NOT_IMPLEMENTED, methodNotImplementedMessage(request.method()));
+            if (request.uri().contains("/internalusers/" + username + "/authtoken") && request.uri().endsWith("/authtoken")) {
+                return ValidationResult.success(username);
             }
-            return ValidationResult.success(username);
+            return ValidationResult.error(RestStatus.NOT_IMPLEMENTED, methodNotImplementedMessage(request.method()));
         });
     }
 

--- a/src/main/java/org/opensearch/security/user/UserService.java
+++ b/src/main/java/org/opensearch/security/user/UserService.java
@@ -242,11 +242,8 @@ public class UserService {
         CharacterRule lowercaseCharacterRule = new CharacterRule(EnglishCharacterData.LowerCase, 1);
         CharacterRule uppercaseCharacterRule = new CharacterRule(EnglishCharacterData.UpperCase, 1);
         CharacterRule numericCharacterRule = new CharacterRule(EnglishCharacterData.Digit, 1);
-        // CharacterRule specialCharacterRule = new CharacterRule(EnglishCharacterData.Special, 1);
 
-        List<CharacterRule> rules = Arrays.asList(lowercaseCharacterRule, uppercaseCharacterRule, numericCharacterRule
-        // specialCharacterRule
-        );
+        List<CharacterRule> rules = Arrays.asList(lowercaseCharacterRule, uppercaseCharacterRule, numericCharacterRule);
         PasswordGenerator passwordGenerator = new PasswordGenerator();
 
         Random random = Randomness.get();

--- a/src/main/java/org/opensearch/security/user/UserService.java
+++ b/src/main/java/org/opensearch/security/user/UserService.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -243,13 +242,10 @@ public class UserService {
         CharacterRule lowercaseCharacterRule = new CharacterRule(EnglishCharacterData.LowerCase, 1);
         CharacterRule uppercaseCharacterRule = new CharacterRule(EnglishCharacterData.UpperCase, 1);
         CharacterRule numericCharacterRule = new CharacterRule(EnglishCharacterData.Digit, 1);
-        CharacterRule specialCharacterRule = new CharacterRule(EnglishCharacterData.Special, 1);
+        // CharacterRule specialCharacterRule = new CharacterRule(EnglishCharacterData.Special, 1);
 
-        List<CharacterRule> rules = Arrays.asList(
-            lowercaseCharacterRule,
-            uppercaseCharacterRule,
-            numericCharacterRule,
-            specialCharacterRule
+        List<CharacterRule> rules = Arrays.asList(lowercaseCharacterRule, uppercaseCharacterRule, numericCharacterRule
+        // specialCharacterRule
         );
         PasswordGenerator passwordGenerator = new PasswordGenerator();
 
@@ -275,17 +271,17 @@ public class UserService {
 
         String authToken = null;
         try {
-            final ObjectMapper mapper = DefaultObjectMapper.objectMapper;
-            JsonNode accountDetails = mapper.readTree(internalUsersConfiguration.getCEntry(accountName).toString());
+            final var accountEntry = DefaultObjectMapper.writeValueAsString(internalUsersConfiguration.getCEntry(accountName), false);
+            JsonNode accountDetails = DefaultObjectMapper.readTree(accountEntry);
             final ObjectNode contentAsNode = (ObjectNode) accountDetails;
             SecurityJsonNode securityJsonNode = new SecurityJsonNode(contentAsNode);
 
-            Optional.ofNullable(securityJsonNode.get("service"))
+            Optional.ofNullable(securityJsonNode.get("attributes").get("service"))
                 .map(SecurityJsonNode::asString)
                 .filter("true"::equalsIgnoreCase)
                 .orElseThrow(() -> new UserServiceException(AUTH_TOKEN_GENERATION_MESSAGE));
 
-            Optional.ofNullable(securityJsonNode.get("enabled"))
+            Optional.ofNullable(securityJsonNode.get("attributes").get("enabled"))
                 .map(SecurityJsonNode::asString)
                 .filter("true"::equalsIgnoreCase)
                 .orElseThrow(() -> new UserServiceException(AUTH_TOKEN_GENERATION_MESSAGE));
@@ -306,7 +302,7 @@ public class UserService {
             saveAndUpdateConfigs(getUserConfigName().toString(), client, CType.INTERNALUSERS, internalUsersConfiguration);
 
             authToken = Base64.getUrlEncoder().encodeToString((accountName + ":" + plainTextPassword).getBytes(StandardCharsets.UTF_8));
-            return new BasicAuthToken(authToken);
+            return new BasicAuthToken("Basic " + authToken);
 
         } catch (JsonProcessingException ex) {
             throw new UserServiceException(FAILED_ACCOUNT_RETRIEVAL_MESSAGE);


### PR DESCRIPTION
### Description
This change ensures that authtoken endpoint works to vend authtoken for `internalusers` API. 
The issue was root-caused to improperly handled [generateAuthToken()](https://github.com/opensearch-project/security/blob/808fe31f640a3543e358ff11365f3d76ae2385c1/src/main/java/org/opensearch/security/user/UserService.java#L264). This PR modifies the associated method and adds missing tests for `/authtoken` endpoint.

Also fixes a small issue where `timeout` parameter is not working as expected for certificates API.

### Issues Resolved
- #4627

### Testing
- integration testing

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
