### PR TITLE
nit: Update deprecation message for _opendistro/_security/kibanainfo API

### DIFF
--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -51,12 +51,14 @@ import org.opensearch.transport.client.node.NodeClient;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.security.dlic.rest.support.Utils.LEGACY_PLUGIN_ROUTE_PREFIX;
-import static org.opensearch.security.dlic.rest.support.Utils.OPENDISTRO_API_DEPRECATION_MESSAGE;
 import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addDeprecatedRoutesPrefix;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class DashboardsInfoAction extends BaseRestHandler {
+
+    private static final String KIBANAINFO_ROUTE_DEPRECATION_MESSAGE =
+        "[_opendistro/_security/kibanainfo] is a deprecated endpoint path. Please use _plugins/_security/dashboardsinfo instead.";;
 
     private static final List<Route> routes = ImmutableList.<Route>builder()
         .addAll(
@@ -68,8 +70,8 @@ public class DashboardsInfoAction extends BaseRestHandler {
         .addAll(
             addDeprecatedRoutesPrefix(
                 ImmutableList.of(
-                    new DeprecatedRoute(GET, "/kibanainfo", OPENDISTRO_API_DEPRECATION_MESSAGE),
-                    new DeprecatedRoute(POST, "/kibanainfo", OPENDISTRO_API_DEPRECATION_MESSAGE)
+                    new DeprecatedRoute(GET, "/kibanainfo", KIBANAINFO_ROUTE_DEPRECATION_MESSAGE),
+                    new DeprecatedRoute(POST, "/kibanainfo", KIBANAINFO_ROUTE_DEPRECATION_MESSAGE)
                 ),
                 LEGACY_PLUGIN_ROUTE_PREFIX
             )


### PR DESCRIPTION
### Description
Update deprecation message for _opendistro/_security/kibanainfo API
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) Maintenance
* Why these changes are required?
The security repo has lingering usages of the terms opendistro and kibana, these will be removed in 4.0
For https://github.com/opensearch-project/security/issues/5092 & https://github.com/opensearch-project/security/issues/5097

* What is the old behavior before changes and new behavior after changes? Update of log line on using deprecated API.
```
2025-03-07 08:37:03 opensearch[data_0][transport_worker][T#4] DEPRECATION RestController:123 - [_opendistro/_security/kibanainfo] is a deprecated endpoint path. Please use _plugins/_security/dashboardsinfo instead.
```
### Issues Resolved
https://github.com/opensearch-project/security/issues/5097

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
