### PR TITLE
Moves @cliu123 to emeritus status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cliu123 @cwperks @DarshitChanpura @peternied @RyanL1997 @scrawfor99 @reta @willyborankin
+* @cwperks @DarshitChanpura @peternied @RyanL1997 @stephen-crawford @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,21 +13,21 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 ## Current Maintainers
 
 | Maintainer       | GitHub ID                                             | Affiliation |
-| ---------------- | ----------------------------------------------------- | ----------- |
-| Chang Liu        | [cliu123](https://github.com/cliu123)                 | Amazon      |
+|------------------|-------------------------------------------------------|-------------|
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
-| Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
+| Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)     | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
 
 ## Emeritus
 
-| Maintainer    | GitHub ID                                           | Affiliation |
-| ------------- | --------------------------------------------------- | ----------- |
-| Dave Lago     | [davidlago](https://github.com/davidlago)           | Contributor |
+| Maintainer | GitHub ID                                 | Affiliation |
+|------------|-------------------------------------------|-------------|
+| Dave Lago  | [davidlago](https://github.com/davidlago) | Contributor |
+| Chang Liu  | [cliu123](https://github.com/cliu123)     | Amazon      |
 
 ## Practices
 


### PR DESCRIPTION
### Description
Moves @cliu123 to emeritus status.


### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
