### PR TITLE
Change log level for log line in OBO Authenticator if OBO is disabled

### DIFF
--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -166,7 +166,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
 
     private AuthCredentials extractCredentials0(final SecurityRequest request) {
         if (!oboEnabled) {
-            log.error("On-behalf-of authentication is disabled");
+            log.debug("On-behalf-of authentication is disabled");
             return null;
         }
 


### PR DESCRIPTION
### Description

Found another log message where the level is set to error, but should be set to a lower level. Setting this log line to debug as this is not indicative of an error in the application.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
