### PR TITLE
Adapt disable dn verification on cert reload changes to SSL refactor

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -74,9 +74,7 @@ public class SslContextHandler {
         if (sameCertificates(newCertificates)) {
             return;
         }
-        if (sslConfiguration.sslParameters().isValidateCertsOnReloadEnabled()) {
-            validateNewCertificates(newCertificates);
-        }
+        validateNewCertificates(newCertificates, sslConfiguration.sslParameters().shouldValidateNewCertDNs());
         invalidateSessions();
         if (sslContext.isClient()) {
             sslContext = sslConfiguration.buildClientSslContext(false);
@@ -143,13 +141,16 @@ public class SslContextHandler {
         }
     }
 
-    private void validateNewCertificates(final List<Certificate> newCertificates) throws CertificateException {
+    private void validateNewCertificates(final List<Certificate> newCertificates, boolean shouldValidateNewCertDNs)
+        throws CertificateException {
         for (final var certificate : newCertificates) {
             certificate.x509Certificate().checkValidity();
         }
-        validateSubjectDns(newCertificates);
-        validateIssuerDns(newCertificates);
-        validateSans(newCertificates);
+        if (shouldValidateNewCertDNs) {
+            validateSubjectDns(newCertificates);
+            validateIssuerDns(newCertificates);
+            validateSans(newCertificates);
+        }
     }
 
     private void invalidateSessions() {

--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -74,7 +74,9 @@ public class SslContextHandler {
         if (sameCertificates(newCertificates)) {
             return;
         }
-        validateNewCertificates(newCertificates);
+        if (sslConfiguration.sslParameters().isValidateCertsOnReloadEnabled()) {
+            validateNewCertificates(newCertificates);
+        }
         invalidateSessions();
         if (sslContext.isClient()) {
             sslContext = sslConfiguration.buildClientSslContext(false);

--- a/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
@@ -40,6 +40,7 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.CLIENT_AUTH_MO
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED_CIPHERS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLE_OPENSSL_IF_AVAILABLE;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.ENFORCE_CERT_RELOAD_DN_VERIFICATION;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.OPENSSL_1_1_1_BETA_9;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.OPENSSL_AVAILABLE;
 
@@ -53,11 +54,20 @@ public class SslParameters {
 
     private final List<String> ciphers;
 
-    private SslParameters(SslProvider provider, final ClientAuth clientAuth, List<String> protocols, List<String> ciphers) {
+    private final boolean validateCertsOnReload;
+
+    private SslParameters(
+        SslProvider provider,
+        final ClientAuth clientAuth,
+        List<String> protocols,
+        List<String> ciphers,
+        boolean validateCertsOnReload
+    ) {
         this.provider = provider;
         this.ciphers = ciphers;
         this.protocols = protocols;
         this.clientAuth = clientAuth;
+        this.validateCertsOnReload = validateCertsOnReload;
     }
 
     public ClientAuth clientAuth() {
@@ -74,6 +84,10 @@ public class SslParameters {
 
     public List<String> allowedProtocols() {
         return protocols;
+    }
+
+    public boolean isValidateCertsOnReloadEnabled() {
+        return validateCertsOnReload;
     }
 
     @Override
@@ -110,6 +124,10 @@ public class SslParameters {
             } else {
                 return SslProvider.JDK;
             }
+        }
+
+        private boolean validateCertsOnReload(final Settings settings) {
+            return settings.getAsBoolean(ENFORCE_CERT_RELOAD_DN_VERIFICATION, true);
         }
 
         private List<String> protocols(final SslProvider provider, final Settings settings, boolean http) {
@@ -181,7 +199,8 @@ public class SslParameters {
                 provider,
                 clientAuth,
                 protocols(provider, sslConfigSettings, http),
-                ciphers(provider, sslConfigSettings)
+                ciphers(provider, sslConfigSettings),
+                validateCertsOnReload(sslConfigSettings)
             );
             if (sslParameters.allowedProtocols().isEmpty()) {
                 throw new OpenSearchSecurityException("No ssl protocols for " + (http ? "HTTP" : "Transport") + " layer");

--- a/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
@@ -54,20 +54,20 @@ public class SslParameters {
 
     private final List<String> ciphers;
 
-    private final boolean validateCertsOnReload;
+    private final boolean validateCertDNsOnReload;
 
     private SslParameters(
         SslProvider provider,
         final ClientAuth clientAuth,
         List<String> protocols,
         List<String> ciphers,
-        boolean validateCertsOnReload
+        boolean validateCertDNsOnReload
     ) {
         this.provider = provider;
         this.ciphers = ciphers;
         this.protocols = protocols;
         this.clientAuth = clientAuth;
-        this.validateCertsOnReload = validateCertsOnReload;
+        this.validateCertDNsOnReload = validateCertDNsOnReload;
     }
 
     public ClientAuth clientAuth() {
@@ -86,8 +86,8 @@ public class SslParameters {
         return protocols;
     }
 
-    public boolean isValidateCertsOnReloadEnabled() {
-        return validateCertsOnReload;
+    public boolean shouldValidateNewCertDNs() {
+        return validateCertDNsOnReload;
     }
 
     @Override
@@ -126,7 +126,7 @@ public class SslParameters {
             }
         }
 
-        private boolean validateCertsOnReload(final Settings settings) {
+        private boolean validateCertDNsOnReload(final Settings settings) {
             return settings.getAsBoolean(ENFORCE_CERT_RELOAD_DN_VERIFICATION, true);
         }
 
@@ -200,7 +200,7 @@ public class SslParameters {
                 clientAuth,
                 protocols(provider, sslConfigSettings, http),
                 ciphers(provider, sslConfigSettings),
-                validateCertsOnReload(sslConfigSettings)
+                validateCertDNsOnReload(sslConfigSettings)
             );
             if (sslParameters.allowedProtocols().isEmpty()) {
                 throw new OpenSearchSecurityException("No ssl protocols for " + (http ? "HTTP" : "Transport") + " layer");

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -48,6 +48,8 @@ public final class SSLConfigConstants {
 
     public static final String CLIENT_AUTH_MODE = "clientauth_mode";
 
+    public static final String ENFORCE_CERT_RELOAD_DN_VERIFICATION = "enforce_cert_reload_dn_verification";
+
     public static final String KEYSTORE_TYPE = "keystore_type";
     public static final String KEYSTORE_ALIAS = "keystore_alias";
     public static final String KEYSTORE_FILEPATH = "keystore_filepath";
@@ -82,8 +84,8 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = "plugins.security.ssl.http.truststore_alias";
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH = "plugins.security.ssl.http.truststore_filepath";
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = "plugins.security.ssl.http.truststore_type";
-    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION =
-        "plugins.security.ssl.http.enforce_cert_reload_dn_verification";
+    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = "plugins.security.ssl.http."
+        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE =
         "plugins.security.ssl.transport.enable_openssl_if_available";
     public static final String SECURITY_SSL_TRANSPORT_ENABLED = "plugins.security.ssl.transport.enabled";
@@ -93,8 +95,8 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION_RESOLVE_HOST_NAME =
         "plugins.security.ssl.transport.resolve_hostname";
 
-    public static final String SECURITY_SSL_TRANSPORT_ENFORCE_CERT_RELOAD_DN_VERIFICATION =
-        "plugins.security.ssl.transport.enforce_cert_reload_dn_verification";
+    public static final String SECURITY_SSL_TRANSPORT_ENFORCE_CERT_RELOAD_DN_VERIFICATION = "plugins.security.ssl.transport."
+        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_TRANSPORT_KEYSTORE_ALIAS = "plugins.security.ssl.transport.keystore_alias";
     public static final String SECURITY_SSL_TRANSPORT_SERVER_KEYSTORE_ALIAS = "plugins.security.ssl.transport.server.keystore_alias";
     public static final String SECURITY_SSL_TRANSPORT_CLIENT_KEYSTORE_ALIAS = "plugins.security.ssl.transport.client.keystore_alias";

--- a/src/test/java/org/opensearch/security/ssl/SecuritySSLReloadCertsActionTests.java
+++ b/src/test/java/org/opensearch/security/ssl/SecuritySSLReloadCertsActionTests.java
@@ -243,8 +243,9 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         assertThat(
             DefaultObjectMapper.readTree(reloadCertsResponse.getBody()).get("error").get("root_cause").get(0).get("reason").asText(),
             is(
-                "OpenSearchSecurityException[Error while initializing http SSL layer from PEM: java.lang.Exception: "
-                    + "New Certs do not have valid Issuer DN, Subject DN or SAN.]; nested: Exception[New Certs do not have valid Issuer DN, Subject DN or SAN.];"
+                "java.security.cert.CertificateException: New certificates do not have valid Issuer DNs. "
+                    + "Current Issuer DNs: [CN=Example Com Inc. Signing CA,OU=Example Com Inc. Signing CA,O=Example Com Inc.,DC=example,DC=com] "
+                    + "new Issuer DNs: [CN=Example Com Inc. Secondary Signing CA,OU=Example Com Inc. Secondary Signing CA,O=Example Com Inc.,DC=example,DC=com]"
             )
         );
     }
@@ -266,8 +267,9 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         assertThat(
             DefaultObjectMapper.readTree(reloadCertsResponse.getBody()).get("error").get("root_cause").get(0).get("reason").asText(),
             is(
-                "OpenSearchSecurityException[Error while initializing http SSL layer from PEM: java.lang.Exception: "
-                    + "New Certs do not have valid Issuer DN, Subject DN or SAN.]; nested: Exception[New Certs do not have valid Issuer DN, Subject DN or SAN.];"
+                "java.security.cert.CertificateException: New certificates do not have valid Issuer DNs. "
+                    + "Current Issuer DNs: [CN=Example Com Inc. Signing CA,OU=Example Com Inc. Signing CA,O=Example Com Inc.,DC=example,DC=com] "
+                    + "new Issuer DNs: [CN=Example Com Inc. Secondary Signing CA,OU=Example Com Inc. Secondary Signing CA,O=Example Com Inc.,DC=example,DC=com]"
             )
         );
     }
@@ -314,8 +316,9 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         assertThat(
             DefaultObjectMapper.readTree(reloadCertsResponse.getBody()).get("error").get("root_cause").get(0).get("reason").asText(),
             is(
-                "OpenSearchSecurityException[Error while initializing transport SSL layer from PEM: java.lang.Exception: "
-                    + "New Certs do not have valid Issuer DN, Subject DN or SAN.]; nested: Exception[New Certs do not have valid Issuer DN, Subject DN or SAN.];"
+                "java.security.cert.CertificateException: New certificates do not have valid Issuer DNs. "
+                    + "Current Issuer DNs: [CN=Example Com Inc. Signing CA,OU=Example Com Inc. Signing CA,O=Example Com Inc.,DC=example,DC=com] "
+                    + "new Issuer DNs: [CN=Example Com Inc. Secondary Signing CA,OU=Example Com Inc. Secondary Signing CA,O=Example Com Inc.,DC=example,DC=com]"
             )
         );
     }
@@ -337,8 +340,9 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         assertThat(
             DefaultObjectMapper.readTree(reloadCertsResponse.getBody()).get("error").get("root_cause").get(0).get("reason").asText(),
             is(
-                "OpenSearchSecurityException[Error while initializing transport SSL layer from PEM: java.lang.Exception: "
-                    + "New Certs do not have valid Issuer DN, Subject DN or SAN.]; nested: Exception[New Certs do not have valid Issuer DN, Subject DN or SAN.];"
+                "java.security.cert.CertificateException: New certificates do not have valid Issuer DNs. "
+                    + "Current Issuer DNs: [CN=Example Com Inc. Signing CA,OU=Example Com Inc. Signing CA,O=Example Com Inc.,DC=example,DC=com] "
+                    + "new Issuer DNs: [CN=Example Com Inc. Secondary Signing CA,OU=Example Com Inc. Secondary Signing CA,O=Example Com Inc.,DC=example,DC=com]"
             )
         );
     }


### PR DESCRIPTION
### Description

Adapts https://github.com/opensearch-project/security/pull/4752 to the changes introduced in https://github.com/opensearch-project/security/pull/4671.

Opening this up in Draft initially while additional testing is performed.

I also opened a [revert PR](https://github.com/opensearch-project/security/pull/4840) as well to solicit feedback from maintainers on which direction we should take to fix the CI failures.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
