### PR TITLE
Revert "Fix covereage-report workflow (#4683)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,8 @@ jobs:
           attempt_limit: 5
           attempt_delay: 2000
           action: codecov/codecov-action@v4
-          env: |
-            CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           with: |
+            token: ${{ secrets.CODECOV_TOKEN }}
             fail_ci_if_error: true
             verbose: true
 


### PR DESCRIPTION
This reverts commit 359272ef4b3811ec794a1c8ac19e7dfcf42906f4.

### Description

This PR reverts a previous change that purportedly fixed the codecov-report CI check. After the PR was merged into main, I observed that the fix was not working as intended and had a false sense of fix because codecov upload works with tokenless uploads on forks.

While the change is a valid way to configure codecov/codecov-action@v4 according to the [README](https://github.com/codecov/codecov-action?tab=readme-ov-file#usage), there is an issue with the usage of `env` inside the `Wandalen/wretry.action@v3.5.0` action which is an action that automatically retries upload on failure. 

```
Warning: Unexpected input(s) 'env', valid inputs are ['action', 'command', 'with', 'current_path', 'steps_context', 'attempt_limit', 'attempt_delay', 'time_out', 'retry_condition', 'github_token']
```

ref: https://github.com/opensearch-project/security/actions/runs/10561243044/job/29257710874

Initially, I made the PR because this check failed on 3 dependabot PRs:

- https://github.com/opensearch-project/security/pull/4678
- https://github.com/opensearch-project/security/pull/4679
- https://github.com/opensearch-project/security/pull/4680

It turns out, the issue is specific to dependabot. [Dependabot does not have access to the secrets](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#accessing-secrets) of the repo and a separate section with `Dependabot Secrets` needs to be populated.

This change should be reverted and the CODECOV_TOKEN should be added to the repo as a `Dependabot Secret`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
