### PR TITLE
Remove failed login attempt for saml authenticator

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/saml/HTTPSamlAuthenticator.java
@@ -88,6 +88,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
     private static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
 
     private static boolean openSamlInitialized = false;
+    public static final String SAML_TYPE = "saml";
 
     private String subjectKey;
     private String rolesKey;
@@ -175,7 +176,7 @@ public class HTTPSamlAuthenticator implements HTTPAuthenticator, Destroyable {
 
     @Override
     public String getType() {
-        return "saml";
+        return SAML_TYPE;
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -75,6 +75,7 @@ import org.greenrobot.eventbus.Subscribe;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator.SAML_TYPE;
 
 public class BackendRegistry {
 
@@ -303,7 +304,9 @@ public class BackendRegistry {
                 if (authDomain.isChallenge()) {
                     final Optional<SecurityResponse> restResponse = httpAuthenticator.reRequestAuthentication(request, null);
                     if (restResponse.isPresent()) {
-                        auditLog.logFailedLogin("<NONE>", false, null, request);
+                        if (!authDomain.getHttpAuthenticator().getType().equals(SAML_TYPE)) {
+                            auditLog.logFailedLogin("<NONE>", false, null, request);
+                        }
                         if (isTraceEnabled) {
                             log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                         }

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -304,6 +304,7 @@ public class BackendRegistry {
                 if (authDomain.isChallenge()) {
                     final Optional<SecurityResponse> restResponse = httpAuthenticator.reRequestAuthentication(request, null);
                     if (restResponse.isPresent()) {
+                        // saml will always hit this to re-request authentication
                         if (!authDomain.getHttpAuthenticator().getType().equals(SAML_TYPE)) {
                             auditLog.logFailedLogin("<NONE>", false, null, request);
                         }


### PR DESCRIPTION
### Description
Removes audit log entry of failed login for all SAML authentication since it will always re-request authentication

### Issues Resolved
Fix: https://github.com/opensearch-project/security/issues/4608
Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
No
Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No
### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
