### PR TITLE
Improves Rest Layer Authz robustness

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
@@ -26,11 +26,13 @@ import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.audit.AuditLogsRule;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.RestClientException;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.testplugins.dummy.CustomLegacyTestPlugin;
 import org.opensearch.test.framework.testplugins.dummyprotected.CustomRestProtectedTestPlugin;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -40,6 +42,7 @@ import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVIL
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateRESTLayer;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateTransportLayer;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
@@ -108,6 +111,17 @@ public class AuthZinRestLayerTests {
             // fail at REST
             assertThat(client.get(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
             auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(MISSING_PRIVILEGES, NO_PERM, GET, "/" + PROTECTED_API));
+        }
+    }
+
+    @Test
+    public void testShouldFailWithoutPermForPathWithoutLeadingSlashes() {
+        try (TestRestClient client = cluster.getRestClient(NO_PERM)) {
+
+            // Protected Routes plugin
+            Exception exception = assertThrows(RestClientException.class, () -> { client.getWithoutLeadingSlash(PROTECTED_API); });
+
+            assertThat(exception.getMessage(), containsString("Error occured during HTTP request execution"));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
@@ -37,14 +37,13 @@ import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.audit.AuditLogsRule;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.RestClientException;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import joptsimple.internal.Strings;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.*;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
 import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVILEGES;
@@ -52,6 +51,7 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.grantedPrivilege;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateRESTLayer;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.userAuthenticatedPredicate;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
@@ -135,6 +135,18 @@ public class WhoAmITests {
             );
 
             assertResponse(client.get(WHOAMI_ENDPOINT), HttpStatus.SC_OK, expectedAuthorizedBody);
+        }
+    }
+
+    @Test
+    public void testWhoAmIWithoutGetPermissionsWithoutLeadingSlashInPath() {
+        try (TestRestClient client = cluster.getRestClient(WHO_AM_I_NO_PERM)) {
+            Exception exception = assertThrows(
+                RestClientException.class,
+                () -> { client.getWithoutLeadingSlash(WHOAMI_PROTECTED_ENDPOINT); }
+            );
+
+            assertThat(exception.getMessage(), containsString("Error occured during HTTP request execution"));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
@@ -43,7 +43,10 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 import joptsimple.internal.Strings;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
 import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVILEGES;

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -110,6 +110,10 @@ public class TestRestClient implements AutoCloseable {
         return executeRequest(new HttpGet(getHttpServerUri() + "/" + path), headers);
     }
 
+    public void getWithoutLeadingSlash(String path, Header... headers) {
+        executeRequest(new HttpGet(getHttpServerUri() + path), headers);
+    }
+
     public HttpResponse getAuthInfo(Header... headers) {
         return executeRequest(new HttpGet(getHttpServerUri() + "/_opendistro/_security/authinfo?pretty"), headers);
     }

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -336,6 +336,9 @@ public class SecurityRestFilter {
      * @return true if the request path matches the route
      */
     private boolean restPathMatches(String requestPath, String handlerPath) {
+        // Trim leading and trailing slashes
+        requestPath = requestPath.replaceAll("^/+", "").replaceAll("/+$", "");
+        handlerPath = handlerPath.replaceAll("^/+", "").replaceAll("/+$", "");
         // Check exact match
         if (handlerPath.equals(requestPath)) {
             return true;

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -335,7 +335,7 @@ public class SecurityRestFilter {
      * @param handlerPath The path from the {@link RestHandler.Route}
      * @return true if the request path matches the route
      */
-    private boolean restPathMatches(String requestPath, String handlerPath) {
+    boolean restPathMatches(String requestPath, String handlerPath) {
         // Trim leading and trailing slashes
         requestPath = requestPath.replaceAll("^/+", "").replaceAll("/+$", "");
         handlerPath = handlerPath.replaceAll("^/+", "").replaceAll("/+$", "");


### PR DESCRIPTION
### Description
This PR improves the robustness of the path check when evaluating whether the path supports rest layer authorization.

* Category : Enhancement

* What is the old behavior before changes and new behavior after changes?
The request will not be evaluated at REST layer if they were missing leading or trailing slashes since restPathMatches() function will filter them out. Post this fix the leading/trailing slashes will not determine whether the path matches, but the actual path will.

### Testing
- automated tests

### Check List
- [x] New functionality includes testing
~- [ ] New functionality has been documented~
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
