### PR TITLE
Removes unused get/post/put cache endpoint

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
@@ -95,9 +95,7 @@ public class DefaultApiAvailabilityIntegrationTest extends AbstractApiIntegratio
 
     @Test
     public void flushCache() throws Exception {
-        withUser(NEW_USER, client -> {
-            forbidden(() -> client.delete(apiPath("cache")));
-        });
+        withUser(NEW_USER, client -> { forbidden(() -> client.delete(apiPath("cache"))); });
         withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> {
             methodNotAllowed(() -> client.get(apiPath("cache")));
             methodNotAllowed(() -> client.postJson(apiPath("cache"), EMPTY_BODY));

--- a/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
@@ -96,15 +96,12 @@ public class DefaultApiAvailabilityIntegrationTest extends AbstractApiIntegratio
     @Test
     public void flushCache() throws Exception {
         withUser(NEW_USER, client -> {
-            forbidden(() -> client.get(apiPath("cache")));
-            forbidden(() -> client.postJson(apiPath("cache"), EMPTY_BODY));
-            forbidden(() -> client.putJson(apiPath("cache"), EMPTY_BODY));
             forbidden(() -> client.delete(apiPath("cache")));
         });
         withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> {
-            notImplemented(() -> client.get(apiPath("cache")));
-            notImplemented(() -> client.postJson(apiPath("cache"), EMPTY_BODY));
-            notImplemented(() -> client.putJson(apiPath("cache"), EMPTY_BODY));
+            methodNotAllowed(() -> client.get(apiPath("cache")));
+            methodNotAllowed(() -> client.postJson(apiPath("cache"), EMPTY_BODY));
+            methodNotAllowed(() -> client.putJson(apiPath("cache"), EMPTY_BODY));
             final var response = ok(() -> client.delete(apiPath("cache")));
             assertThat(response.getBody(), response.getTextFromJsonBody("/message"), is("Cache flushed successfully."));
         });

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -36,11 +36,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
 
     private final static Logger LOGGER = LogManager.getLogger(FlushCacheApiAction.class);
 
-    private static final List<Route> routes = addRoutesPrefix(
-        ImmutableList.of(
-            new Route(Method.DELETE, "/cache")
-        )
-    );
+    private static final List<Route> routes = addRoutesPrefix(ImmutableList.of(new Route(Method.DELETE, "/cache")));
 
     @Inject
     public FlushCacheApiAction(

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -38,10 +38,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
-            new Route(Method.DELETE, "/cache"),
-            new Route(Method.GET, "/cache"),
-            new Route(Method.PUT, "/cache"),
-            new Route(Method.POST, "/cache")
+            new Route(Method.DELETE, "/cache")
         )
     );
 


### PR DESCRIPTION
### Description
Removes Get, Post, Put cache API routes, since only delete is used. This should not be backported to 2.x, and we should add a deprecation notice there as well (although these were never used anyway so the behavior should be consistent)

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
