### PR TITLE
Fix env var password hashing for PBKDF2

### DIFF
--- a/src/main/java/org/opensearch/security/support/SecurityUtils.java
+++ b/src/main/java/org/opensearch/security/support/SecurityUtils.java
@@ -96,16 +96,16 @@ public final class SecurityUtils {
             return in;
         }
 
-        return replaceEnvVarsBC(replaceEnvVarsNonBC(replaceEnvVarsBase64(in)));
+        return replaceEnvVarsBC(replaceEnvVarsNonBC(replaceEnvVarsBase64(in, settings), settings), settings);
     }
 
-    private static String replaceEnvVarsNonBC(String in) {
+    private static String replaceEnvVarsNonBC(String in, Settings settings) {
         // ${env.MY_ENV_VAR}
         // ${env.MY_ENV_VAR:-default}
         Matcher matcher = ENV_PATTERN.matcher(in);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
-            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), false);
+            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), false, settings);
             if (replacement != null) {
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
             }
@@ -114,13 +114,13 @@ public final class SecurityUtils {
         return sb.toString();
     }
 
-    private static String replaceEnvVarsBC(String in) {
+    private static String replaceEnvVarsBC(String in, Settings settings) {
         // ${envbc.MY_ENV_VAR}
         // ${envbc.MY_ENV_VAR:-default}
         Matcher matcher = ENVBC_PATTERN.matcher(in);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
-            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), true);
+            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), true, settings);
             if (replacement != null) {
                 matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
             }
@@ -129,13 +129,13 @@ public final class SecurityUtils {
         return sb.toString();
     }
 
-    private static String replaceEnvVarsBase64(String in) {
+    private static String replaceEnvVarsBase64(String in, Settings settings) {
         // ${envbc.MY_ENV_VAR}
         // ${envbc.MY_ENV_VAR:-default}
         Matcher matcher = ENVBASE64_PATTERN.matcher(in);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
-            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), false);
+            final String replacement = resolveEnvVar(matcher.group(1), matcher.group(2), false, settings);
             if (replacement != null) {
                 matcher.appendReplacement(
                     sb,
@@ -149,16 +149,16 @@ public final class SecurityUtils {
 
     // ${env.MY_ENV_VAR}
     // ${env.MY_ENV_VAR:-default}
-    private static String resolveEnvVar(String envVarName, String mode, boolean bc) {
+    private static String resolveEnvVar(String envVarName, String mode, boolean bc, Settings settings) {
         final String envVarValue = System.getenv(envVarName);
         if (envVarValue == null || envVarValue.isEmpty()) {
             if (mode != null && mode.startsWith(":-") && mode.length() > 2) {
-                return bc ? Hasher.hash(mode.substring(2).toCharArray()) : mode.substring(2);
+                return bc ? Hasher.hash(mode.substring(2).toCharArray(), settings) : mode.substring(2);
             } else {
                 return null;
             }
         } else {
-            return bc ? Hasher.hash(envVarValue.toCharArray()) : envVarValue;
+            return bc ? Hasher.hash(envVarValue.toCharArray(), settings) : envVarValue;
         }
     }
 }

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -204,7 +204,7 @@ public class SecurityAdmin {
                 .longOpt("truststore-type")
                 .hasArg()
                 .argName("type")
-                .desc("JKS or PKCS12, if not given we use the file extension to dectect the type")
+                .desc("JKS or PKCS12, if not given we use the file extension to detect the type")
                 .build()
         );
         options.addOption(
@@ -212,7 +212,7 @@ public class SecurityAdmin {
                 .longOpt("keystore-type")
                 .hasArg()
                 .argName("type")
-                .desc("JKS or PKCS12, if not given we use the file extension to dectect the type")
+                .desc("JKS or PKCS12, if not given we use the file extension to detect the type")
                 .build()
         );
         // CS-ENFORCE-SINGLE


### PR DESCRIPTION
### Description
Category (Bug fix)

Passwords provided as environment variables are always hashed using BCrypt even when configured to use something else. Authentication fails when using PBKDF2 .

### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/4771

### Testing
Initially found testing on a personal cluster. Confirmed fix works.
Included new test for PBKDF2 with PR.
Run Bulk Integration Tests.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
