### PR TITLE
Add TLS configuration settings/endpoints for auxiliary transports

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -69,6 +69,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.SpecialPermission;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.CertFileProps;
 import org.opensearch.security.ssl.util.CertFromFile;
 import org.opensearch.security.ssl.util.CertFromKeystore;
@@ -874,16 +875,16 @@ public class DefaultSecurityKeyStore implements SecurityKeyStore {
     private void initEnabledSSLCiphers() {
 
         final ImmutableSet<String> allowedSecureHttpSSLCiphers = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLCiphers(settings, true)
+            SSLConfigConstants.getSecureSSLCiphers(settings, CertType.HTTP)
         );
         final ImmutableSet<String> allowedSecureTransportSSLCiphers = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLCiphers(settings, false)
+            SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT)
         );
         final ImmutableSet<String> allowedSecureHttpSSLProtocols = ImmutableSet.copyOf(
-            (SSLConfigConstants.getSecureSSLProtocols(settings, true))
+            (SSLConfigConstants.getSecureSSLProtocols(settings, CertType.HTTP))
         );
         final ImmutableSet<String> allowedSecureTransportSSLProtocols = ImmutableSet.copyOf(
-            SSLConfigConstants.getSecureSSLProtocols(settings, false)
+            SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)
         );
 
         if (OpenSearchSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable()) {

--- a/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
@@ -73,17 +73,27 @@ public class ExternalSecurityKeyStore implements SecurityKeyStore {
             final SSLParameters sslParams = new SSLParameters();
             sslParams.setEndpointIdentificationAlgorithm("HTTPS");
             engine.setSSLParameters(sslParams);
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)));
+            engine.setEnabledProtocols(
+                evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT))
+            );
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0]))
+                evalSecure(
+                    engine.getEnabledCipherSuites(),
+                    SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0])
+                )
             );
             engine.setUseClientMode(true);
             return engine;
         } else {
             final SSLEngine engine = externalSslContext.createSSLEngine();
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)));
+            engine.setEnabledProtocols(
+                evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT))
+            );
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0]))
+                evalSecure(
+                    engine.getEnabledCipherSuites(),
+                    SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0])
+                )
             );
             engine.setUseClientMode(true);
             return engine;

--- a/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/ExternalSecurityKeyStore.java
@@ -31,6 +31,7 @@ import javax.net.ssl.SSLParameters;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 
 public class ExternalSecurityKeyStore implements SecurityKeyStore {
@@ -72,17 +73,17 @@ public class ExternalSecurityKeyStore implements SecurityKeyStore {
             final SSLParameters sslParams = new SSLParameters();
             sslParams.setEndpointIdentificationAlgorithm("HTTPS");
             engine.setSSLParameters(sslParams);
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, false)));
+            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)));
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, false).toArray(new String[0]))
+                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0]))
             );
             engine.setUseClientMode(true);
             return engine;
         } else {
             final SSLEngine engine = externalSslContext.createSSLEngine();
-            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, false)));
+            engine.setEnabledProtocols(evalSecure(engine.getEnabledProtocols(), SSLConfigConstants.getSecureSSLProtocols(settings, CertType.TRANSPORT)));
             engine.setEnabledCipherSuites(
-                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, false).toArray(new String[0]))
+                evalSecure(engine.getEnabledCipherSuites(), SSLConfigConstants.getSecureSSLCiphers(settings, CertType.TRANSPORT).toArray(new String[0]))
             );
             engine.setUseClientMode(true);
             return engine;

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -14,23 +14,17 @@ package org.opensearch.security.ssl;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.TrustManagerFactory;
 
-import org.opensearch.common.network.NetworkService;
-import org.opensearch.common.settings.ClusterSettings;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.indices.breaker.CircuitBreakerService;
 import org.opensearch.http.HttpServerTransport;
 import org.opensearch.http.netty4.ssl.SecureNetty4HttpServerTransport;
-import org.opensearch.plugins.NetworkPlugin;
-import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
 import org.opensearch.plugins.SecureAuxTransportSettingsProvider;
+import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
 import org.opensearch.plugins.SecureSettingsFactory;
 import org.opensearch.plugins.SecureTransportSettingsProvider;
 import org.opensearch.plugins.TransportExceptionHandler;
@@ -39,7 +33,6 @@ import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.http.netty.Netty4ConditionalDecompressor;
 import org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier;
 import org.opensearch.security.ssl.transport.SSLConfig;
-import org.opensearch.telemetry.tracing.Tracer;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.Transport;
 import org.opensearch.transport.TransportAdapterProvider;
@@ -214,15 +207,15 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                     @Override
                     public Collection<String> protocols() {
                         return sslSettingsManager.sslConfiguration(CertType.AUX)
-                                .map(config -> config.sslParameters().allowedProtocols())
-                                .orElse(Collections.emptyList());
+                            .map(config -> config.sslParameters().allowedProtocols())
+                            .orElse(Collections.emptyList());
                     }
 
                     @Override
                     public Collection<String> cipherSuites() {
                         return sslSettingsManager.sslConfiguration(CertType.AUX)
-                                .map(config -> config.sslParameters().allowedCiphers())
-                                .orElse(Collections.emptyList());
+                            .map(config -> config.sslParameters().allowedCiphers())
+                            .orElse(Collections.emptyList());
                     }
 
                     @Override

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -198,9 +198,44 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
     public Optional<SecureAuxTransportSettingsProvider> getSecureAuxTransportSettingsProvider(Settings settings) {
         return Optional.of(new SecureAuxTransportSettingsProvider() {
             @Override
-            public Optional<SSLEngine> buildSecureAuxServerEngine() {
-                return sslSettingsManager.sslContextHandler(CertType.AUX).map(SslContextHandler::createSSLEngine);
-            };
+            public Optional<SecureAuxTransportSettingsProvider.SecureAuxTransportParameters> parameters() {
+                return Optional.of(new SecureAuxTransportSettingsProvider.SecureAuxTransportParameters() {
+
+                    @Override
+                    public Optional<String> sslProvider() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX).map(config -> config.sslParameters().provider().name());
+                    }
+
+                    @Override
+                    public Optional<String> clientAuth() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX).map(config -> config.sslParameters().clientAuth().name());
+                    }
+
+                    @Override
+                    public Collection<String> protocols() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX)
+                                .map(config -> config.sslParameters().allowedProtocols())
+                                .orElse(Collections.emptyList());
+                    }
+
+                    @Override
+                    public Collection<String> cipherSuites() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX)
+                                .map(config -> config.sslParameters().allowedCiphers())
+                                .orElse(Collections.emptyList());
+                    }
+
+                    @Override
+                    public Optional<KeyManagerFactory> keyManagerFactory() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX).map(SslConfiguration::keyStoreFactory);
+                    }
+
+                    @Override
+                    public Optional<TrustManagerFactory> trustManagerFactory() {
+                        return sslSettingsManager.sslConfiguration(CertType.AUX).map(SslConfiguration::trustStoreFactory);
+                    }
+                });
+            }
         });
     }
 }

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -698,41 +698,6 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
         settings.add(
                 Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, Property.NodeScope, Property.Filtered)
         );
-        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_CRL_FILE, Property.NodeScope, Property.Filtered));
-        settings.add(Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_VALIDATE, false, Property.NodeScope, Property.Filtered));
-        settings.add(
-                Setting.boolSetting(
-                        SSLConfigConstants.SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP,
-                        false,
-                        Property.NodeScope,
-                        Property.Filtered
-                )
-        );
-        settings.add(
-                Setting.boolSetting(
-                        SSLConfigConstants.SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES,
-                        true,
-                        Property.NodeScope,
-                        Property.Filtered
-                )
-        );
-        settings.add(
-                Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_DISABLE_CRLDP, false, Property.NodeScope, Property.Filtered)
-        );
-        settings.add(
-                Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_DISABLE_OCSP, false, Property.NodeScope, Property.Filtered)
-        );
-        settings.add(
-                Setting.longSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_VALIDATION_DATE, -1, -1, Property.NodeScope, Property.Filtered)
-        );
-        settings.add(
-                Setting.boolSetting(
-                        SSLConfigConstants.SECURITY_SSL_AUX_ENFORCE_CERT_RELOAD_DN_VERIFICATION,
-                        true,
-                        Property.NodeScope,
-                        Property.Filtered
-                )
-        );
 
         return settings;
     }

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -651,6 +651,89 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
             )
         );
 
+        /**
+         * TLS settings for aux transports.
+         */
+        settings.add(
+            Setting.boolSetting(
+                SSLConfigConstants.SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE,
+                OPENSSL_SUPPORTED,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                SSLConfigConstants.SECURITY_SSL_AUX_ENABLED,
+                SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_DEFAULT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.listSetting(
+                SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_CIPHERS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        settings.add(
+            Setting.listSetting(
+                SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_PROTOCOLS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_CLIENTAUTH_MODE, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_KEYSTORE_ALIAS, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_KEYSTORE_FILEPATH, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_KEYSTORE_TYPE, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_TRUSTSTORE_ALIAS, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_TRUSTSTORE_TYPE, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMCERT_FILEPATH, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMKEY_FILEPATH, Property.NodeScope, Property.Filtered));
+        settings.add(
+                Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_CRL_FILE, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_VALIDATE, false, Property.NodeScope, Property.Filtered));
+        settings.add(
+                Setting.boolSetting(
+                        SSLConfigConstants.SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP,
+                        false,
+                        Property.NodeScope,
+                        Property.Filtered
+                )
+        );
+        settings.add(
+                Setting.boolSetting(
+                        SSLConfigConstants.SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES,
+                        true,
+                        Property.NodeScope,
+                        Property.Filtered
+                )
+        );
+        settings.add(
+                Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_DISABLE_CRLDP, false, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+                Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_DISABLE_OCSP, false, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+                Setting.longSetting(SSLConfigConstants.SECURITY_SSL_AUX_CRL_VALIDATION_DATE, -1, -1, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+                Setting.boolSetting(
+                        SSLConfigConstants.SECURITY_SSL_AUX_ENFORCE_CERT_RELOAD_DN_VERIFICATION,
+                        true,
+                        Property.NodeScope,
+                        Property.Filtered
+                )
+        );
+
         return settings;
     }
 

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -696,7 +696,7 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
         settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMCERT_FILEPATH, Property.NodeScope, Property.Filtered));
         settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMKEY_FILEPATH, Property.NodeScope, Property.Filtered));
         settings.add(
-                Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, Property.NodeScope, Property.Filtered)
+            Setting.simpleString(SSLConfigConstants.SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, Property.NodeScope, Property.Filtered)
         );
 
         return settings;

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -147,7 +147,7 @@ public class SslSettingsManager {
 
         if (httpEnabled && !clientNode(settings)) {
             validateHttpSettings(settings);
-            final var httpSslParameters = SslParameters.loader(httpSettings).load(true);
+            final var httpSslParameters = SslParameters.loader(httpSettings).load(CertType.HTTP);
             final var httpTrustAndKeyStore = new SslCertificatesLoader(CertType.HTTP.sslConfigPrefix()).loadConfiguration(environment);
             configurationBuilder.put(
                 CertType.HTTP,
@@ -159,7 +159,7 @@ public class SslSettingsManager {
 
         if (auxEnabled && !clientNode(settings)) {
             validateAuxSettings(settings);
-            final var auxSslParameters = SslParameters.loader(httpSettings).load(true);
+            final var auxSslParameters = SslParameters.loader(auxTransportSettings).load(CertType.AUX);
             final var auxTrustAndKeyStore = new SslCertificatesLoader(CertType.AUX.sslConfigPrefix()).loadConfiguration(environment);
             configurationBuilder.put(
                     CertType.AUX,
@@ -169,7 +169,7 @@ public class SslSettingsManager {
             LOGGER.info("Enabled TLS protocols for auxiliary transport layer : {}", auxSslParameters.allowedProtocols());
         }
 
-        final var transportSslParameters = SslParameters.loader(transportSettings).load(false);
+        final var transportSslParameters = SslParameters.loader(transportSettings).load(CertType.TRANSPORT);
         if (transportEnabled) {
             if (hasExtendedKeyUsageEnabled(transportSettings)) {
                 validateTransportSettings(transportSettings);

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -315,7 +315,7 @@ public class SslSettingsManager {
         if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(PEM_TRUSTED_CAS_FILEPATH)) {
             throw new OpenSearchException(
                     "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                        + transportSettings.get(PEM_TRUSTED_CAS_FILEPATH) + " must be set if client auth is required"
+                        + PEM_TRUSTED_CAS_FILEPATH + " must be set if client auth is required"
             );
         }
     }
@@ -341,7 +341,7 @@ public class SslSettingsManager {
         if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(TRUSTSTORE_FILEPATH)) {
             throw new OpenSearchException(
                     "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                            + transportSettings.get(TRUSTSTORE_FILEPATH) + " must be set if client auth is required"
+                            + TRUSTSTORE_FILEPATH + " must be set if client auth is required"
             );
         }
     }

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -158,7 +158,7 @@ public class SslSettingsManager {
         }
 
         if (auxEnabled && !clientNode(settings)) {
-            validateAuxSettings(httpSettings);
+            validateAuxSettings(settings);
             final var auxSslParameters = SslParameters.loader(httpSettings).load(true);
             final var auxTrustAndKeyStore = new SslCertificatesLoader(CertType.AUX.sslConfigPrefix()).loadConfiguration(environment);
             configurationBuilder.put(

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -162,8 +162,8 @@ public class SslSettingsManager {
             final var auxSslParameters = SslParameters.loader(auxTransportSettings).load(CertType.AUX);
             final var auxTrustAndKeyStore = new SslCertificatesLoader(CertType.AUX.sslConfigPrefix()).loadConfiguration(environment);
             configurationBuilder.put(
-                    CertType.AUX,
-                    new SslConfiguration(auxSslParameters, auxTrustAndKeyStore.v1(), auxTrustAndKeyStore.v2())
+                CertType.AUX,
+                new SslConfiguration(auxSslParameters, auxTrustAndKeyStore.v1(), auxTrustAndKeyStore.v2())
             );
             LOGGER.info("TLS auxiliary transport Provider                    : {}", auxSslParameters.provider());
             LOGGER.info("Enabled TLS protocols for auxiliary transport layer : {}", auxSslParameters.allowedProtocols());
@@ -289,7 +289,7 @@ public class SslSettingsManager {
         } else {
             throw new OpenSearchException(
                 "Wrong auxiliary transport SSL configuration. One of Keystore and Truststore files or X.509 PEM certificates and "
-                        + "PKCS#8 keys groups should be set to configure auxiliary transport."
+                    + "PKCS#8 keys groups should be set to configure auxiliary transport."
             );
         }
     }
@@ -304,18 +304,25 @@ public class SslSettingsManager {
      */
     private void validatePemStoreSettings(CertType transportType, final Settings settings) throws OpenSearchException {
         final var transportSettings = settings.getByPrefix(transportType.sslConfigPrefix());
-        final var clientAuth = ClientAuth.valueOf(transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT));
+        final var clientAuth = ClientAuth.valueOf(
+            transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT)
+        );
         if (!transportSettings.hasValue(PEM_CERT_FILEPATH) || !transportSettings.hasValue(PEM_KEY_FILEPATH)) {
             throw new OpenSearchException(
-                "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                        + String.join(", ", transportSettings.get(PEM_CERT_FILEPATH), transportSettings.get(PEM_KEY_FILEPATH))
-                        + " must be set"
+                "Wrong "
+                    + transportType.name().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + String.join(", ", transportSettings.get(PEM_CERT_FILEPATH), transportSettings.get(PEM_KEY_FILEPATH))
+                    + " must be set"
             );
         }
         if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(PEM_TRUSTED_CAS_FILEPATH)) {
             throw new OpenSearchException(
-                    "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                        + PEM_TRUSTED_CAS_FILEPATH + " must be set if client auth is required"
+                "Wrong "
+                    + transportType.name().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + PEM_TRUSTED_CAS_FILEPATH
+                    + " must be set if client auth is required"
             );
         }
     }
@@ -330,18 +337,25 @@ public class SslSettingsManager {
      */
     private void validateKeyStoreSettings(CertType transportType, final Settings settings) throws OpenSearchException {
         final var transportSettings = settings.getByPrefix(transportType.sslConfigPrefix());
-        final var clientAuth = ClientAuth.valueOf(transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT));
+        final var clientAuth = ClientAuth.valueOf(
+            transportSettings.get(CLIENT_AUTH_MODE, ClientAuth.OPTIONAL.name()).toUpperCase(Locale.ROOT)
+        );
         if (!transportSettings.hasValue(KEYSTORE_FILEPATH)) {
             throw new OpenSearchException(
-                    "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                            + transportSettings.get(KEYSTORE_FILEPATH)
-                            + " must be set"
+                "Wrong "
+                    + transportType.name().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + transportSettings.get(KEYSTORE_FILEPATH)
+                    + " must be set"
             );
         }
         if (clientAuth == ClientAuth.REQUIRE && !transportSettings.hasValue(TRUSTSTORE_FILEPATH)) {
             throw new OpenSearchException(
-                    "Wrong " + transportType.name().toLowerCase(Locale.ROOT) + " SSL configuration. "
-                            + TRUSTSTORE_FILEPATH + " must be set if client auth is required"
+                "Wrong "
+                    + transportType.name().toLowerCase(Locale.ROOT)
+                    + " SSL configuration. "
+                    + TRUSTSTORE_FILEPATH
+                    + " must be set if client auth is required"
             );
         }
     }

--- a/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
+++ b/src/main/java/org/opensearch/security/ssl/SslSettingsManager.java
@@ -50,6 +50,7 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_CERT_FILEP
 import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_KEY_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.PEM_TRUSTED_CAS_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_DEFAULT;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_DEFAULT;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_CLIENT_KEYSTORE_ALIAS;
@@ -471,6 +472,7 @@ public class SslSettingsManager {
         if (!OpenSearchSecuritySSLPlugin.OPENSSL_SUPPORTED
             && OpenSsl.isAvailable()
             && (settings.getAsBoolean(SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE, true)
+                || settings.getAsBoolean(SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE, true)
                 || settings.getAsBoolean(SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE, true))) {
             if (PlatformDependent.javaVersion() < 12) {
                 LOGGER.warn(
@@ -504,6 +506,10 @@ public class SslSettingsManager {
 
             if (settings.hasValue(SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE) == true) {
                 openSslIsEnabled |= Booleans.parseBoolean(settings.get(SECURITY_SSL_HTTP_ENABLE_OPENSSL_IF_AVAILABLE));
+            }
+
+            if (settings.hasValue(SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE) == true) {
+                openSslIsEnabled |= Booleans.parseBoolean(settings.get(SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE));
             }
 
             if (settings.hasValue(SECURITY_SSL_TRANSPORT_ENABLE_OPENSSL_IF_AVAILABLE) == true) {

--- a/src/main/java/org/opensearch/security/ssl/config/CertType.java
+++ b/src/main/java/org/opensearch/security/ssl/config/CertType.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_CLIENT_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
@@ -22,7 +23,8 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_
 public enum CertType {
     HTTP(SSL_HTTP_PREFIX),
     TRANSPORT(SSL_TRANSPORT_PREFIX),
-    TRANSPORT_CLIENT(SSL_TRANSPORT_CLIENT_PREFIX);
+    TRANSPORT_CLIENT(SSL_TRANSPORT_CLIENT_PREFIX),
+    AUX(SSL_AUX_PREFIX);
 
     public static Set<String> TYPES = Arrays.stream(CertType.values())
         .map(CertType::name)

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -23,9 +23,9 @@ import java.util.List;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.OpenSearchSecuritySSLPlugin;
+import org.opensearch.security.ssl.config.CertType;
 
 import io.netty.handler.ssl.OpenSsl;
-import org.opensearch.security.ssl.config.CertType;
 
 public final class SSLConfigConstants {
     /**
@@ -215,10 +215,13 @@ public final class SSLConfigConstants {
     public static String[] getSecureSSLProtocols(Settings settings, CertType certType) {
         List<String> configuredProtocols = null;
 
-        switch (certType){
+        switch (certType) {
             case HTTP -> configuredProtocols = settings.getAsList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, Collections.emptyList());
             case AUX -> configuredProtocols = settings.getAsList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, Collections.emptyList());
-            case TRANSPORT, TRANSPORT_CLIENT -> configuredProtocols = settings.getAsList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, Collections.emptyList());
+            case TRANSPORT, TRANSPORT_CLIENT -> configuredProtocols = settings.getAsList(
+                SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS,
+                Collections.emptyList()
+            );
             default -> throw new RuntimeException("Unsupported cert type: " + certType);
         }
 
@@ -232,10 +235,13 @@ public final class SSLConfigConstants {
     public static List<String> getSecureSSLCiphers(Settings settings, CertType certType) {
         List<String> configuredCiphers = null;
 
-        switch (certType){
+        switch (certType) {
             case HTTP -> configuredCiphers = settings.getAsList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, Collections.emptyList());
             case AUX -> configuredCiphers = settings.getAsList(SECURITY_SSL_AUX_ENABLED_CIPHERS, Collections.emptyList());
-            case TRANSPORT, TRANSPORT_CLIENT -> configuredCiphers = settings.getAsList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, Collections.emptyList());
+            case TRANSPORT, TRANSPORT_CLIENT -> configuredCiphers = settings.getAsList(
+                SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS,
+                Collections.emptyList()
+            );
             default -> throw new RuntimeException("Unsupported cert type: " + certType);
         }
 

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -93,10 +93,14 @@ public final class SSLConfigConstants {
 
     // http truststore settings
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> a6db9df2 (Fill in additional post-fix literals with constants.)
     public static final String SECURITY_SSL_HTTP_CLIENTAUTH_MODE = SSL_HTTP_PREFIX + CLIENT_AUTH_MODE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = SSL_HTTP_PREFIX + TRUSTSTORE_TYPE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = SSL_HTTP_PREFIX + TRUSTSTORE_ALIAS;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH = SSL_HTTP_PREFIX + TRUSTSTORE_FILEPATH;
+<<<<<<< HEAD
     public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
         + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
@@ -109,6 +113,11 @@ public final class SSLConfigConstants {
         + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + "pemtrustedcas_filepath";
 >>>>>>> 21e4080b (Spotless apply)
+=======
+    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
+        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
+    public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
+>>>>>>> a6db9df2 (Fill in additional post-fix literals with constants.)
 
     // http cert revocation list settings
     public static final String SECURITY_SSL_HTTP_CRL_FILE = SSL_HTTP_CRL_PREFIX + "file_path";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -129,6 +129,47 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_CRL_VALIDATION_DATE = SSL_HTTP_CRL_PREFIX + "validation_date";
 
     /**
+     * Auxiliary transport security settings
+     */
+    public static final String AUX_SETTINGS = "aux";
+    public static final String SSL_AUX_PREFIX = SSL_PREFIX + AUX_SETTINGS + ".";
+
+    // aux enable settings
+    public static final boolean SECURITY_SSL_AUX_ENABLED_DEFAULT = false;
+    public static final String SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE = SSL_AUX_PREFIX + "enable_openssl_if_available";
+    public static final String SECURITY_SSL_AUX_ENABLED = SSL_AUX_PREFIX + "enabled";
+    public static final String SECURITY_SSL_AUX_ENABLED_CIPHERS = SSL_AUX_PREFIX + "enabled_ciphers";
+    public static final String SECURITY_SSL_AUX_ENABLED_PROTOCOLS = SSL_AUX_PREFIX + "enabled_protocols";
+
+    // aux allowed settings
+    public static final String[] ALLOWED_OPENSSL_AUX_PROTOCOLS = ALLOWED_SSL_PROTOCOLS;
+    public static final String[] ALLOWED_OPENSSL_AUX_PROTOCOLS_PRIOR_OPENSSL_1_1_1_BETA_9 = { "TLSv1.2", "TLSv1.1", "TLSv1" };
+
+    // aux keystore settings
+    public static final String SECURITY_SSL_AUX_KEYSTORE_TYPE = SSL_AUX_PREFIX + "keystore_type";
+    public static final String SECURITY_SSL_AUX_KEYSTORE_ALIAS = SSL_AUX_PREFIX + "keystore_alias";
+    public static final String SECURITY_SSL_AUX_KEYSTORE_FILEPATH = SSL_AUX_PREFIX + "keystore_filepath";
+    public static final String SECURITY_SSL_AUX_PEMKEY_FILEPATH = SSL_AUX_PREFIX + "pemkey_filepath";
+    public static final String SECURITY_SSL_AUX_PEMCERT_FILEPATH = SSL_AUX_PREFIX + "pemcert_filepath";
+
+    // aux truststore settings
+    public static final String SECURITY_SSL_AUX_CLIENTAUTH_MODE = SSL_AUX_PREFIX + "clientauth_mode";
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_TYPE = SSL_AUX_PREFIX + "truststore_type";
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_ALIAS = SSL_AUX_PREFIX + "truststore_alias";
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH = SSL_AUX_PREFIX + "truststore_filepath";
+    public static final String SECURITY_SSL_AUX_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_AUX_PREFIX + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
+    public static final String SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH = SSL_AUX_PREFIX + "pemtrustedcas_filepath";
+
+    // aux cert revocation list settings
+    public static final String SECURITY_SSL_AUX_CRL_FILE = SSL_AUX_PREFIX + "crl.file_path";
+    public static final String SECURITY_SSL_AUX_CRL_VALIDATE = SSL_AUX_PREFIX + "crl.validate";
+    public static final String SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP = SSL_AUX_PREFIX + "crl.prefer_crlfile_over_ocsp";
+    public static final String SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES = SSL_AUX_PREFIX + "crl.check_only_end_entities";
+    public static final String SECURITY_SSL_AUX_CRL_DISABLE_OCSP = SSL_AUX_PREFIX + "crl.disable_ocsp";
+    public static final String SECURITY_SSL_AUX_CRL_DISABLE_CRLDP = SSL_AUX_PREFIX + "crl.disable_crldp";
+    public static final String SECURITY_SSL_AUX_CRL_VALIDATION_DATE = SSL_AUX_PREFIX + "crl.validation_date";
+
+    /**
      * Transport layer (node-to-node) settings.
      * Transport layer acts both as client and server within the cluster.
      * Security settings for each role may be configured separately.

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -93,32 +93,13 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_PEMCERT_FILEPATH = SSL_HTTP_PREFIX + PEM_CERT_FILEPATH;
 
     // http truststore settings
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> a6db9df2 (Fill in additional post-fix literals with constants.)
     public static final String SECURITY_SSL_HTTP_CLIENTAUTH_MODE = SSL_HTTP_PREFIX + CLIENT_AUTH_MODE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = SSL_HTTP_PREFIX + TRUSTSTORE_TYPE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = SSL_HTTP_PREFIX + TRUSTSTORE_ALIAS;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH = SSL_HTTP_PREFIX + TRUSTSTORE_FILEPATH;
-<<<<<<< HEAD
     public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
         + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
-=======
-    public static final String SECURITY_SSL_HTTP_CLIENTAUTH_MODE = SSL_HTTP_PREFIX + "clientauth_mode";
-    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = SSL_HTTP_PREFIX + "truststore_type";
-    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = SSL_HTTP_PREFIX + "truststore_alias";
-    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH = SSL_HTTP_PREFIX + "truststore_filepath";
-    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
-        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
-    public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + "pemtrustedcas_filepath";
->>>>>>> 21e4080b (Spotless apply)
-=======
-    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
-        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
-    public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
->>>>>>> a6db9df2 (Fill in additional post-fix literals with constants.)
 
     // http cert revocation list settings
     public static final String SECURITY_SSL_HTTP_CRL_FILE = SSL_HTTP_CRL_PREFIX + "file_path";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -92,6 +92,7 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_PEMCERT_FILEPATH = SSL_HTTP_PREFIX + PEM_CERT_FILEPATH;
 
     // http truststore settings
+<<<<<<< HEAD
     public static final String SECURITY_SSL_HTTP_CLIENTAUTH_MODE = SSL_HTTP_PREFIX + CLIENT_AUTH_MODE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = SSL_HTTP_PREFIX + TRUSTSTORE_TYPE;
     public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = SSL_HTTP_PREFIX + TRUSTSTORE_ALIAS;
@@ -99,6 +100,15 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
         + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
+=======
+    public static final String SECURITY_SSL_HTTP_CLIENTAUTH_MODE = SSL_HTTP_PREFIX + "clientauth_mode";
+    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_TYPE = SSL_HTTP_PREFIX + "truststore_type";
+    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS = SSL_HTTP_PREFIX + "truststore_alias";
+    public static final String SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH = SSL_HTTP_PREFIX + "truststore_filepath";
+    public static final String SECURITY_SSL_HTTP_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_HTTP_PREFIX
+        + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
+    public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + "pemtrustedcas_filepath";
+>>>>>>> 21e4080b (Spotless apply)
 
     // http cert revocation list settings
     public static final String SECURITY_SSL_HTTP_CRL_FILE = SSL_HTTP_CRL_PREFIX + "file_path";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -135,7 +135,7 @@ public final class SSLConfigConstants {
     public static final String SSL_AUX_PREFIX = SSL_PREFIX + AUX_SETTINGS + ".";
 
     // aux enable settings
-    public static final boolean SECURITY_SSL_AUX_ENABLED_DEFAULT = false;
+    public static final boolean SECURITY_SSL_AUX_ENABLED_DEFAULT = false; // aux transports are optional
     public static final String SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE = SSL_AUX_PREFIX + "enable_openssl_if_available";
     public static final String SECURITY_SSL_AUX_ENABLED = SSL_AUX_PREFIX + "enabled";
     public static final String SECURITY_SSL_AUX_ENABLED_CIPHERS = SSL_AUX_PREFIX + "enabled_ciphers";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -115,7 +115,6 @@ public final class SSLConfigConstants {
      */
     public static final String AUX_SETTINGS = "aux";
     public static final String SSL_AUX_PREFIX = SSL_PREFIX + AUX_SETTINGS + ".";
-    public static final String SSL_AUX_CRL_PREFIX = SSL_AUX_PREFIX + "crl.";
 
     // aux enable settings
     public static final boolean SECURITY_SSL_AUX_ENABLED_DEFAULT = false; // aux transports are optional
@@ -140,17 +139,7 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_AUX_TRUSTSTORE_TYPE = SSL_AUX_PREFIX + TRUSTSTORE_TYPE;
     public static final String SECURITY_SSL_AUX_TRUSTSTORE_ALIAS = SSL_AUX_PREFIX + TRUSTSTORE_ALIAS;
     public static final String SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH = SSL_AUX_PREFIX + TRUSTSTORE_FILEPATH;
-    public static final String SECURITY_SSL_AUX_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_AUX_PREFIX + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH = SSL_AUX_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
-
-    // aux cert revocation list settings
-    public static final String SECURITY_SSL_AUX_CRL_FILE = SSL_AUX_CRL_PREFIX + "file_path";
-    public static final String SECURITY_SSL_AUX_CRL_VALIDATE = SSL_AUX_CRL_PREFIX + "validate";
-    public static final String SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP = SSL_AUX_CRL_PREFIX + "prefer_crlfile_over_ocsp";
-    public static final String SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES = SSL_AUX_CRL_PREFIX + "check_only_end_entities";
-    public static final String SECURITY_SSL_AUX_CRL_DISABLE_OCSP = SSL_AUX_CRL_PREFIX + "disable_ocsp";
-    public static final String SECURITY_SSL_AUX_CRL_DISABLE_CRLDP = SSL_AUX_CRL_PREFIX + "disable_crldp";
-    public static final String SECURITY_SSL_AUX_CRL_VALIDATION_DATE = SSL_AUX_CRL_PREFIX + "validation_date";
 
     /**
      * Transport layer (node-to-node) settings.

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -133,41 +133,42 @@ public final class SSLConfigConstants {
      */
     public static final String AUX_SETTINGS = "aux";
     public static final String SSL_AUX_PREFIX = SSL_PREFIX + AUX_SETTINGS + ".";
+    public static final String SSL_AUX_CRL_PREFIX = SSL_AUX_PREFIX + "crl.";
 
     // aux enable settings
     public static final boolean SECURITY_SSL_AUX_ENABLED_DEFAULT = false; // aux transports are optional
-    public static final String SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE = SSL_AUX_PREFIX + "enable_openssl_if_available";
-    public static final String SECURITY_SSL_AUX_ENABLED = SSL_AUX_PREFIX + "enabled";
-    public static final String SECURITY_SSL_AUX_ENABLED_CIPHERS = SSL_AUX_PREFIX + "enabled_ciphers";
-    public static final String SECURITY_SSL_AUX_ENABLED_PROTOCOLS = SSL_AUX_PREFIX + "enabled_protocols";
+    public static final String SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE = SSL_AUX_PREFIX + ENABLE_OPENSSL_IF_AVAILABLE;
+    public static final String SECURITY_SSL_AUX_ENABLED = SSL_AUX_PREFIX + ENABLED;
+    public static final String SECURITY_SSL_AUX_ENABLED_CIPHERS = SSL_AUX_PREFIX + ENABLED_CIPHERS;
+    public static final String SECURITY_SSL_AUX_ENABLED_PROTOCOLS = SSL_AUX_PREFIX + ENABLED_PROTOCOLS;
 
     // aux allowed settings
     public static final String[] ALLOWED_OPENSSL_AUX_PROTOCOLS = ALLOWED_SSL_PROTOCOLS;
     public static final String[] ALLOWED_OPENSSL_AUX_PROTOCOLS_PRIOR_OPENSSL_1_1_1_BETA_9 = { "TLSv1.2", "TLSv1.1", "TLSv1" };
 
     // aux keystore settings
-    public static final String SECURITY_SSL_AUX_KEYSTORE_TYPE = SSL_AUX_PREFIX + "keystore_type";
-    public static final String SECURITY_SSL_AUX_KEYSTORE_ALIAS = SSL_AUX_PREFIX + "keystore_alias";
-    public static final String SECURITY_SSL_AUX_KEYSTORE_FILEPATH = SSL_AUX_PREFIX + "keystore_filepath";
-    public static final String SECURITY_SSL_AUX_PEMKEY_FILEPATH = SSL_AUX_PREFIX + "pemkey_filepath";
-    public static final String SECURITY_SSL_AUX_PEMCERT_FILEPATH = SSL_AUX_PREFIX + "pemcert_filepath";
+    public static final String SECURITY_SSL_AUX_KEYSTORE_TYPE = SSL_AUX_PREFIX + KEYSTORE_TYPE;
+    public static final String SECURITY_SSL_AUX_KEYSTORE_ALIAS = SSL_AUX_PREFIX + KEYSTORE_ALIAS;
+    public static final String SECURITY_SSL_AUX_KEYSTORE_FILEPATH = SSL_AUX_PREFIX + KEYSTORE_FILEPATH;
+    public static final String SECURITY_SSL_AUX_PEMKEY_FILEPATH = SSL_AUX_PREFIX + PEM_KEY_FILEPATH;
+    public static final String SECURITY_SSL_AUX_PEMCERT_FILEPATH = SSL_AUX_PREFIX + PEM_CERT_FILEPATH;
 
     // aux truststore settings
-    public static final String SECURITY_SSL_AUX_CLIENTAUTH_MODE = SSL_AUX_PREFIX + "clientauth_mode";
-    public static final String SECURITY_SSL_AUX_TRUSTSTORE_TYPE = SSL_AUX_PREFIX + "truststore_type";
-    public static final String SECURITY_SSL_AUX_TRUSTSTORE_ALIAS = SSL_AUX_PREFIX + "truststore_alias";
-    public static final String SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH = SSL_AUX_PREFIX + "truststore_filepath";
+    public static final String SECURITY_SSL_AUX_CLIENTAUTH_MODE = SSL_AUX_PREFIX + CLIENT_AUTH_MODE;
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_TYPE = SSL_AUX_PREFIX + TRUSTSTORE_TYPE;
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_ALIAS = SSL_AUX_PREFIX + TRUSTSTORE_ALIAS;
+    public static final String SECURITY_SSL_AUX_TRUSTSTORE_FILEPATH = SSL_AUX_PREFIX + TRUSTSTORE_FILEPATH;
     public static final String SECURITY_SSL_AUX_ENFORCE_CERT_RELOAD_DN_VERIFICATION = SSL_AUX_PREFIX + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
-    public static final String SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH = SSL_AUX_PREFIX + "pemtrustedcas_filepath";
+    public static final String SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH = SSL_AUX_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
 
     // aux cert revocation list settings
-    public static final String SECURITY_SSL_AUX_CRL_FILE = SSL_AUX_PREFIX + "crl.file_path";
-    public static final String SECURITY_SSL_AUX_CRL_VALIDATE = SSL_AUX_PREFIX + "crl.validate";
-    public static final String SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP = SSL_AUX_PREFIX + "crl.prefer_crlfile_over_ocsp";
-    public static final String SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES = SSL_AUX_PREFIX + "crl.check_only_end_entities";
-    public static final String SECURITY_SSL_AUX_CRL_DISABLE_OCSP = SSL_AUX_PREFIX + "crl.disable_ocsp";
-    public static final String SECURITY_SSL_AUX_CRL_DISABLE_CRLDP = SSL_AUX_PREFIX + "crl.disable_crldp";
-    public static final String SECURITY_SSL_AUX_CRL_VALIDATION_DATE = SSL_AUX_PREFIX + "crl.validation_date";
+    public static final String SECURITY_SSL_AUX_CRL_FILE = SSL_AUX_CRL_PREFIX + "file_path";
+    public static final String SECURITY_SSL_AUX_CRL_VALIDATE = SSL_AUX_CRL_PREFIX + "validate";
+    public static final String SECURITY_SSL_AUX_CRL_PREFER_CRLFILE_OVER_OCSP = SSL_AUX_CRL_PREFIX + "prefer_crlfile_over_ocsp";
+    public static final String SECURITY_SSL_AUX_CRL_CHECK_ONLY_END_ENTITIES = SSL_AUX_CRL_PREFIX + "check_only_end_entities";
+    public static final String SECURITY_SSL_AUX_CRL_DISABLE_OCSP = SSL_AUX_CRL_PREFIX + "disable_ocsp";
+    public static final String SECURITY_SSL_AUX_CRL_DISABLE_CRLDP = SSL_AUX_CRL_PREFIX + "disable_crldp";
+    public static final String SECURITY_SSL_AUX_CRL_VALIDATION_DATE = SSL_AUX_CRL_PREFIX + "validation_date";
 
     /**
      * Transport layer (node-to-node) settings.

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -28,7 +28,7 @@ import io.netty.handler.ssl.OpenSsl;
 
 public final class SSLConfigConstants {
     /**
-     * Global configurations
+     * Global configurations.
      */
     public static final Long OPENSSL_1_1_1_BETA_9 = 0x10101009L;
     public static final boolean OPENSSL_AVAILABLE = OpenSearchSecuritySSLPlugin.OPENSSL_SUPPORTED && OpenSsl.isAvailable();
@@ -37,7 +37,7 @@ public final class SSLConfigConstants {
     public static final String[] ALLOWED_SSL_PROTOCOLS = { "TLSv1.3", "TLSv1.2", "TLSv1.1" };
 
     /**
-     * Shared settings prefixes/postfixes
+     * Shared settings prefixes/postfixes.
      */
     public static final String ENABLED = "enabled";
     public static final String CLIENT_AUTH_MODE = "clientauth_mode";
@@ -67,7 +67,7 @@ public final class SSLConfigConstants {
     public static final String PEM_KEY_PASSWORD = "pemkey_password";
 
     /**
-     * HTTP transport security settings
+     * HTTP transport security settings.
      */
     public static final String HTTP_SETTINGS = "http";
     public static final String SSL_HTTP_PREFIX = SSL_PREFIX + HTTP_SETTINGS + ".";
@@ -129,7 +129,7 @@ public final class SSLConfigConstants {
     public static final String SECURITY_SSL_HTTP_CRL_VALIDATION_DATE = SSL_HTTP_CRL_PREFIX + "validation_date";
 
     /**
-     * Auxiliary transport security settings
+     * Auxiliary transport security settings.
      */
     public static final String AUX_SETTINGS = "aux";
     public static final String SSL_AUX_PREFIX = SSL_PREFIX + AUX_SETTINGS + ".";

--- a/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/OpenSSLTest.java
@@ -37,6 +37,7 @@ import org.opensearch.common.unit.TimeValue;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.OpenSearchSecurityPlugin;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.AbstractSecurityUnitTest;
@@ -133,7 +134,7 @@ public class OpenSSLTest extends SSLTest {
         // ADH-AES256-SHA256, ADH-CAMELLIA128-SHA
 
         final Set<String> openSSLSecureCiphers = new HashSet<>();
-        for (final String secure : SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false)) {
+        for (final String secure : SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, CertType.TRANSPORT)) {
             if (OpenSsl.isCipherSuiteAvailable(secure)) {
                 openSSLSecureCiphers.add(secure);
             }

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -52,6 +52,7 @@ import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.node.Node;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.security.OpenSearchSecurityPlugin;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
@@ -776,7 +777,7 @@ public class SSLTest extends SingleClusterTest {
         serverContext.init(null, null, null);
         final SSLEngine engine = serverContext.createSSLEngine();
         final List<String> jdkSupportedCiphers = new ArrayList<>(Arrays.asList(engine.getSupportedCipherSuites()));
-        jdkSupportedCiphers.retainAll(SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false));
+        jdkSupportedCiphers.retainAll(SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, CertType.TRANSPORT));
         engine.setEnabledCipherSuites(jdkSupportedCiphers.toArray(new String[0]));
 
         final List<String> jdkEnabledCiphers = Arrays.asList(engine.getEnabledCipherSuites());
@@ -788,11 +789,11 @@ public class SSLTest extends SingleClusterTest {
 
     @Test
     public void testUnmodifieableCipherProtocolConfig() throws Exception {
-        SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0] = "bogus";
-        assertThat(SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false)[0], is("TLSv1.3"));
+        SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT)[0] = "bogus";
+        assertThat(SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT)[0], is("TLSv1.3"));
 
         try {
-            SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, false).set(0, "bogus");
+            SSLConfigConstants.getSecureSSLCiphers(Settings.EMPTY, CertType.TRANSPORT).set(0, "bogus");
             Assert.fail();
         } catch (UnsupportedOperationException e) {
             // expected

--- a/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
@@ -29,6 +29,7 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.cert.X509CertificateHolder;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.config.KeyStoreConfiguration;
 import org.opensearch.security.ssl.config.SslParameters;
 import org.opensearch.security.ssl.config.TrustStoreConfiguration;
@@ -278,7 +279,7 @@ public class SslContextHandlerTest {
     // CS-ENFORCE-SINGLE
 
     SslContextHandler sslContextHandler() {
-        final var sslParameters = SslParameters.loader(Settings.EMPTY).load(false);
+        final var sslParameters = SslParameters.loader(Settings.EMPTY).load(CertType.TRANSPORT);
         final var trustStoreConfiguration = new TrustStoreConfiguration.PemTrustStoreConfiguration(caCertificatePath);
         final var keyStoreConfiguration = new KeyStoreConfiguration.PemKeyStoreConfiguration(
             accessCertificatePath,

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerReloadListenerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerReloadListenerTest.java
@@ -138,16 +138,16 @@ public class SslSettingsManagerReloadListenerTest extends RandomizedTest {
         reloadSslContextOnFilesChanged(
             certType,
             defaultSettingsBuilder()
-                    // Disable transport layer to test server transports independently.
-                    // If certType is TRANSPORT the following line will re-enable it.
-                    .put(SECURITY_SSL_TRANSPORT_ENABLED, false)
-                    .put(enabledSetting, true)
-                    .put(trustStorePathSetting, path(certTypeFilePrefix + "_truststore.jks"))
-                    .put(trustStoreTypeSetting, "jks")
-                    .put(keyStorePathSetting, path(certTypeFilePrefix + "_keystore.p12"))
-                    .put(keyStoreTypeSetting, "pkcs12")
-                    .setSecureSettings(secureSettings)
-                    .build(),
+                // Disable transport layer to test server transports independently.
+                // If certType is TRANSPORT the following line will re-enable it.
+                .put(SECURITY_SSL_TRANSPORT_ENABLED, false)
+                .put(enabledSetting, true)
+                .put(trustStorePathSetting, path(certTypeFilePrefix + "_truststore.jks"))
+                .put(trustStoreTypeSetting, "jks")
+                .put(keyStorePathSetting, path(certTypeFilePrefix + "_keystore.p12"))
+                .put(keyStoreTypeSetting, "pkcs12")
+                .setSecureSettings(secureSettings)
+                .build(),
             (filePrefix, caCertificate, accessKeyAndCertificate) -> {
                 final var trustStore = KeyStore.getInstance("jks");
                 trustStore.load(null, null);
@@ -156,10 +156,10 @@ public class SslSettingsManagerReloadListenerTest extends RandomizedTest {
                 final var keyStore = KeyStore.getInstance("pkcs12");
                 keyStore.load(null, null);
                 keyStore.setKeyEntry(
-                        "pk",
-                        accessKeyAndCertificate.v1(),
-                        certificatesRule.privateKeyPassword().toCharArray(),
-                        new X509Certificate[] { certificatesRule.toX509Certificate(accessKeyAndCertificate.v2()) }
+                    "pk",
+                    accessKeyAndCertificate.v1(),
+                    certificatesRule.privateKeyPassword().toCharArray(),
+                    new X509Certificate[] { certificatesRule.toX509Certificate(accessKeyAndCertificate.v2()) }
                 );
                 writeStore(keyStore, path(String.format("%s_keystore.p12", filePrefix)), keyStorePassword);
             }
@@ -178,27 +178,28 @@ public class SslSettingsManagerReloadListenerTest extends RandomizedTest {
         reloadSslContextOnFilesChanged(
             certType,
             defaultSettingsBuilder()
-                    // Disable transport layer to test server transports independently.
-                    // If certType is TRANSPORT the following line will re-enable it.
-                    .put(SECURITY_SSL_TRANSPORT_ENABLED, false)
-                    .put(enabledSetting, true)
-                    .put(pemTrustCasPathSetting, path(certTypeFilePrefix + "_ca_certificate.pem"))
-                    .put(pemCertPathSetting, path(certTypeFilePrefix + "_access_certificate.pem"))
-                    .put(pemKeyPathSetting, path(certTypeFilePrefix + "_access_certificate_pk.pem"))
-                    .setSecureSettings(secureSettings)
-                    .build(),
+                // Disable transport layer to test server transports independently.
+                // If certType is TRANSPORT the following line will re-enable it.
+                .put(SECURITY_SSL_TRANSPORT_ENABLED, false)
+                .put(enabledSetting, true)
+                .put(pemTrustCasPathSetting, path(certTypeFilePrefix + "_ca_certificate.pem"))
+                .put(pemCertPathSetting, path(certTypeFilePrefix + "_access_certificate.pem"))
+                .put(pemKeyPathSetting, path(certTypeFilePrefix + "_access_certificate_pk.pem"))
+                .setSecureSettings(secureSettings)
+                .build(),
             (filePrefix, caCertificate, accessKeyAndCertificate) -> {
                 writePemContent(path(String.format("%s_ca_certificate.pem", filePrefix)), caCertificate);
                 writePemContent(path(String.format("%s_access_certificate.pem", filePrefix)), accessKeyAndCertificate.v2());
                 writePemContent(
-                        path(String.format("%s_access_certificate_pk.pem", filePrefix)),
-                        privateKeyToPemObject(accessKeyAndCertificate.v1(), certificatesRule.privateKeyPassword())
+                    path(String.format("%s_access_certificate_pk.pem", filePrefix)),
+                    privateKeyToPemObject(accessKeyAndCertificate.v1(), certificatesRule.privateKeyPassword())
                 );
             }
         );
     }
 
-    private void reloadSslContextOnFilesChanged(CertType certType, final Settings settings, final CertificatesWriter certificatesWriter) throws Exception {
+    private void reloadSslContextOnFilesChanged(CertType certType, final Settings settings, final CertificatesWriter certificatesWriter)
+        throws Exception {
         final String certNamePrefix = certType.name().toLowerCase(Locale.ROOT);
         final var defaultCertificates = generateCertificates();
         var defaultKeyPair = defaultCertificates.v1();
@@ -212,15 +213,15 @@ public class SslSettingsManagerReloadListenerTest extends RandomizedTest {
 
         if (randomBoolean()) {
             caCertificate = certificatesRule.generateCaCertificate(
-                    defaultKeyPair,
-                    caCertificate.getNotBefore().toInstant(),
-                    caCertificate.getNotAfter().toInstant().plus(365, ChronoUnit.DAYS)
+                defaultKeyPair,
+                caCertificate.getNotBefore().toInstant(),
+                caCertificate.getNotAfter().toInstant().plus(365, ChronoUnit.DAYS)
             );
         } else {
             accessKeyAndCertificate = certificatesRule.generateAccessCertificate(
-                    defaultKeyPair,
-                    accessKeyAndCertificate.v2().getNotBefore().toInstant(),
-                    accessKeyAndCertificate.v2().getNotAfter().toInstant().plus(365, ChronoUnit.DAYS)
+                defaultKeyPair,
+                accessKeyAndCertificate.v2().getNotBefore().toInstant(),
+                accessKeyAndCertificate.v2().getNotAfter().toInstant().plus(365, ChronoUnit.DAYS)
             );
         }
         certificatesWriter.write(certNamePrefix, caCertificate, accessKeyAndCertificate);

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
@@ -199,7 +199,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
     }
 
     @Test
-    public void serverTransportConfigFailsIfClientAuthRequiredAndJdkTrustStoreNotSet() throws Exception {
+    public void serverTransportConfigFailsIfClientAuthRequiredAndJdkTrustStoreNotSet() {
         configFailsIfClientAuthRequiredAndJdkTrustStoreNotSet(
                 SECURITY_SSL_HTTP_ENABLED,
                 SECURITY_SSL_HTTP_CLIENTAUTH_MODE,
@@ -210,14 +210,34 @@ public class SslSettingsManagerTest extends RandomizedTest {
                 SECURITY_SSL_AUX_KEYSTORE_FILEPATH);
     }
 
-    @Test
-    public void httpConfigFailsIfClientAuthRequiredAndPemTrustedCasNotSet() throws Exception {
-        final var settings = defaultSettingsBuilder().put(SECURITY_SSL_HTTP_ENABLED, true)
-            .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-            .put(SECURITY_SSL_HTTP_PEMKEY_FILEPATH, "aaa")
-            .put(SECURITY_SSL_HTTP_PEMCERT_FILEPATH, "bbb")
-            .build();
+    private void configFailsIfClientAuthRequiredAndPemTrustedCasNotSet(
+            String transportEnabledSetting,
+            String clientAuthEnabledSetting,
+            String pemkeyPathSetting,
+            String pemcertPathSetting
+    ) {
+        final var settings = defaultSettingsBuilder().put(transportEnabledSetting, true)
+                .put(clientAuthEnabledSetting, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+                .put(pemkeyPathSetting, "aaa")
+                .put(pemcertPathSetting, "bbb")
+                .build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
+    }
+
+    @Test
+    public void serverTransportConfigFailsIfClientAuthRequiredAndPemTrustedCasNotSet() {
+        configFailsIfClientAuthRequiredAndPemTrustedCasNotSet(
+            SECURITY_SSL_HTTP_ENABLED,
+            SECURITY_SSL_HTTP_CLIENTAUTH_MODE,
+            SECURITY_SSL_HTTP_PEMKEY_FILEPATH,
+            SECURITY_SSL_HTTP_PEMCERT_FILEPATH
+        );
+        configFailsIfClientAuthRequiredAndPemTrustedCasNotSet(
+            SECURITY_SSL_AUX_ENABLED,
+            SECURITY_SSL_AUX_CLIENTAUTH_MODE,
+            SECURITY_SSL_AUX_PEMKEY_FILEPATH,
+            SECURITY_SSL_AUX_PEMCERT_FILEPATH
+        );
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
@@ -160,68 +160,77 @@ public class SslSettingsManagerTest extends RandomizedTest {
      * Pem store and JKS (Java KeyStore) cannot both be used for transport.
      */
     private void configFailsIfBothPemAndJDKSettingsWereSet(
-           String transportEnabledSetting,
-           List<String> transportJKSSettings,
-           List<String> transportPemStoreSettings
-    ){
+        String transportEnabledSetting,
+        List<String> transportJKSSettings,
+        List<String> transportPemStoreSettings
+    ) {
         final var settings = defaultSettingsBuilder().put(transportEnabledSetting, true)
-                .put(randomFrom(transportJKSSettings), "aaa")
-                .put(randomFrom(transportPemStoreSettings), "bbb")
-                .build();
+            .put(randomFrom(transportJKSSettings), "aaa")
+            .put(randomFrom(transportPemStoreSettings), "bbb")
+            .build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
     }
 
     @Test
     public void configFailsIfBothPemAndJDKSettingsWereSet() throws Exception {
         configFailsIfBothPemAndJDKSettingsWereSet(
-                SECURITY_SSL_HTTP_ENABLED,
-                List.of(SECURITY_SSL_HTTP_KEYSTORE_FILEPATH),
-                List.of(SECURITY_SSL_HTTP_PEMKEY_FILEPATH, SECURITY_SSL_HTTP_PEMCERT_FILEPATH, SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH));
+            SECURITY_SSL_HTTP_ENABLED,
+            List.of(SECURITY_SSL_HTTP_KEYSTORE_FILEPATH),
+            List.of(SECURITY_SSL_HTTP_PEMKEY_FILEPATH, SECURITY_SSL_HTTP_PEMCERT_FILEPATH, SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH)
+        );
         configFailsIfBothPemAndJDKSettingsWereSet(
-                SECURITY_SSL_AUX_ENABLED,
-                List.of(SECURITY_SSL_AUX_KEYSTORE_FILEPATH),
-                List.of(SECURITY_SSL_AUX_PEMKEY_FILEPATH, SECURITY_SSL_AUX_PEMCERT_FILEPATH, SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH));
+            SECURITY_SSL_AUX_ENABLED,
+            List.of(SECURITY_SSL_AUX_KEYSTORE_FILEPATH),
+            List.of(SECURITY_SSL_AUX_PEMKEY_FILEPATH, SECURITY_SSL_AUX_PEMCERT_FILEPATH, SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH)
+        );
         configFailsIfBothPemAndJDKSettingsWereSet(
-                SECURITY_SSL_TRANSPORT_ENABLED,
-                List.of(SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH),
-                List.of(SECURITY_SSL_TRANSPORT_PEMKEY_FILEPATH, SECURITY_SSL_TRANSPORT_PEMCERT_FILEPATH, SECURITY_SSL_TRANSPORT_PEMTRUSTEDCAS_FILEPATH));
+            SECURITY_SSL_TRANSPORT_ENABLED,
+            List.of(SECURITY_SSL_TRANSPORT_KEYSTORE_FILEPATH),
+            List.of(
+                SECURITY_SSL_TRANSPORT_PEMKEY_FILEPATH,
+                SECURITY_SSL_TRANSPORT_PEMCERT_FILEPATH,
+                SECURITY_SSL_TRANSPORT_PEMTRUSTEDCAS_FILEPATH
+            )
+        );
     }
 
     private void configFailsIfClientAuthRequiredAndJdkTrustStoreNotSet(
-            String transportEnabledSetting,
-            String clientAuthEnabledSetting,
-            String keystorePathSetting
+        String transportEnabledSetting,
+        String clientAuthEnabledSetting,
+        String keystorePathSetting
     ) {
         final var settings = defaultSettingsBuilder().put(transportEnabledSetting, true)
-                .put(clientAuthEnabledSetting, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-                .put(keystorePathSetting, certificatesRule.configRootFolder().toString())
-                .build();
+            .put(clientAuthEnabledSetting, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .put(keystorePathSetting, certificatesRule.configRootFolder().toString())
+            .build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
     }
 
     @Test
     public void serverTransportConfigFailsIfClientAuthRequiredAndJdkTrustStoreNotSet() {
         configFailsIfClientAuthRequiredAndJdkTrustStoreNotSet(
-                SECURITY_SSL_HTTP_ENABLED,
-                SECURITY_SSL_HTTP_CLIENTAUTH_MODE,
-                SECURITY_SSL_HTTP_KEYSTORE_FILEPATH);
+            SECURITY_SSL_HTTP_ENABLED,
+            SECURITY_SSL_HTTP_CLIENTAUTH_MODE,
+            SECURITY_SSL_HTTP_KEYSTORE_FILEPATH
+        );
         configFailsIfClientAuthRequiredAndJdkTrustStoreNotSet(
-                SECURITY_SSL_AUX_ENABLED,
-                SECURITY_SSL_AUX_CLIENTAUTH_MODE,
-                SECURITY_SSL_AUX_KEYSTORE_FILEPATH);
+            SECURITY_SSL_AUX_ENABLED,
+            SECURITY_SSL_AUX_CLIENTAUTH_MODE,
+            SECURITY_SSL_AUX_KEYSTORE_FILEPATH
+        );
     }
 
     private void configFailsIfClientAuthRequiredAndPemTrustedCasNotSet(
-            String transportEnabledSetting,
-            String clientAuthEnabledSetting,
-            String pemkeyPathSetting,
-            String pemcertPathSetting
+        String transportEnabledSetting,
+        String clientAuthEnabledSetting,
+        String pemkeyPathSetting,
+        String pemcertPathSetting
     ) {
         final var settings = defaultSettingsBuilder().put(transportEnabledSetting, true)
-                .put(clientAuthEnabledSetting, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-                .put(pemkeyPathSetting, "aaa")
-                .put(pemcertPathSetting, "bbb")
-                .build();
+            .put(clientAuthEnabledSetting, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .put(pemkeyPathSetting, "aaa")
+            .put(pemcertPathSetting, "bbb")
+            .build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
     }
 
@@ -295,8 +304,8 @@ public class SslSettingsManagerTest extends RandomizedTest {
             sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::sslContext).map(SslContext::isServer).orElse(false)
         );
         assertThat(
-                "Built Server SSL context for AUX",
-                sslSettingsManager.sslContextHandler(CertType.AUX).map(SslContextHandler::sslContext).map(SslContext::isServer).orElse(false)
+            "Built Server SSL context for AUX",
+            sslSettingsManager.sslContextHandler(CertType.AUX).map(SslContextHandler::sslContext).map(SslContext::isServer).orElse(false)
         );
     }
 
@@ -536,10 +545,10 @@ public class SslSettingsManagerTest extends RandomizedTest {
 
     private void withAuxSslSettings(final Settings.Builder settingsBuilder) {
         settingsBuilder.put(SECURITY_SSL_AUX_ENABLED, true)
-                .put(SECURITY_SSL_AUX_ENABLED, true)
-                .put(SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, path("ca_aux_certificate.pem"))
-                .put(SECURITY_SSL_AUX_PEMCERT_FILEPATH, path("access_aux_certificate.pem"))
-                .put(SECURITY_SSL_AUX_PEMKEY_FILEPATH, path("access_aux_certificate_pk.pem"));
+            .put(SECURITY_SSL_AUX_ENABLED, true)
+            .put(SECURITY_SSL_AUX_PEMTRUSTEDCAS_FILEPATH, path("ca_aux_certificate.pem"))
+            .put(SECURITY_SSL_AUX_PEMCERT_FILEPATH, path("access_aux_certificate.pem"))
+            .put(SECURITY_SSL_AUX_PEMKEY_FILEPATH, path("access_aux_certificate_pk.pem"));
     }
 
     Settings.Builder defaultSettingsBuilder() {

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
@@ -99,7 +99,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
         final var noTransportSettings = defaultSettingsBuilder().put(transportEnabledSetting, true).build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(noTransportSettings)));
     }
-
+    
     @Test
     public void testFailsIfNoConfigDefine() {
         transportFailsIfNoConfigDefine(SECURITY_SSL_HTTP_ENABLED);
@@ -162,12 +162,6 @@ public class SslSettingsManagerTest extends RandomizedTest {
             .put(keyStoreSettings, "aaa")
             .put(pemKeyStoreSettings, "bbb")
             .build();
-        assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
-    }
-
-    @Test
-    public void httpConfigFailsIfHttpEnabledButButNotDefined() throws Exception {
-        final var settings = defaultSettingsBuilder().put(SECURITY_SSL_HTTP_ENABLED, true).build();
         assertThrows(OpenSearchException.class, () -> new SslSettingsManager(TestEnvironment.newEnvironment(settings)));
     }
 

--- a/src/test/java/org/opensearch/security/ssl/config/JdkSslCertificatesLoaderTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/JdkSslCertificatesLoaderTest.java
@@ -45,6 +45,7 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_T
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_TRUSTSTORE_ALIAS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_TRUSTSTORE_TYPE;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_CLIENT_EXTENDED_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
@@ -68,6 +69,11 @@ public class JdkSslCertificatesLoaderTest extends SslCertificatesLoaderTest {
     @Test
     public void loadHttpSslConfigurationFromKeyAndTrustStoreFiles() throws Exception {
         testJdkBasedSslConfiguration(SSL_HTTP_PREFIX, randomBoolean());
+    }
+
+    @Test
+    public void loadAuxSslConfigurationFromKeyAndTrustStoreFiles() throws Exception {
+        testJdkBasedSslConfiguration(SSL_AUX_PREFIX, randomBoolean());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/ssl/config/PemSslCertificatesLoaderTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/PemSslCertificatesLoaderTest.java
@@ -40,6 +40,7 @@ import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_T
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_PEMCERT_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_PEMKEY_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_SERVER_PEMTRUSTEDCAS_FILEPATH;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_CLIENT_EXTENDED_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
@@ -74,6 +75,11 @@ public class PemSslCertificatesLoaderTest extends SslCertificatesLoaderTest {
     }
 
     @Test
+    public void loadAuxSslConfigurationFromPemFiles() throws Exception {
+        testLoadPemBasedConfiguration(SSL_AUX_PREFIX, randomBoolean());
+    }
+
+    @Test
     public void loadTransportSslConfigurationFromPemFiles() throws Exception {
         testLoadPemBasedConfiguration(SSL_HTTP_PREFIX, false);
     }
@@ -94,7 +100,7 @@ public class PemSslCertificatesLoaderTest extends SslCertificatesLoaderTest {
         }
 
         final var settings = settingsBuilder.build();
-        final var configuration = new SslCertificatesLoader(SSL_HTTP_PREFIX).loadConfiguration(TestEnvironment.newEnvironment(settings));
+        final var configuration = new SslCertificatesLoader(sslConfigPrefix).loadConfiguration(TestEnvironment.newEnvironment(settings));
         if (useAuthorityCertificate) {
             assertTrustStoreConfiguration(
                 configuration.v1(),

--- a/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
@@ -11,12 +11,15 @@
 
 package org.opensearch.security.ssl.config;
 
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -27,64 +30,111 @@ import io.netty.handler.ssl.SslProvider;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.ALLOWED_SSL_CIPHERS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_CLIENTAUTH_MODE;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_CIPHERS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_CLIENTAUTH_MODE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_CIPHERS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_AUX_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_HTTP_PREFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SSL_TRANSPORT_PREFIX;
 
 public class SslParametersTest {
 
-    @Test
-    public void testDefaultSslParameters() throws Exception {
-        final var settings = Settings.EMPTY;
-        final var httpSslParameters = SslParameters.loader(settings).load(true);
-        final var transportSslParameters = SslParameters.loader(settings).load(false);
+    List<String> finalDefaultCiphers;
 
+    @Before
+    public void setup() throws NoSuchAlgorithmException {
         final var defaultCiphers = List.of(ALLOWED_SSL_CIPHERS);
-        final var finalDefaultCiphers = Stream.of(SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites())
+        finalDefaultCiphers = Stream.of(SSLContext.getDefault().getDefaultSSLParameters().getCipherSuites())
             .filter(defaultCiphers::contains)
             .sorted(String::compareTo)
             .collect(Collectors.toList());
+    }
 
+    @Test
+    public void testDefaultSslParametersForHttp() {
+        final var httpSslParameters = SslParameters.loader(Settings.EMPTY).load(CertType.HTTP);
         assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
-        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
-
         assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(httpSslParameters.allowedCiphers(), is(finalDefaultCiphers));
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
+    }
 
+    @Test
+    public void testDefaultSslParametersForAux() {
+        final var auxSslParameters = SslParameters.loader(Settings.EMPTY).load(CertType.AUX);
+        assertThat(auxSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(auxSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
+        assertThat(auxSslParameters.allowedCiphers(), is(finalDefaultCiphers));
+        assertThat(auxSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
+    }
+
+    @Test
+    public void testDefaultSslParametersForTransport() {
+        final var transportSslParameters = SslParameters.loader(Settings.EMPTY).load(CertType.TRANSPORT);
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
         assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(transportSslParameters.allowedCiphers(), is(finalDefaultCiphers));
-
-        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.OPTIONAL));
         assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
     }
 
     @Test
-    public void testCustomSSlParameters() {
+    public void testCustomSSlParametersForHttpAndTransport() {
         final var settings = Settings.builder()
-            .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-            .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
-            .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
-            .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
-            .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
-            .build();
-        final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(true);
-        final var transportSslParameters = SslParameters.loader(settings.getByPrefix(SSL_TRANSPORT_PREFIX)).load(false);
+                .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+                .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+                .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+                .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
+                .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
+                .build();
+        final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(CertType.HTTP);
+        final var transportSslParameters = SslParameters.loader(settings.getByPrefix(SSL_TRANSPORT_PREFIX)).load(CertType.TRANSPORT);
 
         assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
-        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
-
         assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
         assertThat(httpSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
 
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
         assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
         assertThat(transportSslParameters.allowedCiphers(), is(List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384")));
-
-        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
         assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
     }
 
+    @Test
+    public void testCustomSSlParametersForHttpAndAuxAndTransport() {
+        final var settings = Settings.builder()
+                .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+                .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+                .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+                .put(SECURITY_SSL_AUX_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+                .putList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+                .putList(SECURITY_SSL_AUX_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+                .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
+                .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
+                .build();
+
+        final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(CertType.HTTP);
+        final var auxSslParameters = SslParameters.loader(settings.getByPrefix(SSL_AUX_PREFIX)).load(CertType.AUX);
+        final var transportSslParameters = SslParameters.loader(settings.getByPrefix(SSL_TRANSPORT_PREFIX)).load(CertType.TRANSPORT);
+
+        assertThat(httpSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(httpSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(httpSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(httpSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+
+        assertThat(auxSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(auxSslParameters.allowedProtocols(), is(List.of("TLSv1.2")));
+        assertThat(auxSslParameters.allowedCiphers(), is(List.of("TLS_AES_256_GCM_SHA384")));
+        assertThat(auxSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+
+        assertThat(transportSslParameters.provider(), is(SslProvider.JDK));
+        assertThat(transportSslParameters.allowedProtocols(), is(List.of("TLSv1.3", "TLSv1.2")));
+        assertThat(transportSslParameters.allowedCiphers(), is(List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384")));
+        assertThat(transportSslParameters.clientAuth(), is(ClientAuth.REQUIRE));
+    }
 }

--- a/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
+++ b/src/test/java/org/opensearch/security/ssl/config/SslParametersTest.java
@@ -19,7 +19,6 @@ import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -85,12 +84,12 @@ public class SslParametersTest {
     @Test
     public void testCustomSSlParametersForHttpAndTransport() {
         final var settings = Settings.builder()
-                .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-                .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
-                .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
-                .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
-                .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
-                .build();
+            .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
+            .build();
         final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(CertType.HTTP);
         final var transportSslParameters = SslParameters.loader(settings.getByPrefix(SSL_TRANSPORT_PREFIX)).load(CertType.TRANSPORT);
 
@@ -108,15 +107,15 @@ public class SslParametersTest {
     @Test
     public void testCustomSSlParametersForHttpAndAuxAndTransport() {
         final var settings = Settings.builder()
-                .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-                .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
-                .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
-                .put(SECURITY_SSL_AUX_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
-                .putList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
-                .putList(SECURITY_SSL_AUX_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
-                .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
-                .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
-                .build();
+            .put(SECURITY_SSL_HTTP_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(SECURITY_SSL_HTTP_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .put(SECURITY_SSL_AUX_CLIENTAUTH_MODE, ClientAuth.REQUIRE.name().toLowerCase(Locale.ROOT))
+            .putList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, List.of("TLSv1.2", "TLSv1"))
+            .putList(SECURITY_SSL_AUX_ENABLED_CIPHERS, List.of("TLS_AES_256_GCM_SHA384"))
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1.3", "TLSv1.2"))
+            .putList(SECURITY_SSL_TRANSPORT_ENABLED_CIPHERS, List.of("TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"))
+            .build();
 
         final var httpSslParameters = SslParameters.loader(settings.getByPrefix(SSL_HTTP_PREFIX)).load(CertType.HTTP);
         final var auxSslParameters = SslParameters.loader(settings.getByPrefix(SSL_AUX_PREFIX)).load(CertType.AUX);

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
@@ -10,15 +10,12 @@
  */
 package org.opensearch.security.ssl.util;
 
-import java.util.List;
-
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.config.CertType;
 
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_PROTOCOLS;
-import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
 import static org.junit.Assert.assertArrayEquals;
@@ -36,25 +33,34 @@ public class SSLConfigConstantsTest {
 
     @Test
     public void testCustomTLSProtocols() {
-        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+        assertArrayEquals(
+            TLSV1_01,
+            SSLConfigConstants.getSecureSSLProtocols(
                 Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, TLSV1_01).build(),
                 CertType.HTTP
-        ));
-        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+            )
+        );
+        assertArrayEquals(
+            TLSV1_01,
+            SSLConfigConstants.getSecureSSLProtocols(
                 Settings.builder().putList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, TLSV1_01).build(),
                 CertType.AUX
-        ));
-        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+            )
+        );
+        assertArrayEquals(
+            TLSV1_01,
+            SSLConfigConstants.getSecureSSLProtocols(
                 Settings.builder().putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, TLSV1_01).build(),
                 CertType.TRANSPORT
-        ));
+            )
+        );
     }
 
     @Test
     public void testCustomSSLProtocols() {
         final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
             Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, TLSV1_01).build(),
-                CertType.HTTP
+            CertType.HTTP
         );
         assertArrayEquals(TLSV1_01, sslDefaultProtocols);
     }

--- a/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLConfigConstantsTest.java
@@ -15,41 +15,47 @@ import java.util.List;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.ssl.config.CertType;
 
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLED_PROTOCOLS;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_ENABLE_OPENSSL_IF_AVAILABLE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED_PROTOCOLS;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS;
 import static org.junit.Assert.assertArrayEquals;
 
 public class SSLConfigConstantsTest {
+    private static final String[] TLSV1_123 = new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" };
+    private static final String[] TLSV1_01 = new String[] { "TLSv1", "TLSv1.1" };
 
     @Test
     public void testDefaultTLSProtocols() {
-        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, false);
-        assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, tlsDefaultProtocols);
-    }
-
-    @Test
-    public void testDefaultSSLProtocols() {
-        final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, true);
-        assertArrayEquals(new String[] { "TLSv1.3", "TLSv1.2", "TLSv1.1" }, sslDefaultProtocols);
+        assertArrayEquals(TLSV1_123, SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.HTTP));
+        assertArrayEquals(TLSV1_123, SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.AUX));
+        assertArrayEquals(TLSV1_123, SSLConfigConstants.getSecureSSLProtocols(Settings.EMPTY, CertType.TRANSPORT));
     }
 
     @Test
     public void testCustomTLSProtocols() {
-        final var tlsDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
-            Settings.builder().putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
-            false
-        );
-        assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, tlsDefaultProtocols);
+        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+                Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, TLSV1_01).build(),
+                CertType.HTTP
+        ));
+        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+                Settings.builder().putList(SECURITY_SSL_AUX_ENABLED_PROTOCOLS, TLSV1_01).build(),
+                CertType.AUX
+        ));
+        assertArrayEquals(TLSV1_01, SSLConfigConstants.getSecureSSLProtocols(
+                Settings.builder().putList(SECURITY_SSL_TRANSPORT_ENABLED_PROTOCOLS, TLSV1_01).build(),
+                CertType.TRANSPORT
+        ));
     }
 
     @Test
     public void testCustomSSLProtocols() {
         final var sslDefaultProtocols = SSLConfigConstants.getSecureSSLProtocols(
-            Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, List.of("TLSv1", "TLSv1.1")).build(),
-            true
+            Settings.builder().putList(SECURITY_SSL_HTTP_ENABLED_PROTOCOLS, TLSV1_01).build(),
+                CertType.HTTP
         );
-        assertArrayEquals(new String[] { "TLSv1", "TLSv1.1" }, sslDefaultProtocols);
+        assertArrayEquals(TLSV1_01, sslDefaultProtocols);
     }
-
 }


### PR DESCRIPTION
### Description
Add settings for configuring keystore/truststore resources for optional auxiliary client/server transports in OpenSearch core which are supplied and registered by plugins. For more information regarding auxiliary transports see https://github.com/opensearch-project/OpenSearch/pull/16534.

Initially aux transports will only support client-certificate authentication:
https://opensearch.org/docs/latest/security/authentication-backends/client-auth/

Similarly no authorization functionality is included in this PR and is planned for follow up work.

Introduces the following settings for configuring TLS for auxiliary transports:

#### Enable
```
plugins.security.ssl.http.enabled
plugins.security.ssl.aux.clientauth_mode
plugins.security.ssl.aux.enabled_ciphers
plugins.security.ssl.aux.enabled_protocols

// will respect the following global settings
plugins.security.disabled
plugins.security.ssl_only
```
#### Keystore settings
```
// for keystores
plugins.security.ssl.aux.keystore_type
plugins.security.ssl.aux.keystore_alias
plugins.security.ssl.aux.keystore_filepath
plugins.security.ssl.aux.keystore_password
// for pemkeys
plugins.security.ssl.aux.pemkey_filepath
plugins.security.ssl.aux.pemkey_password
```
#### Truststore settings
```
// for truststore
plugins.security.ssl.aux.truststore_type
plugins.security.ssl.aux.truststore_alias
plugins.security.ssl.aux.truststore_filepath
plugins.security.ssl.aux.truststore_password
// for pemcerts
plugins.security.ssl.aux.pemcert_filepath
plugins.security.ssl.aux.pemtrustedcas_filepath
```

### Issues Resolved
#5104

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Added tests for SettingsManager and ContextManager for new transport type.
CI will fail due to missing definitions in core since the corresponding PR adding SecureAuxTransportSettingsProvider is still in review.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
