### PR TITLE
[Backport 2.x] Bump org.junit.jupiter:junit-jupiter from 5.10.3 to 5.11.0 (#4657)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -684,9 +684,9 @@ dependencies {
     testImplementation 'commons-validator:commons-validator:1.9.0'
     testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
     testImplementation "org.springframework:spring-beans:${spring_version}"
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.3'
-    testImplementation('org.awaitility:awaitility:4.2.1') {
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.0'
+    testImplementation('org.awaitility:awaitility:4.2.2') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/4657 to `2.x`