### PR TITLE
Deprecate opendistro_security_roles and add opensearch_security_roles

### DIFF
--- a/config/internal_users.yml
+++ b/config/internal_users.yml
@@ -20,7 +20,7 @@ admin:
 anomalyadmin:
   hash: "$2y$12$TRwAAJgnNo67w3rVUz4FIeLx9Dy/llB79zf9I15CKJ9vkM4ZzAd3."
   reserved: false
-  opendistro_security_roles:
+  opensearch_security_roles:
   - "anomaly_full_access"
   description: "Demo anomaly admin user, using internal role"
 

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
@@ -43,6 +43,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.security.api.PatchPayloadHelper.addOp;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
 import static org.opensearch.security.api.PatchPayloadHelper.replaceOp;
+import static org.opensearch.security.dlic.rest.api.InternalUsersApiAction.OPENDISTRO_SECURITY_ROLES;
+import static org.opensearch.security.dlic.rest.api.InternalUsersApiAction.OPENSEARCH_SECURITY_ROLES;
 import static org.opensearch.security.dlic.rest.api.InternalUsersApiAction.RESTRICTED_FROM_USERNAME;
 
 public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApiIntegrationTest {
@@ -149,11 +151,15 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                 builder.field("attributes", attributes);
             }
             if (securityRoles != null) {
-                builder.field("opendistro_security_roles");
+                builder.field(getRoleField());
                 securityRoles.toXContent(builder, params);
             }
             return builder.endObject();
         };
+    }
+
+    private static String getRoleField() {
+        return randomFrom(List.of(OPENDISTRO_SECURITY_ROLES, OPENSEARCH_SECURITY_ROLES));
     }
 
     static ToXContentObject defaultServiceUser() {

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -359,12 +359,19 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
 
             // Security roles should only contain roles that exist in the roles dynamic config.
             // We should filter out any roles that have hidden rolesmapping.
-            return tmp == null
-                ? ImmutableList.of()
-                : tmp.getOpendistro_security_roles()
+            if (tmp == null) {
+                return ImmutableList.of();
+            } else if (!tmp.getOpensearch_security_roles().isEmpty()) {
+                return tmp.getOpensearch_security_roles()
                     .stream()
                     .filter(role -> !isRolesMappingHidden(role) && rolesV7SecurityDynamicConfiguration.exists(role))
                     .collect(ImmutableList.toImmutableList());
+            } else {
+                return tmp.getOpendistro_security_roles()
+                    .stream()
+                    .filter(role -> !isRolesMappingHidden(role) && rolesV7SecurityDynamicConfiguration.exists(role))
+                    .collect(ImmutableList.toImmutableList());
+            }
         }
 
         // Remove any hidden rolesmapping from the security roles

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/InternalUserV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/InternalUserV7.java
@@ -51,6 +51,7 @@ public class InternalUserV7 implements Hideable, Hashed, StaticDefinable {
     private Map<String, String> attributes = Collections.emptyMap();
     private String description;
     private List<String> opendistro_security_roles = Collections.emptyList();
+    private List<String> opensearch_security_roles = Collections.emptyList();
 
     private InternalUserV7(String hash, boolean reserved, boolean hidden, List<String> backend_roles, Map<String, String> attributes) {
         super();
@@ -117,6 +118,16 @@ public class InternalUserV7 implements Hideable, Hashed, StaticDefinable {
 
     public void setOpendistro_security_roles(List<String> opendistro_security_roles) {
         this.opendistro_security_roles = opendistro_security_roles;
+        this.opensearch_security_roles = opendistro_security_roles;
+    }
+
+    public List<String> getOpensearch_security_roles() {
+        return opensearch_security_roles;
+    }
+
+    public void setOpensearch_security_roles(List<String> opensearch_security_roles) {
+        this.opendistro_security_roles = opensearch_security_roles;
+        this.opensearch_security_roles = opensearch_security_roles;
     }
 
     public Map<String, String> getAttributes() {


### PR DESCRIPTION
Deprecate opendistro_security_roles and add opensearch_security_roles for internal-user APIs.

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required?
https://github.com/opensearch-project/security/issues/5092
* What is the old behavior before changes and new behavior after changes?
```
curl -XPUT -k -u admin:<password> "https://localhost:9200/_plugins/_security/api/internalusers/testuser" -H 'Content-Type: application/json' -d'
{
  "password": "kirkpass!!",
  "opensearch_security_roles": ["manage_snapshots"],
  "backend_roles": ["role 1", "role 2"],
  "attributes": {
    "attribute1": "value1",
    "attribute2": "value2"
  }
}
'

curl -k -u admin:<password> 'https://localhost:9200/_plugins/_security/api/user/testuser?pretty'                                                
{
  "testuser" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [
      "role 1",
      "role 2"
    ],
    "attributes" : {
      "attribute1" : "value1",
      "attribute2" : "value2"
    },
    "opendistro_security_roles" : [
      "manage_snapshots"
    ],
    "opensearch_security_roles" : [
      "manage_snapshots"
    ],
    "static" : false
  }
}



curl -k -u admin:<password> 'https://localhost:9200/_plugins/_security/api/internalusers/testuser?pretty' -X PATCH -d '[{"op": "replace", "path": "/opensearch_security_roles", "value": ["notebooks_full_access","all_access"]}]' -H 'content-type: application/json'

{
  "status" : "OK",
  "message" : "'testuser' updated."
}


curl -k -u admin:<password> 'https://localhost:9200/_plugins/_security/api/user/testuser?pretty'
{
  "testuser" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [
      "role 1",
      "role 2"
    ],
    "attributes" : {
      "attribute1" : "value1",
      "attribute2" : "value2"
    },
    "opendistro_security_roles" : [
      "notebooks_full_access",
      "all_access"
    ],
    "opensearch_security_roles" : [
      "notebooks_full_access",
      "all_access"
    ],
    "static" : false
  }
}

curl -k -u admin:<password> 'https://localhost:9200/_plugins/_security/api/internalusers/testuser?pretty' -X PATCH -d '[{"op": "replace", "path": "/opendistro_security_roles", "value": ["notebooks_full_access"]}]' -H 'content-type: application/json'     

{
  "status" : "OK",
  "message" : "'testuser' updated."
}


curl -k -u admin:<password> 'https://localhost:9200/_opendistro/_security/api/user/testuser?pretty'                                             
{
  "testuser" : {
    "hash" : "",
    "reserved" : false,
    "hidden" : false,
    "backend_roles" : [
      "role 1",
      "role 2"
    ],
    "attributes" : {
      "attribute1" : "value1",
      "attribute2" : "value2"
    },
    "opendistro_security_roles" : [
      "manage_snapshots"
    ],
    "opensearch_security_roles" : [
      "manage_snapshots"
    ],
    "static" : false
  }
}


```


### Issues Resolved
https://github.com/opensearch-project/security/issues/5098


### Testing
Manual testing results above.

Logs
```
[2025-02-18T15:03:11,188][WARN ][org.opensearch.security.dlic.rest.api.InternalUsersApiAction] The field 'opendistro_security_roles' is deprecated and will be removed in a future release. Please use 'opensearch_security_roles' instead.
```

### Check List
- [X] New functionality includes testing
- [TODO] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
