### PR TITLE
Fix logic for determining if a role has no DLS/FLS/FieldMasking restrictions

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -84,6 +84,8 @@ import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
+import static org.opensearch.security.privileges.PrivilegesEvaluator.isClusterPerm;
+
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
@@ -136,7 +138,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
-        if (HeaderHelper.isInternalOrPluginRequest(threadContext)) {
+        if (HeaderHelper.isInternalOrPluginRequest(threadContext) || isClusterPerm(context.getAction())) {
             return true;
         }
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -37,6 +37,7 @@ import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.admin.indices.shrink.ResizeRequest;
 import org.opensearch.action.bulk.BulkItemRequest;
 import org.opensearch.action.bulk.BulkShardRequest;
+import org.opensearch.action.get.MultiGetAction;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -138,7 +139,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
      */
     @Override
     public boolean invoke(PrivilegesEvaluationContext context, final ActionListener<?> listener) {
-        if (HeaderHelper.isInternalOrPluginRequest(threadContext) || isClusterPerm(context.getAction())) {
+        if (HeaderHelper.isInternalOrPluginRequest(threadContext)
+            || (isClusterPerm(context.getAction()) && !MultiGetAction.NAME.equals(context.getAction()))) {
             return true;
         }
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.privileges.IndexPattern;
 import org.opensearch.security.privileges.PrivilegesConfigurationValidationException;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
@@ -149,7 +150,15 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
         // If we found an unrestricted role, we continue with the next index/alias/data stream. If we found a restricted role, we abort
         // early and return true.
 
-        for (String index : resolved.getAllIndicesResolved(context.getClusterStateSupplier(), context.getIndexNameExpressionResolver())) {
+        Set<String> resolvedIndices = resolved.getAllIndicesResolved(context.getClusterStateSupplier(), context.getIndexNameExpressionResolver());
+        Set<String> matchedSystemIndices = SystemIndexRegistry.matchesSystemIndexPattern(resolvedIndices);
+
+        Set<String> regularIndices = new HashSet<>(resolvedIndices);
+        if (matchedSystemIndices != null) {
+            regularIndices.removeAll(matchedSystemIndices);
+        }
+
+        for (String index : regularIndices) {
             if (this.dfmEmptyOverridesAll) {
                 // We assume that we have a restriction unless there are roles without restriction.
                 // Thus, we only have to check the roles without restriction.

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
@@ -150,7 +150,10 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
         // If we found an unrestricted role, we continue with the next index/alias/data stream. If we found a restricted role, we abort
         // early and return true.
 
-        Set<String> resolvedIndices = resolved.getAllIndicesResolved(context.getClusterStateSupplier(), context.getIndexNameExpressionResolver());
+        Set<String> resolvedIndices = resolved.getAllIndicesResolved(
+            context.getClusterStateSupplier(),
+            context.getIndexNameExpressionResolver()
+        );
         Set<String> matchedSystemIndices = SystemIndexRegistry.matchesSystemIndexPattern(resolvedIndices);
 
         Set<String> regularIndices = new HashSet<>(resolvedIndices);

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
@@ -26,7 +26,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.privileges.IndexPattern;
 import org.opensearch.security.privileges.PrivilegesConfigurationValidationException;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
@@ -150,18 +149,7 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
         // If we found an unrestricted role, we continue with the next index/alias/data stream. If we found a restricted role, we abort
         // early and return true.
 
-        Set<String> resolvedIndices = resolved.getAllIndicesResolved(
-            context.getClusterStateSupplier(),
-            context.getIndexNameExpressionResolver()
-        );
-        Set<String> matchedSystemIndices = SystemIndexRegistry.matchesSystemIndexPattern(resolvedIndices);
-
-        Set<String> regularIndices = new HashSet<>(resolvedIndices);
-        if (matchedSystemIndices != null) {
-            regularIndices.removeAll(matchedSystemIndices);
-        }
-
-        for (String index : regularIndices) {
+        for (String index : resolved.getAllIndicesResolved(context.getClusterStateSupplier(), context.getIndexNameExpressionResolver())) {
             if (this.dfmEmptyOverridesAll) {
                 // We assume that we have a restriction unless there are roles without restriction.
                 // Thus, we only have to check the roles without restriction.

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
@@ -185,10 +185,10 @@ public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPriv
 
     /**
      * This is a DLS query where any templates (like ${user.name}) have been interpolated and which has been
-     * succesfully parsed to a QueryBuilder instance.
+     * successfully parsed to a QueryBuilder instance.
      */
     public static class RenderedDlsQuery {
-        public static RenderedDlsQuery MATCH_NONE = new RenderedDlsQuery(new MatchNoneQueryBuilder(), "{\"match_none:\" {}}");
+        public static RenderedDlsQuery MATCH_NONE = new RenderedDlsQuery(new MatchNoneQueryBuilder(), "{\"match_none\": {}}");
 
         private final QueryBuilder queryBuilder;
         private final String renderedSource;


### PR DESCRIPTION
### Description

This PR fixes the logic for determining whether a role is unrestricted with regards to FLS/DLS/FieldMasking restrictions. A role is considered unrestricted if the respective `fls:`, `dls:`, or `masked_fields:` portions are either an empty list or left out of the role definition altogether.

The gist of the problem is that we bypass the [FlsDlsValveImpl if a role has no restrictions](https://github.com/opensearch-project/security/blob/main/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java#L147-L153), but we are not computing whether a role has no restrictions correctly because we are resolving to concrete indices for cluster actions and then applying the default of `{"match_none": {}}` to any resolvable indices such as `.opendistro_security`.

There was a bug seen in CCR tests w/ security: https://github.com/opensearch-project/cross-cluster-replication/issues/1518

The issue can be reproduced by checking out the CCR repo and running:

```
./gradlew integTest -Dbuild.snapshot=true -Psecurity=true --tests "org.opensearch.replication.integ.rest.SecurityCustomRolesIT.test for FOLLOWER that AutoFollow works for user with valid permissions" -i
```

Ensure that any local snapshots for core, security and common-utils are up to date.

For core and common-utils run `./gradlew publishToMavenLocal`

For security run `./gradlew publishZipToMavenLocal`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves https://github.com/opensearch-project/cross-cluster-replication/issues/1518

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
