### PR TITLE
Fix 'integTest' not called with test workflows during release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,6 +564,7 @@ task integrationTest(type: Test) {
     }
 }
 
+tasks.integTest.dependsOn(integrationTest)
 tasks.integrationTest.finalizedBy(jacocoTestReport) // report is always generated after integration tests run
 
 //run the integrationTest task before the check task


### PR DESCRIPTION
### Description
Fix 'integTest' not called with test workflows during release. Adding an  'integTest' as an alias for `integrationTest` task.

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/4805

### Testing
`./gradlew integTest`

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
