### PR TITLE
Use non-deprecated `reindex.remote.allowlist` setting

### DIFF
--- a/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
+++ b/src/test/java/org/opensearch/security/ccstest/RemoteReindexTests.java
@@ -76,7 +76,7 @@ public class RemoteReindexTests extends AbstractSecurityUnitTest {
     }
 
     private Settings crossClusterNodeSettings(ClusterInfo remote) {
-        Settings.Builder builder = Settings.builder().putList("reindex.remote.whitelist", remote.httpHost + ":" + remote.httpPort);
+        Settings.Builder builder = Settings.builder().putList("reindex.remote.allowlist", remote.httpHost + ":" + remote.httpPort);
         return builder.build();
     }
 


### PR DESCRIPTION
### Description
Test fix to replace usage of a deprecated setting

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [ ] ~New Roles/Permissions have a corresponding security dashboards plugin PR~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
