### PR TITLE
[Backport 2.x] Bump org.springframework.kafka:spring-kafka-test from 3.3.0 to 3.3.1 (#4993)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -687,7 +687,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     testImplementation 'commons-validator:commons-validator:1.9.0'
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
+    testImplementation 'org.springframework.kafka:spring-kafka-test:3.3.1'
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'


### PR DESCRIPTION
Backport 289d18fe0a54ca933a3659dcea6684d6a8a454ee from #4993 