### PR TITLE
Remove usages of org.apache.logging.log4j.util.Strings

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -45,7 +45,6 @@ import com.google.common.collect.MultimapBuilder.SetMultimapBuilder;
 import com.google.common.collect.SetMultimap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.util.Strings;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.support.IndicesOptions;
@@ -801,7 +800,7 @@ public class ConfigModelV7 extends ConfigModel {
                 }
             }
 
-            if (Strings.isNotBlank(unresolved)) {
+            if (!(unresolved == null || unresolved.isBlank())) {
                 final String[] resolvedIndicesFromPattern = resolver.concreteIndexNames(
                     cs.state(),
                     IndicesOptions.lenientExpandOpen(),

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/keybyoidc/TestJwts.java
@@ -14,7 +14,6 @@ package com.amazon.dlic.auth.http.jwt.keybyoidc;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import org.apache.logging.log4j.util.Strings;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
@@ -31,7 +30,7 @@ import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 class TestJwts {
     static final String ROLES_CLAIM = "roles";
     static final Set<String> TEST_ROLES = ImmutableSet.of("role1", "role2");
-    static final String TEST_ROLES_STRING = Strings.join(TEST_ROLES, ',');
+    static final String TEST_ROLES_STRING = String.join(",", TEST_ROLES);
 
     static final String TEST_AUDIENCE = "TestAudience";
 


### PR DESCRIPTION
### Description

Opening this PR to remove forbidden usages of org.apache.logging.log4j.util.Strings. This class was made forbidden in core in this PR: https://github.com/opensearch-project/OpenSearch/pull/15238

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

https://github.com/opensearch-project/OpenSearch/issues/15211


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
