### PR TITLE
[Backport 2.x] add ingest pipeline and indices related permissions for anomaly_full_access role

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -79,6 +79,8 @@ anomaly_read_access:
 anomaly_full_access:
   reserved: true
   cluster_permissions:
+    - "cluster:admin/ingest/pipeline/delete"
+    - "cluster:admin/ingest/pipeline/put"
     - 'cluster_monitor'
     - 'cluster:admin/opendistro/ad/*'
   index_permissions:
@@ -90,6 +92,7 @@ anomaly_full_access:
         - 'indices:admin/mappings/fields/get*'
         - 'indices:admin/mappings/get'
         - 'indices:admin/resolve/index'
+        - 'indices:admin/setting/put'
         - 'indices:data/read/field_caps*'
         - 'indices:data/read/search'
         - 'indices_monitor'


### PR DESCRIPTION
Backporting this pr into 2.x branch - https://github.com/opensearch-project/security/pull/5065

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
