### PR TITLE
Explicitly create index before ingesting document in ComplianceAuditlogTest.testWriteLogDiffsEnabledAndLogRequestBodyDisabled

### DIFF
--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -476,14 +476,14 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         updateAuditConfig(AuditTestUtils.createAuditPayload(auditConfig));
 
         try (Client tc = getClient()) {
-            rh.executePutRequest("emp", "{}");
+            rh.executePutRequest("emp", "{\"settings\": {\"index\": {\"number_of_shards\": 1, \"number_of_replicas\": 0}}}");
         }
 
         List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             try (Client tc = getClient()) {
                 rh.executePutRequest("emp/_doc/0?refresh", "{\"name\" : \"Criag\", \"title\" : \"Software Engineer\"}");
             }
-        }, 5);
+        }, 3);
 
         AuditMessage complianceDocWriteMessage = messages.stream()
             .filter(m -> m.getCategory().equals(AuditCategory.COMPLIANCE_DOC_WRITE))

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -475,11 +475,15 @@ public class ComplianceAuditlogTest extends AbstractAuditlogiUnitTest {
         );
         updateAuditConfig(AuditTestUtils.createAuditPayload(auditConfig));
 
+        try (Client tc = getClient()) {
+            rh.executePutRequest("emp", "{}");
+        }
+
         List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
             try (Client tc = getClient()) {
                 rh.executePutRequest("emp/_doc/0?refresh", "{\"name\" : \"Criag\", \"title\" : \"Software Engineer\"}");
             }
-        }, 7);
+        }, 5);
 
         AuditMessage complianceDocWriteMessage = messages.stream()
             .filter(m -> m.getCategory().equals(AuditCategory.COMPLIANCE_DOC_WRITE))


### PR DESCRIPTION
### Description

Small follow-up to https://github.com/opensearch-project/security/pull/4832

This PR fixes a test inconsistency when running on the CI runner vs running the test locally. When running the test locally, I get an additional 2 audit messages in the audit log corresponding to the index being auto created on first document indexed

```
{"audit_cluster_name":"utest_n8_fnull_t353371380541833","audit_node_name":"node_utest_n8_fnull_t353371380541833_num1","audit_trace_task_id":"YhQ8bQAAQACC5F0XAAAAAA:104","audit_transport_request_type":"CreateIndexRequest","audit_category":"INDEX_EVENT","audit_request_origin":"REST","audit_node_id":"YhQ8bQAAQACC5F0XAAAAAA","audit_request_layer":"TRANSPORT","@timestamp":"2024-11-19T20:30:34.523+00:00","audit_format_version":4,"audit_request_privilege":"indices:admin/auto_create","audit_node_host_address":"127.0.0.1","audit_request_effective_user":"CN=kirk,OU=client,O=client,L=Test,C=DE","audit_trace_indices":["emp"],"audit_node_host_name":"127.0.0.1"}
    {"audit_trace_task_parent_id":"YhQ8bQAAQACC5F0XAAAAAA:104","audit_cluster_name":"utest_n8_fnull_t353371380541833","audit_transport_headers":{"_opendistro_security_initial_action_class_header":"CreateIndexRequest","_opendistro_security_origin_header":"REST","_opendistro_security_user_header":"rO0ABXNyACFvcmcub3BlbnNlYXJjaC5zZWN1cml0eS51c2VyLlVzZXKzqL2T65dH3AIABloACmlzSW5qZWN0ZWRMAAphdHRyaWJ1dGVzdAAPTGphdmEvdXRpbC9NYXA7TAAEbmFtZXQAEkxqYXZhL2xhbmcvU3RyaW5nO0wAD3JlcXVlc3RlZFRlbmFudHEAfgACTAAFcm9sZXN0AA9MamF2YS91dGlsL1NldDtMAA1zZWN1cml0eVJvbGVzcQB+AAN4cABzcgAlamF2YS51dGlsLkNvbGxlY3Rpb25zJFN5bmNocm9uaXplZE1hcBtz+QlLSzl7AwACTAABbXEAfgABTAAFbXV0ZXh0ABJMamF2YS9sYW5nL09iamVjdDt4cHNyABFqYXZhLnV0aWwuSGFzaE1hcAUH2sHDFmDRAwACRgAKbG9hZEZhY3RvckkACXRocmVzaG9sZHhwP0AAAAAAAAB3CAAAABAAAAAAeHEAfgAHeHQAJkNOPWtpcmssT1U9Y2xpZW50LE89Y2xpZW50LEw9VGVzdCxDPURFcHNyACVqYXZhLnV0aWwuQ29sbGVjdGlvbnMkU3luY2hyb25pemVkU2V0BsPCeQLu3zwCAAB4cgAsamF2YS51dGlsLkNvbGxlY3Rpb25zJFN5bmNocm9uaXplZENvbGxlY3Rpb24qYfhNCZyZtQMAAkwAAWN0ABZMamF2YS91dGlsL0NvbGxlY3Rpb247TAAFbXV0ZXhxAH4ABnhwc3IAEWphdmEudXRpbC5IYXNoU2V0ukSFlZa4tzQDAAB4cHcMAAAAED9AAAAAAAAAeHEAfgAOeHNxAH4AC3NxAH4AD3cMAAAAED9AAAAAAAAAeHEAfgAReA==","_opendistro_security_remotecn":"utest_n8_fnull_t353371380541833"},"audit_node_name":"node_utest_n8_fnull_t353371380541833_num3","audit_trace_task_id":"zTrSHwAAQACaP5bd_____w:92","audit_transport_request_type":"CreateIndexRequest","audit_category":"INDEX_EVENT","audit_request_origin":"REST","audit_node_id":"zTrSHwAAQACaP5bd_____w","audit_request_layer":"TRANSPORT","@timestamp":"2024-11-19T20:30:34.523+00:00","audit_format_version":4,"audit_request_remote_address":"127.0.0.1","audit_request_privilege":"indices:admin/auto_create","audit_node_host_address":"127.0.0.1","audit_request_effective_user":"CN=kirk,OU=client,O=client,L=Test,C=DE","audit_trace_indices":["emp"],"audit_node_host_name":"127.0.0.1"}
```

This PR explicitly creates the index before checking for audit logs to make the test more robust. I applied the same change on the backport: https://github.com/opensearch-project/security/pull/4918

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
