### PR TITLE
[Backport] [2.x] Bump org.checkerframework:checker-qual from 3.49.0 to 3.49.1 (#5162)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -502,7 +502,7 @@ configurations {
             force "org.apache.httpcomponents:httpcore-nio:4.4.16"
             force "org.apache.httpcomponents:httpasyncclient:4.1.5"
             force "com.google.errorprone:error_prone_annotations:2.35.1"
-            force "org.checkerframework:checker-qual:3.48.3"
+            force "org.checkerframework:checker-qual:3.49.1"
             force "ch.qos.logback:logback-classic:1.5.16"
             force "commons-io:commons-io:2.18.0"
         }
@@ -661,7 +661,7 @@ dependencies {
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.1'
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.5'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
-    runtimeOnly 'org.checkerframework:checker-qual:3.48.3'
+    runtimeOnly 'org.checkerframework:checker-qual:3.49.1'
     runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 


### PR DESCRIPTION
Backport of https://github.com/opensearch-project/security/pull/5162 to `2.x`