### PR TITLE
Handle the audit config being null

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -83,7 +83,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     private static SecurityDynamicConfiguration<TenantV7> staticTenants = SecurityDynamicConfiguration.empty();
     private static final WhitelistingSettings defaultWhitelistingSettings = new WhitelistingSettings();
     private static final AllowlistingSettings defaultAllowlistingSettings = new AllowlistingSettings();
-    private static final AuditConfig defaultAuditConfig = new AuditConfig();
+    private static final AuditConfig defaultAuditConfig = AuditConfig.from(Settings.EMPTY);
 
     static void resetStatics() {
         staticRoles = SecurityDynamicConfiguration.empty();

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -83,6 +83,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     private static SecurityDynamicConfiguration<TenantV7> staticTenants = SecurityDynamicConfiguration.empty();
     private static final WhitelistingSettings defaultWhitelistingSettings = new WhitelistingSettings();
     private static final AllowlistingSettings defaultAllowlistingSettings = new AllowlistingSettings();
+    private static final AuditConfig defaultAuditConfig = new AuditConfig();
 
     static void resetStatics() {
         staticRoles = SecurityDynamicConfiguration.empty();
@@ -314,7 +315,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
         eventBus.post(whitelist == null ? defaultWhitelistingSettings : whitelist);
         eventBus.post(allowlist == null ? defaultAllowlistingSettings : allowlist);
         if (cr.isAuditHotReloadingEnabled()) {
-            eventBus.post(audit);
+            eventBus.post(audit == null ? defaultAuditConfig : audit);
         }
 
         initialized.set(true);


### PR DESCRIPTION
This was causing an error if the audit config was null and was posted to the event bus.

### Description
* Category: Bugfix
* Why these changes are required? An empty audit config causes the logs to be filled with an irrelevant error.
* What is the old behavior before changes and new behavior after changes?
Old behavior:
Lots of errors when the audit config is missing
New behavior:
Audit config is set to the default when missing

### Issues Resolved
#4315 
https://forum.opensearch.org/t/ava-lang-nullpointerexception-cannot-invoke-object-getclass-because-event-is-null/20821/

Is this a backport? No.
Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? No.

### Testing
None

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
