### PR TITLE
Update DlsFlsFilterLeafReader to reflect Apache Lucene 10 APIs changes

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -74,7 +74,6 @@ import org.opensearch.security.support.ConfigConstants;
 
 class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
 
-    private static final String KEYWORD = ".keyword";
     private final FieldInfos flsFieldInfos;
     private final IndexService indexService;
     private final ThreadContext threadContext;
@@ -821,6 +820,11 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         @Override
         public long ord() throws IOException {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public IOBooleanSupplier prepareSeekExact(BytesRef text) throws IOException {
+            return isAllowed(text) ? in.prepareSeekExact(text) : () -> false;
         }
     }
 

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/FlsExistsFieldsTest.java
@@ -38,11 +38,11 @@ public class FlsExistsFieldsTest extends AbstractDlsFlsTest {
                     "@timestamp",
                     "type=date",
                     "host",
-                    "type=text,doc_values=false,norms=true",
+                    "type=text,norms=false",
                     "response",
-                    "type=text,doc_values=false,norms=true",
+                    "type=text,norms=false",
                     "non-existing",
-                    "type=text,doc_values=false,norms=true"
+                    "type=text,norms=false"
                 )
             )
             .actionGet();


### PR DESCRIPTION
### Description
Update `DlsFlsFilterLeafReader` to reflect Apache Lucene 10 APIs changes in the `FilterTermsEnum`

### Issues Resolved
Follow up on https://github.com/opensearch-project/security/pull/5053 and concretely this workaround https://github.com/opensearch-project/security/pull/5053/files#r1950155753

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
