### PR TITLE
Fix codecov test coverage information for directory `integration-tests` 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
         arguments: |
           integrationTest -Dbuild.snapshot=false
 
-    - uses: alehechka/upload-tartifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: integration-${{ matrix.platform }}-JDK${{ matrix.jdk }}-reports


### PR DESCRIPTION
### Description

Fixes #4801. 

Switches the upload of integration-tests artifacts from `upload-tartifact` to `actions/upload-artifact@v4`. This will also properly include the integration-tests coverage data.

* Category: CI fix
* Why these changes are required?  - test coverage data reported to codecov was incomplete
* What is the old behavior before changes and new behavior after changes? - none

### Issues Resolved

Resolves #4801 

### Testing

Test coverage gains visible in codecov: https://app.codecov.io/github/opensearch-project/security/commit/0976a9609e8e0efa8c2361372f73f592fdbb81a3/indirect-changes

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
