### PR TITLE
Fix ChannelAlreadyClosed error in RateLimitersApiActionTest.testInvalidDeleteScenarios

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
@@ -179,13 +179,14 @@ public class RateLimitersApiAction extends AbstractApiAction {
             // Try to remove the listener by name
             if (config.dynamic.auth_failure_listeners.getListeners().remove(listenerName) == null) {
                 notFound(channel, "listener not found");
+            } else {
+                saveOrUpdateConfiguration(client, configuration, new OnSucessActionListener<>(channel) {
+                    @Override
+                    public void onResponse(IndexResponse indexResponse) {
+                        ok(channel, authFailureContent(config));
+                    }
+                });
             }
-            saveOrUpdateConfiguration(client, configuration, new OnSucessActionListener<>(channel) {
-                @Override
-                public void onResponse(IndexResponse indexResponse) {
-                    ok(channel, authFailureContent(config));
-                }
-            });
         }).error((status, toXContent) -> response(channel, status, toXContent)))
             .override(PUT, (channel, request, client) -> loadConfiguration(getConfigType(), false, false).valid(configuration -> {
                 ConfigV7 config = (ConfigV7) configuration.getCEntry(CType.CONFIG.toLCString());


### PR DESCRIPTION
### Description

This PR fixes an issue on Delete scenarios for the new AuthFailureListener endpoints where the authfailurelistener is not found. This issue was found [here](https://github.com/opensearch-project/security/pull/4810#issuecomment-2411245121) and can lead to `Channel already closed` because its performing an internal config update request even if the corresponding auth failure listener is not found. This PR prevents the internal transport config update request from happening if the listener is not found.

Tested by adding [@RepeatRule](https://github.com/opensearch-project/security/pull/3763/files#r1419262032) on the failing test and ensuring that it passes 10x on a single run.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
