### PR TITLE
[2.19] Ensure that all ctypes contain _meta header in migrate API

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -74,19 +74,6 @@ public class MigrateApiAction extends AbstractApiAction {
 
     private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(new Route(Method.POST, "/migrate")));
 
-    private static final List<CType<?>> C_TYPES = List.of(
-        CType.ACTIONGROUPS,
-        CType.AUDIT,
-        CType.ALLOWLIST,
-        CType.CONFIG,
-        CType.INTERNALUSERS,
-        CType.NODESDN,
-        CType.ROLES,
-        CType.ROLESMAPPING,
-        CType.TENANTS,
-        CType.WHITELIST
-    );
-
     @Inject
     public MigrateApiAction(
         final ClusterService clusterService,
@@ -180,7 +167,7 @@ public class MigrateApiAction extends AbstractApiAction {
 
         if (loadedConfig.getVersion() != 1) {
             final ImmutableList.Builder<SecurityDynamicConfiguration<?>> builder = ImmutableList.builder();
-            for (CType<?> ctype : C_TYPES) {
+            for (CType<?> ctype : CType.values()) {
                 final SecurityDynamicConfiguration<?> c7 = (SecurityDynamicConfiguration<?>) load(ctype, true);
                 if (c7.get_meta() == null) {
                     c7.set_meta(new Meta());

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MigrateApiAction.java
@@ -46,6 +46,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.securityconf.Migration;
 import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.Meta;
 import org.opensearch.security.securityconf.impl.NodesDn;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.WhitelistingSettings;
@@ -72,6 +73,19 @@ public class MigrateApiAction extends AbstractApiAction {
     private final static Logger LOGGER = LogManager.getLogger(MigrateApiAction.class);
 
     private static final List<Route> routes = addRoutesPrefix(Collections.singletonList(new Route(Method.POST, "/migrate")));
+
+    private static final List<CType<?>> C_TYPES = List.of(
+        CType.ACTIONGROUPS,
+        CType.AUDIT,
+        CType.ALLOWLIST,
+        CType.CONFIG,
+        CType.INTERNALUSERS,
+        CType.NODESDN,
+        CType.ROLES,
+        CType.ROLESMAPPING,
+        CType.TENANTS,
+        CType.WHITELIST
+    );
 
     @Inject
     public MigrateApiAction(
@@ -102,6 +116,56 @@ public class MigrateApiAction extends AbstractApiAction {
         requestHandlersBuilder.allMethodsNotImplemented().override(Method.POST, (channel, request, client) -> migrate(channel, client));
     }
 
+    protected boolean updateSecurityIndex(
+        final RestChannel channel,
+        final Client client,
+        ImmutableList.Builder<SecurityDynamicConfiguration<?>> builder
+    ) {
+        final List<SecurityDynamicConfiguration<?>> dynamicConfigurations = builder.build();
+        if (dynamicConfigurations.isEmpty()) {
+            LOGGER.info("Nothing to migrate");
+            return false;
+        }
+        final ImmutableList.Builder<String> cTypes = ImmutableList.builderWithExpectedSize(dynamicConfigurations.size());
+        final BulkRequestBuilder br = client.prepareBulk(securityApiDependencies.securityIndexName());
+        br.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+        try {
+            for (SecurityDynamicConfiguration<?> dynamicConfiguration : dynamicConfigurations) {
+                final String id = dynamicConfiguration.getCType().toLCString();
+                LOGGER.info("Updating " + id);
+                final BytesReference xContent = XContentHelper.toXContent(dynamicConfiguration, XContentType.JSON, false);
+                br.add(new IndexRequest().id(id).source(id, xContent));
+                cTypes.add(id);
+            }
+        } catch (final IOException e1) {
+            LOGGER.error("Unable to create bulk request " + e1, e1);
+            internalServerError(channel, "Unable to create bulk request.");
+            return false;
+        }
+
+        br.execute(new ConfigUpdatingActionListener<>(cTypes.build().toArray(new String[0]), client, new ActionListener<BulkResponse>() {
+
+            @Override
+            public void onResponse(BulkResponse response) {
+                if (response.hasFailures()) {
+                    LOGGER.error("Unable to upload migrated configuration because of " + response.buildFailureMessage());
+                    internalServerError(channel, "Unable to upload migrated configuration (bulk index failed).");
+                } else {
+                    LOGGER.debug("Migration completed");
+                    ok(channel, "Migration completed.");
+                }
+
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                LOGGER.error("Unable to upload migrated configuration because of " + e, e);
+                internalServerError(channel, "Unable to upload migrated configuration.");
+            }
+        }));
+        return true;
+    }
+
     @SuppressWarnings("unchecked")
     protected void migrate(final RestChannel channel, final Client client) throws IOException {
 
@@ -115,7 +179,20 @@ public class MigrateApiAction extends AbstractApiAction {
         final SecurityDynamicConfiguration<?> loadedConfig = load(CType.CONFIG, true);
 
         if (loadedConfig.getVersion() != 1) {
-            badRequest(channel, "Can not migrate configuration because it was already migrated.");
+            final ImmutableList.Builder<SecurityDynamicConfiguration<?>> builder = ImmutableList.builder();
+            for (CType<?> ctype : C_TYPES) {
+                final SecurityDynamicConfiguration<?> c7 = (SecurityDynamicConfiguration<?>) load(ctype, true);
+                if (c7.get_meta() == null) {
+                    c7.set_meta(new Meta());
+                    c7.get_meta().setConfig_version(2);
+                    c7.get_meta().setType(ctype.toLCString());
+                    builder.add(c7);
+                }
+            }
+            boolean updated = updateSecurityIndex(channel, client, builder);
+            if (!updated) {
+                badRequest(channel, "Can not migrate configuration because it was already migrated.");
+            }
             return;
         }
 
@@ -199,62 +276,7 @@ public class MigrateApiAction extends AbstractApiAction {
 
                                 @Override
                                 public void onResponse(CreateIndexResponse response) {
-                                    final List<SecurityDynamicConfiguration<?>> dynamicConfigurations = builder.build();
-                                    final ImmutableList.Builder<String> cTypes = ImmutableList.builderWithExpectedSize(
-                                        dynamicConfigurations.size()
-                                    );
-                                    final BulkRequestBuilder br = client.prepareBulk(securityApiDependencies.securityIndexName());
-                                    br.setRefreshPolicy(RefreshPolicy.IMMEDIATE);
-                                    try {
-                                        for (SecurityDynamicConfiguration<?> dynamicConfiguration : dynamicConfigurations) {
-                                            final String id = dynamicConfiguration.getCType().toLCString();
-                                            final BytesReference xContent = XContentHelper.toXContent(
-                                                dynamicConfiguration,
-                                                XContentType.JSON,
-                                                false
-                                            );
-                                            br.add(new IndexRequest().id(id).source(id, xContent));
-                                            cTypes.add(id);
-                                        }
-                                    } catch (final IOException e1) {
-                                        LOGGER.error("Unable to create bulk request " + e1, e1);
-                                        internalServerError(channel, "Unable to create bulk request.");
-                                        return;
-                                    }
-
-                                    br.execute(
-                                        new ConfigUpdatingActionListener<>(
-                                            cTypes.build().toArray(new String[0]),
-                                            client,
-                                            new ActionListener<BulkResponse>() {
-
-                                                @Override
-                                                public void onResponse(BulkResponse response) {
-                                                    if (response.hasFailures()) {
-                                                        LOGGER.error(
-                                                            "Unable to upload migrated configuration because of "
-                                                                + response.buildFailureMessage()
-                                                        );
-                                                        internalServerError(
-                                                            channel,
-                                                            "Unable to upload migrated configuration (bulk index failed)."
-                                                        );
-                                                    } else {
-                                                        LOGGER.debug("Migration completed");
-                                                        ok(channel, "Migration completed.");
-                                                    }
-
-                                                }
-
-                                                @Override
-                                                public void onFailure(Exception e) {
-                                                    LOGGER.error("Unable to upload migrated configuration because of " + e, e);
-                                                    internalServerError(channel, "Unable to upload migrated configuration.");
-                                                }
-                                            }
-                                        )
-                                    );
-
+                                    updateSecurityIndex(channel, client, builder);
                                 }
 
                                 @Override


### PR DESCRIPTION
### Description

This PR creates a small update to the migrate API to ensure that every securityconfig has a `_meta` header when using the v7 models.

This PR is needed to resolve a known migration issue from 2.19 -> 3.0 if any of the security config types in the index are missing the `_meta` portion, but are known to be up to date.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves: https://github.com/opensearch-project/security/issues/5191

### Testing

1. Manually delete the `_meta` portion of one of the yaml files before booting up a cluster.

2. Run the migrate API and ensure that it responds: `{"status":"OK","message":"Migration completed."}`

Run the migrate API with: `curl -XPOST https://admin:myStrongPassword123\!@localhost:9200/_plugins/_security/api/migrate` 

3. Run it again and it should now say that the config is up to date w/ nothing to update:

```
> curl -XPOST https://admin:myStrongPassword123\!@localhost:9200/_plugins/_security/api/migrate -k

{"status":"BAD_REQUEST","message":"Can not migrate configuration because it was already migrated."}
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
