### PR TITLE
Log request body to audit logs

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/InternalAuditLogTest.java
+++ b/src/integrationTest/java/org/opensearch/security/InternalAuditLogTest.java
@@ -9,7 +9,7 @@
 */
 package org.opensearch.security;
 
-import java.io.IOException;
+import java.time.Duration;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.logging.log4j.LogManager;
@@ -48,13 +48,24 @@ public class InternalAuditLogTest {
         .build();
 
     @Test
-    public void testAuditLogShouldBeGreenInSingleNodeCluster() throws IOException {
+    public void testAuditLogShouldBeGreenInSingleNodeCluster() throws InterruptedException {
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             client.get(""); // demo request for insuring audit-log index is created beforehand
-            TestRestClient.HttpResponse indicesResponse = client.get("_cat/indices");
-
-            assertThat(indicesResponse.getBody(), containsString("security-auditlog"));
-            assertThat(indicesResponse.getBody(), containsString("green"));
+            int retriesLeft = 5;
+            while (retriesLeft > 0) {
+                retriesLeft = retriesLeft - 1;
+                try {
+                    TestRestClient.HttpResponse indicesResponse = client.get("_cat/indices");
+                    assertThat(indicesResponse.getBody(), containsString("security-auditlog"));
+                    assertThat(indicesResponse.getBody(), containsString("green"));
+                    break;
+                } catch (AssertionError e) {
+                    if (retriesLeft == 0) {
+                        throw e;
+                    }
+                    Thread.sleep(Duration.ofSeconds(1));
+                }
+            }
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
@@ -34,6 +34,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
 import static org.opensearch.security.auditlog.impl.AuditCategory.FAILED_LOGIN;
 import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
 import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVILEGES;
@@ -136,6 +137,17 @@ public class AuthZinRestLayerTests {
                     "DummyRequest",
                     "cluster:admin/dummy_protected_plugin/dummy/get"
                 )
+            );
+        }
+    }
+
+    @Test
+    public void testRequestBodyIsAuditLogged() {
+        try (TestRestClient client = cluster.getRestClient(REST_PLUS_TRANSPORT)) {
+            String dummyBody = "{\"hello\": \"world\"}";
+            client.postJson(PROTECTED_API, dummyBody);
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateRESTLayer(AUTHENTICATED, REST_PLUS_TRANSPORT, POST, "/" + PROTECTED_API).withRequestBody(dummyBody)
             );
         }
     }

--- a/src/integrationTest/java/org/opensearch/test/framework/audit/AuditMessagePredicate.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/audit/AuditMessagePredicate.java
@@ -44,6 +44,7 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
     private final String effectiveUser;
     private final String index;
     private final String privilege;
+    private final String requestBody;
 
     private AuditMessagePredicate(
         AuditCategory category,
@@ -55,7 +56,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         String transportRequestType,
         String effectiveUser,
         String index,
-        String privilege
+        String privilege,
+        String requestBody
     ) {
         this.category = category;
         this.requestLayer = requestLayer;
@@ -67,10 +69,11 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         this.effectiveUser = effectiveUser;
         this.index = index;
         this.privilege = privilege;
+        this.requestBody = requestBody;
     }
 
     private AuditMessagePredicate(AuditCategory category) {
-        this(category, null, null, null, null, null, null, null, null, null);
+        this(category, null, null, null, null, null, null, null, null, null, null);
     }
 
     public static AuditMessagePredicate auditPredicate(AuditCategory category) {
@@ -120,7 +123,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -135,7 +139,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -150,7 +155,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -165,7 +171,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -184,7 +191,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -199,7 +207,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             type,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -214,7 +223,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             user,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -237,7 +247,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             indexName,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -252,7 +263,24 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilegeAction
+            privilegeAction,
+            requestBody
+        );
+    }
+
+    public Predicate<AuditMessage> withRequestBody(String body) {
+        return new AuditMessagePredicate(
+            category,
+            requestLayer,
+            restRequestPath,
+            restParams,
+            initiatingUser,
+            requestMethod,
+            transportRequestType,
+            effectiveUser,
+            index,
+            privilege,
+            body
         );
     }
 
@@ -269,6 +297,7 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         predicates.add(audit -> Objects.isNull(effectiveUser) || effectiveUser.equals(audit.getEffectiveUser()));
         predicates.add(audit -> Objects.isNull(index) || containIndex(audit, index));
         predicates.add(audit -> Objects.isNull(privilege) || privilege.equals(audit.getPrivilege()));
+        predicates.add(audit -> Objects.isNull(requestBody) || requestBody.equals(audit.getRequestBody()));
         return predicates.stream().reduce(Predicate::and).orElseThrow().test(auditMessage);
     }
 
@@ -303,4 +332,5 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             + '\''
             + '}';
     }
+
 }

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -228,7 +228,6 @@ public class BackendRegistry {
             UserSubject subject = new UserSubjectImpl(threadPool, superuser);
             threadContext.putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
             threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, superuser);
-            auditLog.logSucceededLogin(sslPrincipal, true, null, request);
             return true;
         }
 
@@ -393,9 +392,9 @@ public class BackendRegistry {
             final User impersonatedUser = impersonate(request, authenticatedUser);
             final User effectiveUser = impersonatedUser == null ? authenticatedUser : impersonatedUser;
             threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, effectiveUser);
+            threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_INITIATING_USER, authenticatedUser.getName());
             UserSubject subject = new UserSubjectImpl(threadPool, effectiveUser);
             threadPool.getThreadContext().putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
-            auditLog.logSucceededLogin(effectiveUser.getName(), false, authenticatedUser.getName(), request);
         } else {
             if (isDebugEnabled) {
                 log.debug("User still not authenticated after checking {} auth domains", restAuthDomains.size());
@@ -426,7 +425,6 @@ public class BackendRegistry {
 
                 threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, anonymousUser);
                 threadPool.getThreadContext().putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
-                auditLog.logSucceededLogin(anonymousUser.getName(), false, null, request);
                 if (isDebugEnabled) {
                     log.debug("Anonymous User is authenticated");
                 }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -120,6 +120,8 @@ public class ConfigConstants {
 
     public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_info";
 
+    public static final String OPENDISTRO_SECURITY_INITIATING_USER = OPENDISTRO_SECURITY_CONFIG_PREFIX + "_initiating_user";
+
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";
 


### PR DESCRIPTION

### Description

Currently we do not get request body to audit log, as requests are already authenticated in header verifier level, which does not have access to request body.

SecurityRestFilter has the whole RestRequest object, but it does not authenticate it again. Also, it does not authorize the request if the route is not a named one. The idea here is to do logGrantedPrivileges call even if we do not authorize. This way we will get the request body to audit log.

### Issues Resolved

[[BUG] audit_request_body missing for REST since 2.11
](https://github.com/opensearch-project/security/issues/4094)

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
