### PR TITLE
Fix tests after Apache HttpClient5 / HttpCore5 update since those use deprecated APIs

### DIFF
--- a/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/com/amazon/dlic/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -28,6 +28,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -223,7 +224,7 @@ public class KeySetRetriever implements KeySetProvider {
 
         if (sslConfig != null) {
             final HttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
-                .setSSLSocketFactory(sslConfig.toSSLConnectionSocketFactory())
+                .setTlsSocketStrategy(new DefaultClientTlsStrategy(sslConfig.getSslContext()))
                 .build();
 
             builder.setConnectionManager(cm);

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -178,7 +178,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             Response whoAmIRes = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "/_plugins/_security/whoami"));
             assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
             // The HTTP/1.1 is forced and should be used instead
-            assertThat(HttpVersion.HTTP_1_1, is(whoAmIRes.getStatusLine().getProtocolVersion()));
+            assertThat(whoAmIRes.getStatusLine().getProtocolVersion(), is(HttpVersion.HTTP_1_1));
             JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper.readTree(whoAmIRes.getEntity().getContent());
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
             assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));

--- a/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/SinkProviderTLSTest.java
@@ -65,7 +65,7 @@ public class SinkProviderTLSTest {
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
             .setSslContext(createSSLContext())
-            .register("*", handler)
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();

--- a/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/WebhookAuditLogTest.java
@@ -240,7 +240,7 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .register("*", handler)
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();
@@ -355,7 +355,7 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .register("*", handler)
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();
@@ -393,8 +393,8 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .setSslContext(createSSLContext())
-            .register("*", handler)
+            .setServerSocketFactory(createSSLContext().getServerSocketFactory())
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();
@@ -481,8 +481,8 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .setSslContext(createSSLContext())
-            .register("*", handler)
+            .setServerSocketFactory(createSSLContext().getServerSocketFactory())
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();
@@ -610,8 +610,8 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .setSslContext(createSSLContext())
-            .register("*", handler)
+            .setServerSocketFactory(createSSLContext().getServerSocketFactory())
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();
@@ -717,8 +717,8 @@ public class WebhookAuditLogTest {
         server = ServerBootstrap.bootstrap()
             .setListenerPort(port)
             .setHttpProcessor(HttpProcessors.server("Test/1.1"))
-            .setSslContext(createSSLContext())
-            .register("*", handler)
+            .setServerSocketFactory(createSSLContext().getServerSocketFactory())
+            .setRequestRouter((request, context) -> handler)
             .create();
 
         server.start();

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -44,8 +44,8 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope.Scope;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.apache.hc.client5.http.config.TlsConfig;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
-import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.function.Factory;
@@ -197,14 +197,13 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
                     })
                     .build();
 
-                final AsyncClientConnectionManager cm = PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setTlsStrategy(tlsStrategy)
-                    .build();
-                builder.setConnectionManager(cm);
+                final PoolingAsyncClientConnectionManagerBuilder cm = PoolingAsyncClientConnectionManagerBuilder.create()
+                    .setTlsStrategy(tlsStrategy);
+
                 if (httpVersionPolicy != null) {
-                    builder.setVersionPolicy(httpVersionPolicy);
+                    cm.setDefaultTlsConfig(TlsConfig.custom().setVersionPolicy(httpVersionPolicy).build());
                 }
-                return builder;
+                return builder.setConnectionManager(cm.build());
             });
             return new RestHighLevelClient(restClientBuilder);
         } catch (Exception e) {

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -381,7 +381,9 @@ public class RestHelper {
             hcb.setConnectionManager(cm);
         }
 
-        final RequestConfig.Builder requestConfigBuilder = RequestConfig.custom().setResponseTimeout(Timeout.ofSeconds(60));
+        final RequestConfig.Builder requestConfigBuilder = RequestConfig.custom()
+            .setResponseTimeout(Timeout.ofSeconds(60))
+            .setProtocolUpgradeEnabled(false);
 
         return hcb.setDefaultRequestConfig(requestConfigBuilder.build()).disableAutomaticRetries().build();
     }


### PR DESCRIPTION
### Description
See please  https://github.com/opensearch-project/OpenSearch/pull/16757

### Issues Resolved
See please https://github.com/opensearch-project/security/actions/runs/12813953884/job/35729309491?pr=5034

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
