### PR TITLE
Honor log_request_body setting in compliance audit log

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -644,19 +644,17 @@ public abstract class AbstractAuditLog implements AuditLog {
                         XContentType.JSON
                     )
                 ) {
-                    if (auditConfigFilter.shouldLogRequestBody()) {
-                        Object base64 = parser.map().values().iterator().next();
-                        if (base64 instanceof String) {
-                            msg.addSecurityConfigContentToRequestBody(
-                                new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
-                                id
-                            );
-                        } else {
-                            msg.addSecurityConfigTupleToRequestBody(
-                                new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
-                                id
-                            );
-                        }
+                    Object base64 = parser.map().values().iterator().next();
+                    if (base64 instanceof String) {
+                        msg.addSecurityConfigContentToRequestBody(
+                            new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
+                            id
+                        );
+                    } else {
+                        msg.addSecurityConfigTupleToRequestBody(
+                            new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
+                            id
+                        );
                     }
                 } catch (Exception e) {
                     log.error(e.toString());
@@ -671,9 +669,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                 // originalResult.internalSourceRef()));
 
                 // current source, normally not null or empty
-                if (auditConfigFilter.shouldLogRequestBody()) {
-                    msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
-                }
+                msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
             }
 
         }

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -639,17 +639,19 @@ public abstract class AbstractAuditLog implements AuditLog {
                         XContentType.JSON
                     )
                 ) {
-                    Object base64 = parser.map().values().iterator().next();
-                    if (base64 instanceof String) {
-                        msg.addSecurityConfigContentToRequestBody(
-                            new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
-                            id
-                        );
-                    } else {
-                        msg.addSecurityConfigTupleToRequestBody(
-                            new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
-                            id
-                        );
+                    if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                        Object base64 = parser.map().values().iterator().next();
+                        if (base64 instanceof String) {
+                            msg.addSecurityConfigContentToRequestBody(
+                                new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
+                                id
+                            );
+                        } else {
+                            msg.addSecurityConfigTupleToRequestBody(
+                                new Tuple<XContentType, BytesReference>(XContentType.JSON, currentIndex.source()),
+                                id
+                            );
+                        }
                     }
                 } catch (Exception e) {
                     log.error(e.toString());

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -566,30 +566,33 @@ public abstract class AbstractAuditLog implements AuditLog {
         msg.addComplianceDocVersion(result.getVersion());
         msg.addComplianceOperation(result.isCreated() ? Operation.CREATE : Operation.UPDATE);
 
-        if (complianceConfig.shouldLogDiffsForWrite()
-            && originalResult != null
-            && originalResult.isExists()
-            && originalResult.internalSourceRef() != null) {
+        if (complianceConfig.shouldLogDiffsForWrite()) {
             try {
                 String originalSource = null;
                 String currentSource = null;
+                if (!(originalResult != null && originalResult.isExists() && originalResult.internalSourceRef() != null)) {
+                    // originalSource is empty
+                    originalSource = "{}";
+                }
                 if (securityIndex.equals(shardId.getIndexName())) {
-                    try (
-                        XContentParser parser = XContentHelper.createParser(
-                            NamedXContentRegistry.EMPTY,
-                            THROW_UNSUPPORTED_OPERATION,
-                            originalResult.internalSourceRef(),
-                            XContentType.JSON
-                        )
-                    ) {
-                        Object base64 = parser.map().values().iterator().next();
-                        if (base64 instanceof String) {
-                            originalSource = (new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8));
-                        } else {
-                            originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
+                    if (originalSource == null) {
+                        try (
+                            XContentParser parser = XContentHelper.createParser(
+                                NamedXContentRegistry.EMPTY,
+                                THROW_UNSUPPORTED_OPERATION,
+                                originalResult.internalSourceRef(),
+                                XContentType.JSON
+                            )
+                        ) {
+                            Object base64 = parser.map().values().iterator().next();
+                            if (base64 instanceof String) {
+                                originalSource = (new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8));
+                            } else {
+                                originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
+                            }
+                        } catch (Exception e) {
+                            log.error(e.toString());
                         }
-                    } catch (Exception e) {
-                        log.error(e.toString());
                     }
 
                     try (
@@ -615,7 +618,9 @@ public abstract class AbstractAuditLog implements AuditLog {
                     );
                     msg.addSecurityConfigWriteDiffSource(diffnode.size() == 0 ? "" : diffnode.toString(), id);
                 } else {
-                    originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
+                    if (originalSource == null) {
+                        originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
+                    }
                     currentSource = XContentHelper.convertToJson(currentIndex.source(), false, XContentType.JSON);
                     final JsonNode diffnode = JsonDiff.asJson(
                         DefaultObjectMapper.objectMapper.readTree(originalSource),
@@ -639,7 +644,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                         XContentType.JSON
                     )
                 ) {
-                    if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                    if (auditConfigFilter.shouldLogRequestBody()) {
                         Object base64 = parser.map().values().iterator().next();
                         if (base64 instanceof String) {
                             msg.addSecurityConfigContentToRequestBody(
@@ -666,7 +671,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                 // originalResult.internalSourceRef()));
 
                 // current source, normally not null or empty
-                if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                if (auditConfigFilter.shouldLogRequestBody()) {
                     msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
                 }
             }

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -666,7 +666,9 @@ public abstract class AbstractAuditLog implements AuditLog {
                 // originalResult.internalSourceRef()));
 
                 // current source, normally not null or empty
-                msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
+                if (auditConfigFilter.shouldLogRequestBody() || originalResult == null) {
+                    msg.addTupleToRequestBody(new Tuple<MediaType, BytesReference>(XContentType.JSON, currentIndex.source()));
+                }
             }
 
         }

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -633,7 +633,7 @@ public abstract class AbstractAuditLog implements AuditLog {
             }
         }
 
-        if (!complianceConfig.shouldLogWriteMetadataOnly()) {
+        if (!complianceConfig.shouldLogWriteMetadataOnly() && !complianceConfig.shouldLogDiffsForWrite()) {
             if (securityIndex.equals(shardId.getIndexName())) {
                 // current source, normally not null or empty
                 try (

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -50,7 +50,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
-import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES;
 import static org.junit.Assert.assertThrows;
 
 public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
@@ -64,7 +63,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, false)
             .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS, "emp")
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .put(OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
             .build();
 
         setup(additionalSettings);
@@ -183,7 +182,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             // .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES, "emp")
             .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS, "emp")
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .put(OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
             .build();
 
         setup(additionalSettings);
@@ -264,7 +263,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, false)
             .put(ConfigConstants.SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, true)
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .put(OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
             .build();
 
         setup(additionalSettings);
@@ -320,7 +319,7 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             .put(ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_EXTERNAL_CONFIG_ENABLED, true)
             .put(ConfigConstants.SECURITY_COMPLIANCE_HISTORY_INTERNAL_CONFIG_ENABLED, false)
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
-            .put(OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "authenticated,GRANTED_PRIVILEGES")
             .build();
 
         final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -487,7 +487,13 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
             .findFirst()
             .orElse(null);
         assertThat(complianceDocWriteMessage, notNullValue());
-        assertThat(complianceDocWriteMessage.getRequestBody(), notNullValue());
+        assertThat(
+            (String) complianceDocWriteMessage.getAsMap().get("audit_compliance_diff_content"),
+            containsString(
+                "[{\"op\":\"add\",\"path\":\"/name\",\"value\":\"Criag\"},{\"op\":\"add\",\"path\":\"/title\",\"value\":\"Software Engineer\"}]"
+            )
+        );
+        assertThat(complianceDocWriteMessage.getRequestBody(), nullValue());
 
         messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             try (Client tc = getClient()) {
@@ -496,7 +502,10 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         }, 1);
 
         complianceDocWriteMessage = messages.get(0);
-        assertThat(complianceDocWriteMessage, notNullValue());
+        assertThat(
+            (String) complianceDocWriteMessage.getAsMap().get("audit_compliance_diff_content"),
+            containsString("[{\"op\":\"replace\",\"path\":\"/name\",\"value\":\"Craig\"}]")
+        );
         assertThat(complianceDocWriteMessage.getRequestBody(), nullValue());
     }
 }


### PR DESCRIPTION
### Description

This PR ensures that the value of `log_request_body` is honored for the compliance logging. When using the compliance config, this PR will ensure that the document's source is audit logged in the `audit_request_body` when a document is first created, but otherwise it will not. When `write_log_diffs` is enabled, you can trace the full history of changes to documents on the tracked indices by looking for all events on the target index.

By default, the security index gets events audit logged so Compliant logging is a good feature to use to trace changes to the security configuration.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

https://github.com/opensearch-project/security/issues/4534

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
