### PR TITLE
Bump org.springframework.kafka:spring-kafka-test from 2.9.13 to 3.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
         common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
 
-        kafka_version  = '3.9.0'
+        kafka_version  = '3.7.1'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
         common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
 
-        kafka_version  = '3.7.1'
+        kafka_version  = '3.9.0'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'
@@ -686,7 +686,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     testImplementation 'commons-validator:commons-validator:1.9.0'
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:3.3.0'
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.3'


### PR DESCRIPTION
### Description

Bump org.springframework.kafka:spring-kafka-test from 2.9.13 to 3.3.0.

Unable to update kafka_version to > 3.7.1

~~This is possible now that spring-kafka-test has release 3.3.0: https://github.com/opensearch-project/security/pull/4871#issuecomment-2454926383~~

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
