### PR TITLE
[Backport 2.19] Update `restPathMatches` to handle case with missing leading slash (#5061)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
@@ -139,6 +139,13 @@ public class WhoAmITests {
     }
 
     @Test
+    public void testWhoAmIWithoutGetPermissionsWithoutLeadingSlashInPath() {
+        try (TestRestClient client = cluster.getRestClient(WHO_AM_I_NO_PERM)) {
+            assertThat(client.getWithoutLeadingSlash(WHOAMI_PROTECTED_ENDPOINT).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+        }
+    }
+
+    @Test
     public void testWhoAmIPost() {
         try (TestRestClient client = cluster.getRestClient(WHO_AM_I)) {
             assertThat(client.post(WHOAMI_ENDPOINT).getStatusCode(), equalTo(HttpStatus.SC_OK));

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,8 +113,9 @@ public class TestRestClient implements AutoCloseable {
     }
 
     public HttpResponse getWithoutLeadingSlash(String path, Header... headers) {
-        HttpUriRequest req = new HttpGet(getHttpServerUri());
-        req.setPath(path);
+        URI uri = URI.create(getHttpServerUri());
+        uri = uri.resolve(path);
+        HttpUriRequest req = new HttpGet(uri);
         return executeRequest(req, headers);
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -111,6 +111,12 @@ public class TestRestClient implements AutoCloseable {
         return executeRequest(new HttpGet(getHttpServerUri() + "/" + path), headers);
     }
 
+    public HttpResponse getWithoutLeadingSlash(String path, Header... headers) {
+        HttpUriRequest req = new HttpGet(getHttpServerUri());
+        req.setPath(path);
+        return executeRequest(req, headers);
+    }
+
     public HttpResponse getAuthInfo(Header... headers) {
         return executeRequest(new HttpGet(getHttpServerUri() + "/_opendistro/_security/authinfo?pretty"), headers);
     }

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -333,6 +333,9 @@ public class SecurityRestFilter {
      * @return true if the request path matches the route
      */
     private boolean restPathMatches(String requestPath, String handlerPath) {
+        // Trim leading and trailing slashes
+        requestPath = requestPath.replaceAll("^/+", "").replaceAll("/+$", "");
+        handlerPath = handlerPath.replaceAll("^/+", "").replaceAll("/+$", "");
         // Check exact match
         if (handlerPath.equals(requestPath)) {
             return true;

--- a/src/test/java/org/opensearch/security/filter/RestPathMatchesTests.java
+++ b/src/test/java/org/opensearch/security/filter/RestPathMatchesTests.java
@@ -72,16 +72,37 @@ public class RestPathMatchesTests {
     }
 
     @Test
-    public void testRequestPathMismatch() throws InvocationTargetException, IllegalAccessException {
-        String requestPath = "_plugins/security/api/x/y";
-        String handlerPath = "_plugins/security/api/z/y";
+    public void testMatchWithLeadingSlashDifference() throws InvocationTargetException, IllegalAccessException {
+        String requestPath = "api/v1/resource";
+        String handlerPath = "/api/v1/resource";
+        assertTrue((Boolean) restPathMatches.invoke(securityRestFilter, requestPath, handlerPath));
+    }
+
+    @Test
+    public void testMatchWithTrailingSlashDifference() throws InvocationTargetException, IllegalAccessException {
+        String requestPath = "/api/v1/resource/";
+        String handlerPath = "/api/v1/resource";
+        assertTrue((Boolean) restPathMatches.invoke(securityRestFilter, requestPath, handlerPath));
+    }
+
+    @Test
+    public void testPathsMatchWithMultipleNamedParameters() throws InvocationTargetException, IllegalAccessException {
+        String requestPath = "/api/v1/resource/123/details";
+        String handlerPath = "/api/v1/resource/{id}/details";
+        assertTrue((Boolean) restPathMatches.invoke(securityRestFilter, requestPath, handlerPath));
+    }
+
+    @Test
+    public void testPathsDoNotMatchWithNonMatchingNamedParameterSegment() throws InvocationTargetException, IllegalAccessException {
+        String requestPath = "/api/v1/resource/123/details";
+        String handlerPath = "/api/v1/resource/{id}/summary";
         assertFalse((Boolean) restPathMatches.invoke(securityRestFilter, requestPath, handlerPath));
     }
 
     @Test
-    public void testRequestPathWithExtraSegments() throws InvocationTargetException, IllegalAccessException {
-        String requestPath = "_plugins/security/api/x/y/z";
-        String handlerPath = "_plugins/security/api/x/y";
+    public void testDifferentSegmentCount() throws InvocationTargetException, IllegalAccessException {
+        String requestPath = "/api/v1/resource/123/extra";
+        String handlerPath = "/api/v1/resource/{id}";
         assertFalse((Boolean) restPathMatches.invoke(securityRestFilter, requestPath, handlerPath));
     }
 }

--- a/src/test/java/org/opensearch/security/filter/SecurityRestFilterUnitTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityRestFilterUnitTests.java
@@ -100,4 +100,7 @@ public class SecurityRestFilterUnitTests {
 
         verify(testRestHandlerSpy).handleRequest(any(), any(), any());
     }
+
+    // unit tests for restPathMatches are in RestPathMatchesTests.java
+
 }


### PR DESCRIPTION
Backport #5061 to 2.19