### PR TITLE
Adding index permissions for remote index in AD

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -86,7 +86,12 @@ anomaly_full_access:
         - '*'
       allowed_actions:
         - 'indices:admin/aliases/get'
+        - 'indices:admin/mappings/fields/get'
+        - 'indices:admin/mappings/fields/get*'
         - 'indices:admin/mappings/get'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read/field_caps*'
+        - 'indices:data/read/search'
         - 'indices_monitor'
 
 # Allow users to execute read only k-NN actions


### PR DESCRIPTION
### Description
Adding a few more index permissions for AD full access role. This is due to the fact we now make some additional calls during detector creation to get all necessary information from the remote clusters.

### Issues Resolved
https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/854

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
