### PR TITLE
Add 'good' as a valid value for plugins.security.restapi.password_score_based_validation_strength

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/validation/PasswordValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/PasswordValidator.java
@@ -131,9 +131,10 @@ public class PasswordValidator {
 
         private final String description;
 
-        static final List<ScoreStrength> CONFIGURATION_VALUES = ImmutableList.of(FAIR, STRONG, VERY_STRONG);
+        static final List<ScoreStrength> CONFIGURATION_VALUES = ImmutableList.of(FAIR, GOOD, STRONG, VERY_STRONG);
 
         static final String EXPECTED_CONFIGURATION_VALUES = new StringJoiner(",").add(FAIR.name().toLowerCase(Locale.ROOT))
+            .add(GOOD.name().toLowerCase(Locale.ROOT))
             .add(STRONG.name().toLowerCase(Locale.ROOT))
             .add(VERY_STRONG.name().toLowerCase(Locale.ROOT))
             .toString();


### PR DESCRIPTION
### Description

Small PR that makes sure that the set of valid values for `plugins.security.restapi.password_score_based_validation_strength` matches the public documentation at https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/security-settings/

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
