### PR TITLE
Ensure that dual mode enabled flag from cluster settings can get propagated to core

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.security;
 
 import java.util.Map;

--- a/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
@@ -1,0 +1,64 @@
+package org.opensearch.security;
+
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Test related to SSL-only mode of security plugin. In this mode, the security plugin is responsible only for TLS/SSL encryption.
+ * Therefore, the plugin does not perform authentication and authorization. Moreover, the REST resources (e.g. /_plugins/_security/whoami,
+ * /_plugins/_security/authinfo, etc.) provided by the plugin are not available.
+ */
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class EncryptionInTransitMigrationTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.DEFAULT)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true))
+        .sslOnly(true)
+        .nodeSpecificSettings(0, Map.of(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true))
+        .nodeSpecificSettings(1, Map.of(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true))
+        .extectedNodeStartupCount(2)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .build();
+
+    @Test
+    public void shouldOnlyConnectWithThirdNodeAfterDynamicDualModeChange() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            TestRestClient.HttpResponse response = client.get("_cat/nodes");
+            response.assertStatusCode(200);
+
+            String[] lines = response.getBody().split("\n");
+            assertEquals("Expected 2 nodes in the initial response", 2, lines.length);
+
+            String settingsJson = "{\"persistent\": {\"plugins.security_config.ssl_dual_mode_enabled\": false}}";
+            TestRestClient.HttpResponse settingsResponse = client.putJson("_cluster/settings", settingsJson);
+            settingsResponse.assertStatusCode(200);
+
+            Thread.sleep(2000);
+
+            TestRestClient.HttpResponse secondResponse = client.get("_cat/nodes");
+            secondResponse.assertStatusCode(200);
+
+            String[] secondLines = secondResponse.getBody().split("\n");
+            assertEquals("Expected 3 nodes after disabling SSL dual mode", 3, secondLines.length);
+        } catch (InterruptedException e) {
+            fail("Test failed due to exception: " + e.getMessage());
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -97,6 +97,7 @@ public class LocalOpenSearchCluster {
     private final List<Class<? extends Plugin>> additionalPlugins;
     private final List<Node> nodes = new ArrayList<>();
     private final TestCertificates testCertificates;
+    private final Integer expectedNodeStartupCount;
 
     private File clusterHomeDir;
     private List<String> seedHosts;
@@ -112,13 +113,15 @@ public class LocalOpenSearchCluster {
         ClusterManager clusterManager,
         NodeSettingsSupplier nodeSettingsSupplier,
         List<Class<? extends Plugin>> additionalPlugins,
-        TestCertificates testCertificates
+        TestCertificates testCertificates,
+        Integer expectedNodeStartCount
     ) {
         this.clusterName = clusterName;
         this.clusterManager = clusterManager;
         this.nodeSettingsSupplier = nodeSettingsSupplier;
         this.additionalPlugins = additionalPlugins;
         this.testCertificates = testCertificates;
+        this.expectedNodeStartupCount = expectedNodeStartCount;
         try {
             createClusterDirectory(clusterName);
         } catch (IOException e) {
@@ -198,7 +201,12 @@ public class LocalOpenSearchCluster {
 
         log.info("Startup finished. Waiting for GREEN");
 
-        waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), nodes.size());
+        int expectedCount = nodes.size();
+        if (expectedNodeStartupCount != null) {
+            expectedCount = expectedNodeStartupCount;
+        }
+
+        waitForCluster(ClusterHealthStatus.GREEN, TimeValue.timeValueSeconds(10), expectedCount);
         log.info("Started: {}", this);
 
     }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/MinimumSecuritySettingsSupplierFactory.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/MinimumSecuritySettingsSupplierFactory.java
@@ -28,6 +28,8 @@
 
 package org.opensearch.test.framework.cluster;
 
+import java.util.Map;
+
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.certificate.TestCertificates;
@@ -49,6 +51,16 @@ public class MinimumSecuritySettingsSupplierFactory {
 
     public NodeSettingsSupplier minimumOpenSearchSettings(boolean sslOnly, Settings other) {
         return i -> minimumOpenSearchSettingsBuilder(i, sslOnly).put(other).build();
+    }
+
+    public NodeSettingsSupplier minimumOpenSearchSettings(boolean sslOnly, Map<Integer, Settings> nodeOverride, Settings other) {
+        return i -> {
+            Settings override = nodeOverride.get(i);
+            if (override != null) {
+                return minimumOpenSearchSettingsBuilder(i, sslOnly).put(other).put(override).build();
+            }
+            return minimumOpenSearchSettingsBuilder(i, sslOnly).put(other).build();
+        };
     }
 
     private Settings.Builder minimumOpenSearchSettingsBuilder(int node, boolean sslOnly) {

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2166,7 +2166,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
     @Override
     public Optional<SecureSettingsFactory> getSecureSettingFactory(Settings settings) {
-        return Optional.of(new OpenSearchSecureSettingsFactory(threadPool, sks, evaluateSslExceptionHandler(), securityRestHandler));
+        return Optional.of(
+            new OpenSearchSecureSettingsFactory(threadPool, sks, evaluateSslExceptionHandler(), securityRestHandler, SSLConfig)
+        );
     }
 
     @SuppressWarnings("removal")

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -27,6 +27,7 @@ import org.opensearch.plugins.TransportExceptionHandler;
 import org.opensearch.security.filter.SecurityRestFilter;
 import org.opensearch.security.ssl.http.netty.Netty4ConditionalDecompressor;
 import org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier;
+import org.opensearch.security.ssl.transport.SSLConfig;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportAdapterProvider;
@@ -38,17 +39,20 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
     private final SecurityKeyStore sks;
     private final SslExceptionHandler sslExceptionHandler;
     private final SecurityRestFilter restFilter;
+    private final SSLConfig sslConfig;
 
     public OpenSearchSecureSettingsFactory(
         ThreadPool threadPool,
         SecurityKeyStore sks,
         SslExceptionHandler sslExceptionHandler,
-        SecurityRestFilter restFilter
+        SecurityRestFilter restFilter,
+        SSLConfig sslConfig
     ) {
         this.threadPool = threadPool;
         this.sks = sks;
         this.sslExceptionHandler = sslExceptionHandler;
         this.restFilter = restFilter;
+        this.sslConfig = sslConfig;
     }
 
     @Override
@@ -62,6 +66,11 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                         sslExceptionHandler.logError(t, false);
                     }
                 });
+            }
+
+            @Override
+            public boolean isDualModeEnabled(Settings settings) {
+                return sslConfig.isDualModeEnabled();
             }
 
             @Override

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -69,8 +69,13 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
             }
 
             @Override
-            public boolean isDualModeEnabled(Settings settings) {
-                return sslConfig.isDualModeEnabled();
+            public Optional<SecureTransportParameters> parameters(Settings settings) {
+                return Optional.of(new SecureTransportParameters() {
+                    @Override
+                    public boolean dualModeEnabled() {
+                        return sslConfig.isDualModeEnabled();
+                    }
+                });
             }
 
             @Override

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -674,7 +674,9 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
 
     @Override
     public Optional<SecureSettingsFactory> getSecureSettingFactory(Settings settings) {
-        return Optional.of(new OpenSearchSecureSettingsFactory(threadPool, sks, NOOP_SSL_EXCEPTION_HANDLER, securityRestHandler));
+        return Optional.of(
+            new OpenSearchSecureSettingsFactory(threadPool, sks, NOOP_SSL_EXCEPTION_HANDLER, securityRestHandler, SSLConfig)
+        );
     }
 
     protected Settings migrateSettings(Settings settings) {


### PR DESCRIPTION
### Description

Companion core PR: https://github.com/opensearch-project/OpenSearch/pull/16387

Overrides a new method in the SecureTransportSettingsProvider interface to allow the security plugin to feed this value to core. This is required since the security plugin has a listener on cluster settings and allows this setting to be changed dynamically irrespective of the value in opensearch.yml

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Testing

[latest-dual-mode.zip](https://github.com/user-attachments/files/17439395/latest-dual-mode.zip)

^ Attached above is a sample docker configuration for a 3 node cluster. node1 is commented out originally. All paths in the volumes are paths on my local machine and would need to change for a reproduction.

1. Apply this change and companion core change on top of 2.17 branches of respective repos
   - For core repo run `./gradlew localDistro` to create local snapshot jars for your distro
   - For security run `./gradlew assemble` to create snapshot jars that get placed in `build/distributions/` directory
2. Update all volume mounts to reference the location of the snapshot jars on your local machine. 
3. Spin up nodes 2 and 3 from the attached config using `docker compose down -v && docker compose up`
    - These nodes come up with:
```
plugins.security_config.ssl_dual_mode_enabled: true
plugins.security.ssl_only: true
```
5. Ensure that nodes come up successfully
6. Dynamically change DualMode from true to false
```
curl -XPUT https://localhost:9201/_cluster/settings -k -H "Content-Type: application/json" -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": false}}'
```
7. Uncomment node 1 and bring it up in a new terminal window: `docker compose up opensearch-node1`
8. OpenSearch node 1 should successfully join the cluster with this change and companion PR applied

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
