### PR TITLE
Only run DlsFlsValveImpl.invoke on indices requests

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -83,8 +83,6 @@ import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 
-import static org.opensearch.security.privileges.PrivilegesEvaluator.isIndexPerm;
-
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
@@ -137,7 +135,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
-        if (!isIndexPerm(context.getAction())) {
+        if (!context.getAction().startsWith("indices:")) {
             return true;
         }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -683,7 +683,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
     public void updateConfiguration(SecurityDynamicConfiguration<RoleV7> rolesConfiguration) {
         try {
             if (rolesConfiguration != null) {
-                DlsFlsProcessedConfig oldConfig = this.dlsFlsProcessedConfig.getAndSet(
+                this.dlsFlsProcessedConfig.set(
                     new DlsFlsProcessedConfig(
                         DynamicConfigFactory.addStatics(rolesConfiguration.clone()),
                         clusterService.state().metadata().getIndicesLookup(),
@@ -692,10 +692,6 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         fieldMaskingConfig
                     )
                 );
-
-                if (oldConfig != null) {
-                    oldConfig.shutdown();
-                }
             }
         } catch (Exception e) {
             log.error("Error while updating DLS/FLS configuration with {}", rolesConfiguration, e);

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -680,7 +680,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
     public void updateConfiguration(SecurityDynamicConfiguration<RoleV7> rolesConfiguration) {
         try {
             if (rolesConfiguration != null) {
-                this.dlsFlsProcessedConfig.set(
+                DlsFlsProcessedConfig oldConfig = this.dlsFlsProcessedConfig.getAndSet(
                     new DlsFlsProcessedConfig(
                         DynamicConfigFactory.addStatics(rolesConfiguration.clone()),
                         clusterService.state().metadata().getIndicesLookup(),
@@ -689,6 +689,10 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         fieldMaskingConfig
                     )
                 );
+
+                if (oldConfig != null) {
+                    oldConfig.shutdown();
+                }
             }
         } catch (Exception e) {
             log.error("Error while updating DLS/FLS configuration with {}", rolesConfiguration, e);

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -38,6 +38,7 @@ import org.opensearch.action.admin.indices.shrink.ResizeRequest;
 import org.opensearch.action.bulk.BulkItemRequest;
 import org.opensearch.action.bulk.BulkShardRequest;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.update.UpdateAction;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -135,10 +136,6 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
-        if (!context.getAction().startsWith("indices:")) {
-            return true;
-        }
-
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();
         ActionRequest request = context.getRequest();
         IndexResolverReplacer.Resolved resolved = context.getResolvedRequest();
@@ -268,7 +265,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 }
             }
 
-            if (request instanceof UpdateRequest) {
+            if (UpdateAction.NAME.equals(context.getAction())) {
                 listener.onFailure(new OpenSearchSecurityException("Update is not supported when FLS or DLS or Fieldmasking is activated"));
                 return false;
             }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -83,6 +83,8 @@ import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.opensearch.security.privileges.PrivilegesEvaluator.isIndexPerm;
+
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
@@ -135,6 +137,10 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
+        if (!isIndexPerm(context.getAction())) {
+            return true;
+        }
+
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();
         ActionRequest request = context.getRequest();
         IndexResolverReplacer.Resolved resolved = context.getResolvedRequest();

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -709,6 +709,10 @@ public class PrivilegesEvaluator {
             || (action0.equals(RenderSearchTemplateAction.NAME)));
     }
 
+    public static boolean isIndexPerm(String action0) {
+        return (action0.startsWith("indices:") && !isClusterPerm(action0));
+    }
+
     @SuppressWarnings("unchecked")
     private boolean checkFilteredAliases(Resolved requestedResolved, String action, boolean isDebugEnabled) {
         final String faMode = dcm.getFilteredAliasMode();// getConfigSettings().dynamic.filtered_alias_mode;

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -709,10 +709,6 @@ public class PrivilegesEvaluator {
             || (action0.equals(RenderSearchTemplateAction.NAME)));
     }
 
-    public static boolean isIndexPerm(String action0) {
-        return (action0.startsWith("indices:") && !isClusterPerm(action0));
-    }
-
     @SuppressWarnings("unchecked")
     private boolean checkFilteredAliases(Resolved requestedResolved, String action, boolean isDebugEnabled) {
         final String faMode = dcm.getFilteredAliasMode();// getConfigSettings().dynamic.filtered_alias_mode;

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsProcessedConfig.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsProcessedConfig.java
@@ -71,6 +71,7 @@ public class DlsFlsProcessedConfig extends ClusterStateMetadataDependentPrivileg
         long duration = System.currentTimeMillis() - start;
 
         log.debug("Updating DlsFlsProcessedConfig took {} ms", duration);
+        this.metadataVersionEffective = metadata.version();
     }
 
     @Override


### PR DESCRIPTION
### Description

Companion PR in ISM: https://github.com/opensearch-project/index-management/pull/1311

Fixes an issue seen in ISM's tests after the merge of https://github.com/opensearch-project/security/pull/4380.

Failing test example: https://github.com/opensearch-project/index-management/actions/runs/12013427116/job/33486922892?pr=1310

Failing test error message:

```
[2024-11-25T12:58:24,055][DEBUG][o.o.i.t.a.g.TransportGetTransformAction] [smoketestnode] User and roles string from thread context: john|helpdesk_staff|own_index,helpdesk_role
[2024-11-25T12:58:24,357][DEBUG][o.o.i.t.a.g.TransportGetTransformAction] [smoketestnode] User and roles string from thread context: testUser|test_role_backend|own_index,test_role
[2024-11-25T12:58:24,365][INFO ][o.o.s.p.PrivilegesEvaluator] [smoketestnode] No cluster-level perm match for User [name=testUser, backend_roles=[test_role_backend], requestedTenant=null] Resolved [aliases=[*], allIndices=[*], types=[*], originalRequested=[*], remoteIndices=[]] [Action [cluster:admin/opendistro/transform/stop]] [RolesChecked [own_index, test_role]]. No permissions for [cluster:admin/opendistro/transform/stop]
[2024-11-25T12:58:24,369][WARN ][r.suppressed             ] [smoketestnode] path: /_plugins/_transform/id_1/_stop, params: {transformID=id_1}
org.opensearch.OpenSearchSecurityException: Update is not supported when FLS or DLS or Fieldmasking is activated
	at org.opensearch.security.configuration.DlsFlsValveImpl.invoke(DlsFlsValveImpl.java:268) [opensearch-security-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at org.opensearch.security.filter.SecurityFilter.apply0(SecurityFilter.java:392) [opensearch-security-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at org.opensearch.security.filter.SecurityFilter.apply(SecurityFilter.java:166) [opensearch-security-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at org.opensearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:218) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:190) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.action.support.TransportAction.execute(TransportAction.java:109) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.client.node.NodeClient.executeLocally(NodeClient.java:112) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.client.node.NodeClient.doExecute(NodeClient.java:99) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.client.support.AbstractClient.execute(AbstractClient.java:486) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.indexmanagement.transform.resthandler.RestStopTransformAction.prepareRequest$lambda$0(RestStopTransformAction.kt:41) [opensearch-index-management-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at org.opensearch.rest.BaseRestHandler.handleRequest(BaseRestHandler.java:128) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.security.filter.SecurityRestFilter$AuthczRestHandler.handleRequest(SecurityRestFilter.java:192) [opensearch-security-3.0.0.0-SNAPSHOT.jar:3.0.0.0-SNAPSHOT]
	at org.opensearch.rest.RestController.dispatchRequest(RestController.java:381) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.rest.RestController.tryAllHandlers(RestController.java:467) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT]
	at org.opensearch.rest.RestController.dispatchRequest(RestController.java:287) [opensearch-3.0.0-SNAPSHOT.jar:3.0.0-SNAPSHOT
```

ISM has actions like the [StopTransformRequest](https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/transform/action/stop/StopTransformRequest.kt#L15) that subclass UpdateRequest since behind the scenes, an entry in the ISM system index is updated and to run the request requires passing the ID of the transform with the request. This request is a [cluster request](https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/transform/action/stop/StopTransformAction.kt#L14) meaning that is granted based on the action name alone without having to associate it with indices (behind the scenes the plugin updates its system index entry). 

[DlsFlsValveImpl.invoke](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java#L137) is being called on this request and it is failing because the resolved request is resolving to all indices and the user calling that Stop Transform API has partial index (airlines-*) access.

This PR updates the logic in DlsFlsValveImpl.invoke to not run if the action is not prefixed with `indices:`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves: https://github.com/opensearch-project/index-management/issues/1305

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
