### PR TITLE
[2.x] Avoid ConcurrentModificationException for User class fields

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -1222,7 +1222,10 @@ public class ConfigModelV7 extends ConfigModel {
                 return Collections.emptySet();
             }
 
-            final Set<String> securityRoles = new HashSet<>(user.getSecurityRoles());
+            final Set<String> securityRoles = new HashSet<>();
+            synchronized (user.getSecurityRoles()) {
+                securityRoles.addAll(user.getSecurityRoles());
+            }
 
             if (rolesMappingResolution == ConfigConstants.RolesMappingResolution.BOTH
                 || rolesMappingResolution == ConfigConstants.RolesMappingResolution.BACKENDROLES_ONLY) {

--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -38,6 +38,8 @@ import java.util.Set;
 
 import com.google.common.collect.Lists;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.common.io.stream.Writeable;
@@ -72,10 +74,10 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     /**
      * roles == backend_roles
      */
-    private final Set<String> roles = Collections.synchronizedSet(new HashSet<String>());
-    private final Set<String> securityRoles = Collections.synchronizedSet(new HashSet<String>());
+    private final Set<String> roles = new CopyOnWriteArraySet<>();
+    private final Set<String> securityRoles = new CopyOnWriteArraySet<>();
     private String requestedTenant;
-    private Map<String, String> attributes = Collections.synchronizedMap(new HashMap<>());
+    private final Map<String, String> attributes = new ConcurrentHashMap<>();
     private boolean isInjected = false;
 
     public User(final StreamInput in) throws IOException {
@@ -86,7 +88,10 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
         if (requestedTenant.isEmpty()) {
             requestedTenant = null;
         }
-        attributes = Collections.synchronizedMap(in.readMap(StreamInput::readString, StreamInput::readString));
+        Map<String, String> readAttributes = in.readMap(StreamInput::readString, StreamInput::readString);
+        if (readAttributes != null) {
+            attributes.putAll(readAttributes);
+        }
         securityRoles.addAll(in.readList(StreamInput::readString));
     }
 
@@ -269,10 +274,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
      * @return A modifiable map with all the current custom attributes associated with this user
      */
     public synchronized final Map<String, String> getCustomAttributesMap() {
-        if (attributes == null) {
-            attributes = Collections.synchronizedMap(new HashMap<>());
-        }
-        return attributes;
+        return Collections.unmodifiableMap(attributes);
     }
 
     public final void addSecurityRoles(final Collection<String> securityRoles) {
@@ -282,9 +284,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     }
 
     public final Set<String> getSecurityRoles() {
-        return this.securityRoles == null
-            ? Collections.synchronizedSet(Collections.emptySet())
-            : Collections.unmodifiableSet(this.securityRoles);
+        return Collections.unmodifiableSet(this.securityRoles);
     }
 
     /**


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Bug fix
* Why these changes are required? 
Fix https://github.com/opensearch-project/security/issues/4441
* What is the old behavior before changes and new behavior after changes?
Previously, since the fields were ```Collections.synchronizedSet()``` /``Collections.synchronizedMap()`` - explicit synchronization is required (see https://github.com/opensearch-project/security/issues/4642#issue-2465496301) 

By switching to ``CopyOnWriteArraySet`` and ``ConcurrentHashMap``, we get lock-free reads, safe iteration without explicit synchronization. 

However, CopyOnWriteArraySet can lead to memory overhead - should be minimal as updates/writes are expected to be lower compared to reads.

### Issues Resolved
[List any issues this PR will resolve]
https://github.com/opensearch-project/security/issues/4441

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

tested locally.

### Check List
- [X] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
