### PR TITLE
[Backport 2.x] Add ensureCustomSerialization to ensure that headers are serialized correctly with multiple transport hops (#4741)

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.LegacyESVersion;
+import org.opensearch.Version;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateListener;
@@ -99,6 +100,17 @@ public class ClusterInfoHolder implements ClusterStateListener {
 
     public boolean isInitialized() {
         return initialized;
+    }
+
+    public Version getMinNodeVersion() {
+        if (nodes == null) {
+            if (log.isDebugEnabled()) {
+                log.debug("Cluster Info Holder not initialized yet for 'nodes'");
+            }
+            return null;
+        }
+
+        return nodes.getMinNodeVersion();
     }
 
     public Boolean hasNode(DiscoveryNode node) {

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -185,7 +185,7 @@ public class SecurityFilter implements ActionFilter {
             }
 
             if (threadContext.getTransient(ConfigConstants.USE_JDK_SERIALIZATION) == null) {
-                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, false);
+                threadContext.putTransient(ConfigConstants.USE_JDK_SERIALIZATION, true);
             }
 
             final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -35,11 +35,11 @@ public class Base64Helper {
     }
 
     public static String serializeObject(final Serializable object) {
-        return serializeObject(object, false);
+        return serializeObject(object, true);
     }
 
     public static Serializable deserializeObject(final String string) {
-        return deserializeObject(string, false);
+        return deserializeObject(string, true);
     }
 
     public static Serializable deserializeObject(final String string, final boolean useJDKDeserialization) {
@@ -68,5 +68,29 @@ public class Base64Helper {
         }
         // If we see an exception now, we want the caller to see it -
         return Base64Helper.serializeObject(serializable, true);
+    }
+
+    /**
+     * Ensures that the returned string is custom serialized.
+     *
+     * If the supplied string is a JDK serialized representation, will deserialize it and further serialize using
+     * custom, otherwise returns the string as is.
+     *
+     * @param string original string, can be JDK or custom serialized
+     * @return custom serialized string
+     */
+    public static String ensureCustomSerialized(final String string) {
+        Serializable serializable;
+        try {
+            serializable = Base64Helper.deserializeObject(string, true);
+        } catch (Exception e) {
+            // We received an exception when de-serializing the given string. It is probably custom serialized.
+            // Try to deserialize using custom
+            Base64Helper.deserializeObject(string, false);
+            // Since we could deserialize the object using custom, the string is already custom serialized, return as is
+            return string;
+        }
+        // If we see an exception now, we want the caller to see it -
+        return Base64Helper.serializeObject(serializable, false);
     }
 }

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -54,6 +54,15 @@ public class Base64HelperTest {
     }
 
     @Test
+    public void testEnsureCustomSerialized() {
+        String test = "string";
+        String jdkSerialized = Base64Helper.serializeObject(test, true);
+        String customSerialized = Base64Helper.serializeObject(test, false);
+        assertThat(Base64Helper.ensureCustomSerialized(jdkSerialized), is(customSerialized));
+        assertThat(Base64Helper.ensureCustomSerialized(customSerialized), is(customSerialized));
+    }
+
+    @Test
     public void testDuplicatedItemSizes() {
         var largeObject = new HashMap<String, Object>();
         var hm = new HashMap<>();


### PR DESCRIPTION
Manual backport of #4741 to 2.x

Resolves a conflict in the imports for ClusterInfoHolder between main and 2.x.