### PR TITLE
Improve error message when a node with an incorrectly configured certificate attempts to connect

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -77,8 +77,12 @@ public class ExceptionUtils {
     }
 
     public static OpenSearchException clusterWrongNodeCertConfigException(String sslPrincipal) {
-        return new OpenSearchException("Node presenting certificate with SSL Principal {" + sslPrincipal + "} could" +
-                " not securely connect to the cluster. Please ensure the principal is correct and present in the" +
-                " nodes_dn list.");
+        return new OpenSearchException(
+            "Node presenting certificate with SSL Principal {"
+                + sslPrincipal
+                + "} could"
+                + " not securely connect to the cluster. Please ensure the principal is correct and present in the"
+                + " nodes_dn list."
+        );
     }
 }

--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -76,7 +76,7 @@ public class ExceptionUtils {
         return new OpenSearchException("An error occurred during the creation of Jwk: {}", cause, cause.getMessage());
     }
 
-    public static OpenSearchException createTransportClientNoLongerSupportedException() {
-        return new OpenSearchException("Transport client authentication no longer supported.");
+    public static OpenSearchException clusterWrongNodeCertConfigException() {
+        return new OpenSearchException("Node certificate configuration is wrong or certificate is invalid.");
     }
 }

--- a/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
+++ b/src/main/java/org/opensearch/security/ssl/util/ExceptionUtils.java
@@ -76,7 +76,9 @@ public class ExceptionUtils {
         return new OpenSearchException("An error occurred during the creation of Jwk: {}", cause, cause.getMessage());
     }
 
-    public static OpenSearchException clusterWrongNodeCertConfigException() {
-        return new OpenSearchException("Node certificate configuration is wrong or certificate is invalid.");
+    public static OpenSearchException clusterWrongNodeCertConfigException(String sslPrincipal) {
+        return new OpenSearchException("Node presenting certificate with SSL Principal {" + sslPrincipal + "} could" +
+                " not securely connect to the cluster. Please ensure the principal is correct and present in the" +
+                " nodes_dn list.");
     }
 }

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -290,7 +290,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                     || HeaderHelper.isTrustedClusterRequest(getThreadContext())
                     || HeaderHelper.isExtensionRequest(getThreadContext()))) {
                     // CS-ENFORCE-SINGLE
-                    final OpenSearchException exception = ExceptionUtils.createTransportClientNoLongerSupportedException();
+                    final OpenSearchException exception = ExceptionUtils.clusterWrongNodeCertConfigException();
                     log.error(exception.toString());
                     transportChannel.sendResponse(exception);
                     return;

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -290,7 +290,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                     || HeaderHelper.isTrustedClusterRequest(getThreadContext())
                     || HeaderHelper.isExtensionRequest(getThreadContext()))) {
                     // CS-ENFORCE-SINGLE
-                    final OpenSearchException exception = ExceptionUtils.clusterWrongNodeCertConfigException();
+                    final OpenSearchException exception = ExceptionUtils.clusterWrongNodeCertConfigException(principal);
                     log.error(exception.toString());
                     transportChannel.sendResponse(exception);
                     return;

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -1355,7 +1355,9 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
-        assertThat(ccs.getBody(), containsString("Node certificate configuration is wrong or certificate is invalid."));
+        assertThat(ccs.getBody(), containsString("Node presenting certificate with SSL Principal " +
+                "{CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE} could not securely connect to the cluster. Please" +
+                " ensure the principal is correct and present in the nodes_dn list."));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -1355,9 +1355,14 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
-        assertThat(ccs.getBody(), containsString("Node presenting certificate with SSL Principal " +
-                "{CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE} could not securely connect to the cluster. Please" +
-                " ensure the principal is correct and present in the nodes_dn list."));
+        assertThat(
+            ccs.getBody(),
+            containsString(
+                "Node presenting certificate with SSL Principal "
+                    + "{CN=node-0.example.com,OU=SSL,O=Test,L=Test,C=DE} could not securely connect to the cluster. Please"
+                    + " ensure the principal is correct and present in the nodes_dn list."
+            )
+        );
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/CrossClusterSearchTests.java
@@ -1355,7 +1355,7 @@ public class CrossClusterSearchTests extends AbstractSecurityUnitTest {
         String uri = "cross_cluster_two:twitter/_search?pretty";
         HttpResponse ccs = rh1.executeGetRequest(uri, encodeBasicHeader("twitter", "nagilum"));
         assertThat(ccs.getStatusCode(), equalTo(HttpStatus.SC_INTERNAL_SERVER_ERROR));
-        assertThat(ccs.getBody(), containsString("Transport client authentication no longer supported"));
+        assertThat(ccs.getBody(), containsString("Node certificate configuration is wrong or certificate is invalid."));
     }
 
     @Test


### PR DESCRIPTION
### Description
Updated the error message to understand what is the exact reason of error and renamed the API name to match the intention of API.

### Issues Resolved
Resolves #4601

### Testing
Ran the unit tests

### Check List
- [ x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [ ]  ~New Roles/Permissions have a corresponding security dashboards plugin PR~
- [ x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
