### PR TITLE
[Backport 2.x] Bump com.google.errorprone:error_prone_annotations from 2.30.0 to 2.31.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -502,7 +502,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
             force 'org.checkerframework:checker-qual:3.46.0'
-            force "com.google.errorprone:error_prone_annotations:2.29.2"
+            force "com.google.errorprone:error_prone_annotations:2.31.0"
             force "ch.qos.logback:logback-classic:1.5.6"
         }
     }
@@ -608,7 +608,7 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.17.1'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.7'
-    compileOnly 'com.google.errorprone:error_prone_annotations:2.30.0'
+    compileOnly 'com.google.errorprone:error_prone_annotations:2.31.0'
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     runtimeOnly 'org.ow2.asm:asm:9.7'


### PR DESCRIPTION
Backport 3319dd2b7b4d61eebfe2791921392d53c5d9eeda from #4695