### PR TITLE
Update default behavior for _cat/indices to return indices visible to requesting user

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/AbstractDoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/AbstractDoNotFailOnForbiddenTests.java
@@ -1,0 +1,77 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.security;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public abstract class AbstractDoNotFailOnForbiddenTests {
+
+    /**
+    * Songs accessible for {@link #LIMITED_USER}
+    */
+    protected static final String MARVELOUS_SONGS = "marvelous_songs";
+
+    /**
+    * Songs inaccessible for {@link #LIMITED_USER}
+    */
+    protected static final String HORRIBLE_SONGS = "horrible_songs";
+
+    protected static final String BOTH_INDEX_PATTERN = "*songs";
+
+    protected static final String ID_1 = "1";
+    protected static final String ID_2 = "2";
+    protected static final String ID_3 = "3";
+    protected static final String ID_4 = "4";
+
+    protected static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+    protected static final User LIMITED_USER = new User("limited_user").roles(
+        new Role("limited-role").clusterPermissions(
+            "indices:data/read/mget",
+            "indices:data/read/msearch",
+            "indices:data/read/scroll",
+            "cluster:monitor/state",
+            "cluster:monitor/health"
+        )
+            .indexPermissions(
+                "indices:data/read/search",
+                "indices:data/read/mget*",
+                "indices:data/read/field_caps",
+                "indices:data/read/field_caps*",
+                "indices:data/read/msearch",
+                "indices:data/read/scroll",
+                "indices:monitor/settings/get",
+                "indices:monitor/stats",
+                "indices:admin/aliases/get"
+            )
+            .on(MARVELOUS_SONGS)
+    );
+
+    protected static final User STATS_USER = new User("stats_user").roles(
+        new Role("test_role").clusterPermissions("cluster:monitor/*").indexPermissions("read", "indices:monitor/*").on("hi1")
+    );
+
+    protected static final String BOTH_INDEX_ALIAS = "both-indices";
+    protected static final String FORBIDDEN_INDEX_ALIAS = "forbidden-index";
+
+    private final LocalCluster cluster;
+
+    protected AbstractDoNotFailOnForbiddenTests(LocalCluster cluster) {
+        this.cluster = cluster;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenDisabledTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenDisabledTests.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.security.Song.SONGS;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class DoNotFailOnForbiddenDisabledTests extends AbstractDoNotFailOnForbiddenTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, LIMITED_USER, STATS_USER)
+        .anonymousAuth(false)
+        .build();
+
+    public DoNotFailOnForbiddenDisabledTests() {
+        super(cluster);
+    }
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_1).source(SONGS[0].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_2).source(SONGS[1].asMap()))
+                .actionGet();
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(MARVELOUS_SONGS).id(ID_3).source(SONGS[2].asMap()))
+                .actionGet();
+
+            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(HORRIBLE_SONGS).id(ID_4).source(SONGS[3].asMap()))
+                .actionGet();
+
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(MARVELOUS_SONGS, HORRIBLE_SONGS).alias(BOTH_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).indices(HORRIBLE_SONGS).alias(FORBIDDEN_INDEX_ALIAS)
+                    )
+                )
+                .actionGet();
+
+        }
+    }
+
+    @Test
+    public void shouldPerformCatIndices_positive() throws IOException {
+        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+            Request getIndicesRequest = new Request("GET", "/_cat/indices");
+            // High level client doesn't support _cat/_indices API
+            Response getIndicesResponse = restHighLevelClient.getLowLevelClient().performRequest(getIndicesRequest);
+            List<String> indexes = new BufferedReader(
+                new InputStreamReader(getIndicesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
+            ).lines().collect(Collectors.toList());
+
+            assertThat(indexes.size(), equalTo(1));
+            assertThat(indexes.get(0), containsString("marvelous_songs"));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -38,9 +38,6 @@ import org.opensearch.action.search.SearchScrollRequest;
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.test.framework.TestSecurityConfig;
-import org.opensearch.test.framework.TestSecurityConfig.Role;
-import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
@@ -72,7 +69,6 @@ import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.security.Song.TITLE_MAGNUM_OPUS;
 import static org.opensearch.security.Song.TITLE_NEXT_SONG;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
-import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 import static org.opensearch.test.framework.cluster.SearchRequestFactory.averageAggregationRequest;
 import static org.opensearch.test.framework.cluster.SearchRequestFactory.getSearchScrollRequest;
 import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
@@ -93,54 +89,7 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
-public class DoNotFailOnForbiddenTests {
-
-    /**
-    * Songs accessible for {@link #LIMITED_USER}
-    */
-    private static final String MARVELOUS_SONGS = "marvelous_songs";
-
-    /**
-    * Songs inaccessible for {@link #LIMITED_USER}
-    */
-    private static final String HORRIBLE_SONGS = "horrible_songs";
-
-    private static final String BOTH_INDEX_PATTERN = "*songs";
-
-    private static final String ID_1 = "1";
-    private static final String ID_2 = "2";
-    private static final String ID_3 = "3";
-    private static final String ID_4 = "4";
-
-    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
-    private static final User LIMITED_USER = new User("limited_user").roles(
-        new TestSecurityConfig.Role("limited-role").clusterPermissions(
-            "indices:data/read/mget",
-            "indices:data/read/msearch",
-            "indices:data/read/scroll",
-            "cluster:monitor/state",
-            "cluster:monitor/health"
-        )
-            .indexPermissions(
-                "indices:data/read/search",
-                "indices:data/read/mget*",
-                "indices:data/read/field_caps",
-                "indices:data/read/field_caps*",
-                "indices:data/read/msearch",
-                "indices:data/read/scroll",
-                "indices:monitor/settings/get",
-                "indices:monitor/stats",
-                "indices:admin/aliases/get"
-            )
-            .on(MARVELOUS_SONGS)
-    );
-
-    private static final User STATS_USER = new User("stats_user").roles(
-        new Role("test_role").clusterPermissions("cluster:monitor/*").indexPermissions("read", "indices:monitor/*").on("hi1")
-    );
-
-    private static final String BOTH_INDEX_ALIAS = "both-indices";
-    private static final String FORBIDDEN_INDEX_ALIAS = "forbidden-index";
+public class DoNotFailOnForbiddenTests extends AbstractDoNotFailOnForbiddenTests {
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
@@ -149,6 +98,10 @@ public class DoNotFailOnForbiddenTests {
         .anonymousAuth(false)
         .doNotFailOnForbidden(true)
         .build();
+
+    public DoNotFailOnForbiddenTests() {
+        super(cluster);
+    }
 
     @BeforeClass
     public static void createTestData() {

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -127,6 +127,7 @@ import static org.opensearch.core.rest.RestStatus.ACCEPTED;
 import static org.opensearch.core.rest.RestStatus.BAD_REQUEST;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR;
+import static org.opensearch.core.rest.RestStatus.NOT_FOUND;
 import static org.opensearch.rest.RestRequest.Method.DELETE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -2503,7 +2504,7 @@ public class SearchOperationTest {
             assertThatThrownBy(
                 () -> restHighLevelClient.indices()
                     .getSettings(new GetSettingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
-                statusException(FORBIDDEN)
+                statusException(NOT_FOUND)
             );
             assertThatThrownBy(
                 () -> restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices("*"), DEFAULT),

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -125,6 +125,10 @@ public class PrivilegesEvaluator {
         )
     );
 
+    static final WildcardMatcher DNFOF_BY_DEFAULT_MATCHER = WildcardMatcher.from(
+        ImmutableList.of("indices:monitor/settings/get", "indices:monitor/stats")
+    );
+
     private static final WildcardMatcher ACTION_MATCHER = WildcardMatcher.from("indices:data/read/*search*");
 
     private static final IndicesOptions ALLOW_EMPTY = IndicesOptions.fromOptions(true, true, false, false);
@@ -536,8 +540,7 @@ public class PrivilegesEvaluator {
             }
         }
 
-        boolean dnfofPossible = (dnfofEnabled && DNFOF_MATCHER.test(action0))
-            || Set.of("indices:monitor/settings/get", "indices:monitor/stats").contains(action0);
+        boolean dnfofPossible = (dnfofEnabled && DNFOF_MATCHER.test(action0)) || DNFOF_BY_DEFAULT_MATCHER.test(action0);
 
         presponse = actionPrivileges.hasIndexPrivilege(context, allIndexPermsRequired, requestedResolved);
 

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -121,8 +121,6 @@ public class PrivilegesEvaluator {
             "indices:admin/mappings/fields/get*",
             "indices:admin/shards/search_shards",
             "indices:admin/resolve/index",
-            "indices:monitor/settings/get",
-            "indices:monitor/stats",
             "indices:admin/aliases/get"
         )
     );
@@ -538,7 +536,8 @@ public class PrivilegesEvaluator {
             }
         }
 
-        boolean dnfofPossible = dnfofEnabled && DNFOF_MATCHER.test(action0);
+        boolean dnfofPossible = (dnfofEnabled && DNFOF_MATCHER.test(action0))
+            || Set.of("indices:monitor/settings/get", "indices:monitor/stats").contains(action0);
 
         presponse = actionPrivileges.hasIndexPrivilege(context, allIndexPermsRequired, requestedResolved);
 

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -40,8 +40,6 @@ public class PrivilegesEvaluatorUnitTest {
         "indices:data/read/search",
         "indices:data/read/search/template",
         "indices:data/read/tv",
-        "indices:monitor/settings/get",
-        "indices:monitor/stats",
         "indices:admin/aliases/get"
     );
 


### PR DESCRIPTION
### Description

Opening this PR up to show what's required for changing the default behavior of `_cat/indices` so that it always returns a list of the indices that the requesting user has access to.

This makes it possible to have roles where the index pattern is scoped down from `*`. In the current behavior, this role would always get a forbidden error when calling `_cat/indices` unless `do_not_fail_on_forbidden` is set to true.

```
test:
  cluster_permissions: []
  index_permissions:
    - index_patterns:
        - "test-*"
      allowed_actions:
        - indices_all
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

Resolves https://github.com/opensearch-project/security/issues/5195

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
