### PR TITLE
[Backport 2.x] Bump com.google.errorprone:error_prone_annotations from 2.34.0 to 2.35.1 (#4850)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -501,7 +501,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore:4.4.16"
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
-            force "com.google.errorprone:error_prone_annotations:2.33.0"
+            force "com.google.errorprone:error_prone_annotations:2.35.1"
             force "org.checkerframework:checker-qual:3.48.1"
             force "ch.qos.logback:logback-classic:1.5.11"
             force "commons-io:commons-io:2.17.0"
@@ -609,7 +609,7 @@ dependencies {
     runtimeOnly 'com.eclipsesource.minimal-json:minimal-json:0.9.5'
     runtimeOnly 'commons-codec:commons-codec:1.17.1'
     runtimeOnly 'org.cryptacular:cryptacular:1.2.7'
-    compileOnly 'com.google.errorprone:error_prone_annotations:2.31.0'
+    compileOnly 'com.google.errorprone:error_prone_annotations:2.35.1'
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     runtimeOnly 'org.ow2.asm:asm:9.7.1'


### PR DESCRIPTION
Manual backport of https://github.com/opensearch-project/security/pull/4850 to 2.x