### PR TITLE
[Backport 2.x] Ensure that plugin can update on system index when utilizing pluginSubject.runAs (#5055)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/systemindex/AbstractSystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/AbstractSystemIndexTests.java
@@ -150,6 +150,40 @@ public abstract class AbstractSystemIndexTests {
     }
 
     @Test
+    public void testPluginShouldBeAbleUpdateOnItsSystemIndex() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            HttpResponse response = client.put("try-create-and-bulk-index/" + SYSTEM_INDEX_1);
+
+            assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+            HttpResponse searchResponse = client.get("search-on-system-index/" + SYSTEM_INDEX_1);
+
+            assertThat(searchResponse.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+            assertThat(searchResponse.getIntFromJsonBody("/hits/total/value"), equalTo(2));
+
+            String docId = searchResponse.getTextFromJsonBody("/hits/hits/0/_id");
+
+            HttpResponse updateResponse = client.put("update-on-system-index/" + SYSTEM_INDEX_1 + "/" + docId);
+
+            updateResponse.assertStatusCode(RestStatus.OK.getStatus());
+        }
+
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            HttpResponse searchResponse = client.get(SYSTEM_INDEX_1 + "/_search");
+
+            searchResponse.assertStatusCode(RestStatus.OK.getStatus());
+
+            assertThat(searchResponse.getIntFromJsonBody("/hits/total/value"), equalTo(2));
+
+            String docId = searchResponse.getTextFromJsonBody("/hits/hits/0/_id");
+
+            HttpResponse getResponse = client.get(SYSTEM_INDEX_1 + "/_doc/" + docId);
+
+            assertThat("{\"content\":3}", equalTo(getResponse.bodyAsJsonNode().get("_source").toString()));
+        }
+    }
+
+    @Test
     public void testPluginShouldNotBeAbleToIndexDocumentIntoSystemIndexRegisteredByOtherPlugin() {
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             HttpResponse response = client.put("try-create-and-index/" + SYSTEM_INDEX_2);

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.systemindex.sampleplugin;
+
+import java.util.List;
+
+import org.opensearch.action.update.UpdateRequest;
+import org.opensearch.client.node.NodeClient;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+
+public class RestUpdateOnSystemIndexAction extends BaseRestHandler {
+
+    private final RunAsSubjectClient pluginClient;
+
+    public RestUpdateOnSystemIndexAction(RunAsSubjectClient pluginClient) {
+        this.pluginClient = pluginClient;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, "/update-on-system-index/{index}/{docId}"));
+    }
+
+    @Override
+    public String getName() {
+        return "test_update_on_system_index_action";
+    }
+
+    @Override
+    public RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) {
+        String indexName = request.param("index");
+        String docId = request.param("docId");
+        return new RestChannelConsumer() {
+
+            @Override
+            public void accept(RestChannel channel) throws Exception {
+                UpdateRequest updateRequest = new UpdateRequest();
+                updateRequest.index(indexName);
+                updateRequest.id(docId);
+                updateRequest.doc("content", 3);
+                pluginClient.update(updateRequest, ActionListener.wrap(r -> {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, r.toXContent(channel.newBuilder(), ToXContent.EMPTY_PARAMS)));
+                }, fr -> { channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, String.valueOf(fr))); }));
+            }
+        };
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
@@ -90,7 +90,8 @@ public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, Ide
             new RestBulkIndexDocumentIntoSystemIndexAction(client, pluginClient),
             new RestBulkIndexDocumentIntoMixOfSystemIndexAction(client, pluginClient),
             new RestSearchOnSystemIndexAction(pluginClient),
-            new RestGetOnSystemIndexAction(pluginClient)
+            new RestGetOnSystemIndexAction(pluginClient),
+            new RestUpdateOnSystemIndexAction(pluginClient)
         );
     }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -130,7 +130,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
-
+        if (HeaderHelper.isInternalOrPluginRequest(threadContext)) {
+            return true;
+        }
         EvaluatedDlsFlsConfig evaluatedDlsFlsConfig = configModel.getSecurityRoles()
             .filter(context.getMappedRoles())
             .getDlsFls(context.getUser(), dfmEmptyOverwritesAll, resolver, clusterService, namedXContentRegistry);


### PR DESCRIPTION
(cherry picked from commit ec99e7eb0191e521b2c7046ba3fbfcc633cac6fc)

Backport #5055 to 2.x
