### PR TITLE
Add deprecation warning for GET/POST/PUT cache

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -42,17 +42,17 @@ public class FlushCacheApiAction extends AbstractApiAction {
             new DeprecatedRoute(
                 Method.GET,
                 "/cache",
-                "GET is not supported for /cache endpoint and will be removed in the next major version."
+                "GET is not supported for /cache endpoint and will be removed in the next major version. Use DELETE instead."
             ),
             new DeprecatedRoute(
                 Method.PUT,
                 "/cache",
-                "PUT is not supported for /cache endpoint and will be removed in the next major version."
+                "PUT is not supported for /cache endpoint and will be removed in the next major version. Use DELETE instead."
             ),
             new DeprecatedRoute(
                 Method.POST,
                 "/cache",
-                "POST is not supported for /cache endpoint and will be removed in the next major version."
+                "POST is not supported for /cache endpoint and will be removed in the next major version. Use DELETE instead."
             )
         )
     );

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -30,7 +30,6 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
-import static org.opensearch.security.dlic.rest.api.Responses.methodNotImplemented;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
@@ -43,9 +42,21 @@ public class FlushCacheApiAction extends AbstractApiAction {
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
             new Route(Method.DELETE, "/cache"),
-            new Route(Method.GET, "/cache"),
-            new Route(Method.PUT, "/cache"),
-            new Route(Method.POST, "/cache")
+            new DeprecatedRoute(
+                Method.GET,
+                "/cache",
+                "GET is not supported for /cache endpoint and will be removed in the next major version."
+            ),
+            new DeprecatedRoute(
+                Method.PUT,
+                "/cache",
+                "PUT is not supported for /cache endpoint and will be removed in the next major version."
+            ),
+            new DeprecatedRoute(
+                Method.POST,
+                "/cache",
+                "POST is not supported for /cache endpoint and will be removed in the next major version."
+            )
         )
     );
 
@@ -95,23 +106,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
 
                     }
                 )
-            )
-            .override(Method.GET, (channel, request, client) -> {
-                deprecationLogger.deprecate("GET", "GET is not supported on this endpoint and will be removed in the next major release.");
-                methodNotImplemented(channel, Method.GET);
-            })
-            .override(Method.POST, (channel, request, client) -> {
-                deprecationLogger.deprecate(
-                    "POST",
-                    "POST is not supported on this endpoint and will be removed in the next major release."
-                );
-                methodNotImplemented(channel, Method.POST);
-            })
-            .override(Method.PUT, (channel, request, client) -> {
-                deprecationLogger.deprecate("PUT", "PUT is not supported on this endpoint and will be removed in the next major release.");
-                methodNotImplemented(channel, Method.PUT);
-            });
-
+            );
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
@@ -36,8 +35,6 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 public class FlushCacheApiAction extends AbstractApiAction {
 
     private final static Logger LOGGER = LogManager.getLogger(FlushCacheApiAction.class);
-
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FlushCacheApiAction.class);
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -19,6 +19,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.rest.RestRequest.Method;
@@ -29,12 +30,15 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.dlic.rest.api.Responses.internalServerError;
+import static org.opensearch.security.dlic.rest.api.Responses.methodNotImplemented;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class FlushCacheApiAction extends AbstractApiAction {
 
     private final static Logger LOGGER = LogManager.getLogger(FlushCacheApiAction.class);
+
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(FlushCacheApiAction.class);
 
     private static final List<Route> routes = addRoutesPrefix(
         ImmutableList.of(
@@ -91,7 +95,23 @@ public class FlushCacheApiAction extends AbstractApiAction {
 
                     }
                 )
-            );
+            )
+            .override(Method.GET, (channel, request, client) -> {
+                deprecationLogger.deprecate("GET", "GET is not supported on this endpoint and will be removed in the next major release.");
+                methodNotImplemented(channel, Method.GET);
+            })
+            .override(Method.POST, (channel, request, client) -> {
+                deprecationLogger.deprecate(
+                    "POST",
+                    "POST is not supported on this endpoint and will be removed in the next major release."
+                );
+                methodNotImplemented(channel, Method.GET);
+            })
+            .override(Method.PUT, (channel, request, client) -> {
+                deprecationLogger.deprecate("PUT", "PUT is not supported on this endpoint and will be removed in the next major release.");
+                methodNotImplemented(channel, Method.PUT);
+            });
+
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/FlushCacheApiAction.java
@@ -105,7 +105,7 @@ public class FlushCacheApiAction extends AbstractApiAction {
                     "POST",
                     "POST is not supported on this endpoint and will be removed in the next major release."
                 );
-                methodNotImplemented(channel, Method.GET);
+                methodNotImplemented(channel, Method.POST);
             })
             .override(Method.PUT, (channel, request, client) -> {
                 deprecationLogger.deprecate("PUT", "PUT is not supported on this endpoint and will be removed in the next major release.");


### PR DESCRIPTION
### Description
Adds deprecation warning that GET/POST/PUT methods for cache endpoint is removed in version 3.0.0. 

### Issues Resolved
None
Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
No

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No

### Testing
None
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
