### PR TITLE
nit: remove java version check for reflection args in build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,11 +256,9 @@ test {
     }
     maxParallelForks = 8
     jvmArgs += "-Xmx3072m"
-    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-        jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
-        // this is needed to reflect access system env map.
-        jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
-    }
+    // this is needed to reflect access system env map.
+    jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
     retry {
         failOnPassedAfterRetry = false
         maxRetries = 5
@@ -305,11 +303,9 @@ task copyExtraTestResources(dependsOn: testClasses) {
 def setCommonTestConfig(Test task) {
     task.maxParallelForks = 8
     task.jvmArgs += "-Xmx3072m"
-    if (JavaVersion.current() > JavaVersion.VERSION_1_8) {
-        task.jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
-        // this is needed to reflect access system env map.
-        task.jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
-    }
+    // this is needed to reflect access system env map.
+    task.jvmArgs += "--add-opens=java.base/java.io=ALL-UNNAMED"
+    task.jvmArgs += "--add-opens=java.base/java.util=ALL-UNNAMED"
     task.retry {
         failOnPassedAfterRetry = false
         maxRetries = 5


### PR DESCRIPTION
### Description
Follow-up for https://github.com/opensearch-project/security/pull/5206#discussion_r2012742870

Java 21 as default- https://github.com/opensearch-project/security/blob/main/build.gradle#L98-L99

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
Maintenance
* Why these changes are required?
Maintenance
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved


Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [NA] New functionality has been documented
- [NA] New Roles/Permissions have a corresponding security dashboards plugin PR
- [NA] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
