### PR TITLE
Add validation of authority certificates

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -26,6 +26,8 @@ import org.opensearch.transport.NettyAllocator;
 
 import io.netty.handler.ssl.SslContext;
 
+import static java.util.function.Predicate.not;
+
 public class SslContextHandler {
 
     private SslContext sslContext;
@@ -60,6 +62,14 @@ public class SslContextHandler {
         return sslContext;
     }
 
+    public Stream<Certificate> authorityCertificates() {
+        return authorityCertificates(loadedCertificates);
+    }
+
+    Stream<Certificate> authorityCertificates(final List<Certificate> certificates) {
+        return certificates.stream().filter(not(Certificate::hasKey));
+    }
+
     public Stream<Certificate> keyMaterialCertificates() {
         return keyMaterialCertificates(loadedCertificates);
     }
@@ -71,37 +81,62 @@ public class SslContextHandler {
     void reloadSslContext() throws CertificateException {
         final var newCertificates = sslConfiguration.certificates();
 
-        if (sameCertificates(newCertificates)) {
-            return;
+        boolean hasChanges = false;
+
+        final var loadedAuthorityCertificates = authorityCertificates().collect(Collectors.toList());
+        final var loadedKeyMaterialCertificates = keyMaterialCertificates().collect(Collectors.toList());
+        final var newAuthorityCertificates = authorityCertificates(newCertificates).collect(Collectors.toList());
+        final var newKeyMaterialCertificates = keyMaterialCertificates(newCertificates).collect(Collectors.toList());
+
+        if (notSameCertificates(loadedAuthorityCertificates, newAuthorityCertificates)) {
+            hasChanges = true;
+            validateDates(newAuthorityCertificates);
         }
-        validateNewCertificates(newCertificates, sslConfiguration.sslParameters().shouldValidateNewCertDNs());
-        invalidateSessions();
-        if (sslContext.isClient()) {
-            sslContext = sslConfiguration.buildClientSslContext(false);
-        } else {
-            sslContext = sslConfiguration.buildServerSslContext(false);
+
+        if (notSameCertificates(loadedKeyMaterialCertificates, newKeyMaterialCertificates)) {
+            hasChanges = true;
+            validateNewKeyMaterialCertificates(
+                loadedKeyMaterialCertificates,
+                newKeyMaterialCertificates,
+                sslConfiguration.sslParameters().shouldValidateNewCertDNs()
+            );
         }
-        loadedCertificates.clear();
-        loadedCertificates.addAll(newCertificates);
+        if (hasChanges) {
+            invalidateSessions();
+            if (sslContext.isClient()) {
+                sslContext = sslConfiguration.buildClientSslContext(false);
+            } else {
+                sslContext = sslConfiguration.buildServerSslContext(false);
+            }
+            loadedCertificates.clear();
+            loadedCertificates.addAll(newCertificates);
+        }
     }
 
-    private boolean sameCertificates(final List<Certificate> newCertificates) {
-        final Set<String> currentCertSignatureSet = keyMaterialCertificates().map(Certificate::x509Certificate)
+    private boolean notSameCertificates(final List<Certificate> loadedCertificates, final List<Certificate> newCertificates) {
+        final Set<String> currentCertSignatureSet = loadedCertificates.stream()
+            .map(Certificate::x509Certificate)
             .map(X509Certificate::getSignature)
             .map(s -> new String(s, StandardCharsets.UTF_8))
             .collect(Collectors.toSet());
-        final Set<String> newCertSignatureSet = keyMaterialCertificates(newCertificates).map(Certificate::x509Certificate)
+        final Set<String> newCertSignatureSet = newCertificates.stream()
+            .map(Certificate::x509Certificate)
             .map(X509Certificate::getSignature)
             .map(s -> new String(s, StandardCharsets.UTF_8))
             .collect(Collectors.toSet());
-        return currentCertSignatureSet.equals(newCertSignatureSet);
+        return !currentCertSignatureSet.equals(newCertSignatureSet);
     }
 
-    private void validateSubjectDns(final List<Certificate> newCertificates) throws CertificateException {
-        final List<String> currentSubjectDNs = keyMaterialCertificates().map(Certificate::subject).sorted().collect(Collectors.toList());
-        final List<String> newSubjectDNs = keyMaterialCertificates(newCertificates).map(Certificate::subject)
-            .sorted()
-            .collect(Collectors.toList());
+    private void validateDates(final List<Certificate> newCertificates) throws CertificateException {
+        for (final var certificate : newCertificates) {
+            certificate.x509Certificate().checkValidity();
+        }
+    }
+
+    private void validateSubjectDns(final List<Certificate> loadedCertificates, final List<Certificate> newCertificates)
+        throws CertificateException {
+        final List<String> currentSubjectDNs = loadedCertificates.stream().map(Certificate::subject).sorted().collect(Collectors.toList());
+        final List<String> newSubjectDNs = newCertificates.stream().map(Certificate::subject).sorted().collect(Collectors.toList());
         if (!currentSubjectDNs.equals(newSubjectDNs)) {
             throw new CertificateException(
                 "New certificates do not have valid Subject DNs. Current Subject DNs "
@@ -112,11 +147,10 @@ public class SslContextHandler {
         }
     }
 
-    private void validateIssuerDns(final List<Certificate> newCertificates) throws CertificateException {
-        final List<String> currentIssuerDNs = keyMaterialCertificates().map(Certificate::issuer).sorted().collect(Collectors.toList());
-        final List<String> newIssuerDNs = keyMaterialCertificates(newCertificates).map(Certificate::issuer)
-            .sorted()
-            .collect(Collectors.toList());
+    private void validateIssuerDns(final List<Certificate> loadedCertificates, final List<Certificate> newCertificates)
+        throws CertificateException {
+        final List<String> currentIssuerDNs = loadedCertificates.stream().map(Certificate::issuer).sorted().collect(Collectors.toList());
+        final List<String> newIssuerDNs = newCertificates.stream().map(Certificate::issuer).sorted().collect(Collectors.toList());
         if (!currentIssuerDNs.equals(newIssuerDNs)) {
             throw new CertificateException(
                 "New certificates do not have valid Issuer DNs. Current Issuer DNs: "
@@ -127,11 +161,14 @@ public class SslContextHandler {
         }
     }
 
-    private void validateSans(final List<Certificate> newCertificates) throws CertificateException {
-        final List<String> currentSans = keyMaterialCertificates().map(Certificate::subjectAlternativeNames)
+    private void validateSans(final List<Certificate> loadedCertificates, final List<Certificate> newCertificates)
+        throws CertificateException {
+        final List<String> currentSans = loadedCertificates.stream()
+            .map(Certificate::subjectAlternativeNames)
             .sorted()
             .collect(Collectors.toList());
-        final List<String> newSans = keyMaterialCertificates(newCertificates).map(Certificate::subjectAlternativeNames)
+        final List<String> newSans = newCertificates.stream()
+            .map(Certificate::subjectAlternativeNames)
             .sorted()
             .collect(Collectors.toList());
         if (!currentSans.equals(newSans)) {
@@ -141,15 +178,16 @@ public class SslContextHandler {
         }
     }
 
-    private void validateNewCertificates(final List<Certificate> newCertificates, boolean shouldValidateNewCertDNs)
-        throws CertificateException {
-        for (final var certificate : newCertificates) {
-            certificate.x509Certificate().checkValidity();
-        }
+    private void validateNewKeyMaterialCertificates(
+        final List<Certificate> loadedCertificates,
+        final List<Certificate> newCertificates,
+        boolean shouldValidateNewCertDNs
+    ) throws CertificateException {
+        validateDates(newCertificates);
         if (shouldValidateNewCertDNs) {
-            validateSubjectDns(newCertificates);
-            validateIssuerDns(newCertificates);
-            validateSans(newCertificates);
+            validateSubjectDns(loadedCertificates, newCertificates);
+            validateIssuerDns(loadedCertificates, newCertificates);
+            validateSans(loadedCertificates, newCertificates);
         }
     }
 

--- a/src/test/java/org/opensearch/security/ssl/CertificatesRule.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificatesRule.java
@@ -123,12 +123,21 @@ public class CertificatesRule extends ExternalResource {
 
     public X509CertificateHolder generateCaCertificate(final KeyPair parentKeyPair) throws IOException, NoSuchAlgorithmException,
         OperatorCreationException {
-        return generateCaCertificate(parentKeyPair, generateSerialNumber());
+        final var startAndEndDate = generateStartAndEndDate();
+        return generateCaCertificate(parentKeyPair, generateSerialNumber(), startAndEndDate.v1(), startAndEndDate.v2());
     }
 
-    public X509CertificateHolder generateCaCertificate(final KeyPair parentKeyPair, final BigInteger serialNumber) throws IOException,
-        NoSuchAlgorithmException, OperatorCreationException {
-        final var startAndEndDate = generateStartAndEndDate();
+    public X509CertificateHolder generateCaCertificate(final KeyPair parentKeyPair, final Instant startDate, final Instant endDate)
+        throws IOException, NoSuchAlgorithmException, OperatorCreationException {
+        return generateCaCertificate(parentKeyPair, generateSerialNumber(), startDate, endDate);
+    }
+
+    public X509CertificateHolder generateCaCertificate(
+        final KeyPair parentKeyPair,
+        final BigInteger serialNumber,
+        final Instant startDate,
+        final Instant endDate
+    ) throws IOException, NoSuchAlgorithmException, OperatorCreationException {
         // CS-SUPPRESS-SINGLE: RegexpSingleline Extension should only be used sparingly to keep implementations as generic as possible
         return createCertificateBuilder(
             DEFAULT_SUBJECT_NAME,
@@ -136,8 +145,8 @@ public class CertificatesRule extends ExternalResource {
             parentKeyPair.getPublic(),
             parentKeyPair.getPublic(),
             serialNumber,
-            startAndEndDate.v1(),
-            startAndEndDate.v2()
+            startDate,
+            endDate
         ).addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
             .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign))
             .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BOUNCY_CASTLE_PROVIDER).build(parentKeyPair.getPrivate()));

--- a/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
@@ -84,7 +84,34 @@ public class SslContextHandlerTest {
     }
 
     @Test
-    public void failsIfCertificatesHasInvalidDates() throws Exception {
+    public void failsIfAuthorityCertificateHasInvalidDates() throws Exception {
+        final var sslContextHandler = sslContextHandler();
+        final var keyPair = certificatesRule.generateKeyPair();
+
+        final var caCertificate = certificatesRule.caCertificateHolder();
+
+        var newCaCertificate = certificatesRule.generateCaCertificate(
+            keyPair,
+            caCertificate.getNotAfter().toInstant(),
+            caCertificate.getNotAfter().toInstant().minus(10, ChronoUnit.DAYS)
+        );
+
+        writeCertificates(newCaCertificate, certificatesRule.accessCertificateHolder(), certificatesRule.accessCertificatePrivateKey());
+
+        assertThrows(CertificateException.class, sslContextHandler::reloadSslContext);
+
+        newCaCertificate = certificatesRule.generateCaCertificate(
+            keyPair,
+            caCertificate.getNotBefore().toInstant().plus(10, ChronoUnit.DAYS),
+            caCertificate.getNotAfter().toInstant().plus(20, ChronoUnit.DAYS)
+        );
+        writeCertificates(newCaCertificate, certificatesRule.accessCertificateHolder(), certificatesRule.accessCertificatePrivateKey());
+
+        assertThrows(CertificateException.class, sslContextHandler::reloadSslContext);
+    }
+
+    @Test
+    public void failsIfKeyMaterialCertificateHasInvalidDates() throws Exception {
         final var sslContextHandler = sslContextHandler();
 
         final var accessCertificate = certificatesRule.x509AccessCertificate();
@@ -111,7 +138,7 @@ public class SslContextHandlerTest {
     }
 
     @Test
-    public void filesIfHasNotValidSubjectDNs() throws Exception {
+    public void failsIfKeyMaterialCertificateHasNotValidSubjectDNs() throws Exception {
         final var sslContextHandler = sslContextHandler();
 
         final var keyPair = certificatesRule.generateKeyPair();
@@ -137,7 +164,7 @@ public class SslContextHandlerTest {
     }
 
     @Test
-    public void filesIfHasNotValidIssuerDNs() throws Exception {
+    public void failsIfKeyMaterialCertificateHasNotValidIssuerDNs() throws Exception {
         final var sslContextHandler = sslContextHandler();
 
         final var keyPair = certificatesRule.generateKeyPair();
@@ -163,7 +190,7 @@ public class SslContextHandlerTest {
     }
 
     @Test
-    public void filesIfHasNotValidSans() throws Exception {
+    public void failsIfKeyMaterialCertificateHasNotValidSans() throws Exception {
         final var sslContextHandler = sslContextHandler();
 
         final var keyPair = certificatesRule.generateKeyPair();


### PR DESCRIPTION
### Description

Added validation of authority certificates prior to reloading the SSL context.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
