### PR TITLE
Update 3.0.0 qualifier from alpha1 to beta1

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -3,7 +3,7 @@ name: Plugin Install
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  OPENSEARCH_VERSION: 3.0.0-alpha1
+  OPENSEARCH_VERSION: 3.0.0-beta1
   PLUGIN_NAME: opensearch-security
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -16,15 +16,15 @@ import groovy.json.JsonBuilder
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-        buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+        buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
 
         // 2.0.0-rc1-SNAPSHOT -> 2.0.0.0-rc1-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
 
-        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-alpha1-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-beta1-SNAPSHOT')
 
         kafka_version  = '3.7.1'
         open_saml_version = '5.1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -167,8 +167,7 @@ forbiddenApisTest.enabled = false
 filepermissions.enabled = false
 forbiddenPatterns.enabled = false
 testingConventions.enabled = false
-// TODO Switch this back to true after replacing BC jars with BCFIPS jars
-jarHell.enabled = false
+jarHell.enabled = true
 tasks.whenTaskAdded {task ->
     if(task.name.contains("forbiddenApisIntegrationTest")) {
         task.enabled = false
@@ -576,13 +575,16 @@ tasks.integrationTest.finalizedBy(jacocoTestReport) // report is always generate
 //run the integrationTest task before the check task
 check.dependsOn integrationTest
 
+configurations.all {
+    exclude group:"org.bouncycastle", module: "bc-fips"
+    exclude group:"org.bouncycastle", module:"bctls-fips"
+    exclude group:"org.bouncycastle", module:"bcutil-fips"
+    exclude group:"org.bouncycastle", module:"bcpkix-fips"
+}
+
 dependencies {
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
-    implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}") {
-        exclude(group: 'org.bouncycastle', module: 'bc-fips')
-        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
-        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
-    }
+    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
     implementation "org.apache.httpcomponents.client5:httpclient5-cache:${versions.httpclient5}"
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
@@ -678,16 +680,8 @@ dependencies {
     testImplementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
     implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
     testImplementation "org.opensearch:common-utils:${common_utils_version}"
-    testImplementation("org.opensearch.plugin:reindex-client:${opensearch_version}") {
-        exclude(group: 'org.bouncycastle', module: 'bc-fips')
-        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
-        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
-    }
-    testImplementation("org.opensearch:opensearch-ssl-config:${opensearch_version}") {
-        exclude(group: 'org.bouncycastle', module: 'bc-fips')
-        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
-        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
-    }
+    testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
+    testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
     testImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:lang-mustache-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,8 @@ forbiddenApisTest.enabled = false
 filepermissions.enabled = false
 forbiddenPatterns.enabled = false
 testingConventions.enabled = false
-jarHell.enabled = true
+// TODO Switch this back to true after replacing BC jars with BCFIPS jars
+jarHell.enabled = false
 tasks.whenTaskAdded {task ->
     if(task.name.contains("forbiddenApisIntegrationTest")) {
         task.enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -683,7 +683,11 @@ dependencies {
         exclude(group: 'org.bouncycastle', module: 'bctls-fips')
         exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
     }
-    testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
+    testImplementation("org.opensearch:opensearch-ssl-config:${opensearch_version}") {
+        exclude(group: 'org.bouncycastle', module: 'bc-fips')
+        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
+        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
+    }
     testImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:lang-mustache-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"

--- a/build.gradle
+++ b/build.gradle
@@ -578,7 +578,11 @@ check.dependsOn integrationTest
 
 dependencies {
     implementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
-    implementation "org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}"
+    implementation("org.opensearch.client:opensearch-rest-high-level-client:${opensearch_version}") {
+        exclude(group: 'org.bouncycastle', module: 'bc-fips')
+        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
+        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
+    }
     implementation "org.apache.httpcomponents.client5:httpclient5-cache:${versions.httpclient5}"
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"

--- a/build.gradle
+++ b/build.gradle
@@ -678,7 +678,11 @@ dependencies {
     testImplementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
     implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
     testImplementation "org.opensearch:common-utils:${common_utils_version}"
-    testImplementation "org.opensearch.plugin:reindex-client:${opensearch_version}"
+    testImplementation("org.opensearch.plugin:reindex-client:${opensearch_version}") {
+        exclude(group: 'org.bouncycastle', module: 'bc-fips')
+        exclude(group: 'org.bouncycastle', module: 'bctls-fips')
+        exclude(group: 'org.bouncycastle', module: 'bcutil-fips')
+    }
     testImplementation "org.opensearch:opensearch-ssl-config:${opensearch_version}"
     testImplementation "org.opensearch.plugin:percolator-client:${opensearch_version}"
     testImplementation "org.opensearch.plugin:lang-mustache-client:${opensearch_version}"

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,9 +44,9 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
         opensearch_group = "org.opensearch"
-        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-alpha1-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-beta1-SNAPSHOT')
         jackson_version = System.getProperty("jackson_version", "2.15.2")
     }
     repositories {


### PR DESCRIPTION
### Description

Update 3.0.0 qualifier from alpha1 to beta1

Core updated to beta1 last week: https://github.com/opensearch-project/OpenSearch/pull/17621

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
