### PR TITLE
Test to demonstrate that OpenSearch does not start up with plain v6 configuration

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/legacy/LegacyConfigV6AutoConversionTest.java
+++ b/src/integrationTest/java/org/opensearch/security/legacy/LegacyConfigV6AutoConversionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.legacy;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class LegacyConfigV6AutoConversionTest {
+    static final TestSecurityConfig LEGACY_CONFIG = new TestSecurityConfig()//
+        .rawConfigurationDocumentYaml("config", """
+            opendistro_security:
+              dynamic:
+                authc:
+                  basic_internal_auth_domain:
+                    http_enabled: true
+                    order: 4
+                    http_authenticator:
+                      type: basic
+                      challenge: true
+                    authentication_backend:
+                      type: intern
+                      """)//
+        .rawConfigurationDocumentYaml("internalusers", """
+            admin:
+              readonly: true
+              hash: $2a$12$VcCDgh2NDk07JGN0rjGbM.Ad41qVR/YFJcgHp0UGns5JDymv..TOG
+              roles:
+                - admin
+              attributes:
+                attribute1: value1
+            """)//
+        .rawConfigurationDocumentYaml("roles", """
+            all_access:
+              readonly: true
+              cluster:
+                - UNLIMITED
+              indices:
+                '*':
+                  '*':
+                    - UNLIMITED
+              tenants:
+                admin_tenant: RW
+                """)//
+        .rawConfigurationDocumentYaml("rolesmapping", """
+            all_access:
+              readonly: true
+              backendroles:
+                - admin
+            """)
+        .rawConfigurationDocumentYaml("actiongroups", """
+            TEST:
+              readonly: true
+              permissions:
+                - INDICES_ALL
+                """);
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .config(LEGACY_CONFIG)
+        .build();
+
+    @Test
+    public void checkAuthc() {
+        try (TestRestClient client = cluster.getRestClient("admin", "admin")) {
+            TestRestClient.HttpResponse response = client.get("_opendistro/_security/authinfo");
+            System.out.println(response.getBody());
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -43,6 +43,9 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -93,6 +96,13 @@ public class TestSecurityConfig {
     private Map<String, RoleMapping> rolesMapping = new LinkedHashMap<>();
 
     private Map<String, ActionGroup> actionGroups = new LinkedHashMap<>();
+
+    /**
+     * A map from document id to a string containing config JSON.
+     * If this is not null, it will be used ALTERNATIVELY to all other configuration contained in this class.
+     * Can be used to simulate invalid configuration or legacy configuration.
+     */
+    private Map<String, String> rawConfigurationDocuments;
 
     private String indexName = ".opendistro_security";
 
@@ -210,6 +220,27 @@ public class TestSecurityConfig {
 
     public List<ActionGroup> actionGroups() {
         return List.copyOf(actionGroups.values());
+    }
+
+    /**
+     * Specifies raw document content for the configuration index as YAML document. If this method is used,
+     * then ONLY the raw documents will be written to the configuration index. Any other configuration specified
+     * by the roles() or users() method will be ignored.
+     * Can be used to simulate invalid configuration or legacy configuration.
+     */
+    public TestSecurityConfig rawConfigurationDocumentYaml(String configTypeId, String configDocumentAsYaml) {
+        try {
+            if (this.rawConfigurationDocuments == null) {
+                this.rawConfigurationDocuments = new LinkedHashMap<>();
+            }
+
+            JsonNode node = new ObjectMapper(new YAMLFactory()).readTree(configDocumentAsYaml);
+
+            this.rawConfigurationDocuments.put(configTypeId, new ObjectMapper().writeValueAsString(node));
+            return this;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static class Config implements ToXContentObject {
@@ -964,15 +995,24 @@ public class TestSecurityConfig {
         }
         client.admin().indices().create(new CreateIndexRequest(indexName).settings(settings)).actionGet();
 
-        writeSingleEntryConfigToIndex(client, CType.CONFIG, config);
-        if (auditConfiguration != null) {
-            writeSingleEntryConfigToIndex(client, CType.AUDIT, "config", auditConfiguration);
+        if (rawConfigurationDocuments == null) {
+            writeSingleEntryConfigToIndex(client, CType.CONFIG, config);
+            if (auditConfiguration != null) {
+                writeSingleEntryConfigToIndex(client, CType.AUDIT, "config", auditConfiguration);
+            }
+            writeConfigToIndex(client, CType.ROLES, roles);
+            writeConfigToIndex(client, CType.INTERNALUSERS, internalUsers);
+            writeConfigToIndex(client, CType.ROLESMAPPING, rolesMapping);
+            writeEmptyConfigToIndex(client, CType.ACTIONGROUPS);
+            writeEmptyConfigToIndex(client, CType.TENANTS);
+        } else {
+            // Write raw configuration alternatively to the normal configuration
+
+            for (Map.Entry<String, String> entry : this.rawConfigurationDocuments.entrySet()) {
+                writeConfigToIndex(client, entry.getKey(), entry.getValue());
+            }
         }
-        writeConfigToIndex(client, CType.ROLES, roles);
-        writeConfigToIndex(client, CType.INTERNALUSERS, internalUsers);
-        writeConfigToIndex(client, CType.ROLESMAPPING, rolesMapping);
-        writeEmptyConfigToIndex(client, CType.ACTIONGROUPS);
-        writeEmptyConfigToIndex(client, CType.TENANTS);
+
     }
 
     public void updateInternalUsersConfiguration(Client client, List<User> users) {
@@ -1003,6 +1043,18 @@ public class TestSecurityConfig {
                     .setRefreshPolicy(IMMEDIATE)
                     .source(configType.toLCString(), bytesReference)
             ).actionGet();
+        } catch (Exception e) {
+            throw new RuntimeException("Error while initializing config for " + indexName, e);
+        }
+    }
+
+    private void writeConfigToIndex(Client client, String documentId, String jsonString) {
+        try {
+            log.info("Writing raw security configuration into index {}:\n{}", documentId, jsonString);
+
+            BytesReference bytesReference = toByteReference(jsonString);
+            client.index(new IndexRequest(indexName).id(documentId).setRefreshPolicy(IMMEDIATE).source(documentId, bytesReference))
+                .actionGet();
         } catch (Exception e) {
             throw new RuntimeException("Error while initializing config for " + indexName, e);
         }


### PR DESCRIPTION
### Description

Do not merge!

This is just a test implementation that demonstrates that currently OpenSearch is not able to start up based on a plain legacy v6 configuration.

The test leads to a cluster startup failure with these errors:

```
2024-09-22 09:48:48 opensearch[cluster_manager_1][clusterManagerService#updateTask][T#1] INFO  PluginsService:310 - PluginService:onIndexModule index:[.opendistro_security/V2k5ExEPQeCxgfqCqFPEfA]
2024-09-22 09:48:48 opensearch[cluster_manager_1][clusterManagerService#updateTask][T#1] INFO  MetadataMappingService:326 - [.opendistro_security/V2k5ExEPQeCxgfqCqFPEfA] update_mapping [_doc]
2024-09-22 09:48:48 opensearch[cluster_manager_1][transport_worker][T#10] WARN  ConfigurationLoaderSecurity7:183 - No data for tenants while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES]  (index=.opendistro_security)
2024-09-22 09:48:48 opensearch[data_0][system_read][T#1] WARN  ConfigurationLoaderSecurity7:183 - No data for tenants while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES]  (index=.opendistro_security)
2024-09-22 09:48:48 opensearch[cluster_manager_0][transport_worker][T#9] WARN  ConfigurationLoaderSecurity7:183 - No data for tenants while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES]  (index=.opendistro_security)
2024-09-22 09:48:48 opensearch[cluster_manager_2][transport_worker][T#9] WARN  ConfigurationLoaderSecurity7:183 - No data for tenants while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES]  (index=.opendistro_security)
2024-09-22 09:48:48 opensearch[data_1][system_read][T#1] WARN  ConfigurationLoaderSecurity7:183 - No data for tenants while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES]  (index=.opendistro_security)
WARNING: A restricted method in java.lang.foreign.Linker has been called
WARNING: java.lang.foreign.Linker::downcallHandle has been called by the unnamed module
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for this module

2024-09-22 09:48:58 SUITE-LegacyConfigV6AutoConversionTest-seed#[EA8291E27E18659E] ERROR LocalCluster:258 - Local ES cluster start failed
java.lang.RuntimeException: ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
	at org.opensearch.test.framework.cluster.LocalCluster.triggerConfigurationReload(LocalCluster.java:294) ~[integrationTest/:?]
	at org.opensearch.test.framework.cluster.LocalCluster.initSecurityIndex(LocalCluster.java:272) ~[integrationTest/:?]
	at org.opensearch.test.framework.cluster.LocalCluster.start(LocalCluster.java:248) [integrationTest/:?]
	at org.opensearch.test.framework.cluster.LocalCluster.before(LocalCluster.java:150) [integrationTest/:?]
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50) [junit-4.13.2.jar:4.13.2]
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$2.evaluate(ThreadLeakControl.java:426) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSuite(RandomizedRunner.java:716) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.RandomizedRunner.access$200(RandomizedRunner.java:138) [randomizedtesting-runner-2.8.1.jar:?]
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:637) [randomizedtesting-runner-2.8.1.jar:?]

java.lang.RuntimeException: ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
java.lang.RuntimeException: java.lang.RuntimeException: ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
	at __randomizedtesting.SeedInfo.seed([EA8291E27E18659E]:0)
	at org.opensearch.test.framework.cluster.LocalCluster.start(LocalCluster.java:259)
	at org.opensearch.test.framework.cluster.LocalCluster.before(LocalCluster.java:150)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$2.evaluate(ThreadLeakControl.java:426)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSuite(RandomizedRunner.java:716)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.access$200(RandomizedRunner.java:138)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:637)
Caused by: java.lang.RuntimeException: ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
	at org.opensearch.test.framework.cluster.LocalCluster.triggerConfigurationReload(LocalCluster.java:294)
	at org.opensearch.test.framework.cluster.LocalCluster.initSecurityIndex(LocalCluster.java:272)
	at org.opensearch.test.framework.cluster.LocalCluster.start(LocalCluster.java:248)
	... 9 more


ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
java.lang.RuntimeException: ConfigUpdateResponse produced failures: [FailedNodeException[Failed node [wtldg___T_-ewOir_____w]]; nested: RemoteTransportException[[data_0][127.0.0.1:47310][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: TimeoutException[Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [yaLASgAAQAC746CY_____w]]; nested: RemoteTransportException[[data_1][127.0.0.1:47311][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [Kgswtv__T_-Xj0eI_____w]]; nested: RemoteTransportException[[cluster_manager_2][127.0.0.1:47302][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [w6j1YwAAQACR-jP8_____w]]; nested: RemoteTransportException[[cluster_manager_0][127.0.0.1:47300][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];, FailedNodeException[Failed node [NaXKCgAAQACAVbO______w]]; nested: RemoteTransportException[[cluster_manager_1][127.0.0.1:47301][cluster:admin/opendistro_security/config/update[n]]]; nested: OpenSearchException[java.util.concurrent.TimeoutException: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)]; nested: NotSerializableExceptionWrapper[timeout_exception: Timeout after 10SECONDS while retrieving configuration for [ROLESMAPPING, NODESDN, WHITELIST, CONFIG, TENANTS, AUDIT, ACTIONGROUPS, INTERNALUSERS, ALLOWLIST, ROLES](index=.opendistro_security)];]
	at org.opensearch.test.framework.cluster.LocalCluster.triggerConfigurationReload(LocalCluster.java:294)
	at org.opensearch.test.framework.cluster.LocalCluster.initSecurityIndex(LocalCluster.java:272)
	at org.opensearch.test.framework.cluster.LocalCluster.start(LocalCluster.java:248)
	at org.opensearch.test.framework.cluster.LocalCluster.before(LocalCluster.java:150)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:50)
	at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$StatementRunner.run(ThreadLeakControl.java:390)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl.forkTimeoutingTask(ThreadLeakControl.java:843)
	at com.carrotsearch.randomizedtesting.ThreadLeakControl$2.evaluate(ThreadLeakControl.java:426)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.runSuite(RandomizedRunner.java:716)
	at com.carrotsearch.randomizedtesting.RandomizedRunner.access$200(RandomizedRunner.java:138)
	at com.carrotsearch.randomizedtesting.RandomizedRunner$2.run(RandomizedRunner.java:637)
``` 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
