### PR TITLE
Assume default of v7 models if _meta portion is not present

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -290,7 +290,7 @@ public class ConfigurationLoaderSecurity7 {
 
             final String jsonAsString = SecurityUtils.replaceEnvVars(new String(parser.binaryValue(), StandardCharsets.UTF_8), settings);
             final JsonNode jsonNode = DefaultObjectMapper.readTree(jsonAsString);
-            int configVersion = 1;
+            int configVersion = 2;
 
             if (jsonNode.get("_meta") != null) {
                 assert jsonNode.get("_meta").get("type").asText().equals(id);


### PR DESCRIPTION
### Description

With logic introduced in 2.18 to [auto-convert security config models from v6 to v7](https://github.com/opensearch-project/security/pull/4753) we can now safely assume that any values in the security index are in the v7 format. There was an issue seen in upgrading from 2.19 -> 3.0.0-alpha1 if one of the security yaml files did not include a `_meta` portion with `config_version: 2` because we assume security config models are in the v6 format if this section is missing. To fix the issue, I propose updating the default to assume v7 models as there already is auto conversion in place.

This PR will be backported to 2.19.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves https://github.com/opensearch-project/security/issues/5191

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
