### PR TITLE
Add Nils Bandener (Github: nibix) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @peternied @RyanL1997 @stephen-crawford @reta @willyborankin
+* @cwperks @DarshitChanpura @nibix @peternied @RyanL1997 @stephen-crawford @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -21,6 +21,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)     | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
+| Nils Bandener    | [nibix](https://github.com/nibix)                     | Eliatra     |
 
 ## Emeritus
 


### PR DESCRIPTION
I have nominated, and maintainers have agreed to add Nils Bandener (@nibix) as a co-maintainer, who has kindly accepted.

Nils has made many valuable contributions and given insight into the OpenSearch Security repo over the last few years.

Notable code contributions from Nils include:
 
- New integrationTest framework: https://github.com/opensearch-project/security/pull/1967
- New algorithm for resolving action groups: https://github.com/opensearch-project/security/pull/4448
- Separated DLS/FLS privilege evaluation from action privilege evaluation: https://github.com/opensearch-project/security/pull/4490
- Remove special handling for do_not_fail_on_forbidden on cluster actions: https://github.com/opensearch-project/security/pull/4486
 
Nils has engaged in maintenance of the code base like fixing flaky tests and bug fixes as well. Here are some examples:
 
- Fixed READ_ACTIONS required by TermsAggregationEvaluator: https://github.com/opensearch-project/security/pull/4582
- Fixed flaky BWC test: https://github.com/opensearch-project/security/pull/4446
- Fixed test failures in FlsAndFieldMaskingTests: https://github.com/opensearch-project/security/pull/4548
 
See all code contributions (Open + Closed) from Nils here: https://github.com/opensearch-project/security/pulls?q=is%3Apr+author%3Anibix
 
Nils has also contributed valuable insight on many occasions including submission of 5 RFCs:
 
- See issues submitted by Nils here: https://github.com/opensearch-project/security/issues?q=is%3Aissue+author%3Anibix
 
Nils regularly contributes to conversation on Pull Requests, RFCs and other issues:
 
- Insightful comment from Nils on recent RFC: https://github.com/opensearch-project/security/issues/4500#issuecomment-2204198581
- Example where Nils contributed valuable insight on a PR: https://github.com/opensearch-project/security/pull/2765
- Example where Nils contributed valuable insight in an issue: https://github.com/opensearch-project/security/issues/2195#issuecomment-1298228764
 
See all PRs where Nils has engaged as a commenter: https://github.com/opensearch-project/security/pulls?q=is%3Apr+commenter%3Anibix
 
See all issues where Nils has engaged as a commenter: https://github.com/opensearch-project/security/issues?q=is%3Aissue+commenter%3Anibix
 
Additionally, Nils is active in the community and has given a talk at OpenSearch Con EU: https://opensearch.org/community/members/nbendener.html