### PR TITLE
[2.x] Update common_utils version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
 
-        common_utils_version = System.getProperty("common_utils.version", '2.9.0.0-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
         kafka_version  = '3.7.1'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -46,7 +46,7 @@ buildscript {
     ext {
         opensearch_version = System.getProperty("opensearch.version", "2.20.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
-        common_utils_version = System.getProperty("common_utils.version", '2.9.0.0-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
         jackson_version = System.getProperty("jackson_version", "2.15.2")
     }
     repositories {


### PR DESCRIPTION
### Description

Updates common-utils version to 2.19.0.0 to resolve build failures see in https://github.com/opensearch-project/security/pull/5139

The ci checks started failing because 2.9.0.0-SNAPSHOT version of common-utils no longer exists.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
