### PR TITLE
Add ensureCustomSerialization to ensure that headers are serialized correctly with multiple transport hops

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -29,6 +29,7 @@ package org.opensearch.security.configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterStateListener;
 import org.opensearch.cluster.node.DiscoveryNode;
@@ -65,6 +66,17 @@ public class ClusterInfoHolder implements ClusterStateListener {
 
     public boolean isInitialized() {
         return initialized;
+    }
+
+    public Version getMinNodeVersion() {
+        if (nodes == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cluster Info Holder not initialized yet for 'nodes'");
+            }
+            return null;
+        }
+
+        return nodes.getMinNodeVersion();
     }
 
     public Boolean hasNode(DiscoveryNode node) {

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -185,7 +185,7 @@ public class SecurityFilter implements ActionFilter {
             }
 
             if (threadContext.getTransient(ConfigConstants.USE_JDK_SERIALIZATION) == null) {
-                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, false);
+                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, true);
             }
 
             final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -39,7 +39,7 @@ public class Base64Helper {
     }
 
     public static Serializable deserializeObject(final String string) {
-        return deserializeObject(string, false);
+        return deserializeObject(string, true);
     }
 
     public static Serializable deserializeObject(final String string, final boolean useJDKDeserialization) {

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -69,4 +69,28 @@ public class Base64Helper {
         // If we see an exception now, we want the caller to see it -
         return Base64Helper.serializeObject(serializable, true);
     }
+
+    /**
+     * Ensures that the returned string is custom serialized.
+     *
+     * If the supplied string is a JDK serialized representation, will deserialize it and further serialize using
+     * custom, otherwise returns the string as is.
+     *
+     * @param string original string, can be JDK or custom serialized
+     * @return custom serialized string
+     */
+    public static String ensureCustomSerialized(final String string) {
+        Serializable serializable;
+        try {
+            serializable = Base64Helper.deserializeObject(string, true);
+        } catch (Exception e) {
+            // We received an exception when de-serializing the given string. It is probably custom serialized.
+            // Try to deserialize using custom
+            Base64Helper.deserializeObject(string, false);
+            // Since we could deserialize the object using custom, the string is already custom serialized, return as is
+            return string;
+        }
+        // If we see an exception now, we want the caller to see it -
+        return Base64Helper.serializeObject(serializable, false);
+    }
 }

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -35,7 +35,7 @@ public class Base64Helper {
     }
 
     public static String serializeObject(final Serializable object) {
-        return serializeObject(object, false);
+        return serializeObject(object, true);
     }
 
     public static Serializable deserializeObject(final String string) {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -231,13 +231,13 @@ public class SecurityInterceptor {
             }
 
             try {
-                if (serializationFormat == SerializationFormat.JDK) {
-                    Map<String, String> jdkSerializedHeaders = new HashMap<>();
+                if (serializationFormat == SerializationFormat.CustomSerializer_2_11) {
+                    Map<String, String> customSerializedHeaders = new HashMap<>();
                     HeaderHelper.getAllSerializedHeaderNames()
                         .stream()
                         .filter(k -> headerMap.get(k) != null)
-                        .forEach(k -> jdkSerializedHeaders.put(k, Base64Helper.ensureJDKSerialized(headerMap.get(k))));
-                    headerMap.putAll(jdkSerializedHeaders);
+                        .forEach(k -> customSerializedHeaders.put(k, Base64Helper.ensureCustomSerialized(headerMap.get(k))));
+                    headerMap.putAll(customSerializedHeaders);
                 }
                 getThreadContext().putHeader(headerMap);
             } catch (IllegalArgumentException iae) {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -39,6 +39,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.get.GetRequest;
@@ -231,13 +232,22 @@ public class SecurityInterceptor {
             }
 
             try {
-                if (serializationFormat == SerializationFormat.CustomSerializer_2_11) {
-                    Map<String, String> customSerializedHeaders = new HashMap<>();
-                    HeaderHelper.getAllSerializedHeaderNames()
-                        .stream()
-                        .filter(k -> headerMap.get(k) != null)
-                        .forEach(k -> customSerializedHeaders.put(k, Base64Helper.ensureCustomSerialized(headerMap.get(k))));
-                    headerMap.putAll(customSerializedHeaders);
+                if (clusterInfoHolder.getMinNodeVersion().before(Version.V_2_14_0)) {
+                    if (serializationFormat == SerializationFormat.JDK) {
+                        Map<String, String> jdkSerializedHeaders = new HashMap<>();
+                        HeaderHelper.getAllSerializedHeaderNames()
+                            .stream()
+                            .filter(k -> headerMap.get(k) != null)
+                            .forEach(k -> jdkSerializedHeaders.put(k, Base64Helper.ensureJDKSerialized(headerMap.get(k))));
+                        headerMap.putAll(jdkSerializedHeaders);
+                    } else if (serializationFormat == SerializationFormat.CustomSerializer_2_11) {
+                        Map<String, String> customSerializedHeaders = new HashMap<>();
+                        HeaderHelper.getAllSerializedHeaderNames()
+                            .stream()
+                            .filter(k -> headerMap.get(k) != null)
+                            .forEach(k -> customSerializedHeaders.put(k, Base64Helper.ensureCustomSerialized(headerMap.get(k))));
+                        headerMap.putAll(customSerializedHeaders);
+                    }
                 }
                 getThreadContext().putHeader(headerMap);
             } catch (IllegalArgumentException iae) {

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -232,7 +232,7 @@ public class SecurityInterceptor {
             }
 
             try {
-                if (clusterInfoHolder.getMinNodeVersion().before(Version.V_2_14_0)) {
+                if (clusterInfoHolder.getMinNodeVersion() == null || clusterInfoHolder.getMinNodeVersion().before(Version.V_2_14_0)) {
                     if (serializationFormat == SerializationFormat.JDK) {
                         Map<String, String> jdkSerializedHeaders = new HashMap<>();
                         HeaderHelper.getAllSerializedHeaderNames()

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -54,6 +54,15 @@ public class Base64HelperTest {
     }
 
     @Test
+    public void testEnsureCustomSerialized() {
+        String test = "string";
+        String jdkSerialized = Base64Helper.serializeObject(test, true);
+        String customSerialized = Base64Helper.serializeObject(test, false);
+        assertThat(Base64Helper.ensureCustomSerialized(jdkSerialized), is(customSerialized));
+        assertThat(Base64Helper.ensureCustomSerialized(customSerialized), is(customSerialized));
+    }
+
+    @Test
     public void testDuplicatedItemSizes() {
         var largeObject = new HashMap<String, Object>();
         var hm = new HashMap<>();

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -219,7 +219,6 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 String serializedUserHeader = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
-                System.out.println("serializedUserHeader: " + serializedUserHeader);
                 assertThat(serializedUserHeader, is(Base64Helper.serializeObject(user, true)));
                 senderLatch.get().countDown();
             }

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -334,13 +334,13 @@ public class SecurityInterceptorTests {
     public void testSendRequestDecorateRemoteConnectionUsesJDKSerialization() {
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER, Base64Helper.serializeObject(user, false));
         completableRequestDecorateWithPreviouslyPopulatedHeaders(
-                jdkSerializedSender,
-                connection3,
-                action,
-                request,
-                options,
-                handler,
-                localNode
+            jdkSerializedSender,
+            connection3,
+            action,
+            request,
+            options,
+            handler,
+            localNode
         );
     }
 

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -119,9 +119,12 @@ public class SecurityInterceptorTests {
     private Connection connection3;
     private DiscoveryNode otherRemoteNode;
     private Connection connection4;
+    private DiscoveryNode remoteNodeWithCustomSerialization;
+    private Connection connection5;
 
     private AsyncSender sender;
-    private AsyncSender serializedSender;
+    private AsyncSender jdkSerializedSender;
+    private AsyncSender customSerializedSender;
     private AtomicReference<CountDownLatch> senderLatch = new AtomicReference<>(new CountDownLatch(1));
 
     @Before
@@ -199,7 +202,14 @@ public class SecurityInterceptorTests {
         otherRemoteNode = new DiscoveryNode("remote-node2", new TransportAddress(remoteAddress, 9876), remoteNodeVersion);
         connection4 = transportService.getConnection(otherRemoteNode);
 
-        serializedSender = new AsyncSender() {
+        remoteNodeWithCustomSerialization = new DiscoveryNode(
+            "remote-node-with-custom-serialization",
+            new TransportAddress(localAddress, 7456),
+            Version.V_2_12_0
+        );
+        connection5 = transportService.getConnection(remoteNodeWithCustomSerialization);
+
+        jdkSerializedSender = new AsyncSender() {
             @Override
             public <T extends TransportResponse> void sendRequest(
                 Connection connection,
@@ -209,7 +219,23 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 String serializedUserHeader = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
+                System.out.println("serializedUserHeader: " + serializedUserHeader);
                 assertThat(serializedUserHeader, is(Base64Helper.serializeObject(user, true)));
+                senderLatch.get().countDown();
+            }
+        };
+
+        customSerializedSender = new AsyncSender() {
+            @Override
+            public <T extends TransportResponse> void sendRequest(
+                Connection connection,
+                String action,
+                TransportRequest request,
+                TransportRequestOptions options,
+                TransportResponseHandler<T> handler
+            ) {
+                String serializedUserHeader = threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER);
+                assertThat(serializedUserHeader, is(Base64Helper.serializeObject(user, false)));
                 senderLatch.get().countDown();
             }
         };
@@ -265,6 +291,27 @@ public class SecurityInterceptorTests {
         senderLatch.set(new CountDownLatch(1));
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    final void completableRequestDecorateWithPreviouslyPopulatedHeaders(
+        AsyncSender sender,
+        Connection connection,
+        String action,
+        TransportRequest request,
+        TransportRequestOptions options,
+        TransportResponseHandler handler,
+        DiscoveryNode localNode
+    ) {
+        securityInterceptor.sendRequestDecorate(sender, connection, action, request, options, handler, localNode);
+        try {
+            senderLatch.get().await(1, TimeUnit.SECONDS);
+        } catch (final InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Reset the latch so another request can be processed
+        senderLatch.set(new CountDownLatch(1));
+    }
+
     @Test
     public void testSendRequestDecorateLocalConnection() {
 
@@ -278,16 +325,30 @@ public class SecurityInterceptorTests {
     public void testSendRequestDecorateRemoteConnection() {
 
         // this is a remote request
-        completableRequestDecorate(serializedSender, connection3, action, request, options, handler, localNode);
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
         // this is a remote request where the transport address is different
-        completableRequestDecorate(serializedSender, connection4, action, request, options, handler, localNode);
+        completableRequestDecorate(jdkSerializedSender, connection4, action, request, options, handler, localNode);
+    }
+
+    @Test
+    public void testSendRequestDecorateRemoteConnectionUsesCustomSerialization() {
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_USER_HEADER, Base64Helper.serializeObject(user));
+        completableRequestDecorateWithPreviouslyPopulatedHeaders(
+            customSerializedSender,
+            connection5,
+            action,
+            request,
+            options,
+            handler,
+            localNode
+        );
     }
 
     @Test
     public void testSendNoOriginNodeCausesSerialization() {
 
         // this is a request where the local node is null; have to use the remote connection since the serialization will fail
-        completableRequestDecorate(serializedSender, connection3, action, request, options, handler, null);
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, null);
     }
 
     @Test
@@ -296,7 +357,7 @@ public class SecurityInterceptorTests {
         // The completable version swallows the NPE so have to call actual method
         assertThrows(
             java.lang.NullPointerException.class,
-            () -> securityInterceptor.sendRequestDecorate(serializedSender, null, action, request, options, handler, localNode)
+            () -> securityInterceptor.sendRequestDecorate(jdkSerializedSender, null, action, request, options, handler, localNode)
         );
     }
 
@@ -328,7 +389,7 @@ public class SecurityInterceptorTests {
                 ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS,
                 String.valueOf(new TransportAddress(new InetSocketAddress("8.8.8.8", 80)))
             );
-        completableRequestDecorate(serializedSender, connection3, action, request, options, handler, localNode);
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
     }
 
     @Test
@@ -351,7 +412,7 @@ public class SecurityInterceptorTests {
         // this is a local request
         completableRequestDecorate(sender, connection1, action, request, options, handler, localNode);
         // this is a remote request
-        completableRequestDecorate(serializedSender, connection3, action, request, options, handler, localNode);
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
     }
 
     @Test
@@ -363,7 +424,7 @@ public class SecurityInterceptorTests {
         // this is a local request
         completableRequestDecorate(sender, connection1, action, request, options, handler, localNode);
         // this is a remote request
-        completableRequestDecorate(serializedSender, connection3, action, request, options, handler, localNode);
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR fixes multiple issue:

- https://github.com/opensearch-project/security/issues/4494
- https://github.com/opensearch-project/security/issues/4670

When upgrading from 2.11/2.12/2.13 to >= 2.14, there can be an issue when deserializing threadContext headers on the receiving node due to the transmitting node re-using the serialization format from a previous transport hop.

This was particularly seen in scenarios where there is a chain of transport hops, such as 2.14 (Coordinator node) -> 2.14 node -> 2.12 node

These scenarios can happen on ingestion during rolling upgrades where a replica shard may temporarily be on an older node than a primary shard.

This PR adds logic in the SecurityInterceptor to re-serialize the headers if they have previously been populated from a prior transport hop for backwards compatibility.

This PR adds a version check to the logic around ensureJdkSerialization and ensureCustomSerialization to only execute the logic in a mixed cluster containing nodes < 2.14. If all nodes are >= 2.14 then this logic is redundant and adds additional overhead.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

- Resolves https://github.com/opensearch-project/security/issues/4494
- Resolves https://github.com/opensearch-project/security/issues/4670

### Testing

Creating this PR in Draft until testing details are added.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
