### PR TITLE
Set default value for key/trust store type as constant for JDK PKCS setup

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
@@ -14,7 +14,6 @@ package org.opensearch.security.ssl.config;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
-import java.security.KeyStore;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,6 +26,7 @@ import org.opensearch.env.Environment;
 
 import static org.opensearch.security.ssl.SecureSSLSettings.SECURE_SUFFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_PASSWORD;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_TYPE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_ALIAS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_KEY_PASSWORD;
@@ -123,7 +123,7 @@ public class SslCertificatesLoader {
     ) {
         return new KeyStoreConfiguration.JdkKeyStoreConfiguration(
             resolvePath(environment.settings().get(sslConfigSuffix + KEYSTORE_FILEPATH), environment),
-            environment.settings().get(sslConfigSuffix + KEYSTORE_TYPE, KeyStore.getDefaultType()),
+            environment.settings().get(sslConfigSuffix + KEYSTORE_TYPE, DEFAULT_STORE_TYPE),
             settings.get(KEYSTORE_ALIAS, null),
             keyStorePassword,
             keyPassword
@@ -137,7 +137,7 @@ public class SslCertificatesLoader {
     ) {
         return new TrustStoreConfiguration.JdkTrustStoreConfiguration(
             resolvePath(environment.settings().get(sslConfigSuffix + TRUSTSTORE_FILEPATH), environment),
-            environment.settings().get(sslConfigSuffix + TRUSTSTORE_TYPE, KeyStore.getDefaultType()),
+            environment.settings().get(sslConfigSuffix + TRUSTSTORE_TYPE, DEFAULT_STORE_TYPE),
             settings.get(TRUSTSTORE_ALIAS, null),
             trustStorePassword
         );

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -28,6 +28,8 @@ import io.netty.handler.ssl.OpenSsl;
 
 public final class SSLConfigConstants {
 
+    public static final String DEFAULT_STORE_TYPE = "JKS";
+
     public static final String SSL_PREFIX = "plugins.security.ssl.";
 
     public static final String HTTP_SETTINGS = "http";

--- a/src/test/java/org/opensearch/security/ssl/config/JdkSslCertificatesLoaderTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/JdkSslCertificatesLoaderTest.java
@@ -30,6 +30,7 @@ import static java.util.Objects.isNull;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_PASSWORD;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_TYPE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ENABLED;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_ALIAS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_FILEPATH;
@@ -54,7 +55,7 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.TRUSTSTORE_TYP
 
 public class JdkSslCertificatesLoaderTest extends SslCertificatesLoaderTest {
 
-    static final Function<String, String> resolveKeyStoreType = s -> isNull(s) ? KeyStore.getDefaultType() : s;
+    static final Function<String, String> resolveKeyStoreType = s -> isNull(s) ? DEFAULT_STORE_TYPE : s;
 
     static final String SERVER_TRUSTSTORE_ALIAS = "server-truststore-alias";
 


### PR DESCRIPTION
### Description

The `KeyStore.getDefaultType()` method returns `JKS` by default for all `JDK` versions prior to `JDK 23`,
which switches the default to `PKCS12`. Since the refactored version uses
`KeyStore.getDefaultType()`, it could break backward compatibility with older `JDK` versions.

[JDK 21 docs](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/KeyStore.html#getDefaultType()) vs [JDK23 docs](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/security/KeyStore.html#getDefaultType())


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
