### PR TITLE
Ensure that plugin can search on system index when utilizing pluginSubject.runAs

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexTests.java
@@ -239,6 +239,40 @@ public class SystemIndexTests {
     }
 
     @Test
+    public void testPluginShouldBeAbleUpdateOnItsSystemIndex() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            HttpResponse response = client.put("try-create-and-bulk-index/" + SYSTEM_INDEX_1);
+
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+            HttpResponse searchResponse = client.get("search-on-system-index/" + SYSTEM_INDEX_1);
+
+            assertThat(searchResponse.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+            assertThat(searchResponse.getIntFromJsonBody("/hits/total/value"), equalTo(2));
+
+            String docId = searchResponse.getTextFromJsonBody("/hits/hits/0/_id");
+
+            HttpResponse updateResponse = client.put("update-on-system-index/" + SYSTEM_INDEX_1 + "/" + docId);
+
+            updateResponse.assertStatusCode(RestStatus.OK.getStatus());
+        }
+
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            HttpResponse searchResponse = client.get(SYSTEM_INDEX_1 + "/_search");
+
+            searchResponse.assertStatusCode(RestStatus.OK.getStatus());
+
+            assertThat(searchResponse.getIntFromJsonBody("/hits/total/value"), equalTo(2));
+
+            String docId = searchResponse.getTextFromJsonBody("/hits/hits/0/_id");
+
+            HttpResponse getResponse = client.get(SYSTEM_INDEX_1 + "/_doc/" + docId);
+
+            assertThat("{\"content\":3}", equalTo(getResponse.bodyAsJsonNode().get("_source").toString()));
+        }
+    }
+
+    @Test
     public void testPluginShouldNotBeAbleToBulkIndexDocumentIntoMixOfSystemIndexWhereAtLeastOneDoesNotBelongToPlugin() {
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
             client.put(".system-index1");

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.systemindex.sampleplugin;
+
+import java.util.List;
+
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class RestUpdateOnSystemIndexAction extends BaseRestHandler {
+
+    private final RunAsSubjectClient pluginClient;
+
+    public RestUpdateOnSystemIndexAction(RunAsSubjectClient pluginClient) {
+        this.pluginClient = pluginClient;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, "/update-on-system-index/{index}/{docId}"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_update_on_system_index_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String indexName = request.param("index");
+        String docId = request.param("docId");
+        return new RestChannelConsumer() {
+
+            @Override
+            public void accept(RestChannel channel) throws Exception {
+                UpdateRequest updateRequest = new UpdateRequest();
+                updateRequest.index(indexName);
+                updateRequest.id(docId);
+                updateRequest.doc("content", 3);
+                pluginClient.update(updateRequest, ActionListener.wrap(r -> {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, r.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS)));
+                }, fr -> { channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, String.valueOf(fr))); }));
+            }
+        };
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
@@ -90,7 +90,8 @@ public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, Ide
             new RestBulkIndexDocumentIntoSystemIndexAction(client, pluginClient),
             new RestBulkIndexDocumentIntoMixOfSystemIndexAction(client, pluginClient),
             new RestSearchOnSystemIndexAction(pluginClient),
-            new RestGetOnSystemIndexAction(pluginClient)
+            new RestGetOnSystemIndexAction(pluginClient),
+            new RestUpdateOnSystemIndexAction(pluginClient)
         );
     }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -81,6 +81,7 @@ import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.threadpool.ThreadPool;
 
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
@@ -135,6 +136,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
+        if (HeaderHelper.isInternalOrPluginRequest(threadContext)) {
+            return true;
+        }
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();
         ActionRequest request = context.getRequest();
         IndexResolverReplacer.Resolved resolved = context.getResolvedRequest();


### PR DESCRIPTION
### Description

Test run in JS w/ failure related to update request: https://github.com/opensearch-project/job-scheduler/actions/runs/12934907118/job/36096320325?pr=714

Similar to https://github.com/opensearch-project/security/pull/5032, but for the use-case where a plugin issues an update request.

While testing https://github.com/opensearch-project/job-scheduler/pull/714, I ran into an issue where a plugin was not able to perform update operations on an index when replacing `try (ThreadContext.StoredContext ctx = threadContext.stashContext()) { ... }` with the new replacement `pluginSubject.runAs(() -> { ... })` because the security plugin calls [dlsFlsValve.invoke](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/filter/SecurityFilter.java#L386-L388) after privilege evaluation is complete and successful for regular users. This PR updates the codepaths to account for the introduction of pluginSubject as a separate form of a system-level request.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
