### PR TITLE
Move Stephen to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @derek-ho @nibix @peternied @RyanL1997 @stephen-crawford @reta @willyborankin
+* @cwperks @DarshitChanpura @derek-ho @nibix @peternied @RyanL1997 @reta @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,17 +19,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
-| Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)     | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Aiven       |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
 | Nils Bandener    | [nibix](https://github.com/nibix)                     | Eliatra     |
 
 ## Emeritus
 
-| Maintainer | GitHub ID                                 | Affiliation |
-|------------|-------------------------------------------|-------------|
-| Dave Lago  | [davidlago](https://github.com/davidlago) | Contributor |
-| Chang Liu  | [cliu123](https://github.com/cliu123)     | Amazon      |
+| Maintainer | GitHub ID                                               | Affiliation |
+|------------|---------------------------------------------------------|-------------|
+| Dave Lago  | [davidlago](https://github.com/davidlago)               | Contributor |
+| Chang Liu  | [cliu123](https://github.com/cliu123)                   | Amazon      |
+| Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Contributor |
+
 
 ## Practices
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,10 +25,10 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Emeritus
 
-| Maintainer | GitHub ID                                               | Affiliation |
-|------------|---------------------------------------------------------|-------------|
-| Dave Lago  | [davidlago](https://github.com/davidlago)               | Contributor |
-| Chang Liu  | [cliu123](https://github.com/cliu123)                   | Amazon      |
+| Maintainer       | GitHub ID                                               | Affiliation |
+|------------------|---------------------------------------------------------|-------------|
+| Dave Lago        | [davidlago](https://github.com/davidlago)               | Contributor |
+| Chang Liu        | [cliu123](https://github.com/cliu123)                   | Amazon      |
 | Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Contributor |
 
 


### PR DESCRIPTION
### Description
Moves @stephen-crawford to emeritus maintainer

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
