### PR TITLE
Reduce log level in HttpJwtAuthenticator if request cannot be authenticated

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -215,7 +215,9 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                 }
             }
         }
-        log.error("Failed to parse JWT token using any of the available parsers");
+        if (log.isDebugEnabled()) {
+            log.debug("Unable to authenticate JWT Token with any configured signing key");
+        }
         return null;
     }
 

--- a/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -215,9 +215,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                 }
             }
         }
-        if (log.isDebugEnabled()) {
-            log.debug("Unable to authenticate JWT Token with any configured signing key");
-        }
+        log.debug("Unable to authenticate JWT Token with any configured signing key");
         return null;
     }
 


### PR DESCRIPTION
### Description

Reduces a log message in HttpJwtAuthenticator to debug level if the request cannot be authenticated with any of the configured signing keys.

If authentication fails across all configured authentication domains, there is a catch all warning message in BackendRegistry [here](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/auth/BackendRegistry.java#L432-L436). This message in HttpJwtAuthenticator is redundant and can be reduced in severity since it is not an error in the application and expected behavior if a request is sent with a bad JWT. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Resolves: https://github.com/opensearch-project/security/issues/4910

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
