### PR TITLE
Use bc-fips to avoid jar hell with core.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
         jaxb_version = '2.3.9'
         spring_version = '6.2.4'
         bouncycastle_version = '1.78'
+        bc_fips = '2.0.0'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -585,7 +586,7 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.9.0'
-    implementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bc-fips:${bc_fips}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
     implementation 'com.rfksystems:blake2b:2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -704,6 +704,7 @@ dependencies {
     }
     testImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
     testImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
+    testImplementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
 
     // Only osx-x86_64, osx-aarch_64, linux-x86_64, linux-aarch_64, windows-x86_64 are available
     if (osdetector.classifier in ["osx-x86_64", "osx-aarch_64", "linux-x86_64", "linux-aarch_64", "windows-x86_64"]) {
@@ -745,6 +746,7 @@ dependencies {
     integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
     integrationTestImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
     integrationTestImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
+    integrationTestImplementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
     integrationTestImplementation('org.awaitility:awaitility:4.3.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }


### PR DESCRIPTION
### Description

Testing with [this fix](https://github.com/opensearch-project/security/pull/5197) for the [core change to bouncycastle](https://github.com/opensearch-project/OpenSearch/pull/17507/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df) dependencies and noticing plugin installation is giving jar hell.


bcprov-jdk18on-1.78.jar and bc-fips-2.0.0.jar both have class org.bouncycastle.internal.asn1.eac.EACObjectIdentifiers.
Explicitely using bc-fips as implementation depenency appears to fix this issue:
org.bouncycastle:bcprov-jdk18on:1.78
->
org.bouncycastle:bc-fips:2.0.0

```
-> Installing file:///Users/carrofin/fdev/repos/security/build/distributions/opensearch-security-3.0.0.0-alpha1-SNAPSHOT.zip
-> Downloading file:///Users/carrofin/fdev/repos/security/build/distributions/opensearch-security-3.0.0.0-alpha1-SNAPSHOT.zip
[=================================================] 100%
-> Failed installing file:///Users/carrofin/fdev/repos/security/build/distributions/opensearch-security-3.0.0.0-alpha1-SNAPSHOT.zip
-> Rolling back file:///Users/carrofin/fdev/repos/security/build/distributions/opensearch-security-3.0.0.0-alpha1-SNAPSHOT.zip
-> Rolled back file:///Users/carrofin/fdev/repos/security/build/distributions/opensearch-security-3.0.0.0-alpha1-SNAPSHOT.zip
Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-security due to jar hell
        at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:733)
        at org.opensearch.plugins.PluginsService.checkJarHellForPlugin(PluginsService.java:373)
        at org.opensearch.tools.cli.plugin.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:831)
        at org.opensearch.tools.cli.plugin.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:808)
        at org.opensearch.tools.cli.plugin.InstallPluginCommand.installPlugin(InstallPluginCommand.java:843)
        at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:275)
        at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:249)
        at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
        at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
        at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
        at org.opensearch.cli.Command.main(Command.java:101)
        at org.opensearch.tools.cli.plugin.PluginCli.main(PluginCli.java:66)
Caused by: java.lang.IllegalStateException: jar hell!
class: org.bouncycastle.internal.asn1.eac.EACObjectIdentifiers
jar1: /Users/carrofin/fdev/repos/OpenSearch/distribution/archives/darwin-tar/build/install/opensearch-3.0.0-SNAPSHOT/plugins/.installing-16777383944250648854/bcprov-jdk18on-1.78.jar
jar2: /Users/carrofin/fdev/repos/OpenSearch/distribution/archives/darwin-tar/build/install/opensearch-3.0.0-SNAPSHOT/plugins/.installing-16777383944250648854/bc-fips-2.0.0.jar
        at org.opensearch.common.bootstrap.JarHell.checkClass(JarHell.java:316)
        at org.opensearch.common.bootstrap.JarHell.checkJarHell(JarHell.java:215)
        at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:719)
        ... 12 more
```

### Issues Resolved
N/A

### Testing


### Check List
~~- [ ] New functionality includes testing~~
~~- [ ] New functionality has been documented~~
~~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~~
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~~
~~- [ ] Commits are signed per the DCO using --signoff~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
