### PR TITLE
Replaces password generator step to a secure password generator action

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -16,8 +16,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - id: random-password
-        uses: peternied/random-name@v1
+      - name: Generate Strong Password
+        id: generate-password
+        uses: DarshitChanpura/secure-password-action@v1.0.0
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -45,11 +46,11 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
-          admin-password: ${{ steps.random-password.outputs.generated_name }}
+          admin-password: ${{ steps.generate-password.outputs.password }}
           jdk-version: 21
 
       - name: Run sanity tests
         uses: gradle/gradle-build-action@v3
         with:
           cache-disabled: true
-          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.random-password.outputs.generated_name }} -i
+          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.generate-password.outputs.password }} -i


### PR DESCRIPTION
Current step generates names as password which may not be strong enough for future CI given that we require a strong password now.
 
### Testing
- CI

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
