### PR TITLE
Adding stop-replication permission to index_management_full_access

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -241,6 +241,7 @@ index_management_full_access:
         - '*'
       allowed_actions:
         - 'indices:admin/opensearch/ism/*'
+        - 'indices:internal/plugins/replication/index/stop'
 
 # Allows users to use all cross cluster replication functionality at leader cluster
 cross_cluster_replication_leader_full_access:


### PR DESCRIPTION
### Description

This change adds an additional permission to  index_management_full_access role in config/roles.yml. 
This permission is needed to execute the newly added "stop_replication action" added in index-management plugin - https://github.com/opensearch-project/index-management/pull/1198

### Issues Resolved
Related to https://github.com/opensearch-project/index-management/issues/726

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
