### PR TITLE
Allow multiple signing keys to be provided

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -14,6 +14,8 @@ package com.amazon.dlic.auth.http.jwt;
 import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -54,7 +56,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private static final Pattern BASIC = Pattern.compile("^\\s*Basic\\s.*", Pattern.CASE_INSENSITIVE);
     private static final String BEARER = "bearer ";
 
-    private final JwtParser jwtParser;
+    private final List<JwtParser> jwtParsers = new ArrayList<>();
     private final String jwtHeaderName;
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
@@ -68,6 +70,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         super();
 
         String signingKey = settings.get("signing_key");
+        List<String> signingKeysSplit = new ArrayList<>();
         jwtUrlParameter = settings.get("jwt_url_parameter");
         jwtHeaderName = settings.get("jwt_header", AUTHORIZATION);
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
@@ -83,19 +86,31 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
             );
         }
 
-        final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(signingKey, log);
-        if (jwtParserBuilder == null) {
-            jwtParser = null;
+        boolean multipleKeys = signingKey != null && signingKey.contains(",");
+        if (multipleKeys) {
+            String[] keyArray = signingKey.replace(",\\s+", ",").split(","); // Remove spaces
+            signingKeysSplit.addAll(Arrays.asList(keyArray));
         } else {
-            if (requireIssuer != null) {
-                jwtParserBuilder.requireIssuer(requireIssuer);
-            }
+            signingKeysSplit.add(signingKey);
+        }
 
-            final SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(new SpecialPermission());
+        for (String key : signingKeysSplit) {
+            JwtParser jwtParser;
+            final JwtParserBuilder jwtParserBuilder = KeyUtils.createJwtParserBuilderFromSigningKey(key, log);
+            if (jwtParserBuilder == null) {
+                jwtParser = null;
+            } else {
+                if (requireIssuer != null) {
+                    jwtParserBuilder.requireIssuer(requireIssuer);
+                }
+
+                final SecurityManager sm = System.getSecurityManager();
+                if (sm != null) {
+                    sm.checkPermission(new SpecialPermission());
+                }
+                jwtParser = AccessController.doPrivileged((PrivilegedAction<JwtParser>) jwtParserBuilder::build);
             }
-            jwtParser = AccessController.doPrivileged((PrivilegedAction<JwtParser>) jwtParserBuilder::build);
+            jwtParsers.add(jwtParser);
         }
     }
 
@@ -120,7 +135,8 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     }
 
     private AuthCredentials extractCredentials0(final SecurityRequest request) {
-        if (jwtParser == null) {
+
+        if (jwtParsers.isEmpty() || jwtParsers.getFirst() == null) {
             log.error("Missing Signing Key. JWT authentication will not work");
             return null;
         }
@@ -157,39 +173,43 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
             }
         }
 
-        try {
-            final Claims claims = jwtParser.parseClaimsJws(jwtToken).getBody();
+        for (JwtParser jwtParser : jwtParsers) {
+            try {
 
-            if (!requiredAudience.isEmpty()) {
-                assertValidAudienceClaim(claims);
-            }
+                final Claims claims = jwtParser.parseClaimsJws(jwtToken).getBody();
 
-            final String subject = extractSubject(claims, request);
+                if (!requiredAudience.isEmpty()) {
+                    assertValidAudienceClaim(claims);
+                }
 
-            if (subject == null) {
-                log.error("No subject found in JWT token");
+                final String subject = extractSubject(claims, request);
+
+                if (subject == null) {
+                    log.error("No subject found in JWT token");
+                    return null;
+                }
+
+                final String[] roles = extractRoles(claims, request);
+
+                final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
+
+                for (Entry<String, Object> claim : claims.entrySet()) {
+                    ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
+                }
+
+                return ac;
+
+            } catch (WeakKeyException e) {
+                log.error("Cannot authenticate user with JWT because of ", e);
                 return null;
+            } catch (Exception e) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Invalid or expired JWT token.", e);
+                }
             }
-
-            final String[] roles = extractRoles(claims, request);
-
-            final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
-
-            for (Entry<String, Object> claim : claims.entrySet()) {
-                ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
-            }
-
-            return ac;
-
-        } catch (WeakKeyException e) {
-            log.error("Cannot authenticate user with JWT because of ", e);
-            return null;
-        } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.debug("Invalid or expired JWT token.", e);
-            }
-            return null;
         }
+        log.error("Failed to parse JWT token using any of the available parsers");
+        return null;
     }
 
     private void assertValidAudienceClaim(Claims claims) throws BadJWTException {

--- a/src/main/java/org/opensearch/security/util/KeyUtils.java
+++ b/src/main/java/org/opensearch/security/util/KeyUtils.java
@@ -54,8 +54,7 @@ public class KeyUtils {
                         PublicKey key = null;
 
                         final String minimalKeyFormat = signingKey.replace("-----BEGIN PUBLIC KEY-----\n", "")
-                            .replace("-----END PUBLIC KEY-----", "");
-
+                            .replace("-----END PUBLIC KEY-----", "").trim();
                         final byte[] decoded = Base64.getDecoder().decode(minimalKeyFormat);
 
                         try {

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -14,6 +14,7 @@ package com.amazon.dlic.auth.http.jwt;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
@@ -533,6 +534,286 @@ public class HTTPJwtAuthenticatorTest {
 
         Assert.assertNull(credentials);
     }
+
+    @Test
+    public void testMultipleSigningKeysParseSuccessfully() throws NoSuchAlgorithmException {
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair pair1 = keyGen.generateKeyPair();
+        PrivateKey priv1 = pair1.getPrivate();
+        PublicKey pub1 = pair1.getPublic();
+
+        KeyPair pair2 = keyGen.generateKeyPair();
+        PrivateKey priv2 = pair2.getPrivate();
+        PublicKey pub2 = pair2.getPublic();
+
+        String jwsToken1 = Jwts.builder().setSubject("Leonard McCoy").signWith(priv1, SignatureAlgorithm.RS256).compact();
+        String jwsToken2 = Jwts.builder().setSubject("Stephen Crawford").signWith(priv2, SignatureAlgorithm.RS256).compact();
+
+        Settings settings = Settings.builder()
+                .put(
+                        "signing_key",
+                        "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub1.getEncoded()) + "-----END PUBLIC KEY-----,-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub2.getEncoded()) + "-----END PUBLIC KEY-----"
+                )
+                .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers1 = new HashMap<String, String>();
+        headers1.put("Authorization", "Bearer " + jwsToken1);
+
+        AuthCredentials creds1 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers1, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds1);
+        assertThat(creds1.getUsername(), is("Leonard McCoy"));
+        assertThat(creds1.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers2 = new HashMap<String, String>();
+        headers2.put("Authorization", "Bearer " + jwsToken2);
+        AuthCredentials creds2 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers2, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds2);
+        assertThat(creds2.getUsername(), is("Stephen Crawford"));
+        assertThat(creds2.getBackendRoles().size(), is(0));
+    }
+
+    @Test
+    public void testMultipleSigningKeysParseWithSpacesSuccessfully() throws NoSuchAlgorithmException {
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair pair1 = keyGen.generateKeyPair();
+        PrivateKey priv1 = pair1.getPrivate();
+        PublicKey pub1 = pair1.getPublic();
+
+        KeyPair pair2 = keyGen.generateKeyPair();
+        PrivateKey priv2 = pair2.getPrivate();
+        PublicKey pub2 = pair2.getPublic();
+
+        String jwsToken1 = Jwts.builder().setSubject("Leonard McCoy").signWith(priv1, SignatureAlgorithm.RS256).compact();
+        String jwsToken2 = Jwts.builder().setSubject("Stephen Crawford").signWith(priv2, SignatureAlgorithm.RS256).compact();
+
+        Settings settings = Settings.builder()
+                .put(
+                        "signing_key",
+                        "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub1.getEncoded()) + "-----END PUBLIC KEY-----,     -----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub2.getEncoded()) + "-----END PUBLIC KEY-----"
+                )
+                .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers1 = new HashMap<String, String>();
+        headers1.put("Authorization", "Bearer " + jwsToken1);
+
+        AuthCredentials creds1 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers1, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds1);
+        assertThat(creds1.getUsername(), is("Leonard McCoy"));
+        assertThat(creds1.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers2 = new HashMap<String, String>();
+        headers2.put("Authorization", "Bearer " + jwsToken2);
+        AuthCredentials creds2 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers2, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds2);
+        assertThat(creds2.getUsername(), is("Stephen Crawford"));
+        assertThat(creds2.getBackendRoles().size(), is(0));
+    }
+
+    @Test
+    public void testMultipleSigningKeysMixedAlgsParseSuccessfully() throws NoSuchAlgorithmException {
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair pair1 = keyGen.generateKeyPair();
+        PrivateKey priv1 = pair1.getPrivate();
+        PublicKey pub1 = pair1.getPublic();
+
+        KeyPairGenerator keyGen2 = KeyPairGenerator.getInstance("EC");
+        keyGen2.initialize(521);
+        KeyPair pair = keyGen2.generateKeyPair();
+        PrivateKey priv2 = pair.getPrivate();
+        PublicKey pub2 = pair.getPublic();
+
+        String jwsToken1 = Jwts.builder().setSubject("Leonard McCoy").signWith(priv1, SignatureAlgorithm.RS256).compact();
+
+        String jwsToken2 = Jwts.builder().setSubject("Stephen Crawford").signWith(priv2, SignatureAlgorithm.ES512).compact();
+
+        Settings settings = Settings.builder()
+                .put(
+                        "signing_key",
+                        "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub1.getEncoded()) + "-----END PUBLIC KEY-----," + BaseEncoding.base64().encode(pub2.getEncoded())
+                )
+                .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers1 = new HashMap<String, String>();
+        headers1.put("Authorization", "Bearer " + jwsToken1);
+
+        AuthCredentials creds1 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers1, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds1);
+        assertThat(creds1.getUsername(), is("Leonard McCoy"));
+        assertThat(creds1.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers2 = new HashMap<String, String>();
+        headers2.put("Authorization", "Bearer " + jwsToken2);
+        AuthCredentials creds2 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers2, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds2);
+        assertThat(creds2.getUsername(), is("Stephen Crawford"));
+        assertThat(creds2.getBackendRoles().size(), is(0));
+    }
+
+    @Test
+    public void testManyMultipleSigningKeysMixedAlgsParseSuccessfully() throws NoSuchAlgorithmException {
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair pair1 = keyGen.generateKeyPair();
+        PrivateKey priv1 = pair1.getPrivate();
+        PublicKey pub1 = pair1.getPublic();
+
+        KeyPairGenerator keyGen2 = KeyPairGenerator.getInstance("EC");
+        keyGen2.initialize(521);
+        KeyPair pair = keyGen2.generateKeyPair();
+        PrivateKey priv2 = pair.getPrivate();
+        PublicKey pub2 = pair.getPublic();
+
+        KeyPairGenerator keyGen3 = KeyPairGenerator.getInstance("RSA");
+        keyGen3.initialize(2048);
+        KeyPair pair3 = keyGen3.generateKeyPair();
+        PrivateKey priv3 = pair3.getPrivate();
+        PublicKey pub3 = pair3.getPublic();
+
+        KeyPairGenerator keyGen4 = KeyPairGenerator.getInstance("EC");
+        keyGen4.initialize(521);
+        KeyPair pair4 = keyGen4.generateKeyPair();
+        PrivateKey priv4 = pair4.getPrivate();
+        PublicKey pub4 = pair4.getPublic();
+
+        String jwsToken1 = Jwts.builder().setSubject("Stephen Crawford").signWith(priv1, SignatureAlgorithm.RS256).compact();
+        String jwsToken2 = Jwts.builder().setSubject("Craig Perkins").signWith(priv2, SignatureAlgorithm.ES512).compact();
+        String jwsToken3 = Jwts.builder().setSubject("Darshit Chanpura").signWith(priv3, SignatureAlgorithm.RS256).compact();
+        String jwsToken4 = Jwts.builder().setSubject("Derek Ho").signWith(priv4, SignatureAlgorithm.ES512).compact();
+
+        Settings settings = Settings.builder()
+                .put(
+                        "signing_key",
+                        "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub1.getEncoded()) + "-----END PUBLIC KEY-----," + BaseEncoding.base64().encode(pub2.getEncoded()) + "," + "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub3.getEncoded()) + "-----END PUBLIC KEY-----," + BaseEncoding.base64().encode(pub4.getEncoded())
+                )
+                .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers1 = new HashMap<String, String>();
+        headers1.put("Authorization", "Bearer " + jwsToken1);
+
+        AuthCredentials creds1 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers1, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds1);
+        assertThat(creds1.getUsername(), is("Stephen Crawford"));
+        assertThat(creds1.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers2 = new HashMap<String, String>();
+        headers2.put("Authorization", "Bearer " + jwsToken2);
+        AuthCredentials creds2 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers2, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds2);
+        assertThat(creds2.getUsername(), is("Craig Perkins"));
+        assertThat(creds2.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers3 = new HashMap<String, String>();
+        headers3.put("Authorization", "Bearer " + jwsToken3);
+
+        AuthCredentials creds3 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers3, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds3);
+        assertThat(creds3.getUsername(), is("Darshit Chanpura"));
+        assertThat(creds3.getBackendRoles().size(), is(0));
+
+        Map<String, String> headers4 = new HashMap<String, String>();
+        headers4.put("Authorization", "Bearer " + jwsToken4);
+        AuthCredentials creds4 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers4, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNotNull(creds4);
+        assertThat(creds4.getUsername(), is("Derek Ho"));
+        assertThat(creds4.getBackendRoles().size(), is(0));
+    }
+
+    @Test
+    public void testMultipleSigningKeysFailToParseReturnsNull() throws NoSuchAlgorithmException {
+
+
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048);
+        KeyPair pair1 = keyGen.generateKeyPair();
+        PrivateKey priv1 = pair1.getPrivate();
+        PublicKey pub1 = pair1.getPublic();
+
+        KeyPair pair2 = keyGen.generateKeyPair();
+        PrivateKey priv2 = pair2.getPrivate();
+        PublicKey pub2 = pair2.getPublic();
+
+        String invalidJwsToken = "123invalidtoken..";
+
+        Settings settings = Settings.builder()
+                .put(
+                        "signing_key",
+                        "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub1.getEncoded()) + "-----END PUBLIC KEY-----,     -----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub2.getEncoded()) + "-----END PUBLIC KEY-----"
+                )
+                .build();
+
+        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
+        Map<String, String> headers1 = new HashMap<String, String>();
+        headers1.put("Authorization", "Bearer " + invalidJwsToken);
+
+        AuthCredentials creds1 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers1, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNull(creds1);
+
+        Map<String, String> headers2 = new HashMap<String, String>();
+        headers2.put("Authorization", "Bearer " + invalidJwsToken);
+        AuthCredentials creds2 = jwtAuth.extractCredentials(
+                new FakeRestRequest(headers2, new HashMap<String, String>()).asSecurityRequest(),
+                null
+        );
+
+        Assert.assertNull(creds2);
+    }
+
+
 
     /** extracts a default user credential from a request header */
     private AuthCredentials extractCredentialsFromJwtHeader(final Settings.Builder settingsBuilder, final JwtBuilder jwtBuilder) {


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
This change is an enhancement which allows users to provide multiple signing keys when configuring JWT options. 
Previously, users could only specify a single signing key when configuring their JWT options. As a result, if a user wanted to rotate their key, they would experience some amount of downtime since the cluster would have to reinitialize the update security configuration. This change does not stop the required bouncing, but because you can now provide multiple keys, you can provide backup(s) key(s) which means even when the cluster bounces you have the ability to send JWT requests with the backup key(s). 

To specify the multiple keys, you just need to use the same method as before but separate the keys with a comma i.e. <key 1>, <key 2>, etc....

### Issues Resolved
[List any issues this PR will resolve]
This PR addresses: https://github.com/opensearch-project/security/issues/4613

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]
I added several new tests to the existing HTTPJWTAuthenticatorTest class.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] ~New Roles/Permissions have a corresponding security dashboards plugin PR~
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
