### PR TITLE
Refactor SafeSerializationUtils for better performance

### DIFF
--- a/src/main/java/org/opensearch/security/support/SafeSerializationUtils.java
+++ b/src/main/java/org/opensearch/security/support/SafeSerializationUtils.java
@@ -17,12 +17,11 @@ import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import org.opensearch.security.auth.UserInjector;
@@ -57,7 +56,7 @@ public final class SafeSerializationUtils {
         LdapAttribute.class
     );
 
-    private static final List<Class<?>> SAFE_ASSIGNABLE_FROM_CLASSES = ImmutableList.of(
+    private static final Set<Class<?>> SAFE_ASSIGNABLE_FROM_CLASSES = ImmutableSet.of(
         InetAddress.class,
         Number.class,
         Collection.class,
@@ -66,12 +65,23 @@ public final class SafeSerializationUtils {
     );
 
     private static final Set<String> SAFE_CLASS_NAMES = Collections.singleton("org.ldaptive.LdapAttribute$LdapAttributeValues");
+    private static final Map<Class<?>, Boolean> safeClassCache = new ConcurrentHashMap<>();
 
     static boolean isSafeClass(Class<?> cls) {
-        return cls.isArray()
-            || SAFE_CLASSES.contains(cls)
-            || SAFE_CLASS_NAMES.contains(cls.getName())
-            || SAFE_ASSIGNABLE_FROM_CLASSES.stream().anyMatch(c -> c.isAssignableFrom(cls));
+        return safeClassCache.computeIfAbsent(cls, SafeSerializationUtils::computeIsSafeClass);
+    }
+
+    private static boolean computeIsSafeClass(Class<?> cls) {
+        return cls.isArray() || SAFE_CLASSES.contains(cls) || SAFE_CLASS_NAMES.contains(cls.getName()) || isAssignableFromSafeClass(cls);
+    }
+
+    private static boolean isAssignableFromSafeClass(Class<?> cls) {
+        for (Class<?> safeClass : SAFE_ASSIGNABLE_FROM_CLASSES) {
+            if (safeClass.isAssignableFrom(cls)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     static void prohibitUnsafeClasses(Class<?> clazz) throws IOException {
@@ -79,5 +89,4 @@ public final class SafeSerializationUtils {
             throw new IOException("Unauthorized serialization attempt " + clazz.getName());
         }
     }
-
 }

--- a/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
+++ b/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
@@ -1,0 +1,88 @@
+package org.opensearch.security.support;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.*;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import org.opensearch.security.auth.UserInjector;
+import org.opensearch.security.user.User;
+
+import com.amazon.dlic.auth.ldap.LdapUser;
+import org.ldaptive.AbstractLdapBean;
+import org.ldaptive.LdapAttribute;
+import org.ldaptive.LdapEntry;
+import org.ldaptive.SearchEntry;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SafeSerializationUtilsTest {
+
+    @Test
+    public void testSafeClasses() {
+        assertTrue(SafeSerializationUtils.isSafeClass(String.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(InetSocketAddress.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(Pattern.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(User.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(UserInjector.InjectedUser.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(SourceFieldsContext.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(LdapUser.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(SearchEntry.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(LdapEntry.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(AbstractLdapBean.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(LdapAttribute.class));
+    }
+
+    @Test
+    public void testSafeAssignableClasses() {
+        assertTrue(SafeSerializationUtils.isSafeClass(InetAddress.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(Integer.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(ArrayList.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(HashMap.class));
+        assertTrue(SafeSerializationUtils.isSafeClass(Enum.class));
+    }
+
+    @Test
+    public void testArraysAreSafe() {
+        assertTrue(SafeSerializationUtils.isSafeClass(String[].class));
+        assertTrue(SafeSerializationUtils.isSafeClass(int[].class));
+        assertTrue(SafeSerializationUtils.isSafeClass(Object[].class));
+    }
+
+    @Test
+    public void testUnsafeClasses() {
+        assertFalse(SafeSerializationUtils.isSafeClass(SafeSerializationUtilsTest.class));
+        assertFalse(SafeSerializationUtils.isSafeClass(Runtime.class));
+    }
+
+    @Test
+    public void testProhibitUnsafeClasses() {
+        try {
+            SafeSerializationUtils.prohibitUnsafeClasses(String.class);
+        } catch (IOException e) {
+            fail("Should not throw exception for safe class");
+        }
+
+        try {
+            SafeSerializationUtils.prohibitUnsafeClasses(SafeSerializationUtilsTest.class);
+            fail("Should throw exception for unsafe class");
+        } catch (IOException e) {
+            assertEquals("Unauthorized serialization attempt " + SafeSerializationUtilsTest.class.getName(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInheritance() {
+        class CustomArrayList extends ArrayList<String> {}
+        assertTrue(SafeSerializationUtils.isSafeClass(CustomArrayList.class));
+
+        class CustomMap extends HashMap<String, Integer> {}
+        assertTrue(SafeSerializationUtils.isSafeClass(CustomMap.class));
+    }
+}


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) - Enhancement
* Why these changes are required? Resolves https://github.com/opensearch-project/security/issues/4760
* What is the old behavior before changes and new behavior after changes?
Adds a cache to avoid repeated checks for same class. Removes usage of stream() in favor of a for loop

### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/security/issues/4760

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]
UTs

### Check List
- [X] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
