### PR TITLE
Remove deprecation comment for protected indices settings

### DIFF
--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -332,7 +332,6 @@ public class ConfigConstants {
     public static final String SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES = "plugins.security.unsupported.load_static_resources";
     public static final String SECURITY_UNSUPPORTED_ACCEPT_INVALID_CONFIG = "plugins.security.unsupported.accept_invalid_config";
 
-    // Protected indices settings. Marked for deprecation, after all config indices move to System indices.
     public static final String SECURITY_PROTECTED_INDICES_ENABLED_KEY = "plugins.security.protected_indices.enabled";
     public static final Boolean SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT = false;
     public static final String SECURITY_PROTECTED_INDICES_KEY = "plugins.security.protected_indices.indices";


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) - Maintenance
* Why these changes are required? The setting is documented here- https://github.com/opensearch-project/security/blob/main/config/opensearch.yml.example#L214-L221
This can continue as a feature of security plugin to mark certain indices which can be access by specific ```plugins.security.protected_indices.roles``` roles
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
https://github.com/opensearch-project/security/issues/3190

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [NA] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
