### PR TITLE
Fix issue with jwt attribute parsing of lists

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -200,7 +200,6 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                             ac.addAttribute(key, String.valueOf(value));
                         }
                     } else {
-                        // For non-list values, continue with the current approach
                         ac.addAttribute(key, String.valueOf(value));
                     }
                 }

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -189,7 +189,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                     String key = "attr.jwt." + claim.getKey();
                     Object value = claim.getValue();
 
-                    if (value instanceof List) {
+                    if (value instanceof Collection<?>) {
                         try {
                             // Convert the list to a JSON array string
                             String jsonValue = DefaultObjectMapper.writeValueAsString(value, false);

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -33,6 +33,7 @@ import org.opensearch.SpecialPermission;
 import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.HTTPAuthenticator;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityResponse;
@@ -185,7 +186,23 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                 final AuthCredentials ac = new AuthCredentials(subject, roles).markComplete();
 
                 for (Entry<String, Object> claim : claims.entrySet()) {
-                    ac.addAttribute("attr.jwt." + claim.getKey(), String.valueOf(claim.getValue()));
+                    String key = "attr.jwt." + claim.getKey();
+                    Object value = claim.getValue();
+
+                    if (value instanceof List) {
+                        try {
+                            // Convert the list to a JSON array string
+                            String jsonValue = DefaultObjectMapper.writeValueAsString(value, false);
+                            ac.addAttribute(key, jsonValue);
+                        } catch (Exception e) {
+                            log.warn("Failed to convert list claim to JSON for key: " + key, e);
+                            // Fallback to string representation
+                            ac.addAttribute(key, String.valueOf(value));
+                        }
+                    } else {
+                        // For non-list values, continue with the current approach
+                        ac.addAttribute(key, String.valueOf(value));
+                    }
                 }
 
                 return ac;

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -267,7 +267,7 @@ public class OnBehalfOfAuthenticatorTest {
         Map<String, String> expectedAttributes = new HashMap<>();
         expectedAttributes.put("attr.jwt.iss", "cluster_0");
         expectedAttributes.put("attr.jwt.sub", "Leonard McCoy");
-        expectedAttributes.put("attr.jwt.aud", "[ext_0]");
+        expectedAttributes.put("attr.jwt.aud", "[\"ext_0\"]");
 
         String jwsToken = Jwts.builder()
             .setIssuer(clusterName)


### PR DESCRIPTION
### Description

Fixes issue in the JWT authenticator when parsing a claim that contains a list value. The existing parsing logic works as-is, but the problem arises when you try to use the parsed value in a DLS clause using the `${attr.jwt.claim}` syntax.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves: https://github.com/opensearch-project/security/issues/4267

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
