### PR TITLE
adding alerting comments security actions to roles.yml

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -37,7 +37,6 @@ alerting_read_access:
     - 'cluster:admin/opensearch/alerting/remote/indexes/get'
     - 'cluster:admin/opensearch/alerting/workflow/get'
     - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
-    - 'cluster:admin/opensearch/alerting/comments/search'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -32,6 +32,7 @@ alerting_read_access:
     - 'cluster:admin/opendistro/alerting/destination/get'
     - 'cluster:admin/opendistro/alerting/monitor/get'
     - 'cluster:admin/opendistro/alerting/monitor/search'
+    - 'cluster:admin/opensearch/alerting/comments/search'
     - 'cluster:admin/opensearch/alerting/findings/get'
     - 'cluster:admin/opensearch/alerting/remote/indexes/get'
     - 'cluster:admin/opensearch/alerting/workflow/get'

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -36,6 +36,7 @@ alerting_read_access:
     - 'cluster:admin/opensearch/alerting/remote/indexes/get'
     - 'cluster:admin/opensearch/alerting/workflow/get'
     - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
+    - 'cluster:admin/opensearch/alerting/comments/search'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:
@@ -44,6 +45,7 @@ alerting_ack_alerts:
     - 'cluster:admin/opendistro/alerting/alerts/*'
     - 'cluster:admin/opendistro/alerting/chained_alerts/*'
     - 'cluster:admin/opendistro/alerting/workflow_alerts/*'
+    - 'cluster:admin/opensearch/alerting/comments/search'
 
 # Allows users to use all alerting functionality
 alerting_full_access:


### PR DESCRIPTION
### Description
Adding new alerting comments security permissions to existing alerting plugin roles for new Alerting Comments feature: https://github.com/opensearch-project/alerting/pull/1561
* Category: Addition as part of new feature
* Why these changes are required?: to ensure proper and intended permissioning of comments in the alerting plugin
* What is the old behavior before changes and new behavior after changes?: before the changes, there was no way to specify what users and what roles had access to what comments. This change allows for that to happen.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
Not a backport PR, but would like this PR backported to 2.15

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
