### PR TITLE
Generalize public key reading in the JWT authenticator

### DIFF
--- a/src/main/java/org/opensearch/security/util/KeyUtils.java
+++ b/src/main/java/org/opensearch/security/util/KeyUtils.java
@@ -52,8 +52,8 @@ public class KeyUtils {
                 } else {
                     try {
                         PublicKey key = null;
-
-                        final String minimalKeyFormat = signingKey.replace("-----BEGIN PUBLIC KEY-----\n", "")
+                        final String minimalKeyFormat = signingKey.replaceAll("\\r|\\n", "")
+                            .replace("-----BEGIN PUBLIC KEY-----", "")
                             .replace("-----END PUBLIC KEY-----", "")
                             .trim();
                         final byte[] decoded = Base64.getDecoder().decode(minimalKeyFormat);

--- a/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -389,7 +389,6 @@ public class HTTPJwtAuthenticatorTest {
 
     @Test
     public void testRS256() throws Exception {
-
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(2048);
         KeyPair pair = keyGen.generateKeyPair();
@@ -397,21 +396,8 @@ public class HTTPJwtAuthenticatorTest {
         PublicKey pub = pair.getPublic();
 
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.RS256).compact();
-        Settings settings = Settings.builder()
-            .put(
-                "signing_key",
-                "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub.getEncoded()) + "-----END PUBLIC KEY-----"
-            )
-            .build();
-
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", "Bearer " + jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
-            null
-        );
+        String signingKey = "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub.getEncoded()) + "-----END PUBLIC KEY-----";
+        AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
 
         Assert.assertNotNull(creds);
         assertThat(creds.getUsername(), is("Leonard McCoy"));
@@ -437,7 +423,6 @@ public class HTTPJwtAuthenticatorTest {
 
     @Test
     public void testRS256WithNewlines() throws Exception {
-
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(2048);
         KeyPair pair = keyGen.generateKeyPair();
@@ -445,23 +430,25 @@ public class HTTPJwtAuthenticatorTest {
         PublicKey pub = pair.getPublic();
 
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.RS256).compact();
+
         String signingKey = "-----BEGIN PUBLIC KEY-----\n"
             + formatKeyWithNewlines(BaseEncoding.base64().encode(pub.getEncoded()))
             + "\n-----END PUBLIC KEY-----";
+        AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
+
+        Assert.assertNotNull(creds);
+        assertThat(creds.getUsername(), is("Leonard McCoy"));
+        assertThat(creds.getBackendRoles().size(), is(0));
+    }
+
+    private AuthCredentials testJwtAuthenticationWithSigningKey(String signingKey, String jwsToken) throws NoSuchAlgorithmException {
         Settings settings = Settings.builder().put("signing_key", signingKey).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
         headers.put("Authorization", "Bearer " + jwsToken);
 
-        AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
-            null
-        );
-
-        Assert.assertNotNull(creds);
-        assertThat(creds.getUsername(), is("Leonard McCoy"));
-        assertThat(creds.getBackendRoles().size(), is(0));
+        return jwtAuth.extractCredentials(new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(), null);
     }
 
     @Test
@@ -473,17 +460,10 @@ public class HTTPJwtAuthenticatorTest {
         PrivateKey priv = pair.getPrivate();
         PublicKey pub = pair.getPublic();
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(pub.getEncoded())).build();
+        String signingKey = BaseEncoding.base64().encode(pub.getEncoded());
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.ES512).compact();
 
-        HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("Authorization", jwsToken);
-
-        AuthCredentials creds = jwtAuth.extractCredentials(
-            new FakeRestRequest(headers, new HashMap<String, String>()).asSecurityRequest(),
-            null
-        );
+        AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
 
         Assert.assertNotNull(creds);
         assertThat(creds.getUsername(), is("Leonard McCoy"));


### PR DESCRIPTION
### Description

This PR generalizes public key reading in the JWT authenticator to support configuring the JWT authenticator with inline public cert like this:

```
jwt_auth_domain:
  description: "Authenticate via Json Web Token"
  http_enabled: true
  transport_enabled: true
  order: 0
  http_authenticator:
    type: jwt
    challenge: false
    config:
      signing_key: |-
        -----BEGIN PUBLIC KEY-----
        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA64L6PDUm1ySNWIJiuxEv
        OA92MDmrevshZEWQsN98pkrp8pbCOVjA5OseddXOYVlXunbv1FMooGwVkOCAk6s3
        rxffHP2tN4NJRvvEDr/uoWKj22mV9cqyVar13HvdKkTm0MN1nDjo1fv1YBL5Xq7E
        2Ak6d0soKIg/RFzzv7JqLkUCsQ5krhm08A11cBbI8jqsebsiRCa7HkRyUalYLRVh
        NHf9Dxf3rmVoKtHs1jKRMm9NiAl1aa6U/BDzlM45uX9yNaOYiqNVbQIufwxiy4/a
        gbmkvuqTf/Pm6jzX09h0nb7CIiy+3AbbnncaZ8UjwKZ8iJJ8XTDtHuerM8eN728F
        NwIDAQAB
        -----END PUBLIC KEY-----
      jwt_header: "Authorization"
```

Currently, the JWT authenticator will fail to initialize because it is not removing the line endings when parsing this value. The resulting error was:

```
2024-06-05 10:54:13 [2024-06-05T16:54:13,013][ERROR][c.a.d.a.h.j.HTTPJwtAuthenticator] [opensearch-node1] Error while creating JWT authenticator
2024-06-05 10:54:13 java.lang.IllegalArgumentException: Illegal base64 character a
2024-06-05 10:54:13 at java.base/java.util.Base64$Decoder.decode0(Base64.java:852) ~[?:?]
2024-06-05 10:54:13 at java.base/java.util.Base64$Decoder.decode(Base64.java:570) ~[?:?]
2024-06-05 10:54:13 at java.base/java.util.Base64$Decoder.decode(Base64.java:593) ~[?:?]
2024-06-05 10:54:13 at org.opensearch.security.util.KeyUtils$1.run(KeyUtils.java:58) [opensearch-security-2.14.0.0.jar:2.14.0.0]
2024-06-05 10:54:13 at org.opensearch.security.util.KeyUtils$1.run(KeyUtils.java:45) [opensearch-security-2.14.0.0.jar:2.14.0.0]
2024-06-05 10:54:13 at java.base/java.security.AccessController.doPrivileged(AccessController.java:319) [?:?]
2024-06-05 10:54:13 at org.opensearch.security.util.KeyUtils.createJwtParserBuilderFromSigningKey(KeyUtils.java:45) [opensearch-security-2.14.0.0.jar:2.14.0.0]
2024-06-05 10:54:13 at com.amazon.dlic.auth.http.jwt.HTTPJwtAuthenticator.<init>(HTTPJwtAuthenticator.java:88) [opensearch-security-2.14.0.0.jar:2.14.0.0]
2024-06-05 10:54:13 at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62) ~[?:?]
2024-06-05 10:54:13 at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:502) ~[?:?]
2024-06-05 10:54:13 at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:486) ~[?:?]
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

Resolves: https://github.com/opensearch-project/security/issues/4406

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
