### PR TITLE
Fix SSL config for JDK PKCS setup

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
@@ -62,6 +62,7 @@ public class SslCertificatesLoader {
         final var settings = environment.settings();
         final var sslConfigSettings = settings.getByPrefix(fullSslConfigSuffix);
         if (settings.hasValue(sslConfigSuffix + KEYSTORE_FILEPATH)) {
+            final var keyStorePassword = resolvePassword(sslConfigSuffix + KEYSTORE_PASSWORD, settings, DEFAULT_STORE_PASSWORD);
             return Tuple.tuple(
                 environment.settings().hasValue(sslConfigSuffix + TRUSTSTORE_FILEPATH)
                     ? buildJdkTrustStoreConfiguration(
@@ -73,8 +74,12 @@ public class SslCertificatesLoader {
                 buildJdkKeyStoreConfiguration(
                     sslConfigSettings,
                     environment,
-                    resolvePassword(sslConfigSuffix + KEYSTORE_PASSWORD, settings, DEFAULT_STORE_PASSWORD),
-                    resolvePassword(fullSslConfigSuffix + KEYSTORE_KEY_PASSWORD, settings, DEFAULT_STORE_PASSWORD)
+                    keyStorePassword,
+                    resolvePassword(
+                        fullSslConfigSuffix + KEYSTORE_KEY_PASSWORD,
+                        settings,
+                        keyStorePassword != null ? String.valueOf(keyStorePassword) : null
+                    )
                 )
             );
         } else {


### PR DESCRIPTION
### Description

Set the  `keystore_password` by default same as the `keystore_keypassword` setting

### Issues Resolved
#4961

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
