### PR TITLE
Undeprecate securityadmin script

### DIFF
--- a/tools/audit_config_migrater.bat
+++ b/tools/audit_config_migrater.bat
@@ -1,11 +1,6 @@
 @echo off
 set DIR=%~dp0
 
-echo "**************************************************************************"
-echo "** This tool will be deprecated in the next major release of OpenSearch **"
-echo "** https://github.com/opensearch-project/security/issues/1755           **"
-echo "**************************************************************************"
-
 if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
 ) else if defined JAVA_HOME (

--- a/tools/audit_config_migrater.sh
+++ b/tools/audit_config_migrater.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "**************************************************************************"
-echo "** This tool will be deprecated in the next major release of OpenSearch **"
-echo "** https://github.com/opensearch-project/security/issues/1755           **"
-echo "**************************************************************************"
-
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then

--- a/tools/hash.bat
+++ b/tools/hash.bat
@@ -1,11 +1,6 @@
 @echo off
 set DIR=%~dp0
 
-echo "**************************************************************************"
-echo "** This tool will be deprecated in the next major release of OpenSearch **"
-echo "** https://github.com/opensearch-project/security/issues/1755           **"
-echo "**************************************************************************"
-
 if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
 ) else if defined JAVA_HOME (

--- a/tools/hash.sh
+++ b/tools/hash.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "**************************************************************************" >&2
-echo "** This tool will be deprecated in the next major release of OpenSearch **" >&2
-echo "** https://github.com/opensearch-project/security/issues/1755           **" >&2
-echo "**************************************************************************" >&2
-
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then

--- a/tools/securityadmin.bat
+++ b/tools/securityadmin.bat
@@ -1,11 +1,6 @@
 @echo off
 set DIR=%~dp0
 
-echo "**************************************************************************"
-echo "** This tool will be deprecated in the next major release of OpenSearch **"
-echo "** https://github.com/opensearch-project/security/issues/1755           **"
-echo "**************************************************************************"
-
 if defined OPENSEARCH_JAVA_HOME (
   set BIN_PATH="%OPENSEARCH_JAVA_HOME%\bin\java.exe"
 ) else if defined JAVA_HOME (

--- a/tools/securityadmin.sh
+++ b/tools/securityadmin.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-echo "**************************************************************************"
-echo "** This tool will be deprecated in the next major release of OpenSearch **"
-echo "** https://github.com/opensearch-project/security/issues/1755           **"
-echo "**************************************************************************"
-
 SCRIPT_PATH="${BASH_SOURCE[0]}"
 if ! [ -x "$(command -v realpath)" ]; then
     if [ -L "$SCRIPT_PATH" ]; then


### PR DESCRIPTION
### Description
There was some recent engagement/concern from the community (for example @spapadop) about the deprecation of security admin script. Since there is no concrete plan to remove/replace it, we should remove the deprecation warning. We can add this back in if/when we decide to and have a viable alternative for the script. 

### Issues Resolved
None
Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
No

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No

### Testing
Script no longer prints the warning out
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
