### PR TITLE
[Backport] [2.x] Bump org.mockito:mockito-core from 5.15.2 to 5.16.0 (#5161)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -751,7 +751,7 @@ dependencies {
     integrationTestImplementation "org.apache.httpcomponents:fluent-hc:4.5.14"
     integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.16"
     integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
-    integrationTestImplementation "org.mockito:mockito-core:5.14.2"
+    integrationTestImplementation "org.mockito:mockito-core:5.16.0"
 
     //spotless
     implementation('com.google.googlejavaformat:google-java-format:1.25.2') {


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/5161 to `2.x`