### PR TITLE
Log io.netty.internal.tcnative.SSLContext availability warning only when OpenSSL is explicitly enabled but not available

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchException;
+import org.opensearch.common.Booleans;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.security.ssl.config.CertType;
@@ -374,10 +375,23 @@ public class SslSettingsManager {
 
             LOGGER.debug("OpenSSL available ciphers {}", OpenSsl.availableOpenSslCipherSuites());
         } else {
-            LOGGER.warn(
-                "OpenSSL not available (this is not an error, we simply fallback to built-in JDK SSL) because of {}",
-                OpenSsl.unavailabilityCause()
-            );
+            boolean openSslIsEnabled = false;
+
+            if (settings.hasValue(SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE) == true) {
+                openSslIsEnabled |= Booleans.parseBoolean(settings.get(SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE));
+            }
+
+            if (settings.hasValue(SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE) == true) {
+                openSslIsEnabled |= Booleans.parseBoolean(settings.get(SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE));
+            }
+
+            if (openSslIsEnabled == true) {
+                /* only print warning if OpenSsl is enabled explicitly but not available */
+                LOGGER.warn(
+                    "OpenSSL not available (this is not an error, we simply fallback to built-in JDK SSL) because of ",
+                    OpenSsl.unavailabilityCause()
+                );
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Log `io.netty.internal.tcnative.SSLContext` availability warning only when OpenSSL is explicitly enabled but not available

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/4881

### Testing
The log is clean now , will be printed out if `SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE` or `SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE` is enabled.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
