### PR TITLE
[Backport 2.x] Log request body to audit logs (#5071)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/AuthZinRestLayerTests.java
@@ -1,0 +1,265 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.rest;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.AuditCompliance;
+import org.opensearch.test.framework.AuditConfiguration;
+import org.opensearch.test.framework.AuditFilters;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.testplugins.dummy.CustomLegacyTestPlugin;
+import org.opensearch.test.framework.testplugins.dummyprotected.CustomRestProtectedTestPlugin;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
+import static org.opensearch.security.auditlog.impl.AuditCategory.FAILED_LOGIN;
+import static org.opensearch.security.auditlog.impl.AuditCategory.GRANTED_PRIVILEGES;
+import static org.opensearch.security.auditlog.impl.AuditCategory.MISSING_PRIVILEGES;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateRESTLayer;
+import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateTransportLayer;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class AuthZinRestLayerTests {
+    protected final static TestSecurityConfig.User REST_ONLY = new TestSecurityConfig.User("rest_only").roles(
+        new Role("rest_only_role").clusterPermissions("security:dummy_protected/get").clusterPermissions("cluster:admin/dummy_plugin/dummy")
+    );
+
+    protected final static TestSecurityConfig.User TRANSPORT_ONLY = new TestSecurityConfig.User("transport_only").roles(
+        new Role("transport_only_role").clusterPermissions("cluster:admin/dummy_plugin/dummy")
+    );
+
+    protected final static TestSecurityConfig.User REST_PLUS_TRANSPORT = new TestSecurityConfig.User("rest_plus_transport").roles(
+        new Role("rest_plus_transport_role").clusterPermissions("security:dummy_protected/get")
+            .clusterPermissions("cluster:admin/dummy_plugin/dummy", "cluster:admin/dummy_protected_plugin/dummy/get")
+    );
+
+    protected final static TestSecurityConfig.User NO_PERM = new TestSecurityConfig.User("no_perm").roles(new Role("no_perm_role"));
+
+    protected final static TestSecurityConfig.User UNREGISTERED = new TestSecurityConfig.User("unregistered");
+
+    public static final String UNPROTECTED_BASE_ENDPOINT = "_plugins/_dummy";
+    public static final String PROTECTED_BASE_ENDPOINT = "_plugins/_dummy_protected";
+    public static final String UNPROTECTED_API = UNPROTECTED_BASE_ENDPOINT + "/dummy";
+    public static final String PROTECTED_API = PROTECTED_BASE_ENDPOINT + "/dummy";
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(REST_ONLY, REST_PLUS_TRANSPORT, TRANSPORT_ONLY, NO_PERM)
+        .plugin(CustomLegacyTestPlugin.class)
+        .plugin(CustomRestProtectedTestPlugin.class)
+        .audit(
+            new AuditConfiguration(true).compliance(new AuditCompliance().enabled(true))
+                .filters(new AuditFilters().enabledRest(true).enabledTransport(true).resolveBulkRequests(true))
+        )
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    /** Basic Access check */
+
+    @Test
+    public void testShouldNotAllowUnregisteredUsers() {
+        try (TestRestClient client = cluster.getRestClient(UNREGISTERED)) {
+            // Legacy plugin
+            assertThat(client.get(UNPROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(FAILED_LOGIN, UNREGISTERED, GET, "/" + UNPROTECTED_API));
+
+            // Protected Routes plugin
+            assertThat(client.get(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(FAILED_LOGIN, UNREGISTERED, GET, "/" + PROTECTED_API));
+        }
+    }
+
+    @Test
+    public void testAccessDeniedForUserWithNoPermissions() {
+        try (TestRestClient client = cluster.getRestClient(NO_PERM)) {
+            // fail at Transport (won't have a rest authz success audit log since this is not a protected endpoint)
+            assertThat(client.get(UNPROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(MISSING_PRIVILEGES, NO_PERM, "DummyRequest", "cluster:admin/dummy_plugin/dummy")
+            );
+
+            // fail at REST
+            assertThat(client.get(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(MISSING_PRIVILEGES, NO_PERM, GET, "/" + PROTECTED_API));
+        }
+    }
+
+    @Test
+    public void testShouldFailWithoutPermForPathWithoutLeadingSlashes() {
+        try (TestRestClient client = cluster.getRestClient(NO_PERM)) {
+
+            // Protected Routes plugin
+            assertThat(client.getWithoutLeadingSlash(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+        }
+    }
+
+    /** AuthZ in REST Layer check */
+
+    @Test
+    public void testShouldAllowAtRestAndBlockAtTransport() {
+        try (TestRestClient client = cluster.getRestClient(REST_ONLY)) {
+            assertThat(client.get(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            // granted at Rest layer
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(GRANTED_PRIVILEGES, REST_ONLY, GET, "/" + PROTECTED_API));
+            // missing at Transport layer
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(
+                    MISSING_PRIVILEGES,
+                    REST_ONLY,
+                    "DummyRequest",
+                    "cluster:admin/dummy_protected_plugin/dummy/get"
+                )
+            );
+        }
+    }
+
+    @Test
+    public void testRequestBodyIsAuditLogged() {
+        try (TestRestClient client = cluster.getRestClient(REST_PLUS_TRANSPORT)) {
+            String dummyBody = "{\"hello\": \"world\"}";
+            client.postJson(PROTECTED_API, dummyBody);
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateRESTLayer(AUTHENTICATED, REST_PLUS_TRANSPORT, POST, "/" + PROTECTED_API).withRequestBody(dummyBody)
+            );
+        }
+    }
+
+    @Test
+    public void testShouldAllowAtRestAndTransport() {
+        try (TestRestClient client = cluster.getRestClient(REST_PLUS_TRANSPORT)) {
+            assertOKResponseFromProtectedPlugin(client);
+
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(GRANTED_PRIVILEGES, REST_PLUS_TRANSPORT, GET, "/" + PROTECTED_API));
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(
+                    GRANTED_PRIVILEGES,
+                    REST_PLUS_TRANSPORT,
+                    "DummyRequest",
+                    "cluster:admin/dummy_protected_plugin/dummy/get"
+                )
+            );
+        }
+    }
+
+    @Test
+    public void testShouldBlockAccessToEndpointForWhichUserHasNoPermission() {
+        try (TestRestClient client = cluster.getRestClient(REST_ONLY)) {
+            assertThat(client.post(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(MISSING_PRIVILEGES, REST_ONLY, POST, "/" + PROTECTED_API));
+        }
+
+        try (TestRestClient client = cluster.getRestClient(REST_PLUS_TRANSPORT)) {
+            assertThat(client.post(PROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(MISSING_PRIVILEGES, REST_PLUS_TRANSPORT, POST, "/" + PROTECTED_API));
+        }
+    }
+
+    /** Backwards compatibility check */
+
+    @Test
+    public void testBackwardsCompatibility() {
+
+        // TRANSPORT_ONLY should have access to legacy endpoint, but not protected endpoint
+        try (TestRestClient client = cluster.getRestClient(TRANSPORT_ONLY)) {
+            TestRestClient.HttpResponse res = client.get(PROTECTED_API);
+            assertThat(res.getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+            auditLogsRule.assertExactlyOne(privilegePredicateRESTLayer(MISSING_PRIVILEGES, TRANSPORT_ONLY, GET, "/" + PROTECTED_API));
+
+            assertOKResponseFromLegacyPlugin(client);
+            // check that there is no log for REST layer AuthZ since this is an unprotected endpoint
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(GRANTED_PRIVILEGES, TRANSPORT_ONLY, GET, UNPROTECTED_API));
+            // check that there is exactly 1 message for Transport Layer privilege evaluation
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(GRANTED_PRIVILEGES, TRANSPORT_ONLY, "DummyRequest", "cluster:admin/dummy_plugin/dummy")
+            );
+        }
+
+        // REST_ONLY should have access to legacy endpoint (protected endpoint already tested above)
+        try (TestRestClient client = cluster.getRestClient(REST_ONLY)) {
+            assertOKResponseFromLegacyPlugin(client);
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(GRANTED_PRIVILEGES, REST_ONLY, GET, UNPROTECTED_API));
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(GRANTED_PRIVILEGES, REST_ONLY, "DummyRequest", "cluster:admin/dummy_plugin/dummy")
+            );
+        }
+
+        // DUMMY_WITH_TRANSPORT_PERM should have access to legacy endpoint (protected endpoint already tested above)
+        try (TestRestClient client = cluster.getRestClient(REST_PLUS_TRANSPORT)) {
+            assertOKResponseFromLegacyPlugin(client);
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(GRANTED_PRIVILEGES, REST_PLUS_TRANSPORT, GET, UNPROTECTED_API));
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(
+                    GRANTED_PRIVILEGES,
+                    REST_PLUS_TRANSPORT,
+                    "DummyRequest",
+                    "cluster:admin/dummy_plugin/dummy"
+                )
+            );
+        }
+
+        // NO_PERM should not have access to legacy endpoint (protected endpoint already tested above)
+        try (TestRestClient client = cluster.getRestClient(NO_PERM)) {
+            assertThat(client.get(UNPROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(MISSING_PRIVILEGES, NO_PERM, GET, UNPROTECTED_API));
+            auditLogsRule.assertExactlyOne(
+                privilegePredicateTransportLayer(MISSING_PRIVILEGES, NO_PERM, "DummyRequest", "cluster:admin/dummy_plugin/dummy")
+            );
+        }
+
+        // UNREGISTERED should not have access to legacy endpoint (protected endpoint already tested above)
+        try (TestRestClient client = cluster.getRestClient(UNREGISTERED)) {
+            assertThat(client.get(UNPROTECTED_API).getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(MISSING_PRIVILEGES, UNREGISTERED, GET, UNPROTECTED_API));
+            auditLogsRule.assertExactly(
+                0,
+                privilegePredicateTransportLayer(MISSING_PRIVILEGES, UNREGISTERED, "DummyRequest", "cluster:admin/dummy_plugin/dummy")
+            );
+            auditLogsRule.assertExactly(0, privilegePredicateRESTLayer(FAILED_LOGIN, UNREGISTERED, GET, UNPROTECTED_API));
+        }
+    }
+
+    /** Helper Methods */
+    private void assertOKResponseFromLegacyPlugin(TestRestClient client) {
+        String expectedResponseFromLegacyPlugin = "{\"response_string\":\"Hello from dummy plugin\"}";
+        TestRestClient.HttpResponse res = client.get(UNPROTECTED_API);
+        assertThat(res.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(res.getBody(), equalTo(expectedResponseFromLegacyPlugin));
+    }
+
+    private void assertOKResponseFromProtectedPlugin(TestRestClient client) {
+        String expectedResponseFromProtectedPlugin = "{\"response_string\":\"Hello from dummy protected plugin\"}";
+        TestRestClient.HttpResponse res = client.get(PROTECTED_API);
+        assertThat(res.getStatusCode(), equalTo(HttpStatus.SC_OK));
+        assertThat(res.getBody(), equalTo(expectedResponseFromProtectedPlugin));
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/audit/AuditMessagePredicate.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/audit/AuditMessagePredicate.java
@@ -44,6 +44,7 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
     private final String effectiveUser;
     private final String index;
     private final String privilege;
+    private final String requestBody;
 
     private AuditMessagePredicate(
         AuditCategory category,
@@ -55,7 +56,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         String transportRequestType,
         String effectiveUser,
         String index,
-        String privilege
+        String privilege,
+        String requestBody
     ) {
         this.category = category;
         this.requestLayer = requestLayer;
@@ -67,10 +69,11 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         this.effectiveUser = effectiveUser;
         this.index = index;
         this.privilege = privilege;
+        this.requestBody = requestBody;
     }
 
     private AuditMessagePredicate(AuditCategory category) {
-        this(category, null, null, null, null, null, null, null, null, null);
+        this(category, null, null, null, null, null, null, null, null, null, null);
     }
 
     public static AuditMessagePredicate auditPredicate(AuditCategory category) {
@@ -120,7 +123,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -135,7 +139,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -150,7 +155,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -165,7 +171,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -184,7 +191,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -199,7 +207,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             type,
             effectiveUser,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -214,7 +223,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             user,
             index,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -237,7 +247,8 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             indexName,
-            privilege
+            privilege,
+            requestBody
         );
     }
 
@@ -252,7 +263,24 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             transportRequestType,
             effectiveUser,
             index,
-            privilegeAction
+            privilegeAction,
+            requestBody
+        );
+    }
+
+    public Predicate<AuditMessage> withRequestBody(String body) {
+        return new AuditMessagePredicate(
+            category,
+            requestLayer,
+            restRequestPath,
+            restParams,
+            initiatingUser,
+            requestMethod,
+            transportRequestType,
+            effectiveUser,
+            index,
+            privilege,
+            body
         );
     }
 
@@ -269,6 +297,7 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
         predicates.add(audit -> Objects.isNull(effectiveUser) || effectiveUser.equals(audit.getEffectiveUser()));
         predicates.add(audit -> Objects.isNull(index) || containIndex(audit, index));
         predicates.add(audit -> Objects.isNull(privilege) || privilege.equals(audit.getPrivilege()));
+        predicates.add(audit -> Objects.isNull(requestBody) || requestBody.equals(audit.getRequestBody()));
         return predicates.stream().reduce(Predicate::and).orElseThrow().test(auditMessage);
     }
 
@@ -303,4 +332,5 @@ public class AuditMessagePredicate implements Predicate<AuditMessage> {
             + '\''
             + '}';
     }
+
 }

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -228,7 +228,6 @@ public class BackendRegistry {
             UserSubject subject = new UserSubjectImpl(threadPool, superuser);
             threadContext.putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
             threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, superuser);
-            auditLog.logSucceededLogin(sslPrincipal, true, null, request);
             return true;
         }
 
@@ -393,9 +392,9 @@ public class BackendRegistry {
             final User impersonatedUser = impersonate(request, authenticatedUser);
             final User effectiveUser = impersonatedUser == null ? authenticatedUser : impersonatedUser;
             threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, effectiveUser);
+            threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_INITIATING_USER, authenticatedUser.getName());
             UserSubject subject = new UserSubjectImpl(threadPool, effectiveUser);
             threadPool.getThreadContext().putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
-            auditLog.logSucceededLogin(effectiveUser.getName(), false, authenticatedUser.getName(), request);
         } else {
             if (isDebugEnabled) {
                 log.debug("User still not authenticated after checking {} auth domains", restAuthDomains.size());
@@ -426,7 +425,6 @@ public class BackendRegistry {
 
                 threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, anonymousUser);
                 threadPool.getThreadContext().putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, subject);
-                auditLog.logSucceededLogin(anonymousUser.getName(), false, null, request);
                 if (isDebugEnabled) {
                     log.debug("Anonymous User is authenticated");
                 }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -118,6 +118,8 @@ public class ConfigConstants {
 
     public static final String OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "user_info";
 
+    public static final String OPENDISTRO_SECURITY_INITIATING_USER = OPENDISTRO_SECURITY_CONFIG_PREFIX + "_initiating_user";
+
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";
 


### PR DESCRIPTION
Signed-off-by: Timo Olkkonen <timo.olkkonen@reaktor.com>
Co-authored-by: Timo Olkkonen <timo.olkkonen@reaktor.com>
Co-authored-by: Andrey Pleskach <ples@aiven.io>
(cherry picked from commit 00204dd49ae555856f13a319dd805e69a29c8ee2)

### Description

Currently we do not get request body to audit log, as requests are already authenticated in header verifier level, which does not have access to request body.

SecurityRestFilter has the whole RestRequest object, but it does not authenticate it again. Also, it does not authorize the request if the route is not a named one. The idea here is to do logGrantedPrivileges call even if we do not authorize. This way we will get the request body to audit log.

### Issues Resolved

[[BUG] audit_request_body missing for REST since 2.11
](https://github.com/opensearch-project/security/issues/4094)

This is a backport from [5071](https://github.com/opensearch-project/security/pull/5071)

### Testing

I have tested this manually on limited scope.  Also, I added a test case to AuthZInRestLayerTests, which I have also included in this backport.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
