### PR TITLE
Escape pipe character for injected users

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -111,6 +111,7 @@ import org.greenrobot.eventbus.Subscribe;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.traceAction;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT;
+import static org.opensearch.security.support.SecurityUtils.escapePipe;
 
 public class PrivilegesEvaluator {
 
@@ -275,12 +276,14 @@ public class PrivilegesEvaluator {
     private void setUserInfoInThreadContext(User user) {
         if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
             StringJoiner joiner = new StringJoiner("|");
-            joiner.add(user.getName());
-            joiner.add(String.join(",", user.getRoles()));
-            joiner.add(String.join(",", user.getSecurityRoles()));
+            // Escape any pipe characters in the values before joining
+            joiner.add(escapePipe(user.getName()));
+            joiner.add(escapePipe(String.join(",", user.getRoles())));
+            joiner.add(escapePipe(String.join(",", user.getSecurityRoles())));
+
             String requestedTenant = user.getRequestedTenant();
             if (!Strings.isNullOrEmpty(requestedTenant)) {
-                joiner.add(requestedTenant);
+                joiner.add(escapePipe(requestedTenant));
             }
             threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, joiner.toString());
         }

--- a/src/main/java/org/opensearch/security/support/SecurityUtils.java
+++ b/src/main/java/org/opensearch/security/support/SecurityUtils.java
@@ -140,4 +140,12 @@ public final class SecurityUtils {
             return bc ? Hasher.hash(envVarValue.toCharArray(), settings) : envVarValue;
         }
     }
+
+    // Helper method to escape pipe characters
+    public static String escapePipe(String input) {
+        if (input == null) {
+            return "";
+        }
+        return input.replace("|", "\\|");
+    }
 }

--- a/src/test/java/org/opensearch/security/support/SecurityUtilsTest.java
+++ b/src/test/java/org/opensearch/security/support/SecurityUtilsTest.java
@@ -70,4 +70,41 @@ public class SecurityUtilsTest {
             );
         });
     }
+
+    @Test
+    public void testEscapePipe_NullInput() {
+        assertThat("Null input should return empty string",
+                SecurityUtils.escapePipe(null), equalTo(""));
+    }
+
+    @Test
+    public void testEscapePipe_EmptyString() {
+        assertThat("Empty string should return empty string",
+                SecurityUtils.escapePipe(""), equalTo(""));
+    }
+
+    @Test
+    public void testEscapePipe_StringWithoutPipe() {
+        assertThat("String without pipe should remain unchanged",
+                SecurityUtils.escapePipe("normal string"), equalTo("normal string"));
+    }
+
+    @Test
+    public void testEscapePipe_SinglePipe() {
+        assertThat("Single pipe should be escaped",
+                SecurityUtils.escapePipe("before|after"), equalTo("before\\|after"));
+    }
+
+    @Test
+    public void testEscapePipe_MultiplePipes() {
+        assertThat("Multiple pipes should all be escaped",
+                SecurityUtils.escapePipe("a|b|c"), equalTo("a\\|b\\|c"));
+    }
+
+    @Test
+    public void testEscapePipe_MultiplePipesConsecutive() {
+        assertThat("Consecutive pipes should all be escaped",
+                SecurityUtils.escapePipe("|||"), equalTo("\\|\\|\\|"));
+    }
+
 }


### PR DESCRIPTION
### Description

Escape pipe while setting UserInfo in ThreadContext

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) 
Bug fix
* Why these changes are required?
Allow OIDC use-cases where username contain pipes.
* What is the old behavior before changes and new behavior after changes?
usernames, roles & tenants will escape pipe character if present.

### Issues Resolved
https://github.com/opensearch-project/security/issues/2756

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
