### PR TITLE
Fixed use of rolesMappingConfiguration in InternalUsersApiActionValidationTest

### DIFF
--- a/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
@@ -72,13 +72,13 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         config.set("all_access", objectMapper.createObjectNode());
         config.set("regular_role", objectMapper.createObjectNode());
 
-        config.set("some_role_with_static_mapping", objectMapper.createObjectNode().put("static", true));
+        config.set("some_role_with_static_mapping", objectMapper.createObjectNode());
         config.set("some_role_with_reserved_mapping", objectMapper.createObjectNode().put("reserved", true));
         config.set("some_role_with_hidden_mapping", objectMapper.createObjectNode().put("hidden", true));
 
         final var rolesMappingConfiguration = SecurityDynamicConfiguration.fromJson(
             objectMapper.writeValueAsString(config),
-            CType.ROLES,
+            CType.ROLESMAPPING,
             2,
             1,
             1
@@ -191,7 +191,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         userJson = objectMapper.createObjectNode()
             .set("opendistro_security_roles", objectMapper.createArrayNode().add("some_role_with_static_mapping"));
         result = internalUsersApiAction.validateSecurityRoles(SecurityConfiguration.of(userJson, "some_user", configuration));
-        assertFalse(result.isValid());
+        assertTrue(result.isValid());
     }
 
     private InternalUsersApiAction createInternalUsersApiAction() {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
@@ -60,7 +60,6 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         allClusterPermissions.setCluster_permissions(List.of("*"));
         @SuppressWarnings("unchecked")
         final var c = (SecurityDynamicConfiguration<RoleV7>) rolesConfiguration;
-        c.putCEntry("some_role_with_static_mapping", allClusterPermissions);
         c.putCEntry("some_role_with_reserved_mapping", allClusterPermissions);
         c.putCEntry("some_role_with_hidden_mapping", allClusterPermissions);
 
@@ -72,7 +71,6 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         config.set("all_access", objectMapper.createObjectNode());
         config.set("regular_role", objectMapper.createObjectNode());
 
-        config.set("some_role_with_static_mapping", objectMapper.createObjectNode());
         config.set("some_role_with_reserved_mapping", objectMapper.createObjectNode().put("reserved", true));
         config.set("some_role_with_hidden_mapping", objectMapper.createObjectNode().put("hidden", true));
 
@@ -187,11 +185,6 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
             .set("opendistro_security_roles", objectMapper.createArrayNode().add("some_role_with_reserved_mapping"));
         result = internalUsersApiAction.validateSecurityRoles(SecurityConfiguration.of(userJson, "some_user", configuration));
         assertFalse(result.isValid());
-        // should not be ok to set role with static role mapping
-        userJson = objectMapper.createObjectNode()
-            .set("opendistro_security_roles", objectMapper.createArrayNode().add("some_role_with_static_mapping"));
-        result = internalUsersApiAction.validateSecurityRoles(SecurityConfiguration.of(userJson, "some_user", configuration));
-        assertTrue(result.isValid());
     }
 
     private InternalUsersApiAction createInternalUsersApiAction() {


### PR DESCRIPTION
### Description

While working on https://github.com/opensearch-project/security/pull/4546, I encountered weird behavior in InternalUsersApiActionValidationTest. Closer analysis revealed that the behavior came from the fact that the test erroneously parsed a roles mapping JSON config as `CType.ROLES` and not as `CType.ROLESMAPPING`.

 I have now switched the config type to `CType.ROLESMAPPING`. 

This has a couple of consequences:

- The roles mapping config type does not have a `static` property, so it cannot be marked as such.
- This causes the behavior of one test to flip: `InternalUsersApiActionValidationTest.validateSecurityRolesWithImmutableRolesMappingConfig`, last assert.

Side note: To be honest, I am a bit confused by the test `validateSecurityRolesWithImmutableRolesMappingConfig` - why should have a user no reserved roles or static roles assigned? Despite the change, the test demonstrates that reserved roles cannot be assigned.

* Category: Test fix
* Why these changes are required? - As the changes in !4546 do some more strict validations, the wrong assignment of the wrong config type leads to issues.
* What is the old behavior before changes and new behavior after changes? - as this is a test fix, no behavior changes.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
