### PR TITLE
Improve coverage: Adding tests for ConfigurationRepository class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -248,39 +248,6 @@ task listTasksAsJSON {
     }
 }
 
-test {
-    include '**/*.class'
-    filter {
-        excludeTestsMatching "org.opensearch.security.sanity.tests.*"
-    }
-    maxParallelForks = 8
-    jvmArgs += "-Xmx3072m"
-    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
-        // this is needed to reflect access system env map.
-        jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
-    }
-    retry {
-        failOnPassedAfterRetry = false
-        maxRetries = 5
-    }
-    jacoco {
-        excludes = [
-                "com.sun.jndi.dns.*",
-                "com.sun.security.sasl.gsskerb.*",
-                "java.sql.*",
-                "javax.script.*",
-                "org.jcp.xml.dsig.internal.dom.*",
-                "sun.nio.cs.ext.*",
-                "sun.security.ec.*",
-                "sun.security.jgss.*",
-                "sun.security.pkcs11.*",
-                "sun.security.smartcardio.*",
-                "sun.util.resources.provider.*"
-        ]
-    }
-}
-
 task copyExtraTestResources(dependsOn: testClasses) {
 
     copy {
@@ -330,6 +297,40 @@ def setCommonTestConfig(Test task) {
     }
     task.dependsOn copyExtraTestResources
     task.finalizedBy jacocoTestReport
+}
+
+test {
+    include '**/*.class'
+    filter {
+        excludeTestsMatching "org.opensearch.security.sanity.tests.*"
+    }
+    maxParallelForks = 8
+    jvmArgs += "-Xmx3072m"
+    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
+        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+        // this is needed to reflect access system env map.
+        jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
+    }
+    retry {
+        failOnPassedAfterRetry = false
+        maxRetries = 5
+    }
+    jacoco {
+        excludes = [
+                "com.sun.jndi.dns.*",
+                "com.sun.security.sasl.gsskerb.*",
+                "java.sql.*",
+                "javax.script.*",
+                "org.jcp.xml.dsig.internal.dom.*",
+                "sun.nio.cs.ext.*",
+                "sun.security.ec.*",
+                "sun.security.jgss.*",
+                "sun.security.pkcs11.*",
+                "sun.security.smartcardio.*",
+                "sun.util.resources.provider.*"
+        ]
+    }
+    setCommonTestConfig(it)
 }
 
 task citest(type: Test) {

--- a/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
@@ -283,7 +283,7 @@ public class ComplianceConfig {
     /**
      * Create compliance configuration from Settings defined in opensearch.yml
      * @param settings settings
-     * @param dateProvider how the current date/time is evalated for audit logs that rollover
+     * @param dateProvider how the current date/time is evaluated for audit logs that rollover
      * @return compliance configuration
      */
     public static ComplianceConfig from(Settings settings, Supplier<DateTime> dateProvider) {

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -178,8 +178,8 @@ public class ConfigurationRepository implements ClusterStateListener {
     public String getConfigDirectory() {
         String lookupDir = System.getProperty("security.default_init.dir");
         final String cd = lookupDir != null
-            ? (lookupDir + "/")
-            : new Environment(settings, configPath).configDir().toAbsolutePath().toString() + "/opensearch-security/";
+            ? (lookupDir + File.separator)
+            : new Environment(settings, configPath).configDir().toAbsolutePath().resolve("opensearch-security").toString() + File.separator;
         return cd;
     }
 

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationRepository.java
@@ -49,6 +49,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
@@ -101,7 +102,7 @@ public class ConfigurationRepository implements ClusterStateListener {
     private final Client client;
     private final Cache<CType<?>, SecurityDynamicConfiguration<?>> configCache;
     private final List<ConfigurationChangeListener> configurationChangedListener;
-    private final ConfigurationLoaderSecurity7 cl;
+    private ConfigurationLoaderSecurity7 cl;
     private final Settings settings;
     private final Path configPath;
     private final ClusterService clusterService;
@@ -142,6 +143,11 @@ public class ConfigurationRepository implements ClusterStateListener {
         cl = new ConfigurationLoaderSecurity7(client, threadPool, settings, clusterService);
         configCache = CacheBuilder.newBuilder().build();
         this.securityIndexHandler = securityIndexHandler;
+    }
+
+    @VisibleForTesting
+    void setConfigurationLoader(ConfigurationLoaderSecurity7 configurationLoader) {
+        cl = configurationLoader;
     }
 
     private Path resolveConfigDir() {

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -294,7 +294,7 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     }
 
     @Override
-    public final boolean isInitialized() {
+    public boolean isInitialized() {
         return initialized.get();
     }
 

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -533,7 +533,8 @@ public class ConfigurationRepositoryTest {
     }
 
     @Test(expected = OpenSearchException.class)
-    public void getConfigurationsFromIndex_existingSecurityIndexMappingMetaDataNull_NoResult() throws InterruptedException, TimeoutException {
+    public void getConfigurationsFromIndex_existingSecurityIndexMappingMetaDataNull_NoResult() throws InterruptedException,
+        TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
         ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -15,21 +15,38 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Set;
+import java.util.concurrent.TimeoutException;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.block.ClusterBlocks;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.state.SecurityConfig;
@@ -38,11 +55,16 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.SecurityIndexHandler;
 import org.opensearch.security.transport.SecurityInterceptorTests;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
 import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.ClusterAdminClient;
+import org.opensearch.transport.client.IndicesAdminClient;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.OngoingStubbing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -52,7 +74,10 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE;
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -60,6 +85,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -70,11 +96,31 @@ public class ConfigurationRepositoryTest {
     @Mock
     private Client localClient;
     @Mock
+    private AdminClient adminClient;
+    @Mock
+    private ClusterAdminClient clusterAdminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
     private AuditLog auditLog;
     @Mock
     private Path path;
     @Mock
     private ClusterService clusterService;
+    @Mock
+    private ClusterState clusterState;
+    @Mock
+    private ClusterBlocks clusterBlocks;
+    @Mock
+    private DynamicConfigFactory dynamicConfigFactory;
+    @Mock
+    private DiscoveryNode discoveryNode;
+    @Mock
+    private Metadata metadata;
+    @Mock
+    private IndexMetadata securityIndexMetadata;
+    @Mock
+    private MappingMetadata securityIndexMappingMetadata;
 
     private ThreadPool threadPool;
 
@@ -83,6 +129,8 @@ public class ConfigurationRepositoryTest {
 
     @Mock
     private ClusterChangedEvent event;
+
+    private static final String TEST_CONFIG_DIR = "./src/test/resources";
 
     @Before
     public void setUp() {
@@ -103,6 +151,20 @@ public class ConfigurationRepositoryTest {
         when(event.state().metadata()).thenReturn(mock(Metadata.class));
 
         when(event.state().custom(SecurityMetadata.TYPE)).thenReturn(null);
+
+        // Cluster Mocks
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterService.localNode()).thenReturn(discoveryNode);
+        when(clusterState.blocks()).thenReturn(clusterBlocks);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.index(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX)).thenReturn(securityIndexMetadata);
+
+        when(securityIndexMetadata.mapping()).thenReturn(securityIndexMappingMetadata);
+
+        // Client mocks
+        when(localClient.admin()).thenReturn(adminClient);
+        when(adminClient.cluster()).thenReturn(clusterAdminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
     }
 
     private ConfigurationRepository createConfigurationRepository(Settings settings) {
@@ -133,13 +195,93 @@ public class ConfigurationRepositoryTest {
         ConfigurationRepository configRepository = createConfigurationRepository(settings);
 
         final var result = configRepository.initOnNodeStart();
-
         assertThat(result.join(), is(true));
+    }
+
+    @Test
+    public void initOnNodeStart_whenClusterAvailable() {
+        Settings settings = Settings.builder().put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true).build();
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+        when(clusterBlocks.hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)).thenReturn(false);
+
+        configRepository.initOnNodeStart().join();
+
+        verify(clusterBlocks, times(1)).hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void initOnNodeStart_whenClusterInitiallyUnavailable() {
+        Settings settings = Settings.builder().put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true).build();
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+        when(clusterBlocks.hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)).thenReturn(true, true, false);
+
+        configRepository.initOnNodeStart().join();
+
+        verify(clusterBlocks, times(3)).hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE);
+    }
+
+    @Test
+    public void initOnNodeStart_installDefaultConfigSuccess() throws InterruptedException, TimeoutException {
+        // Required for ComplianceConfig in audit.yml to work
+        setupObjectMapperInjectables();
+
+        Settings settings = Settings.builder()
+            .put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true)
+            .put("path.home", TEST_CONFIG_DIR)
+            .put(ConfigConstants.SECURITY_UNSUPPORTED_DELAY_INITIALIZATION_SECONDS, 1)
+            .build();
+        System.setProperty("security.default_init.dir", TEST_CONFIG_DIR);
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        configRepository.setDynamicConfigFactory(dynamicConfigFactory);
+
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
+
+        // Cluster Status mocks
+        when(clusterBlocks.hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE)).thenReturn(false);
+
+        // Node mocks
+        when(discoveryNode.getName()).thenReturn("node1");
+
+        CreateIndexResponse createIndexResponse = new CreateIndexResponse(true, true, ".opendistro_security");
+
+        ClusterHealthResponse clusterHealthResponse = mock(ClusterHealthResponse.class);
+
+        IndexResponse indexResponse = mock(IndexResponse.class);
+
+        when(indicesAdminClient.create(any(CreateIndexRequest.class))).thenReturn(
+            getCreateIndexResponsePlainActionFuture(createIndexResponse)
+        );
+        when(clusterAdminClient.health(any(ClusterHealthRequest.class))).thenReturn(
+            getClusterHealthResponsePlainActionFuture(clusterHealthResponse)
+        );
+        when(localClient.index(any(IndexRequest.class))).thenReturn(getIndexResponsePlainActionFuture(indexResponse));
+
+        setupIndexResponseForDefaultConfig(indexResponse);
+
+        when(dynamicConfigFactory.isInitialized()).thenReturn(false, true);
+
+        configRepository.initOnNodeStart().join();
+
+        verify(clusterBlocks, times(1)).hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE);
+        verify(indexResponse, times(10)).getId();
     }
 
     @Test
     public void initOnNodeStart_withSecurityIndexNotCreatedShouldNotSetInstallDefaultConfig() {
         Settings settings = Settings.builder().put(ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, false).build();
+
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+
+        final var result = configRepository.initOnNodeStart();
+
+        assertThat(result.join(), is(false));
+    }
+
+    @Test
+    public void initOnNodeStart_withSecurityIndexNotCreatedShouldSetInstallDefaultConfig() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_BACKGROUND_INIT_IF_SECURITYINDEX_NOT_EXIST, true).build();
 
         ConfigurationRepository configRepository = createConfigurationRepository(settings);
 
@@ -278,6 +420,143 @@ public class ConfigurationRepositoryTest {
         verifyNoMoreInteractions(securityIndexHandler);
     }
 
+    @Test
+    public void testGetConfigDirectory_WithSystemProperty() {
+        // Backup original system property if exists
+        String originalProperty = System.getProperty("security.default_init.dir");
+        try {
+            // Set test system property
+            System.setProperty("security.default_init.dir", "/test/path");
+            ConfigurationRepository configRepository = createConfigurationRepository(Settings.EMPTY);
+            String result = configRepository.getConfigDirectory();
+            assertThat(result, is("/test/path/"));
+        } finally {
+            // Cleanup: Reset system property to original state
+            if (originalProperty != null) {
+                System.setProperty("security.default_init.dir", originalProperty);
+            } else {
+                System.clearProperty("security.default_init.dir");
+            }
+        }
+    }
+
+    @Test
+    public void testGetConfigDirectory_WithoutSystemProperty() {
+        System.clearProperty("security.default_init.dir");
+        when(path.toAbsolutePath()).thenReturn(Path.of("/config/base/path"));
+        Settings settings = Settings.builder().put("path.home", "/config/base/path").build();
+        ConfigurationRepository configRepository = createConfigurationRepository(settings);
+        String result = configRepository.getConfigDirectory();
+
+        assertThat(result, is("/config/base/path/opensearch-security/"));
+    }
+
+    @Test
+    public void isAuditHotReloadingEnabled_shouldReturnFalseWhenAuditConfigDocNotPresentInIndex() {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        when(configurationLoaderSecurity7.isAuditConfigDocPresentInIndex()).thenReturn(false);
+        boolean result = configurationRepository.isAuditHotReloadingEnabled();
+
+        assertThat("Audit hot reloading should be false", result, is(false));
+    }
+
+    @Test
+    public void isAuditHotReloadingEnabled_shouldReturnTrueWhenAuditConfigDocPresentInIndex() {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        when(configurationLoaderSecurity7.isAuditConfigDocPresentInIndex()).thenReturn(true);
+        boolean result = configurationRepository.isAuditHotReloadingEnabled();
+
+        assertThat("Audit hot reloading should be true", result, is(true));
+    }
+
+    @Test
+    public void isAuditHotReloadingEnabled_shouldReturnFalseIfNotSet() {
+        Settings settings = Settings.builder().put(SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE, true).build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+
+        boolean result = configurationRepository.isAuditHotReloadingEnabled();
+
+        assertThat("Audit hot reloading should return false if not set", result, is(false));
+    }
+
+    @Test
+    public void getConfigurationsFromIndex_Success() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
+
+        ConfigurationMap result = configurationRepository.getConfigurationsFromIndex(CType.values(), false);
+
+        assertThat(result.size(), is(10));
+    }
+
+    @Test(expected = OpenSearchException.class)
+    public void getConfigurationsFromIndex_Partial() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of(CType.CONFIG));
+
+        configurationRepository.getConfigurationsFromIndex(CType.values(), false);
+    }
+
+    @Test(expected = OpenSearchException.class)
+    public void getConfigurationsFromIndex_NoResult() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
+
+        configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
+    }
+
+    @Test(expected = OpenSearchException.class)
+    public void getConfigurationsFromIndex_SecurityIndexMetadataNull() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
+        when(metadata.index(OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX)).thenReturn(null);
+
+        configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
+    }
+
+    @Test(expected = OpenSearchException.class)
+    public void getConfigurationsFromIndex_SecurityIndexMappingMetaDataNull() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
+        when(securityIndexMetadata.mapping()).thenReturn(null);
+
+        configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
+    }
+
+    @Test
+    public void getConfigurationsFromIndex_SecurityIndexNotInitiallyReady() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
+        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
+        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
+        setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
+
+        ConfigurationMap result = configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
+
+        assertThat(result.size(), is(10));
+    }
+
     void assertClusterState(final ArgumentCaptor<ClusterStateUpdateTask> clusterStateUpdateTaskCaptor) throws Exception {
         final var initializedStateUpdate = clusterStateUpdateTaskCaptor.getValue();
         assertThat(initializedStateUpdate.priority(), is(Priority.IMMEDIATE));
@@ -287,4 +566,72 @@ public class ConfigurationRepositoryTest {
         assertNotNull(securityMetadata.configuration());
     }
 
+    private static void setupIndexResponseForDefaultConfig(IndexResponse indexResponse) {
+        OngoingStubbing<String> stubbingOperation = when(indexResponse.getId());
+
+        for (String configId : getConfigurationIdsInOrder()) {
+            stubbingOperation = stubbingOperation.thenReturn(configId);
+        }
+    }
+
+    private static PlainActionFuture<IndexResponse> getIndexResponsePlainActionFuture(IndexResponse indexResponse) {
+        return new PlainActionFuture<>() {
+            @Override
+            public IndexResponse actionGet() {
+                return indexResponse;
+            }
+        };
+    }
+
+    private static PlainActionFuture<ClusterHealthResponse> getClusterHealthResponsePlainActionFuture(
+        ClusterHealthResponse clusterHealthResponse
+    ) {
+        return new PlainActionFuture<>() {
+            @Override
+            public ClusterHealthResponse actionGet() {
+                return clusterHealthResponse;
+            }
+        };
+    }
+
+    private static PlainActionFuture<CreateIndexResponse> getCreateIndexResponsePlainActionFuture(CreateIndexResponse createIndexResponse) {
+        return new PlainActionFuture<>() {
+            @Override
+            public CreateIndexResponse actionGet() {
+                return createIndexResponse;
+            }
+        };
+    }
+
+    private static void setupObjectMapperInjectables() {
+        InjectableValues.Std injectableValues = new InjectableValues.Std();
+        injectableValues.addValue(Settings.class, Settings.EMPTY);
+        DefaultObjectMapper.inject(injectableValues);
+    }
+
+    // The order is important here as it matches order in initOnNodeStart()
+    private static String[] getConfigurationIdsInOrder() {
+        return new String[] {
+            "config",
+            "roles",
+            "rolesmapping",
+            "internalusers",
+            "actiongroups",
+            "tenants",
+            "nodesdn",
+            "whitelist",
+            "allowlist",
+            "audit" };
+    }
+
+    private static void setupConfigurationLoaderMock(ConfigurationLoaderSecurity7 configurationLoaderSecurity7, Set<CType<?>> ctypes)
+        throws InterruptedException, TimeoutException {
+        ConfigurationMap.Builder result = new ConfigurationMap.Builder();
+
+        for (CType<?> cType : ctypes) {
+            result.with(SecurityDynamicConfiguration.empty(cType));
+        }
+
+        when(configurationLoaderSecurity7.load(any(), anyLong(), any(), anyBoolean())).thenReturn(result.build());
+    }
 }

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -443,12 +443,23 @@ public class ConfigurationRepositoryTest {
     @Test
     public void testGetConfigDirectory_WithoutSystemProperty() {
         System.clearProperty("security.default_init.dir");
-        when(path.toAbsolutePath()).thenReturn(Path.of("/config/base/path"));
-        Settings settings = Settings.builder().put("path.home", "/config/base/path").build();
+
+        String basePathString = System.getProperty("os.name").toLowerCase().contains("win")
+            ? "C:\\config\\base\\path"
+            : "/config/base/path";
+
+        Path basePath = Path.of(basePathString);
+        when(path.toAbsolutePath()).thenReturn(basePath);
+
+        Settings settings = Settings.builder().put("path.home", basePathString).build();
         ConfigurationRepository configRepository = createConfigurationRepository(settings);
         String result = configRepository.getConfigDirectory();
 
-        assertThat(result, is("/config/base/path/opensearch-security/"));
+        String expectedPath = System.getProperty("os.name").toLowerCase().contains("win")
+            ? "C:\\config\\base\\path\\opensearch-security\\"
+            : "/config/base/path/opensearch-security/";
+
+        assertThat(result, is(expectedPath));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -521,7 +521,7 @@ public class ConfigurationRepositoryTest {
     }
 
     @Test(expected = OpenSearchException.class)
-    public void getConfigurationsFromIndex_SecurityIndexMetadataNull() throws InterruptedException, TimeoutException {
+    public void getConfigurationsFromIndex_existingSecurityIndexMetadataNull_NoResult() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
         ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
@@ -533,7 +533,7 @@ public class ConfigurationRepositoryTest {
     }
 
     @Test(expected = OpenSearchException.class)
-    public void getConfigurationsFromIndex_SecurityIndexMappingMetaDataNull() throws InterruptedException, TimeoutException {
+    public void getConfigurationsFromIndex_existingSecurityIndexMappingMetaDataNull_NoResult() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
         ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -266,7 +266,7 @@ public class ConfigurationRepositoryTest {
         configRepository.initOnNodeStart().join();
 
         verify(clusterBlocks, times(1)).hasGlobalBlockWithStatus(RestStatus.SERVICE_UNAVAILABLE);
-        verify(indexResponse, times(10)).getId();
+        verify(indexResponse, times(CType.values().size())).getId();
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -62,7 +62,6 @@ import org.opensearch.transport.client.IndicesAdminClient;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.OngoingStubbing;
 
@@ -121,6 +120,8 @@ public class ConfigurationRepositoryTest {
     private IndexMetadata securityIndexMetadata;
     @Mock
     private MappingMetadata securityIndexMappingMetadata;
+    @Mock
+    private ConfigurationLoaderSecurity7 configurationLoaderSecurity7;
 
     private ThreadPool threadPool;
 
@@ -176,7 +177,8 @@ public class ConfigurationRepositoryTest {
             localClient,
             clusterService,
             auditLog,
-            securityIndexHandler
+            securityIndexHandler,
+            configurationLoaderSecurity7
         );
     }
 
@@ -232,8 +234,6 @@ public class ConfigurationRepositoryTest {
             .build();
         System.setProperty("security.default_init.dir", TEST_CONFIG_DIR);
         ConfigurationRepository configRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configRepository.setConfigurationLoader(configurationLoaderSecurity7);
         configRepository.setDynamicConfigFactory(dynamicConfigFactory);
 
         setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
@@ -455,8 +455,6 @@ public class ConfigurationRepositoryTest {
     public void isAuditHotReloadingEnabled_shouldReturnFalseWhenAuditConfigDocNotPresentInIndex() {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         when(configurationLoaderSecurity7.isAuditConfigDocPresentInIndex()).thenReturn(false);
         boolean result = configurationRepository.isAuditHotReloadingEnabled();
 
@@ -467,8 +465,6 @@ public class ConfigurationRepositoryTest {
     public void isAuditHotReloadingEnabled_shouldReturnTrueWhenAuditConfigDocPresentInIndex() {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         when(configurationLoaderSecurity7.isAuditConfigDocPresentInIndex()).thenReturn(true);
         boolean result = configurationRepository.isAuditHotReloadingEnabled();
 
@@ -489,8 +485,6 @@ public class ConfigurationRepositoryTest {
     public void getConfigurationsFromIndex_Success() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
 
         ConfigurationMap result = configurationRepository.getConfigurationsFromIndex(CType.values(), false);
@@ -502,8 +496,6 @@ public class ConfigurationRepositoryTest {
     public void getConfigurationsFromIndex_Partial() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of(CType.CONFIG));
 
         configurationRepository.getConfigurationsFromIndex(CType.values(), false);
@@ -513,8 +505,6 @@ public class ConfigurationRepositoryTest {
     public void getConfigurationsFromIndex_NoResult() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
 
         configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
@@ -524,8 +514,6 @@ public class ConfigurationRepositoryTest {
     public void getConfigurationsFromIndex_existingSecurityIndexMetadataNull_NoResult() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
         when(metadata.index(OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX)).thenReturn(null);
 
@@ -537,8 +525,6 @@ public class ConfigurationRepositoryTest {
         TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, Set.of());
         when(securityIndexMetadata.mapping()).thenReturn(null);
 
@@ -549,8 +535,6 @@ public class ConfigurationRepositoryTest {
     public void getConfigurationsFromIndex_SecurityIndexNotInitiallyReady() throws InterruptedException, TimeoutException {
         Settings settings = Settings.builder().build();
         ConfigurationRepository configurationRepository = createConfigurationRepository(settings);
-        ConfigurationLoaderSecurity7 configurationLoaderSecurity7 = Mockito.mock(ConfigurationLoaderSecurity7.class);
-        configurationRepository.setConfigurationLoader(configurationLoaderSecurity7);
         setupConfigurationLoaderMock(configurationLoaderSecurity7, CType.values());
 
         ConfigurationMap result = configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.security.configuration;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -425,11 +426,15 @@ public class ConfigurationRepositoryTest {
         // Backup original system property if exists
         String originalProperty = System.getProperty("security.default_init.dir");
         try {
-            // Set test system property
-            System.setProperty("security.default_init.dir", "/test/path");
+            // Create platform-independent path
+            Path testPath = Path.of("test", "path");
+            System.setProperty("security.default_init.dir", testPath.toString());
+
             ConfigurationRepository configRepository = createConfigurationRepository(Settings.EMPTY);
             String result = configRepository.getConfigDirectory();
-            assertThat(result, is("/test/path/"));
+
+            String expectedPath = testPath.toString() + File.separator;
+            assertThat(result, is(expectedPath));
         } finally {
             // Cleanup: Reset system property to original state
             if (originalProperty != null) {


### PR DESCRIPTION
### Description
Improve coverage: Adding tests for ConfigurationRepository class
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Maintenance
* Why these changes are required?
https://github.com/opensearch-project/security/issues/3255
* What is the old behavior before changes and new behavior after changes?
NA

### Issues Resolved
https://github.com/opensearch-project/security/issues/3255

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
