### PR TITLE
Generate jacoco report for integTestRemote task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -841,6 +841,9 @@ task integTestRemote(type: RestIntegTestTask) {
 }
 
 integTestRemote.enabled = System.getProperty("tests.rest.cluster") != null
+
+tasks.integTestRemote.finalizedBy(jacocoTestReport) // report is always generated after integration tests run
+
 // should be updated appropriately, when we add integTests in future
 integTest.enabled = false
 


### PR DESCRIPTION
### Description

Generates a jacoco report after the `integTestRemote` task is run. This is the task used for release time testing and should be finalized by generating a code cov report w/ jacoco

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Resolves https://github.com/opensearch-project/security/issues/4869

### Testing

Run the task similar to:

`./gradlew integTestRemote -Dtests.rest.cluster="localhost:9200" -Dtests.cluster="localhost:9200" -Dsecurity_enabled=true -Dtests.clustername=opensearch -Dhttps=true -Duser=admin -Dpassword=myStrongPassword123\!`

Verify that reports are generated in

```
build/reports/jacoco/test/
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
