### PR TITLE
[2.x] Optimize privilege evaluation for index permissions across '*' index pattern (i.e. all_access role)

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -79,6 +79,7 @@ public class ConfigModelV7 extends ConfigModel {
     private RoleMappingHolder roleMappingHolder;
     private SecurityDynamicConfiguration<RoleV7> roles;
     private SecurityDynamicConfiguration<TenantV7> tenants;
+    private final static Set<String> ALL_INDICES = Set.of("*");
 
     public ConfigModelV7(
         SecurityDynamicConfiguration<RoleV7> roles,
@@ -1000,12 +1001,12 @@ public class ConfigModelV7 extends ConfigModel {
         if (resolved.isLocalAll()) {
             indexMatcherAndPermissions = ipatterns.stream()
                 .filter(indexPattern -> "*".equals(indexPattern.getUnresolvedIndexPattern(user)))
-                .map(p -> new IndexMatcherAndPermissions(Set.of("*"), p.perms))
+                .map(p -> new IndexMatcherAndPermissions(ALL_INDICES, p.perms))
                 .toArray(IndexMatcherAndPermissions[]::new);
         } else {
             indexMatcherAndPermissions = ipatterns.stream().map(p -> {
                 if ("*".equals(p.getUnresolvedIndexPattern(user))) {
-                    return new IndexMatcherAndPermissions(Set.of("*"), p.perms);
+                    return new IndexMatcherAndPermissions(ALL_INDICES, p.perms);
                 }
                 return new IndexMatcherAndPermissions(p.attemptResolveIndexNames(user, resolver, cs), p.perms);
             }).toArray(IndexMatcherAndPermissions[]::new);

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -1000,12 +1000,15 @@ public class ConfigModelV7 extends ConfigModel {
         if (resolved.isLocalAll()) {
             indexMatcherAndPermissions = ipatterns.stream()
                 .filter(indexPattern -> "*".equals(indexPattern.getUnresolvedIndexPattern(user)))
-                .map(p -> new IndexMatcherAndPermissions(p.attemptResolveIndexNames(user, resolver, cs), p.perms))
+                .map(p -> new IndexMatcherAndPermissions(Set.of("*"), p.perms))
                 .toArray(IndexMatcherAndPermissions[]::new);
         } else {
-            indexMatcherAndPermissions = ipatterns.stream()
-                .map(p -> new IndexMatcherAndPermissions(p.attemptResolveIndexNames(user, resolver, cs), p.perms))
-                .toArray(IndexMatcherAndPermissions[]::new);
+            indexMatcherAndPermissions = ipatterns.stream().map(p -> {
+                if ("*".equals(p.getUnresolvedIndexPattern(user))) {
+                    return new IndexMatcherAndPermissions(Set.of("*"), p.perms);
+                }
+                return new IndexMatcherAndPermissions(p.attemptResolveIndexNames(user, resolver, cs), p.perms);
+            }).toArray(IndexMatcherAndPermissions[]::new);
         }
         return resolvedRequestedIndices.stream()
             .allMatch(

--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -721,7 +721,7 @@ public class ConfigModelV7 extends ConfigModel {
             IndexNameExpressionResolver resolver,
             ClusterService cs
         ) {
-            if ("*".equals(getUnresolvedIndexPattern(user))) {
+            if ("*".equals(indexPattern)) {
                 return new IndexMatcherAndPermissions(ALL_INDICES, perms);
             }
             return new IndexMatcherAndPermissions(attemptResolveIndexNames(user, resolver, cs), perms);
@@ -1011,7 +1011,7 @@ public class ConfigModelV7 extends ConfigModel {
         IndexMatcherAndPermissions[] indexMatcherAndPermissions;
         if (resolved.isLocalAll()) {
             indexMatcherAndPermissions = ipatterns.stream()
-                .filter(indexPattern -> "*".equals(indexPattern.getUnresolvedIndexPattern(user)))
+                .filter(indexPattern -> "*".equals(indexPattern.indexPattern))
                 .map(p -> p.getIndexMatcherAndPermissions(user, resolver, cs))
                 .toArray(IndexMatcherAndPermissions[]::new);
         } else {


### PR DESCRIPTION
### Description

Creating this backport to explore a small optimization for the all_access role when evaluating index permissions in clusters with a large number of indices.

This PR is not a strategic fix like https://github.com/opensearch-project/security/pull/4898. https://github.com/opensearch-project/security/pull/4898 takes a holistic approach to optimize privilege evaluation for any type of role definition.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Performance improvement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
