### PR TITLE
Fix bug where admin can read system index

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
@@ -82,7 +82,7 @@ public class SystemIndexTests {
     }
 
     @Test
-    public void adminShouldNotBeAbleToReadSystemIndex() {
+    public void regularUserShouldGetNoResultsWhenSearchingSystemIndex() {
         // Create system index and index a dummy document as the super admin user, data returned to super admin
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
             HttpResponse response1 = client.put(".system-index1");

--- a/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
@@ -80,4 +80,29 @@ public class SystemIndexTests {
             assertThat(response4.getStatusCode(), equalTo(RestStatus.FORBIDDEN.getStatus()));
         }
     }
+
+    @Test
+    public void adminShouldNotBeAbleToReadSecurityIndex() {
+        // Create system index and index a dummy document as the super admin user, data returned to super admin
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            HttpResponse response1 = client.put(".system-index1");
+
+            assertThat(response1.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+            String doc = "{\"field\":\"value\"}";
+            HttpResponse adminPostResponse = client.postJson(".system-index1/_doc/1?refresh=true", doc);
+            assertThat(adminPostResponse.getStatusCode(), equalTo(RestStatus.CREATED.getStatus()));
+            HttpResponse response2 = client.get(".system-index1/_search");
+
+            assertThat(response2.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+            assertThat(response2.getBody(), response2.getBody().contains("\"hits\":{\"total\":{\"value\":1,\"relation\":\"eq\"}"));
+        }
+
+        // Regular users should not be able to read it
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            // regular user cannot read system index
+            HttpResponse response1 = client.get(".system-index1/_search");
+
+            assertThat(response1.getBody(), response1.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
+        }
+    }
 }

--- a/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SystemIndexTests.java
@@ -82,7 +82,7 @@ public class SystemIndexTests {
     }
 
     @Test
-    public void adminShouldNotBeAbleToReadSecurityIndex() {
+    public void adminShouldNotBeAbleToReadSystemIndex() {
         // Create system index and index a dummy document as the super admin user, data returned to super admin
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
             HttpResponse response1 = client.put(".system-index1");

--- a/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityFlsDlsIndexSearcherWrapper.java
@@ -41,7 +41,7 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.support.SecurityUtils;
 
-public class SecurityFlsDlsIndexSearcherWrapper extends SecurityIndexSearcherWrapper {
+public class SecurityFlsDlsIndexSearcherWrapper extends SystemIndexSearcherWrapper {
 
     public final Logger log = LogManager.getLogger(this.getClass());
 

--- a/src/main/java/org/opensearch/security/configuration/SystemIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SystemIndexSearcherWrapper.java
@@ -50,7 +50,7 @@ import org.opensearch.security.user.User;
 
 import org.greenrobot.eventbus.Subscribe;
 
-public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
+public class SystemIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     protected final ThreadContext threadContext;
@@ -69,7 +69,7 @@ public class SecurityIndexSearcherWrapper implements CheckedFunction<DirectoryRe
     private final Boolean systemIndexPermissionEnabled;
 
     // constructor is called per index, so avoid costly operations here
-    public SecurityIndexSearcherWrapper(
+    public SystemIndexSearcherWrapper(
         final IndexService indexService,
         final Settings settings,
         final AdminDNs adminDNs,


### PR DESCRIPTION
### Description
Prevents reads on security system index registered through core

### Issues Resolved
Fix: #4755 
Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
No
Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No
### Testing
Added unit test
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
