### PR TITLE
[Backport 2.x] Bump org.checkerframework:checker-qual from 3.47.0 to 3.48.1 (#4808) and ch.qos.logback:logback-classic from 1.5.8 to 1.5.10 (#4807)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -501,9 +501,9 @@ configurations {
             force "org.apache.httpcomponents:httpcore:4.4.16"
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
-            force 'org.checkerframework:checker-qual:3.47.0'
-            force "com.google.errorprone:error_prone_annotations:2.31.0"
-            force "ch.qos.logback:logback-classic:1.5.8"
+            force "com.google.errorprone:error_prone_annotations:2.33.0"
+            force "org.checkerframework:checker-qual:3.48.1"
+            force "ch.qos.logback:logback-classic:1.5.10"
             force "commons-io:commons-io:2.17.0"
         }
     }
@@ -653,7 +653,7 @@ dependencies {
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.1'
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.4'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
-    runtimeOnly 'org.checkerframework:checker-qual:3.47.0'
+    runtimeOnly 'org.checkerframework:checker-qual:3.48.1'
     runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 


### PR DESCRIPTION
Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 1b24f8ef43d9af030ebba7a4a9c8e1f52d4f1220)

### Description

Backports #4807 and #4808 to 2.x

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
