### PR TITLE
Fixing route for SecurityInfoAction

### DIFF
--- a/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityInfoAction.java
@@ -65,8 +65,8 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class SecurityInfoAction extends BaseRestHandler {
     private static final List<Route> routes = addRoutesPrefix(
-            ImmutableList.of(new Route(GET, "/authinfo"), new Route(POST, "/authinfo"))
-            PLUGIN_ROUTE_PREFIX
+        ImmutableList.of(new Route(GET, "/authinfo"), new Route(POST, "/authinfo")),
+        PLUGIN_ROUTE_PREFIX
     );
 
     private static final List<DeprecatedRoute> deprecatedRoutes = addDeprecatedRoutesPrefix(


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Bug fix
* Why these changes are required?
Fix route for authinfo action - it should /_plugins/_security/authinfo - broken by https://github.com/opensearch-project/security/pull/5102/files#diff-2a389d982744879123d6802950a6958010434baa060ddf7c30965a167c1a4dca
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
