### PR TITLE
Adding Alerting Comments and Correlation Alerts system indices

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -59,6 +59,8 @@ public class SecuritySettingsConfigurer {
         ".plugins-ml-stop-words",
         ".opendistro-alerting-config",
         ".opendistro-alerting-alert*",
+        ".opensearch-alerting-comments*",
+        ".opensearch-sap-correlation-alerts",
         ".opendistro-anomaly-results*",
         ".opendistro-anomaly-detector*",
         ".opendistro-anomaly-checkpoints",


### PR DESCRIPTION
### Description
Adding Alerting Comments and Correlation Alerts system indices to SecuritySettingsConfigurer.

To be backported to 2.15 and 2.16.

Separate PRs within our respective Alerting and Security Analytics plugins are being raised to update `getSystemIndexDescriptors()`, which will cover the >= 2.17 cases of allowing these indices to be registered in Security as system indices.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
