### PR TITLE
[Backport 2.x] Add Nils Bandener (Github: nibix) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cliu123 @cwperks @DarshitChanpura @davidlago @peternied @RyanL1997 @scrawfor99 @reta @willyborankin
+* @cwperks @DarshitChanpura @nibix @peternied @RyanL1997 @stephen-crawford @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -20,6 +20,7 @@
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
+| Nils Bandener    | [nibix](https://github.com/nibix)                     | Eliatra     |
 
 ## Practices
 


### PR DESCRIPTION
Backport of #4672 to 2.x.