### PR TITLE
Interim build fix for PluginSubject related changes

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -109,6 +109,7 @@ import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.HttpServerTransport.Dispatcher;
 import org.opensearch.http.netty4.ssl.SecureNetty4HttpServerTransport;
+import org.opensearch.identity.PluginSubject;
 import org.opensearch.identity.Subject;
 import org.opensearch.identity.noop.NoopSubject;
 import org.opensearch.index.IndexModule;
@@ -119,6 +120,7 @@ import org.opensearch.plugins.ClusterPlugin;
 import org.opensearch.plugins.ExtensionAwarePlugin;
 import org.opensearch.plugins.IdentityPlugin;
 import org.opensearch.plugins.MapperPlugin;
+import org.opensearch.plugins.Plugin;
 import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
 import org.opensearch.plugins.SecureSettingsFactory;
 import org.opensearch.plugins.SecureTransportSettingsProvider;
@@ -164,6 +166,7 @@ import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
 import org.opensearch.security.http.NonSslHttpServerTransport;
 import org.opensearch.security.http.XFFResolver;
+import org.opensearch.security.identity.NoopPluginSubject;
 import org.opensearch.security.identity.SecurityTokenManager;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.privileges.PrivilegesInterceptor;
@@ -2102,7 +2105,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     }
 
     @Override
-    public Subject getSubject() {
+    public Subject getCurrentSubject() {
         // Not supported
         return new NoopSubject();
     }
@@ -2110,6 +2113,11 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     @Override
     public SecurityTokenManager getTokenManager() {
         return tokenManager;
+    }
+
+    @Override
+    public PluginSubject getPluginSubject(Plugin plugin) {
+        return new NoopPluginSubject(threadPool);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/identity/NoopPluginSubject.java
+++ b/src/main/java/org/opensearch/security/identity/NoopPluginSubject.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.identity;
+
+import java.security.Principal;
+import java.util.concurrent.Callable;
+
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.identity.NamedPrincipal;
+import org.opensearch.identity.PluginSubject;
+import org.opensearch.threadpool.ThreadPool;
+
+public class NoopPluginSubject implements PluginSubject {
+    private final ThreadPool threadPool;
+
+    public NoopPluginSubject(ThreadPool threadPool) {
+        super();
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public Principal getPrincipal() {
+        return NamedPrincipal.UNAUTHENTICATED;
+    }
+
+    @Override
+    public <T> T runAs(Callable<T> callable) throws Exception {
+        try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
+            return callable.call();
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes compilation issues due to a change in the IdentityPlugin interface introduced in https://github.com/opensearch-project/OpenSearch/pull/14630

There is a [PR open on this repo](https://github.com/opensearch-project/security/pull/4665) to implement the extension points as intended, but the PR will need some time for thorough review.

This PR is an interim change to ensure that the plugin compiles. The code is not currently used and guarded by the [identity feature flag](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/util/FeatureFlags.java#L88): `opensearch.experimental.feature.identity.enabled` 

The PluginSubject being introduced in this PR is a noop and simply stashes the ThreadContext.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

Related to: https://github.com/opensearch-project/security/issues/4439

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
