### PR TITLE
Fixed bulk index requests in BWC tests and hardened assertions

### DIFF
--- a/bwc-test/src/test/java/org/opensearch/security/bwc/Song.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/Song.java
@@ -52,6 +52,8 @@ public class Song {
     public static final String GENRE_JAZZ = "jazz";
     public static final String GENRE_BLUES = "blues";
 
+    public static final String[] GENRES = new String[] { GENRE_BLUES, GENRE_JAZZ, GENRE_ROCK };
+
     public static final String QUERY_TITLE_NEXT_SONG = FIELD_TITLE + ":" + "\"" + TITLE_NEXT_SONG + "\"";
     public static final String QUERY_TITLE_POISON = FIELD_TITLE + ":" + TITLE_POISON;
     public static final String QUERY_TITLE_MAGNUM_OPUS = FIELD_TITLE + ":" + TITLE_MAGNUM_OPUS;
@@ -112,7 +114,11 @@ public class Song {
             UUID.randomUUID().toString(),
             UUID.randomUUID().toString(),
             Randomness.get().nextInt(5),
-            UUID.randomUUID().toString()
+            randomGenre()
         );
+    }
+
+    static String randomGenre() {
+        return GENRES[Randomness.get().nextInt(GENRES.length)];
     }
 }


### PR DESCRIPTION
### Description

So far, the BWC test `SecurityBackwardsCompatibilityIT.testDataIngestionAndSearchBackwardsCompatibility()` did not ingest any documents, as the submitted bulk requests were invalid. 

The test already asserted that `_bulk` API calls returned a 200 OK HTTP status. However, this is not sufficient, as the `_bulk` API also returns a 200 status if processing of the bulk items fails.  Such failures are only reflected item-wise in the response body. This indeed happened, as the test erroneously serialized a string containing the JSON document again as JSON, creating a JSON string containing JSON. This was rejected by OpenSearch.

This is now fixed - additional assertions have been created to verify that the items of the bulk request are actually indexed.

Additionally, the DLS rules of the user would not match any of the ingested documents. This would have caused the `_search` API always to return empty result sets - even if any documents were ingested.

The indexed test documents were adjusted to have proper `genre` attributes which can match the configured DLS rule. Additional assertions were added that verify that the DLS and FLS rules are correctly applied to the result set.

* Category: Test fix
* Why these changes are required? - the test did not cover as much functionality as it should
* What is the old behavior before changes and new behavior after changes? - no changes
 
### Testing

- Verified behavior in CI

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
