### PR TITLE
[CVE-2024-38808] [1.3] Bump spring-framework dependency to 2.9.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ ext {
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'
-    kafka_version  = '3.7.0'
+    kafka_version  = '3.7.1'
 
     if (buildVersionQualifier) {
         opensearch_build += "-${buildVersionQualifier}"
@@ -88,7 +88,7 @@ configurations.all {
         force "org.scala-lang:scala-library:2.13.9"
         force "org.apache.bcel:bcel:6.6.0" // This line should be removed once Spotbugs is upgraded to 4.7.4
         force "org.xerial.snappy:snappy-java:1.1.10.5"
-        force "org.apache.zookeeper:zookeeper:3.9.2"
+        force "org.apache.zookeeper:zookeeper:3.9.3"
         force "ch.qos.logback:logback-core:1.2.13"
         force "ch.qos.logback:logback-classic:1.2.13"
         force "org.bitbucket.b_c:jose4j:0.9.4"

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,7 @@ configurations.all {
         force "org.apache.commons:commons-lang3:3.4"
         force "org.springframework:spring-core:5.3.39"
         force "org.springframework:spring-expression:5.3.39"
+        force "org.springframework:spring-context:5.3.39"
         force "com.google.guava:guava:32.1.1-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"

--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ configurations.all {
         force 'commons-cli:commons-cli:1.3.1'
         force 'org.apache.httpcomponents:httpcore:4.4.12'
         force "org.apache.commons:commons-lang3:3.4"
-        force "org.springframework:spring-core:5.3.28"
-        force "org.springframework:spring-expression:5.3.28"
+        force "org.springframework:spring-core:5.3.39"
+        force "org.springframework:spring-expression:5.3.39"
         force "com.google.guava:guava:32.1.1-jre"
         force "com.fasterxml.woodstox:woodstox-core:6.4.0"
         force "org.scala-lang:scala-library:2.13.9"
@@ -205,7 +205,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.13'
     testImplementation 'org.mockito:mockito-core:2.23.0'
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.10'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
     testImplementation 'javax.servlet:servlet-api:2.5'
     testImplementation 'com.unboundid:unboundid-ldapsdk:4.0.9'
     testImplementation 'com.github.stephenc.jcip:jcip-annotations:1.0-1'


### PR DESCRIPTION

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
