### PR TITLE
Replace upload-tartifact with native actions upload artifact

### DIFF
--- a/.github/actions/run-bwc-suite/action.yaml
+++ b/.github/actions/run-bwc-suite/action.yaml
@@ -50,7 +50,7 @@ runs:
           -Dbwc.version.previous=${{ steps.build-previous.outputs.built-version }}
           -Dbwc.version.next=${{ steps.build-next.outputs.built-version }} -i
 
-    - uses: alehechka/upload-tartifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ inputs.report-artifact-name }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     - run: OPENDISTRO_SECURITY_TEST_OPENSSL_OPT=true ./gradlew test
 
-    - uses: alehechka/upload-tartifact@v2
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{ matrix.jdk }}-${{ matrix.test-run }}-reports


### PR DESCRIPTION
### Description
Fixes #4801
Switches the upload of integration-tests artifacts from `upload-tartifact` to `actions/upload-artifact@v4`

* Category - Workflow fix
* Why these changes are required? - Test coverage data reported to codecov was incomplete
* What is the old behavior before changes and new behavior after changes? - None

### Issues Resolved
Fixes #4801 ([PR](#4802 ) addressed it but few instances were remaining)

### Testing


### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
