### PR TITLE
perm changes for correlationAlerts

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -411,7 +411,7 @@ security_analytics_ack_alerts:
   reserved: true
   cluster_permissions:
     - 'cluster:admin/opensearch/securityanalytics/alerts/*'
-    - 'cluster:admin/opensearch/securityanalytics/correlationAlerts/ack'
+    - 'cluster:admin/opensearch/securityanalytics/correlationAlerts/*'
     - 'cluster:admin/opensearch/securityanalytics/threatintel/alerts/*'
 
 # Allows users to use all Flow Framework functionality


### PR DESCRIPTION
### Description
Permission changed from `cluster:admin/opensearch/securityanalytics/correlationAlerts/ack'` to `cluster:admin/opensearch/securityanalytics/correlationAlerts/*` i.e someone who can acknowledge should to be able to view the correlationAlerts too

some one who can ack needs to be able to view the alert too

### Issues Resolved
Feature Issue: https://github.com/opensearch-project/security-analytics/issues/988

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
yes, backport to 2.x and 2.17 if branch is cut

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

No

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
