### PR TITLE
Add .ltrstore to system indices

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -74,7 +74,8 @@ public class SecuritySettingsConfigurer {
         ".geospatial-ip2geo-data*",
         ".plugins-flow-framework-config",
         ".plugins-flow-framework-templates",
-        ".plugins-flow-framework-state"
+        ".plugins-flow-framework-state",
+        ".ltrstore*"
     );
     static final Integer DEFAULT_PASSWORD_MIN_LENGTH = 8;
     static String ADMIN_PASSWORD = "";


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement)
* Why these changes are required?
Adding ltr plugin in 2.19
* What is the old behavior before changes and new behavior after changes?
LTR specific indices which start with ".ltrstore" will be prevented from being modified without API calls.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
