### PR TITLE
Add bouncycastle version directly in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ buildscript {
         guava_version = '33.4.0-jre'
         jaxb_version = '2.3.9'
         spring_version = '6.2.4'
+        bouncycastle_version = '1.78'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -584,7 +585,7 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.9.0'
-    implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
+    implementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
     implementation 'com.rfksystems:blake2b:2.0.0'
@@ -664,7 +665,7 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.5'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.49.1'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
+    runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
@@ -700,8 +701,8 @@ dependencies {
     testImplementation('org.awaitility:awaitility:4.3.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
-    testImplementation "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
-    testImplementation "org.bouncycastle:bcutil-jdk18on:${versions.bouncycastle}"
+    testImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
+    testImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
 
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
@@ -741,8 +742,8 @@ dependencies {
     integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     integrationTestImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-    integrationTestImplementation "org.bouncycastle:bcpkix-jdk18on:${versions.bouncycastle}"
-    integrationTestImplementation "org.bouncycastle:bcutil-jdk18on:${versions.bouncycastle}"
+    integrationTestImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
+    integrationTestImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
     integrationTestImplementation('org.awaitility:awaitility:4.3.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }


### PR DESCRIPTION
### Description

`bouncycastle` was removed from the gradle version catalog in https://github.com/opensearch-project/OpenSearch/pull/17507/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df.

This PR sets the same version inline in security's build.gradle file

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
