### PR TITLE
Fix issue in HashingStoredFieldVisitor with stored fields

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
@@ -1,6 +1,7 @@
 package org.opensearch.security;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -67,6 +68,7 @@ public class StoredFieldsTests {
                   ]
                 }
                 """);
+            fieldSearchResponse.assertStatusCode(HttpStatus.SC_OK);
             Assert.assertTrue(fieldSearchResponse.getBody().contains("raw"));
             Assert.assertTrue(fieldSearchResponse.getBody().contains("hello"));
             Assert.assertTrue(fieldSearchResponse.getBody().contains("restricted"));
@@ -88,6 +90,7 @@ public class StoredFieldsTests {
                   ]
                 }
                 """);
+            fieldSearchResponse.assertStatusCode(HttpStatus.SC_OK);
             Assert.assertTrue(fieldSearchResponse.getBody().contains("raw"));
             Assert.assertTrue(fieldSearchResponse.getBody().contains("hello"));
             Assert.assertFalse(fieldSearchResponse.getBody().contains("restricted"));

--- a/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
 package org.opensearch.security;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;

--- a/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
@@ -1,0 +1,94 @@
+package org.opensearch.security;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.client.Client;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class StoredFieldsTests {
+    static final TestSecurityConfig.User TEST_USER_MASKED_FIELDS = new TestSecurityConfig.User("test_user_masked_fields").roles(
+        new TestSecurityConfig.Role("role_masked_fields").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .maskedFields("restricted")
+            .on("test_index")
+    );
+
+    static final TestSecurityConfig.User TEST_USER_FLS = new TestSecurityConfig.User("test_user_fls").roles(
+        new TestSecurityConfig.Role("role_fls").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .fls("~restricted")
+            .on("test_index")
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(TEST_USER_MASKED_FIELDS, TEST_USER_FLS)
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            CreateIndexResponse r = client.admin()
+                .indices()
+                .prepareCreate("test_index")
+                .setMapping("raw", "type=keyword,store=true", "restricted", "type=keyword,store=true")
+                .get();
+
+            client.prepareIndex("test_index").setRefreshPolicy(IMMEDIATE).setSource("raw", "hello", "restricted", "boo!").get();
+        }
+    }
+
+    @Test
+    public void testStoredWithWithApplicableMaskedFieldRestrictions() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER_MASKED_FIELDS)) {
+            TestRestClient.HttpResponse normalSearchResponse = client.get("test_index/_search");
+            Assert.assertFalse(normalSearchResponse.getBody().contains("boo!"));
+
+            TestRestClient.HttpResponse fieldSearchResponse = client.postJson("test_index/_search", """
+                {
+                  "stored_fields": [
+                    "raw",
+                    "restricted"
+                  ]
+                }
+                """);
+            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
+            Assert.assertTrue(fieldSearchResponse.getBody().contains("restricted"));
+        }
+    }
+
+    @Test
+    public void testStoredWithWithApplicableFlsRestrictions() {
+        try (TestRestClient client = cluster.getRestClient(TEST_USER_FLS)) {
+            TestRestClient.HttpResponse normalSearchResponse = client.get("test_index/_search");
+            Assert.assertFalse(normalSearchResponse.getBody().contains("boo!"));
+
+            TestRestClient.HttpResponse fieldSearchResponse = client.postJson("test_index/_search", """
+                {
+                  "stored_fields": [
+                    "raw",
+                    "restricted"
+                  ]
+                }
+                """);
+            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
+            Assert.assertFalse(fieldSearchResponse.getBody().contains("restricted"));
+        }
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/StoredFieldsTests.java
@@ -67,8 +67,10 @@ public class StoredFieldsTests {
                   ]
                 }
                 """);
-            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
+            Assert.assertTrue(fieldSearchResponse.getBody().contains("raw"));
+            Assert.assertTrue(fieldSearchResponse.getBody().contains("hello"));
             Assert.assertTrue(fieldSearchResponse.getBody().contains("restricted"));
+            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
         }
     }
 
@@ -86,8 +88,10 @@ public class StoredFieldsTests {
                   ]
                 }
                 """);
-            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
+            Assert.assertTrue(fieldSearchResponse.getBody().contains("raw"));
+            Assert.assertTrue(fieldSearchResponse.getBody().contains("hello"));
             Assert.assertFalse(fieldSearchResponse.getBody().contains("restricted"));
+            Assert.assertFalse(fieldSearchResponse.getBody().contains("boo!"));
         }
     }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -729,6 +729,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
 
         @Override
         public void binaryField(final FieldInfo fieldInfo, final byte[] value) throws IOException {
+
             if (fieldInfo.name.equals("_source")) {
                 final BytesReference bytesRef = new BytesArray(value);
                 final Tuple<XContentType, Map<String, Object>> bytesRefTuple = XContentHelper.convertToMap(
@@ -817,6 +818,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
             }
 
             if (v != null && (v instanceof String || v instanceof byte[])) {
+
                 final String field = stack.isEmpty() ? key : Joiner.on('.').join(stack) + "." + key;
                 final MaskedField mf = maskedFieldsMap.getMaskedField(field).orElse(null);
                 if (mf != null) {


### PR DESCRIPTION
### Description

This PR fixes a bug inside HashingStoredFieldVisitor to account for [stored_fields](https://opensearch.org/docs/latest/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields) which are stored separately from `_source` in the backing index. This PR also adds integ tests to verify the correct behavior.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
