### PR TITLE
Fixes version matcher string in demo config installer

### DIFF
--- a/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/Installer.java
@@ -330,19 +330,21 @@ public class Installer {
 
         // Extract OpenSearch version and Security version
         File[] opensearchLibFiles = new File(OPENSEARCH_LIB_PATH).listFiles(
-            pathname -> pathname.getName().matches("opensearch-core-(.*).jar")
+            pathname -> pathname.getName().matches("opensearch-core-(\\d+(\\.\\d+)*(-[a-zA-Z0-9]+)?(-SNAPSHOT)?).jar")
         );
 
         if (opensearchLibFiles != null && opensearchLibFiles.length > 0) {
-            OPENSEARCH_VERSION = opensearchLibFiles[0].getName().replaceAll("opensearch-core-(.*).jar", "$1");
+            OPENSEARCH_VERSION = opensearchLibFiles[0].getName()
+                .replaceAll("opensearch-core-(\\d+(\\.\\d+)*(-[a-zA-Z0-9]+)?(-SNAPSHOT)?).jar", "$1");
         }
 
         File[] securityFiles = new File(OPENSEARCH_PLUGINS_DIR + "opensearch-security").listFiles(
-            pathname -> pathname.getName().startsWith("opensearch-security-") && pathname.getName().endsWith(".jar")
+            pathname -> pathname.getName().matches("opensearch-security-\\d+(\\.\\d+)*(-[a-zA-Z0-9]+)?(-SNAPSHOT)?.jar")
         );
 
         if (securityFiles != null && securityFiles.length > 0) {
-            SECURITY_VERSION = securityFiles[0].getName().replaceAll("opensearch-security-(.*).jar", "$1");
+            SECURITY_VERSION = securityFiles[0].getName()
+                .replaceAll("opensearch-security-(\\d+(\\.\\d+)*(-[a-zA-Z0-9]+)?(-SNAPSHOT)?).jar", "$1");
         }
     }
 

--- a/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
+++ b/src/test/java/org/opensearch/security/tools/democonfig/InstallerTests.java
@@ -118,7 +118,7 @@ public class InstallerTests {
 
         // set initsecurity and cluster_mode to no
         readInputStream("y" + System.lineSeparator() + "n" + System.lineSeparator() + "n" + System.lineSeparator()); // pass all 3 inputs as
-                                                                                                                     // y
+        // y
         installer.gatherUserInputs();
 
         verifyStdOutContainsString("Install demo certificates?");
@@ -134,7 +134,7 @@ public class InstallerTests {
 
         // set initsecurity and cluster_mode to no
         readInputStream("y" + System.lineSeparator() + "y" + System.lineSeparator() + "y" + System.lineSeparator()); // pass all 3 inputs as
-                                                                                                                     // y
+        // y
         installer.gatherUserInputs();
 
         verifyStdOutContainsString("Install demo certificates?");
@@ -175,7 +175,7 @@ public class InstallerTests {
         assertThat(installer.cluster_mode, is(true));
 
         readInputStream("y" + System.lineSeparator() + "y" + System.lineSeparator() + "y" + System.lineSeparator()); // pass all 3 inputs as
-                                                                                                                     // y
+        // y
         installer.gatherUserInputs();
 
         verifyStdOutContainsString("Install demo certificates?");
@@ -307,8 +307,8 @@ public class InstallerTests {
         setUpSecurityDirectories();
         installer.setSecurityVariables();
 
-        assertThat(installer.OPENSEARCH_VERSION, is(equalTo("osVersion")));
-        assertThat(installer.SECURITY_VERSION, is(equalTo("version")));
+        assertThat(installer.OPENSEARCH_VERSION, is(equalTo("3.0.0-Version")));
+        assertThat(installer.SECURITY_VERSION, is(equalTo("3.0.0.0-version")));
         tearDownSecurityDirectories();
     }
 
@@ -481,8 +481,11 @@ public class InstallerTests {
         createDirectory(installer.OPENSEARCH_LIB_PATH);
         createDirectory(installer.OPENSEARCH_CONF_DIR);
         createDirectory(installer.OPENSEARCH_PLUGINS_DIR + "opensearch-security");
-        createFile(installer.OPENSEARCH_LIB_PATH + "opensearch-core-osVersion.jar");
-        createFile(installer.OPENSEARCH_PLUGINS_DIR + "opensearch-security" + File.separator + "opensearch-security-version.jar");
+        createFile(installer.OPENSEARCH_LIB_PATH + "opensearch-core-3.0.0-Version.jar");
+        createFile(
+            installer.OPENSEARCH_PLUGINS_DIR + "opensearch-security" + File.separator + "opensearch-security-common-3.0.0.0-version.jar"
+        );
+        createFile(installer.OPENSEARCH_PLUGINS_DIR + "opensearch-security" + File.separator + "opensearch-security-3.0.0.0-version.jar");
         createFile(installer.OPENSEARCH_CONF_DIR + File.separator + "securityadmin_demo.sh");
     }
 


### PR DESCRIPTION
### Description
A bug was discovered in Installer.java while working on #5016, where the version matcher string matched everything after `opensearch-security`. WIth #5016 introducing packages like `opensearch-security-client` and `openserch-secrurity-common` the version matcher spewed out `common-3.0.0.0` instead out `3.0.0.0`. This PR fixes it to only spew out the version along with qualifier and snapshot string.

### Issues Resolved
unblocks #5016 


### Testing
Unit tests

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
