### PR TITLE
Adds a quick fix to flaky test and corrects run-time error

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -12,6 +12,7 @@ package org.opensearch.security;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -462,8 +462,9 @@ public class DoNotFailOnForbiddenTests {
             Request getIndicesRequest = new Request("GET", "/_cat/indices");
             // High level client doesn't support _cat/_indices API
             Response getIndicesResponse = restHighLevelClient.getLowLevelClient().performRequest(getIndicesRequest);
-            List<String> indexes = new BufferedReader(new InputStreamReader(getIndicesResponse.getEntity().getContent())).lines()
-                .collect(Collectors.toList());
+            List<String> indexes = new BufferedReader(
+                new InputStreamReader(getIndicesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+            ).lines().collect(Collectors.toList());
 
             assertThat(indexes.size(), equalTo(1));
             assertThat(indexes.get(0), containsString("marvelous_songs"));
@@ -476,8 +477,9 @@ public class DoNotFailOnForbiddenTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
             Request getAliasesRequest = new Request("GET", "/_cat/aliases");
             Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
-            List<String> aliases = new BufferedReader(new InputStreamReader(getAliasesResponse.getEntity().getContent())).lines()
-                .collect(Collectors.toList());
+            List<String> aliases = new BufferedReader(
+                new InputStreamReader(getAliasesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+            ).lines().collect(Collectors.toList());
 
             // Does not fail on forbidden, but alias response only contains index which user has access to
             assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));
@@ -490,8 +492,9 @@ public class DoNotFailOnForbiddenTests {
         try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
             Request getAliasesRequest = new Request("GET", "/_cat/aliases");
             Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
-            List<String> aliases = new BufferedReader(new InputStreamReader(getAliasesResponse.getEntity().getContent())).lines()
-                .collect(Collectors.toList());
+            List<String> aliases = new BufferedReader(
+                new InputStreamReader(getAliasesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+            ).lines().collect(Collectors.toList());
 
             // Admin has access to all
             assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));

--- a/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
+++ b/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
+import org.junit.After;
 import org.junit.Test;
 
 import org.opensearch.security.auth.UserInjector;
@@ -34,6 +35,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class SafeSerializationUtilsTest {
+
+    @After
+    public void clearCache() {
+        SafeSerializationUtils.safeClassCache.clear();
+    }
 
     @Test
     public void testSafeClasses() {


### PR DESCRIPTION
### Description
Fixes a flaky test: SafeSerializationUtilsTests#testCaching and resolves a gradle build error caused by missing syntax.


### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
