### PR TITLE
Add Derek Ho (github: derek-ho) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @nibix @peternied @RyanL1997 @stephen-crawford @reta @willyborankin
+* @cwperks @DarshitChanpura @derek-ho @nibix @peternied @RyanL1997 @stephen-crawford @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -17,6 +17,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
+| Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)     | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |


### PR DESCRIPTION
I have nominated, and maintainers have agreed to add Derek Ho (@derek-ho) as a co-maintainer, who has kindly accepted.

Derek has made many valuable contributions and given insightful comments on reviews in many PRs over the last year.
 
Notable code contributions from Derek include:
 
- Add initial changes to expose an endpoint for auth failure listener get call: https://github.com/opensearch-project/security/pull/4641
  - This change is a good example of an enhancement to the security plugin to deliver value to the community
- Add cat/alias support for DNFOF: https://github.com/opensearch-project/security/pull/4436
- Add support for ipv6 ip address in user injection: https://github.com/opensearch-project/security/pull/4399
- Use GHA derek-ho/start-opensearch for OpenSearch plugin install tests: https://github.com/opensearch-project/security/pull/4063
 
Derek has engaged in maintenance of the code base by submitting numerous bug fixes and improving CI checks. Here are some examples:
 
- Removes unused get/post/put cache endpoint: https://github.com/opensearch-project/security/pull/4761
- Update PR template to raise awareness of security dashboards plugin static list: https://github.com/opensearch-project/security/pull/4476
- Fix Bug with Install demo configuration running in cluster mode with -y: https://github.com/opensearch-project/security/pull/3935
 
See all code contributions (Open + Closed) from Derek here: https://github.com/opensearch-project/security/commits?author=derek-ho
 
Derek also routinely opens up issues on the Security repo with valuable feature requests and reports of deficiencies (28 in total):
 
- See issues submitted by Derek here: https://github.com/opensearch-project/security/issues?q=is%3Aissue+author%3Aderek-ho
 
Derek regularly contributes to conversation on Pull Requests and other issues (including RFCs):
 
- Insightful comment from Derek on an RFC: https://github.com/opensearch-project/security/issues/3916#issuecomment-1881898221
- Example where Derek contributed valuable insight on a PR: https://github.com/opensearch-project/security/pull/4628#discussion_r1711647404
- Example where Derek contributed valuable insight in an issue: https://github.com/opensearch-project/security/issues/3705#issuecomment-1836592874
 
See all PRs where Derek has engaged as a commenter: https://github.com/opensearch-project/security/pulls?q=is%3Apr+commenter%3Aderek-ho
 
See all issues where Derek has engaged as a commenter: https://github.com/opensearch-project/security/issues?q=is%3Aissue+commenter%3Aderek-ho
 
Additionally, Derek is active in the community and has given a talk at OpenSearch Con SF: https://www.youtube.com/watch?v=lU2QxmhvtWo