### PR TITLE
More tests for FLS and field masking

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/ServiceAccountAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/ServiceAccountAuthenticationTest.java
@@ -78,7 +78,7 @@ public class ServiceAccountAuthenticationTest {
                 SECURITY_RESTAPI_ROLES_ENABLED,
                 List.of("user_admin__all_access"),
                 SECURITY_SYSTEM_INDICES_KEY,
-                List.of(TEST_SYS_INDEX.getName())
+                List.of(TEST_SYS_INDEX.name())
             )
         )
         .authc(AUTHC_HTTPBASIC_INTERNAL)
@@ -103,13 +103,13 @@ public class ServiceAccountAuthenticationTest {
     public void testReadSysIndexWithServiceAccountCred() {
         try (TestRestClient client = cluster.getRestClient(SERVICE_ACCOUNT_ADMIN_USER)) {
             client.confirmCorrectCredentials(SERVICE_ACCOUNT_USER_NAME);
-            TestRestClient.HttpResponse response = client.get(TEST_SYS_INDEX.getName());
+            TestRestClient.HttpResponse response = client.get(TEST_SYS_INDEX.name());
             response.assertStatusCode(HttpStatus.SC_OK);
 
             String responseBody = response.getBody();
 
             assertNotNull("Response body should not be null", responseBody);
-            assertTrue(responseBody.contains(TEST_SYS_INDEX.getName()));
+            assertTrue(responseBody.contains(TEST_SYS_INDEX.name()));
         }
     }
 
@@ -117,7 +117,7 @@ public class ServiceAccountAuthenticationTest {
     public void testReadNonSysIndexWithServiceAccountCred() {
         try (TestRestClient client = cluster.getRestClient(SERVICE_ACCOUNT_ADMIN_USER)) {
             client.confirmCorrectCredentials(SERVICE_ACCOUNT_USER_NAME);
-            TestRestClient.HttpResponse response = client.get(TEST_NON_SYS_INDEX.getName());
+            TestRestClient.HttpResponse response = client.get(TEST_NON_SYS_INDEX.name());
             response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
 
             String responseBody = response.getBody();
@@ -131,7 +131,7 @@ public class ServiceAccountAuthenticationTest {
     public void testReadBothWithServiceAccountCred() {
         TestRestClient client = cluster.getRestClient(SERVICE_ACCOUNT_ADMIN_USER);
         client.confirmCorrectCredentials(SERVICE_ACCOUNT_USER_NAME);
-        TestRestClient.HttpResponse response = client.get((TEST_SYS_INDEX.getName() + "," + TEST_NON_SYS_INDEX.getName()));
+        TestRestClient.HttpResponse response = client.get((TEST_SYS_INDEX.name() + "," + TEST_NON_SYS_INDEX.name()));
         response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
 
         String responseBody = response.getBody();

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -356,7 +356,6 @@ public class FlsFmIntegrationTests {
                     "source_ip"
                   ]
                 }""");
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             assertThat(
                 response,
@@ -384,7 +383,6 @@ public class FlsFmIntegrationTests {
                     "attr_text_1"
                   ]
                 }""");
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             assertThat(
                 response,
@@ -443,7 +441,15 @@ public class FlsFmIntegrationTests {
                 }""");
             assertThat(response, isOk());
             if (user.reference(FIELD_IS_AGGREGABLE).test("attr_keyword")) {
-                assertThat(response, hasAggregation("keyword_agg", whereBucketsEqual(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED)).aggregation("attr_keyword"))));
+                assertThat(
+                    response,
+                    hasAggregation(
+                        "keyword_agg",
+                        whereBucketsEqual(
+                            TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED)).aggregation("attr_keyword")
+                        )
+                    )
+                );
             } else {
                 assertThat(response, hasAggregation("keyword_agg", whereBucketsAreEmpty()));
             }
@@ -522,7 +528,6 @@ public class FlsFmIntegrationTests {
                   }
                 }""");
             assertThat(response, isOk());
-            System.out.println(response.getBody());
             if (user.reference(FIELD_IS_AGGREGABLE).test("attr_binary")) {
                 assertThat(response, hasAggregation("binary_agg", whereBucketsEqual(TEST_DOCUMENTS.aggregation("attr_binary", 10))));
             } else {
@@ -574,7 +579,6 @@ public class FlsFmIntegrationTests {
                     }
                   }
                 }""");
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_1")) {
                 assertThat(
@@ -622,7 +626,6 @@ public class FlsFmIntegrationTests {
                     }
                   }
                 }""");
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             if (user.reference(FIELD_IS_SEARCHABLE).test("attr_keyword_doc_values_disabled")) {
                 assertThat(
@@ -681,7 +684,6 @@ public class FlsFmIntegrationTests {
                   }
                 }""");
             assertThat(response, isOk());
-            System.out.println(response.getBody());
             if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_doc_values_disabled_nullable")) {
                 assertThat(
                     response,
@@ -747,7 +749,6 @@ public class FlsFmIntegrationTests {
                     ]
                 }""");
 
-            System.out.println(response.getBody());
             // TODO: Assert for case where attr_keyword is hidden by FLS an assertion that no values are exposed in the sort attribute of
             // hits
             assertThat(response, isOk());
@@ -799,7 +800,6 @@ public class FlsFmIntegrationTests {
             TestRestClient.HttpResponse response = client.get(
                 TEST_INDEX.name() + "/_termvectors/" + testDocument.id() + "?term_statistics=true&payloads=true&fields=*"
             );
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             assertThat(
                 response,

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -23,7 +23,6 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import com.google.common.collect.ImmutableMap;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.bouncycastle.util.encoders.Hex;
@@ -759,41 +758,36 @@ public class FlsFmIntegrationTests {
         }
     }
 
-    @Ignore
     @Test
     public void termVectors() {
-        // Term vectors on FLS/FM protected documents fail with an internal OpenSearch assertion error
-        // java.lang.AssertionError: null
-        // at __randomizedtesting.SeedInfo.seed([36B4FFBCDDE3E188]:0) ~[?:?]
-        // at org.opensearch.action.termvectors.TermVectorsWriter.writeTermWithDocsAndPos(TermVectorsWriter.java:213)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.termvectors.TermVectorsWriter.setFields(TermVectorsWriter.java:139)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.termvectors.TermVectorsResponse.setFields(TermVectorsResponse.java:414)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:161)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:97)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:148)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:62)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at
-        // org.opensearch.action.support.single.shard.TransportSingleShardAction.lambda$asyncShardOperation$0(TransportSingleShardAction.java:131)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:994)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
-        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-        // at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
-        // at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
-        // at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
-
+        if (user == Users.MASKING_ON_TEXT
+            || user == Users.MASKING_ON_KEYWORD
+            || user == Users.MASKING_ON_BINARY
+            || user == Users.MASKING_ON_IP
+            || user == Users.MASKING_ON_STORED_FIELD) {
+            // Term vectors on field masking protected documents fail with an internal OpenSearch assertion error
+            // java.lang.AssertionError
+            // at __randomizedtesting.SeedInfo.seed([972D41C822130990]:0)
+            // at org.opensearch.action.termvectors.TermVectorsResponse.buildTermStatistics(TermVectorsResponse.java:269)
+            // at org.opensearch.action.termvectors.TermVectorsResponse.buildTerm(TermVectorsResponse.java:252)
+            // at org.opensearch.action.termvectors.TermVectorsResponse.buildField(TermVectorsResponse.java:235)
+            // at org.opensearch.action.termvectors.TermVectorsResponse.toXContent(TermVectorsResponse.java:216)
+            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:62)
+            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:57)
+            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:49)
+            // at org.opensearch.rest.action.RestResponseListener.processResponse(RestResponseListener.java:52)
+            // at org.opensearch.rest.action.RestActionListener.onResponse(RestActionListener.java:64)
+            // at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:115)
+            // at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:109)
+            // at
+            // org.opensearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction$2.handleResponse(TransportSingleShardAction.java:298)
+            // at
+            // org.opensearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction$2.handleResponse(TransportSingleShardAction.java:284)
+            // at
+            // org.opensearch.security.transport.SecurityInterceptor$RestoringTransportResponseHandler.handleResponse(SecurityInterceptor.java:420)
+            // at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleResponse(TransportService.java:1495)
+            return;
+        }
         TestData.TestDocument testDocument = TEST_DATA.anyDocument();
 
         try (TestRestClient client = cluster.getRestClient(user)) {

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -283,6 +283,11 @@ public class FlsFmIntegrationTests {
         .nodeSettings(ImmutableMap.of("plugins.security.compliance.salt", FIELD_MASKING_SALT))
         .build();
 
+    /**
+     * This test has two main objectives. It ensures:
+     * - that the document is only found when the DLS rule allows it. This gives coverage for DlsFlsFilterLeafReader.DlsGetEvaluator
+     * - that the document sources in a search response are properly filtered according to FLS/FM rules. This gives coverage for FlsStoredFieldVisitor.binaryField() and FlsDocumentFilter
+     */
     @Test
     public void get() {
         TestData.TestDocument testDocument = TEST_DATA.anyDocument();
@@ -293,6 +298,11 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test has two main objectives. It ensures:
+     * - that the returned documents only contain allowed documents according to DLS rules. This gives coverage for DlsFlsValveImpl.handleSearchContext() (via a SearchOperationListener)
+     * - that the document sources in a search response are properly filtered according to FLS/FM rules. This gives coverage for FlsStoredFieldVisitor.binaryField() and FlsDocumentFilter
+     */
     @Test
     public void search_source() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -305,6 +315,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test ensures that fields returned in the search response are filtered according to FLS/FM rules.
+     * This gives coverage for DlsFlsFilterLeafReader.getFieldInfos().
+     */
     @Test
     public void search_fields() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -343,6 +357,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test ensures that docvalue_fields returned in the search response are filtered according to FLS/FM rules.
+     * This gives coverage for ?
+     */
     @Test
     public void search_docValueFields() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -370,6 +388,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test ensures that stored fields returned in the search response are filtered according to FLS/FM rules.
+     * This gives coverage for all *field methods in FlsStoredFieldVisitor (via the different data types of the fields).
+     */
     @Test
     public void search_storedFields() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -397,6 +419,12 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test has two main objectives. It ensures for string (keyword) fields:
+     * - that an empty aggregation is returned when the attribute to be aggregated on is not allowed by FLS.
+     * - that the aggregation has properly masked bucket keys when the attribute to be aggregated on is protected by field masking.
+     * This gives coverage for the *SortedSetDocValues methods in DlsFlsFilterLeafReader
+     */
     @Test
     public void search_aggregation_keywordAttribute() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -410,6 +438,7 @@ public class FlsFmIntegrationTests {
                     }
                   }
                 }""");
+            System.out.println(response.getBody());
             assertThat(response, isOk());
             if (user.reference(FIELD_IS_AGGREGABLE).test("attr_text_1")) {
                 assertThat(
@@ -425,6 +454,12 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test has two main objectives. It ensures for string (keyword) fields:
+     * - that an empty aggregation is returned when the attribute to be aggregated on is not allowed by FLS.
+     * - that the aggregation has properly masked bucket keys when the attribute to be aggregated on is protected by field masking.
+     * This gives coverage for the *SortedSetDocValues methods in DlsFlsFilterLeafReader
+     */
     @Test
     public void search_aggregation_explicitKeywordAttribute() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -455,6 +490,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test replicates the above aggregation tests for fields of type IP.
+     * This gives coverage for the *SortedSetDocValues methods in DlsFlsFilterLeafReader
+     */
     @Test
     public void search_aggregation_ip() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -481,6 +520,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This test replicates the above aggregation tests for fields of type binary.
+     * This gives coverage for the *BinaryDocValues methods in DlsFlsFilterLeafReader
+     */
     @Test
     public void search_aggregation_binary() {
         if (user == Users.MASKING_ON_BINARY) {
@@ -535,6 +578,10 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * This method verifies that search queries are only possible on fields if they are not protected by FLS/FM.
+     * This gives coverage for the terms() method in DlsFlsFilterLeafReader
+     */
     @Test
     public void search_abilityToSearch_textAttribute() {
         try (TestRestClient client = cluster.getRestClient(user)) {
@@ -551,6 +598,9 @@ public class FlsFmIntegrationTests {
         }
     }
 
+    /**
+     * Same test as before, but verfies keyword fields
+     */
     @Test
     public void search_abilityToSearch_keywordAttribute() {
         try (TestRestClient client = cluster.getRestClient(user)) {

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -438,7 +438,6 @@ public class FlsFmIntegrationTests {
                     }
                   }
                 }""");
-            System.out.println(response.getBody());
             assertThat(response, isOk());
             if (user.reference(FIELD_IS_AGGREGABLE).test("attr_text_1")) {
                 assertThat(

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -1,0 +1,847 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.privileges.dlsfls;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.google.common.collect.ImmutableMap;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.bouncycastle.util.encoders.Hex;
+
+import org.opensearch.plugin.mapper.MapperSizePlugin;
+import org.opensearch.test.framework.TestData;
+import org.opensearch.test.framework.TestIndex;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import com.rfksystems.blake2b.Blake2b;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.correspondingToDocument;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.emptyHits;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.hasAggregation;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.hasSearchHits;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.hasSource;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.isTermVectorsResultWithFields;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereBucketsAreEmpty;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereBucketsAreEmptyOrZero;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereBucketsEqual;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereDocumentSourceEquals;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereFieldsEquals;
+import static org.opensearch.test.framework.matcher.RestDocumentMatchers.whereNonEmptyBucketsExist;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+/**
+ * This int tests defines a test matrix using parameters and methods to test FLS and field masking:
+ * <ul>
+ * <li>On the parameter level, different users with different FLS/FM configs are used for test execution. The user are associated with test oracles which help validating the test results.
+ * <li>On the test method level, different operations (get, search, aggregation, terms vectors) are used with the defined users.
+ * </ul>
+ */
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class FlsFmIntegrationTests {
+
+    static final TestData TEST_DATA = TestData.DEFAULT;
+    static final TestData.TestDocuments TEST_DOCUMENTS = TEST_DATA.documents();
+    static final TestIndex TEST_INDEX = TestIndex.name("test_index").setting("index.number_of_shards", 5).data(TEST_DATA).build();
+    static final String FIELD_MASKING_SALT = "mytestsaresalted";
+    static byte[] FIELD_MASKING_SALT_BYTES = FIELD_MASKING_SALT.getBytes(StandardCharsets.UTF_8);
+
+    static final TestSecurityConfig.User.MetadataKey<TestData.DocumentTransformer> DOC_WITH_FLS_FM_APPLIED =
+        new TestSecurityConfig.User.MetadataKey<>("doc_with_fls_fm_applied", TestData.DocumentTransformer.class);
+
+    /**
+     * A predicate assigned to a user that determines whether a field can be searched by this user.
+     * Fields protected by FLS and field masking cannot be searched.
+     */
+    static final TestSecurityConfig.User.MetadataKey<FieldNamePredicate> FIELD_IS_SEARCHABLE = new TestSecurityConfig.User.MetadataKey<>(
+        "field_is_searchable",
+        FieldNamePredicate.class
+    );
+
+    /**
+     * A predicate assigned to a user that determines whether a field can be searched by this user.
+     * Fields protected by FLS cannot be aggregated. However, fields protected by field masking can be aggregated.
+     */
+    static final TestSecurityConfig.User.MetadataKey<FieldNamePredicate> FIELD_IS_AGGREGABLE = new TestSecurityConfig.User.MetadataKey<>(
+        "field_is_aggregable",
+        FieldNamePredicate.class
+    );
+
+    interface Users {
+        TestSecurityConfig.User FULL = new TestSecurityConfig.User("full").description("May see everything")
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro").indexPermissions("read").on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc)
+            .reference(FIELD_IS_SEARCHABLE, field -> true)
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_TEXT = new TestSecurityConfig.User("fls_exclusion_on_text").description(
+            "May not see attr_text_1"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~attr_text_1")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("attr_text_1"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_text_1"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("attr_text_1"));
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_STORED_FIELD = new TestSecurityConfig.User("fls_exclusion_on_stored_field").description(
+            "May not see attr_text_stored"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~attr_text_stored")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("attr_text_stored"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_text_stored"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("attr_text_stored"));
+
+        TestSecurityConfig.User FLS_INCLUSION_ON_TEXT = new TestSecurityConfig.User("fls_inclusion_on_text").description(
+            "May only see attr_text_1"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("attr_text_1")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withOnlyAttributes("attr_text_1"))
+            .reference(FIELD_IS_SEARCHABLE, field -> field.startsWith("attr_text_1"))
+            .reference(FIELD_IS_AGGREGABLE, field -> field.startsWith("attr_text_1"));
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_NESTED_ATTRIBUTE = new TestSecurityConfig.User("fls_exclusion_on_nested_attribute")
+            .description("May not see attr_object.obj_attr_text_1")
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~attr_object.obj_attr_text_1")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("attr_object.obj_attr_text_1"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_object.obj_attr_text_1"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("attr_object.obj_attr_text_1"));
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_OBJECT_ATTRIBUTE = new TestSecurityConfig.User("fls_exclusion_on_object_attribute")
+            .description("May not see attr_object")
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~attr_object")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("attr_object"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_object"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("attr_object"));
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_INTEGER_NUMBER = new TestSecurityConfig.User("fls_exclusion_on_integer_number")
+            .description("May not see attr_int")
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~attr_int")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("attr_int"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_int"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("attr_int"));
+
+        TestSecurityConfig.User FLS_EXCLUSION_ON_IP = new TestSecurityConfig.User("fls_exclusion_on_ip").description(
+            "May not see source_ip"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .fls("~source_ip")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.withoutAttributes("source_ip"))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("source_ip"))
+            .reference(FIELD_IS_AGGREGABLE, field -> !field.startsWith("source_ip"));
+
+        TestSecurityConfig.User MASKING_ON_TEXT = new TestSecurityConfig.User("masking_on_text").description(
+            "May see attr_text_1 only masked"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .maskedFields("attr_text_1")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.applyFieldTransform("attr_text_1", blake2b(FIELD_MASKING_SALT_BYTES)))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_text_1"))
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        TestSecurityConfig.User MASKING_ON_KEYWORD = new TestSecurityConfig.User("masking_on_keyword").description(
+            "May see attr_keyword only masked"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .maskedFields("attr_keyword", "attr_keyword_doc_values_disabled")
+                    .on(TEST_INDEX)
+            )
+            .reference(
+                DOC_WITH_FLS_FM_APPLIED,
+                doc -> doc.applyFieldTransform("attr_keyword", blake2b(FIELD_MASKING_SALT_BYTES))
+                    .applyFieldTransform("attr_keyword_doc_values_disabled", blake2b(FIELD_MASKING_SALT_BYTES))
+            )
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_keyword"))
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        TestSecurityConfig.User MASKING_ON_STORED_FIELD = new TestSecurityConfig.User("masking_on_stored_field").description(
+            "May see attr_text_stored only masked"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .maskedFields("attr_text_stored")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.applyFieldTransform("attr_text_stored", blake2b(FIELD_MASKING_SALT_BYTES)))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_text_stored"))
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        TestSecurityConfig.User MASKING_ON_IP = new TestSecurityConfig.User("masking_on_ip").description("May see source_ip only masked")
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .maskedFields("source_ip")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.applyFieldTransform("source_ip", blake2b(FIELD_MASKING_SALT_BYTES)))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("source_ip"))
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        TestSecurityConfig.User MASKING_ON_BINARY = new TestSecurityConfig.User("masking_on_binary").description(
+            "May see attr_binary only masked"
+        )
+            .roles(
+                new TestSecurityConfig.Role("role").clusterPermissions("cluster_composite_ops_ro")
+                    .indexPermissions("read")
+                    .maskedFields("attr_binary")
+                    .on(TEST_INDEX)
+            )
+            .reference(DOC_WITH_FLS_FM_APPLIED, doc -> doc.applyFieldTransform("attr_binary", blake2b(FIELD_MASKING_SALT_BYTES)))
+            .reference(FIELD_IS_SEARCHABLE, field -> !field.startsWith("attr_binary"))
+            .reference(FIELD_IS_AGGREGABLE, field -> true);
+
+        List<TestSecurityConfig.User> ALL = Arrays.asList(
+            FULL,
+            FLS_EXCLUSION_ON_TEXT,
+            FLS_INCLUSION_ON_TEXT,
+            FLS_EXCLUSION_ON_STORED_FIELD,
+            FLS_EXCLUSION_ON_NESTED_ATTRIBUTE,
+            FLS_EXCLUSION_ON_OBJECT_ATTRIBUTE,
+            FLS_EXCLUSION_ON_INTEGER_NUMBER,
+            FLS_EXCLUSION_ON_IP,
+            MASKING_ON_TEXT,
+            MASKING_ON_KEYWORD,
+            MASKING_ON_STORED_FIELD,
+            MASKING_ON_IP,
+            MASKING_ON_BINARY
+        );
+
+    }
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .plugin(MapperSizePlugin.class)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(Users.ALL)
+        .indices(TEST_INDEX)
+        .nodeSettings(ImmutableMap.of("plugins.security.compliance.salt", FIELD_MASKING_SALT))
+        .build();
+
+    @Test
+    public void get() {
+        TestData.TestDocument testDocument = TEST_DATA.anyDocument();
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(TEST_INDEX.name() + "/_doc/" + testDocument.id());
+            assertThat(response, isOk());
+            assertThat(response, hasSource(testDocument.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))));
+        }
+    }
+
+    @Test
+    public void search_source() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(TEST_INDEX.name() + "/_search");
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                hasSearchHits(whereDocumentSourceEquals(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+            );
+        }
+    }
+
+    @Test
+    public void search_fields() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "fields": [
+                    "attr_text_1",
+                    "attr_text_2",
+                    "attr_binary",
+                    "attr_int",
+                    "source_ip",
+                    "attr_object.obj_attr_text_1",
+                    "attr_object.obj_attr_object.obj_obj_attr_text"
+                  ]
+                }""");
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                hasSearchHits(
+                    whereFieldsEquals(
+                        TEST_DOCUMENTS.applyTransform(
+                            user.reference(DOC_WITH_FLS_FM_APPLIED),
+                            d -> d.withOnlyAttributes(
+                                "attr_text_1",
+                                "attr_text_2",
+                                "attr_binary",
+                                "attr_int",
+                                "source_ip",
+                                "attr_object.obj_attr_text_1",
+                                "attr_object.obj_attr_object.obj_obj_attr_text"
+                            )
+                        )
+                    )
+                )
+            );
+        }
+    }
+
+    @Test
+    public void search_docValueFields() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "docvalue_fields": [
+                    "attr_text_1.keyword",
+                    "attr_text_2.keyword",
+                    "attr_int",
+                    "source_ip"
+                  ]
+                }""");
+            System.out.println(response.getBody());
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                hasSearchHits(
+                    whereFieldsEquals(
+                        TEST_DOCUMENTS.applyTransform(
+                            user.reference(DOC_WITH_FLS_FM_APPLIED),
+                            d -> d.withOnlyAttributes("attr_text_1", "attr_text_2", "attr_int", "source_ip")
+                        )
+                    )
+                )
+            );
+        }
+    }
+
+    @Test
+    public void search_storedFields() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "stored_fields": [
+                    "attr_text_stored"
+                  ],
+                  "fields": [
+                    "attr_text_1"
+                  ]
+                }""");
+            System.out.println(response.getBody());
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                hasSearchHits(
+                    whereFieldsEquals(
+                        TEST_DOCUMENTS.applyTransform(
+                            user.reference(DOC_WITH_FLS_FM_APPLIED),
+                            d -> d.withOnlyAttributes("attr_text_stored", "attr_text_1")
+                        )
+                    )
+                )
+            );
+        }
+    }
+
+    @Test
+    public void search_aggregation_keywordAttribute() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "aggs": {
+                    "keyword_agg": {
+                      "terms": {
+                        "field": "attr_text_1.keyword"
+                      }
+                    }
+                  }
+                }""");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_AGGREGABLE).test("attr_text_1")) {
+                assertThat(
+                    response,
+                    hasAggregation(
+                        "keyword_agg",
+                        whereBucketsEqual(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED)).aggregation("attr_text_1"))
+                    )
+                );
+            } else {
+                assertThat(response, hasAggregation("keyword_agg", whereBucketsAreEmpty()));
+            }
+        }
+    }
+
+    @Test
+    public void search_aggregation_explicitKeywordAttribute() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "aggs": {
+                    "keyword_agg": {
+                      "terms": {
+                        "field": "attr_keyword"
+                      }
+                    }
+                  }
+                }""");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_AGGREGABLE).test("attr_keyword")) {
+                assertThat(response, hasAggregation("keyword_agg", whereBucketsEqual(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED)).aggregation("attr_keyword"))));
+            } else {
+                assertThat(response, hasAggregation("keyword_agg", whereBucketsAreEmpty()));
+            }
+        }
+    }
+
+    @Test
+    public void search_aggregation_ip() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "aggs": {
+                    "ip_agg": {
+                      "ip_range": {
+                        "field": "source_ip",
+                        "ranges": [
+                           { "to": "103.105.0.0" },
+                           { "from": "103.105.0.0" }
+                        ]
+                      }
+                    }
+                  }
+                }""");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_AGGREGABLE).test("source_ip")) {
+                assertThat(response, hasAggregation("ip_agg", whereNonEmptyBucketsExist()));
+            } else {
+                assertThat(response, hasAggregation("ip_agg", whereBucketsAreEmptyOrZero()));
+            }
+        }
+    }
+
+    @Test
+    public void search_aggregation_binary() {
+        if (user == Users.MASKING_ON_BINARY) {
+            // Field masking on a binary field produces an error 500. Skip this until it is fixed.
+            // This exception is encountered:
+            // Caused by: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last source index 100 out of bounds for byte[64]
+            // at java.lang.System.arraycopy(Native Method) ~[?:?]
+            // at org.apache.lucene.util.BytesRefBuilder.copyBytes(BytesRefBuilder.java:106) ~[lucene-core-10.1.0.jar:10.1.0
+            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.util.BytesRefBuilder.copyBytes(BytesRefBuilder.java:114) ~[lucene-core-10.1.0.jar:10.1.0
+            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at
+            // org.opensearch.search.aggregations.bucket.terms.MapStringTermsAggregator$ValuesSourceCollectorSource$1.collect(MapStringTermsAggregator.java:229)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.aggregations.LeafBucketCollector.collect(LeafBucketCollector.java:123)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.apache.lucene.search.MultiCollector$MultiLeafCollector.collect(MultiCollector.java:221)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.MatchAllDocsQuery$1$1$1.score(MatchAllDocsQuery.java:61) ~[lucene-core-10.1.0.jar:10.1.0
+            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.opensearch.search.internal.CancellableBulkScorer.score(CancellableBulkScorer.java:71)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.searchLeaf(ContextIndexSearcher.java:356)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:305)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:269)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.query.QueryPhase.searchWithCollector(QueryPhase.java:355)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            return;
+        }
+
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "aggs": {
+                    "binary_agg": {
+                      "terms": {
+                        "field": "attr_binary",
+                        "min_doc_count": 10
+                      }
+                    }
+                  }
+                }""");
+            assertThat(response, isOk());
+            System.out.println(response.getBody());
+            if (user.reference(FIELD_IS_AGGREGABLE).test("attr_binary")) {
+                assertThat(response, hasAggregation("binary_agg", whereBucketsEqual(TEST_DOCUMENTS.aggregation("attr_binary", 10))));
+            } else {
+                assertThat(response, hasAggregation("binary_agg", whereBucketsAreEmpty()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_textAttribute() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(TEST_INDEX.name() + "/_search?q=attr_text_2:coffee");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_2")) {
+                assertThat(
+                    response,
+                    hasSearchHits(whereDocumentSourceEquals(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_keywordAttribute() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(TEST_INDEX.name() + "/_search?q=attr_text_1.keyword:dept_a_1");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_1")) {
+                assertThat(
+                    response,
+                    hasSearchHits(whereDocumentSourceEquals(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_keywordAttribute_prefixQuery() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "query": {
+                    "prefix": {
+                      "attr_text_1.keyword": "dept_a"
+                    }
+                  }
+                }""");
+            System.out.println(response.getBody());
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_1")) {
+                assertThat(
+                    response,
+                    hasSearchHits(
+                        whereDocumentSourceEquals(
+                            TEST_DOCUMENTS.where(d -> d.attrText1().startsWith("dept_a"))
+                                .applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))
+                        )
+                    )
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_explicitKeywordAttribute() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(TEST_INDEX.name() + "/_search?q=attr_keyword.keyword:dept_a_1");
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_keyword")) {
+                assertThat(
+                    response,
+                    hasSearchHits(whereDocumentSourceEquals(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_explicitKeywordAttribute_rangeQuery() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "query": {
+                    "range": {
+                      "attr_keyword_doc_values_disabled": {
+                        "gte": "dept_a",
+                        "lte": "dept_c"
+                      }
+                    }
+                  }
+                }""");
+            System.out.println(response.getBody());
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_keyword_doc_values_disabled")) {
+                assertThat(
+                    response,
+                    hasSearchHits(
+                        whereDocumentSourceEquals(
+                            TEST_DOCUMENTS.where(
+                                d -> d.attrKeywordDocValuesDisabled().startsWith("dept_a")
+                                    || d.attrKeywordDocValuesDisabled().startsWith("dept_b")
+                                    || d.attrKeywordDocValuesDisabled().startsWith("dept_c")
+                            ).applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))
+                        )
+                    )
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_abilityToSearch_numericRange() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(
+                TEST_INDEX.name() + "/_search?q=" + URLEncoder.encode("attr_int:[5000 TO 9000]", StandardCharsets.US_ASCII)
+            );
+            assertThat(response, isOk());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_int")) {
+                assertThat(
+                    response,
+                    hasSearchHits(
+                        whereDocumentSourceEquals(
+                            TEST_DOCUMENTS.where(d -> d.attrInt() >= 5000 && d.attrInt() <= 9000)
+                                .applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))
+                        )
+                    )
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    /**
+     * The exists query internally operates on the _field_names field which gets special treatment in DlsFlsFilterLeafReader
+     */
+    @Test
+    public void search_abilityToSearch_exists() {
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                  "query": {
+                    "exists": {
+                      "field": "attr_text_doc_values_disabled_nullable"
+                    }
+                  }
+                }""");
+            assertThat(response, isOk());
+            System.out.println(response.getBody());
+            if (user.reference(FIELD_IS_SEARCHABLE).test("attr_text_doc_values_disabled_nullable")) {
+                assertThat(
+                    response,
+                    hasSearchHits(
+                        whereDocumentSourceEquals(
+                            TEST_DOCUMENTS.where(d -> d.content().containsKey("attr_text_doc_values_disabled_nullable"))
+                                .applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))
+                        )
+                    )
+                );
+            } else {
+                assertThat(response, hasSearchHits(emptyHits()));
+            }
+        }
+    }
+
+    @Test
+    public void search_sortBy_explicitKeywordAttribute() {
+        if (user == Users.MASKING_ON_KEYWORD) {
+            // Sorting by a masked field produces an error 500. Skip this until this is fixed.
+            // This exception is encountered:
+            // Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.lucene.index.Terms.iterator()" because the return value
+            // of "org.apache.lucene.index.LeafReader.terms(String)" is null
+            // at org.apache.lucene.search.comparators.TermOrdValComparator$CompetitiveIterator.init(TermOrdValComparator.java:573)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.comparators.TermOrdValComparator$CompetitiveIterator.update(TermOrdValComparator.java:546)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at
+            // org.apache.lucene.search.comparators.TermOrdValComparator$TermOrdValLeafComparator.updateCompetitiveIterator(TermOrdValComparator.java:458)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at
+            // org.apache.lucene.search.comparators.TermOrdValComparator$TermOrdValLeafComparator.setHitsThresholdReached(TermOrdValComparator.java:285)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.MultiLeafFieldComparator.setHitsThresholdReached(MultiLeafFieldComparator.java:98)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.TopFieldCollector$TopFieldLeafCollector.countHit(TopFieldCollector.java:83)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.TopFieldCollector$SimpleFieldCollector$1.collect(TopFieldCollector.java:200)
+            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.Weight$DefaultBulkScorer.scoreRange(Weight.java:324) ~[lucene-core-10.1.0.jar:10.1.0
+            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.apache.lucene.search.Weight$DefaultBulkScorer.score(Weight.java:264) ~[lucene-core-10.1.0.jar:10.1.0
+            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
+            // at org.opensearch.search.internal.CancellableBulkScorer.score(CancellableBulkScorer.java:71)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.searchLeaf(ContextIndexSearcher.java:356)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:305)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:269)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // at org.opensearch.search.query.QueryPhase.searchWithCollector(QueryPhase.java:355)
+            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            return;
+        }
+
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.postJson(TEST_INDEX.name() + "/_search", """
+                {
+                    "sort" : [
+                       { "attr_keyword": "asc"},
+                       { "attr_long" : "desc" }
+                    ]
+                }""");
+
+            System.out.println(response.getBody());
+            // TODO: Assert for case where attr_keyword is hidden by FLS an assertion that no values are exposed in the sort attribute of
+            // hits
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                hasSearchHits(whereDocumentSourceEquals(TEST_DOCUMENTS.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+            );
+        }
+    }
+
+    @Ignore
+    @Test
+    public void termVectors() {
+        // Term vectors on FLS/FM protected documents fail with an internal OpenSearch assertion error
+        // java.lang.AssertionError: null
+        // at __randomizedtesting.SeedInfo.seed([36B4FFBCDDE3E188]:0) ~[?:?]
+        // at org.opensearch.action.termvectors.TermVectorsWriter.writeTermWithDocsAndPos(TermVectorsWriter.java:213)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.termvectors.TermVectorsWriter.setFields(TermVectorsWriter.java:139)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.termvectors.TermVectorsResponse.setFields(TermVectorsResponse.java:414)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:161)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:97)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:148)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:62)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at
+        // org.opensearch.action.support.single.shard.TransportSingleShardAction.lambda$asyncShardOperation$0(TransportSingleShardAction.java:131)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:994)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52)
+        // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+        // at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
+        // at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
+        // at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
+
+        TestData.TestDocument testDocument = TEST_DATA.anyDocument();
+
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(
+                TEST_INDEX.name() + "/_termvectors/" + testDocument.id() + "?term_statistics=true&payloads=true&fields=*"
+            );
+            System.out.println(response.getBody());
+            assertThat(response, isOk());
+            assertThat(
+                response,
+                isTermVectorsResultWithFields(correspondingToDocument(testDocument.applyTransform(user.reference(DOC_WITH_FLS_FM_APPLIED))))
+            );
+        }
+    }
+
+    TestSecurityConfig.User user;
+
+    public FlsFmIntegrationTests(TestSecurityConfig.User user) {
+        this.user = user;
+    }
+
+    @ParametersFactory(shuffle = false)
+    public static Collection<Object[]> params() {
+        List<Object[]> result = new ArrayList<>();
+
+        for (TestSecurityConfig.User user : Users.ALL) {
+            result.add(new Object[] { user });
+        }
+
+        return result;
+    }
+
+    @FunctionalInterface
+    interface FieldNamePredicate extends Predicate<String> {
+
+    }
+
+    static Function<Object, Object> blake2b(byte[] salt) {
+        return (value) -> {
+            if (!(value instanceof String stringValue)) {
+                return value;
+            }
+            byte[] stringValueBytes = stringValue.getBytes(StandardCharsets.UTF_8);
+            Blake2b hash = new Blake2b(null, 32, salt, null);
+            hash.update(stringValueBytes, 0, stringValueBytes.length);
+            final byte[] out = new byte[hash.getDigestSize()];
+            hash.digest(out, 0);
+            return new String(Hex.encode(out), StandardCharsets.UTF_8);
+        };
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsFmIntegrationTests.java
@@ -359,7 +359,7 @@ public class FlsFmIntegrationTests {
 
     /**
      * This test ensures that docvalue_fields returned in the search response are filtered according to FLS/FM rules.
-     * This gives coverage for ?
+     * This gives coverage for the get*DocValues() methods in DlsFlsFilterLeafReader.
      */
     @Test
     public void search_docValueFields() {
@@ -527,32 +527,7 @@ public class FlsFmIntegrationTests {
     public void search_aggregation_binary() {
         if (user == Users.MASKING_ON_BINARY) {
             // Field masking on a binary field produces an error 500. Skip this until it is fixed.
-            // This exception is encountered:
-            // Caused by: java.lang.ArrayIndexOutOfBoundsException: arraycopy: last source index 100 out of bounds for byte[64]
-            // at java.lang.System.arraycopy(Native Method) ~[?:?]
-            // at org.apache.lucene.util.BytesRefBuilder.copyBytes(BytesRefBuilder.java:106) ~[lucene-core-10.1.0.jar:10.1.0
-            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.util.BytesRefBuilder.copyBytes(BytesRefBuilder.java:114) ~[lucene-core-10.1.0.jar:10.1.0
-            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at
-            // org.opensearch.search.aggregations.bucket.terms.MapStringTermsAggregator$ValuesSourceCollectorSource$1.collect(MapStringTermsAggregator.java:229)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.aggregations.LeafBucketCollector.collect(LeafBucketCollector.java:123)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.apache.lucene.search.MultiCollector$MultiLeafCollector.collect(MultiCollector.java:221)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.MatchAllDocsQuery$1$1$1.score(MatchAllDocsQuery.java:61) ~[lucene-core-10.1.0.jar:10.1.0
-            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.opensearch.search.internal.CancellableBulkScorer.score(CancellableBulkScorer.java:71)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.searchLeaf(ContextIndexSearcher.java:356)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:305)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:269)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.query.QueryPhase.searchWithCollector(QueryPhase.java:355)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // Issue: https://github.com/opensearch-project/security/issues/5253
             return;
         }
 
@@ -752,39 +727,7 @@ public class FlsFmIntegrationTests {
     public void search_sortBy_explicitKeywordAttribute() {
         if (user == Users.MASKING_ON_KEYWORD) {
             // Sorting by a masked field produces an error 500. Skip this until this is fixed.
-            // This exception is encountered:
-            // Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.lucene.index.Terms.iterator()" because the return value
-            // of "org.apache.lucene.index.LeafReader.terms(String)" is null
-            // at org.apache.lucene.search.comparators.TermOrdValComparator$CompetitiveIterator.init(TermOrdValComparator.java:573)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.comparators.TermOrdValComparator$CompetitiveIterator.update(TermOrdValComparator.java:546)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at
-            // org.apache.lucene.search.comparators.TermOrdValComparator$TermOrdValLeafComparator.updateCompetitiveIterator(TermOrdValComparator.java:458)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at
-            // org.apache.lucene.search.comparators.TermOrdValComparator$TermOrdValLeafComparator.setHitsThresholdReached(TermOrdValComparator.java:285)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.MultiLeafFieldComparator.setHitsThresholdReached(MultiLeafFieldComparator.java:98)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.TopFieldCollector$TopFieldLeafCollector.countHit(TopFieldCollector.java:83)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.TopFieldCollector$SimpleFieldCollector$1.collect(TopFieldCollector.java:200)
-            // ~[lucene-core-10.1.0.jar:10.1.0 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.Weight$DefaultBulkScorer.scoreRange(Weight.java:324) ~[lucene-core-10.1.0.jar:10.1.0
-            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.apache.lucene.search.Weight$DefaultBulkScorer.score(Weight.java:264) ~[lucene-core-10.1.0.jar:10.1.0
-            // 884954006de769dc43b811267230d625886e6515 - 2024-12-17 16:15:44]
-            // at org.opensearch.search.internal.CancellableBulkScorer.score(CancellableBulkScorer.java:71)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.searchLeaf(ContextIndexSearcher.java:356)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:305)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.internal.ContextIndexSearcher.search(ContextIndexSearcher.java:269)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
-            // at org.opensearch.search.query.QueryPhase.searchWithCollector(QueryPhase.java:355)
-            // ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
+            // Issue: https://github.com/opensearch-project/security/issues/5254
             return;
         }
 
@@ -815,26 +758,7 @@ public class FlsFmIntegrationTests {
             || user == Users.MASKING_ON_IP
             || user == Users.MASKING_ON_STORED_FIELD) {
             // Term vectors on field masking protected documents fail with an internal OpenSearch assertion error
-            // java.lang.AssertionError
-            // at __randomizedtesting.SeedInfo.seed([972D41C822130990]:0)
-            // at org.opensearch.action.termvectors.TermVectorsResponse.buildTermStatistics(TermVectorsResponse.java:269)
-            // at org.opensearch.action.termvectors.TermVectorsResponse.buildTerm(TermVectorsResponse.java:252)
-            // at org.opensearch.action.termvectors.TermVectorsResponse.buildField(TermVectorsResponse.java:235)
-            // at org.opensearch.action.termvectors.TermVectorsResponse.toXContent(TermVectorsResponse.java:216)
-            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:62)
-            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:57)
-            // at org.opensearch.rest.action.RestToXContentListener.buildResponse(RestToXContentListener.java:49)
-            // at org.opensearch.rest.action.RestResponseListener.processResponse(RestResponseListener.java:52)
-            // at org.opensearch.rest.action.RestActionListener.onResponse(RestActionListener.java:64)
-            // at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:115)
-            // at org.opensearch.action.support.TransportAction$1.onResponse(TransportAction.java:109)
-            // at
-            // org.opensearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction$2.handleResponse(TransportSingleShardAction.java:298)
-            // at
-            // org.opensearch.action.support.single.shard.TransportSingleShardAction$AsyncSingleAction$2.handleResponse(TransportSingleShardAction.java:284)
-            // at
-            // org.opensearch.security.transport.SecurityInterceptor$RestoringTransportResponseHandler.handleResponse(SecurityInterceptor.java:420)
-            // at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleResponse(TransportService.java:1495)
+            // Issue: https://github.com/opensearch-project/security/issues/5255
             return;
         }
         TestData.TestDocument testDocument = TEST_DATA.anyDocument();

--- a/src/integrationTest/java/org/opensearch/test/framework/TestData.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestData.java
@@ -1,0 +1,802 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.test.framework;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.refresh.RefreshRequest;
+import org.opensearch.action.delete.DeleteRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.transport.client.Client;
+
+/**
+ * Creates set set of randomized documents than can be written to a test index. Especially useful for creating
+ * test data for testing DLS/FLS.
+ * <p>
+ * This class uses several techniques to create realistic situations:
+ * <ul>
+ *    <li>A fraction of documents is deleted again after having been created.
+ *    <li>Uses diverse mapping types and configurations
+ *    <li>It creates enough documents to make sure that they are spread around shards (see DEFAULT_DOCUMENT_COUNT below)
+ *    <li>Index settings should be defined using the TestIndex class to make sure that there are interesting constellations of shards and replicas
+ * </ul>
+ */
+public class TestData {
+    private static final Logger log = LogManager.getLogger(TestData.class);
+
+    public static int DEFAULT_SEED = 1234;
+    public static int DEFAULT_DOCUMENT_COUNT = 300;
+
+    public static TestData get() {
+        return DEFAULT;
+    }
+
+    public static TestData.Builder documentCount(int documentCount) {
+        return new Builder().documentCount(documentCount);
+    }
+
+    public static final TestData DEFAULT;
+
+    public static final ImmutableSet<String> TEXT_FIELD_NAMES = ImmutableSet.of(
+        "attr_text_1",
+        "attr_text_2",
+        "attr_text_termvectors",
+        "attr_text_stored",
+        "attr_object.obj_attr_text_1",
+        "attr_object.obj_attr_text_2",
+        "attr_object.obj_attr_object.obj_obj_attr_text"
+    );
+
+    private static final Cache<Key, TestData> cache;
+
+    static {
+        cache = CacheBuilder.newBuilder().softValues().initialCapacity(3).build();
+        DEFAULT = documentCount(DEFAULT_DOCUMENT_COUNT).get();
+    }
+
+    private String[] ipAddresses;
+    private String[] threeWordPhrases;
+    private String[] departments = new String[] { "dept_a_1", "dept_a_2", "dept_a_3", "dept_b_1", "dept_b_2", "dept_c", "dept_d" };
+    private int size;
+    private int deletedDocumentCount;
+    private int refreshAfter;
+    private Map<String, TestDocument> allDocuments;
+    private Map<String, TestDocument> retainedDocuments;
+    private Map<String, Map<String, TestDocument>> documentsByDepartment;
+    private Set<String> deletedDocuments;
+    private long subRandomSeed;
+
+    public TestData(int seed, int size, int deletedDocumentCount, int refreshAfter) {
+        Random random = new Random(seed);
+        this.ipAddresses = createRandomIpAddresses(random);
+        this.threeWordPhrases = createRandomThreeWordPhrases(random);
+        this.size = size;
+        this.deletedDocumentCount = deletedDocumentCount;
+        this.refreshAfter = refreshAfter;
+        // this.additionalAttributes = additionalAttributes;
+        this.subRandomSeed = random.nextLong();
+        this.createTestDocuments(random);
+    }
+
+    private TestData(
+        String[] ipAddresses,
+        String[] departments,
+        int size,
+        int deletedDocumentCount,
+        int refreshAfter,
+        Map<String, TestDocument> allDocuments,
+        Map<String, TestDocument> retainedDocuments,
+        Map<String, Map<String, TestDocument>> documentsByDepartment,
+        Set<String> deletedDocuments,
+        long subRandomSeed
+    ) {
+        super();
+        this.ipAddresses = ipAddresses;
+        this.departments = departments;
+        this.size = size;
+        this.deletedDocumentCount = deletedDocumentCount;
+        this.refreshAfter = refreshAfter;
+        this.allDocuments = allDocuments;
+        this.retainedDocuments = retainedDocuments;
+        this.documentsByDepartment = documentsByDepartment;
+        // this.additionalAttributes = additionalAttributes;
+        this.deletedDocuments = deletedDocuments;
+        this.subRandomSeed = subRandomSeed;
+    }
+
+    public void createIndex(Client client, String name, Settings settings) {
+        log.info(
+            "creating test index "
+                + name
+                + "; size: "
+                + size
+                + "; deletedDocumentCount: "
+                + deletedDocumentCount
+                + "; refreshAfter: "
+                + refreshAfter
+        );
+
+        Random random = new Random(subRandomSeed);
+        long start = System.currentTimeMillis();
+        String mapping = """
+            {
+              "_doc": {
+                "properties": {
+                  "source_ip": {"type": "ip"},
+                  "attr_text_stored": {"type": "text", "store": true},
+                  "attr_text_doc_values_disabled": {"type": "text", "store": true, "doc_values": false, "norms": false},
+                  "attr_text_doc_values_disabled_nullable": {"type": "text", "store": true, "doc_values": false, "norms": false},
+                  "attr_keyword": {"type": "keyword"},
+                  "attr_keyword_doc_values_disabled": {"type": "keyword", "store": true, "doc_values": false, "norms": false},
+                  "attr_boolean": {"type": "boolean"},
+                  "attr_long": {"type": "long"},
+                  "attr_int": {"type": "integer"},
+                  "attr_double": {"type": "double"},
+                  "attr_binary": {"type": "binary", "doc_values": true},
+                  "attr_text_termvectors": {
+                    "type": "text",
+                    "term_vector": "with_positions_offsets_payloads",
+                    "store": true,
+                    "analyzer": "standard",
+                    "fields": {
+                      "keyword": {"type": "keyword"}
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        client.admin().indices().create(new CreateIndexRequest(name).settings(settings).mapping(mapping)).actionGet();
+        int nextRefresh = (int) Math.floor((random.nextGaussian() * 0.5 + 0.5) * refreshAfter);
+        int i = 0;
+
+        for (Map.Entry<String, TestDocument> entry : allDocuments.entrySet()) {
+            String id = entry.getKey();
+            TestDocument document = entry.getValue();
+
+            client.index(new IndexRequest(name).source(document.content, XContentType.JSON).id(id)).actionGet();
+
+            if (i > nextRefresh) {
+                client.admin().indices().refresh(new RefreshRequest(name)).actionGet();
+                double g = random.nextGaussian();
+
+                nextRefresh = (int) Math.floor((g * 0.5 + 1) * refreshAfter) + i + 1;
+            }
+
+            i++;
+        }
+
+        client.admin().indices().refresh(new RefreshRequest(name)).actionGet();
+
+        for (String id : deletedDocuments) {
+            client.delete(new DeleteRequest(name, id)).actionGet();
+        }
+
+        client.admin().indices().refresh(new RefreshRequest(name)).actionGet();
+        log.info("Test index creation finished after " + (System.currentTimeMillis() - start) + " ms");
+    }
+
+    private void createTestDocuments(Random random) {
+
+        Map<String, TestDocument> allDocuments = new HashMap<>(size);
+
+        for (int i = 0; i < size; i++) {
+            TestDocument document = randomDocument(random);
+            allDocuments.put(document.id, document);
+        }
+
+        List<String> createdDocIds = new ArrayList<>(allDocuments.keySet());
+
+        Collections.shuffle(createdDocIds, random);
+
+        Set<String> deletedDocuments = new HashSet<>(deletedDocumentCount);
+        Map<String, TestDocument> retainedDocuments = new HashMap<>(allDocuments);
+
+        for (int i = 0; i < deletedDocumentCount; i++) {
+            String id = createdDocIds.get(i);
+            deletedDocuments.add(id);
+            retainedDocuments.remove(id);
+        }
+
+        Map<String, Map<String, TestDocument>> documentsByDepartment = new HashMap<>();
+
+        for (Map.Entry<String, TestDocument> entry : retainedDocuments.entrySet()) {
+            String dept = (String) entry.getValue().content().get("dept");
+            documentsByDepartment.computeIfAbsent(dept, (k) -> new HashMap<>()).put(entry.getKey(), entry.getValue());
+        }
+
+        this.allDocuments = Collections.unmodifiableMap(allDocuments);
+        this.retainedDocuments = Collections.unmodifiableMap(retainedDocuments);
+        this.deletedDocuments = Collections.unmodifiableSet(deletedDocuments);
+        this.documentsByDepartment = documentsByDepartment;
+    }
+
+    private String[] createRandomIpAddresses(Random random) {
+        String[] result = new String[2000];
+
+        for (int i = 0; i < result.length; i++) {
+            result[i] = (random.nextInt(10) + 100)
+                + "."
+                + (random.nextInt(5) + 100)
+                + "."
+                + random.nextInt(255)
+                + "."
+                + random.nextInt(255);
+        }
+
+        return result;
+    }
+
+    private String[] createRandomThreeWordPhrases(Random random) {
+        String[] w1 = new String[] {
+            "Pretty",
+            "Super",
+            "Mostly",
+            "Reasonably",
+            "Jolly",
+            "Rather",
+            "Surprisingly",
+            "Somewhat",
+            "Damn",
+            "Quite",
+            "Fairly",
+            "Moderately",
+            "Actually",
+            "Impressively",
+            "Suspiciously",
+            "Sufficiently",
+            "Suitably" };
+        String[] w2 = new String[] {
+            "good",
+            "fine",
+            "nice",
+            "decent",
+            "alright",
+            "cool",
+            "great",
+            "acceptable",
+            "smooth",
+            "awesome",
+            "good",
+            "good",
+            "fine",
+            "surreal",
+            "superb" };
+        String[] w3 = new String[] {
+            "coffee",
+            "pie",
+            "hotel",
+            "bar",
+            "diner",
+            "tea",
+            "cake",
+            "soup",
+            "place",
+            "present",
+            "shrubbery",
+            "code",
+            "coffee",
+            "coffee",
+            "coffee" };
+
+        String[] result = new String[2000];
+        for (int i = 0; i < result.length; i++) {
+
+            result[i] = w1[random.nextInt(w1.length)] + " " + w2[random.nextInt(w2.length)] + " " + w3[random.nextInt(w3.length)];
+        }
+
+        return result;
+    }
+
+    private TestDocument randomDocument(Random random) {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+        builder.put("source_ip", randomIpAddress(random));
+        builder.put("attr_text_1", randomDepartmentName(random));
+        builder.put("attr_text_2", randomThreeWordPhrase(random));
+        builder.put("attr_text_termvectors", randomThreeWordPhrase(random));
+        builder.put("attr_text_stored", randomThreeWordPhrase(random));
+        builder.put("attr_text_doc_values_disabled", randomDepartmentName(random));
+        if (random.nextBoolean()) {
+            builder.put("attr_text_doc_values_disabled_nullable", "value_" + random.nextInt());
+        }
+        builder.put("attr_keyword", randomDepartmentName(random));
+        builder.put("attr_keyword_doc_values_disabled", randomDepartmentName(random));
+        builder.put("attr_boolean", random.nextBoolean());
+        builder.put("attr_long", random.nextLong());
+        builder.put("attr_int", random.nextInt(10000));
+        builder.put("attr_double", random.nextDouble());
+        builder.put("attr_binary", randomBinaryValue(random));
+        builder.put(
+            "attr_object",
+            ImmutableMap.of(
+                "obj_attr_text_1",
+                randomDepartmentName(random),
+                "obj_attr_text_2",
+                "value_" + random.nextInt(),
+                "obj_attr_long",
+                random.nextLong(),
+                "obj_attr_object",
+                ImmutableMap.of("obj_obj_attr_text", "value_" + random.nextInt())
+            )
+        );
+
+        return new TestDocument(randomId(random), builder.build());
+    }
+
+    private String randomIpAddress(Random random) {
+        return ipAddresses[random.nextInt(ipAddresses.length)];
+    }
+
+    private String randomDepartmentName(Random random) {
+        return departments[random.nextInt(departments.length)];
+    }
+
+    private String randomThreeWordPhrase(Random random) {
+        return threeWordPhrases[random.nextInt(threeWordPhrases.length)];
+    }
+
+    private String randomBinaryValue(Random random) {
+        int r = random.nextInt(12);
+
+        // Create some outstanding values for binary
+        if (r == 1 || r == 2 || r == 3) {
+            return "top1++vj5H8=";
+        } else if (r == 4 || r == 5) {
+            return "top2++Mg6Lk=";
+        } else if (r == 6) {
+            return "top3++H8MaE=";
+        } else {
+            byte[] binary = new byte[8];
+            random.nextBytes(binary);
+            return Base64.getEncoder().encodeToString(binary);
+        }
+    }
+
+    private static String randomId(Random random) {
+        UUID uuid = new UUID(random.nextLong(), random.nextLong());
+        ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[16]);
+        byteBuffer.putLong(uuid.getMostSignificantBits());
+        byteBuffer.putLong(uuid.getLeastSignificantBits());
+        return Base64.getUrlEncoder().encodeToString(byteBuffer.array()).replace("=", "");
+    }
+
+    public int getSize() {
+        return size - deletedDocumentCount;
+    }
+
+    public int getDeletedDocumentCount() {
+        return deletedDocumentCount;
+    }
+
+    public TestDocuments documents() {
+        return new TestDocuments(this.retainedDocuments);
+    }
+
+    public TestDocument anyDocument() {
+        return retainedDocuments.values().iterator().next();
+    }
+
+    public TestDocument anyDocumentForDepartment(String dept) {
+        Map<String, TestDocument> docs = this.documentsByDepartment.get(dept);
+
+        if (docs == null) {
+            return null;
+        }
+
+        return docs.values().iterator().next();
+    }
+
+    private static class Key {
+
+        private final int seed;
+        private final int size;
+        private final int deletedDocumentCount;
+        private final int refreshAfter;
+        // private final ImmutableMap<String, Object> additionalAttributes;
+
+        public Key(int seed, int size, int deletedDocumentCount, int refreshAfter) {
+            super();
+            this.seed = seed;
+            this.size = size;
+            this.deletedDocumentCount = deletedDocumentCount;
+            this.refreshAfter = refreshAfter;
+            // this.additionalAttributes = additionalAttributes;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + deletedDocumentCount;
+            result = prime * result + refreshAfter;
+            result = prime * result + seed;
+            result = prime * result + size;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Key other = (Key) obj;
+            if (deletedDocumentCount != other.deletedDocumentCount) {
+                return false;
+            }
+            if (refreshAfter != other.refreshAfter) {
+                return false;
+            }
+            if (seed != other.seed) {
+                return false;
+            }
+            if (size != other.size) {
+                return false;
+            }
+            return true;
+        }
+
+    }
+
+    public static class Builder {
+
+        private int seed = DEFAULT_SEED;
+        private int size = DEFAULT_DOCUMENT_COUNT;
+        private int deletedDocumentCount = -1;
+        private double deletedDocumentFraction = 0.06;
+        private int refreshAfter = -1;
+        private int segmentCount = 17;
+
+        public Builder() {
+            super();
+        }
+
+        public Builder seed(int seed) {
+            this.seed = seed;
+            return this;
+        }
+
+        public Builder documentCount(int size) {
+            this.size = size;
+            return this;
+        }
+
+        public Builder deletedDocumentCount(int deletedDocumentCount) {
+            this.deletedDocumentCount = deletedDocumentCount;
+            return this;
+        }
+
+        public Builder refreshAfter(int refreshAfter) {
+            this.refreshAfter = refreshAfter;
+            return this;
+        }
+
+        public Builder deletedDocumentFraction(double deletedDocumentFraction) {
+            this.deletedDocumentFraction = deletedDocumentFraction;
+            return this;
+        }
+
+        public Builder segmentCount(int segmentCount) {
+            this.segmentCount = segmentCount;
+            return this;
+        }
+
+        public Key toKey() {
+            if (deletedDocumentCount == -1) {
+                this.deletedDocumentCount = (int) (this.size * deletedDocumentFraction);
+            }
+
+            if (refreshAfter == -1) {
+                this.refreshAfter = this.size / this.segmentCount;
+            }
+
+            return new Key(seed, size, deletedDocumentCount, refreshAfter);
+        }
+
+        public TestData get() {
+            Key key = toKey();
+
+            try {
+                return cache.get(key, () -> new TestData(seed, size, deletedDocumentCount, refreshAfter));
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class TestDocuments {
+        private final Map<String, TestDocument> documents;
+        private final Function<TestDocument, TestDocument> transformerFunction;
+
+        TestDocuments(Map<String, TestDocument> documents) {
+            this.documents = documents;
+            this.transformerFunction = Function.identity();
+        }
+
+        TestDocuments(Map<String, TestDocument> documents, Function<TestDocument, TestDocument> transformerFunction) {
+            this.documents = documents;
+            this.transformerFunction = transformerFunction;
+        }
+
+        public TestDocuments applyTransform(DocumentTransformer transformerFunction) {
+            return new TestDocuments(this.documents, this.transformerFunction.andThen(transformerFunction::transform));
+        }
+
+        public TestDocuments applyTransform(DocumentTransformer... transformerFunctions) {
+            TestDocuments current = this;
+
+            for (DocumentTransformer transformerFunction : transformerFunctions) {
+                current = current.applyTransform(transformerFunction);
+            }
+
+            return current;
+        }
+
+        public TestDocuments where(Predicate<TestDocument> testDocumentPredicate) {
+            ImmutableMap.Builder<String, TestDocument> mapBuilder = ImmutableMap.builder();
+            for (TestDocument testDocument : this.documents.values()) {
+                if (testDocumentPredicate.test(testDocument)) {
+                    mapBuilder.put(testDocument.id, testDocument);
+                }
+            }
+            return new TestDocuments(mapBuilder.build(), transformerFunction);
+        }
+
+        public Map<Object, Integer> aggregation(String attribute) {
+            Map<Object, Integer> result = new HashMap<>();
+
+            for (TestDocument testDocument : this.documents.values()) {
+                testDocument = this.transformerFunction.apply(testDocument);
+                Object value = testDocument.content.get(attribute);
+                if (value != null) {
+                    if (attribute.equals("attr_binary") && ((String) value).endsWith("=")) {
+                        // In OpenSearch, an aggregation on binary data strips trailing padding chars. Do the same here
+                        value = ((String) value).replace("=", "");
+                    }
+
+                    result.merge(value, 1, Integer::sum);
+                }
+            }
+
+            return result;
+        }
+
+        public Map<Object, Integer> aggregation(String attribute, int minDocCount) {
+            Map<Object, Integer> aggregation = aggregation(attribute);
+            Map<Object, Integer> result = new HashMap<>();
+
+            for (Map.Entry<Object, Integer> entry : aggregation.entrySet()) {
+                if (entry.getValue() >= minDocCount) {
+                    result.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            return result;
+        }
+
+        public TestDocument get(String id) {
+            TestDocument document = documents.get(id);
+            if (document != null) {
+                return this.transformerFunction.apply(document);
+            } else {
+                return null;
+            }
+        }
+    }
+
+    public static class TestDocument {
+        private final String id;
+        private final ImmutableMap<String, ?> content;
+
+        TestDocument(String id, ImmutableMap<String, ?> content) {
+            this.id = id;
+            this.content = content;
+        }
+
+        public String id() {
+            return id;
+        }
+
+        public Map<String, ?> content() {
+            return content;
+        }
+
+        public String attrText1() {
+            return (String) this.content.get("attr_text_1");
+        }
+
+        public String attrKeywordDocValuesDisabled() {
+            return (String) this.content.get("attr_keyword_doc_values_disabled");
+        }
+
+        public int attrInt() {
+            return ((Number) this.content.get("attr_int")).intValue();
+        }
+
+        public String sourceIp() {
+            return (String) this.content.get("source_ip");
+        }
+
+        public Object getAttributeByPath(String... attributes) {
+            Object current = this.content;
+
+            for (int i = 0; i < attributes.length; i++) {
+
+                if (current instanceof Map<?, ?> currentObject) {
+                    current = currentObject.get(attributes[i]);
+                } else {
+                    return null;
+                }
+            }
+
+            return current;
+        }
+
+        public TestDocument withoutAttributes(String... attributes) {
+            return withoutAttributes(Set.of(attributes));
+        }
+
+        public TestDocument withoutAttributes(Set<String> attributesToBeRemoved) {
+            Map<String, Object> result = new HashMap<>();
+            withoutAttributesRecursively(this.content, result, attributesToBeRemoved, "");
+            return new TestDocument(this.id, ImmutableMap.copyOf(result));
+        }
+
+        private void withoutAttributesRecursively(
+            Map<?, ?> source,
+            Map<String, Object> target,
+            Set<String> attributesToBeRemoved,
+            String attributePrefix
+        ) {
+
+            for (Map.Entry<?, ?> sourceEntry : source.entrySet()) {
+                String attributeNameWithPath = attributePrefix + sourceEntry.getKey();
+                if (attributesToBeRemoved.contains(attributeNameWithPath)) {
+                    continue;
+                }
+                Object sourceValue = sourceEntry.getValue();
+                if (sourceValue instanceof Map<?, ?> nestedSourceMap) {
+                    Map<String, Object> nestedTargetMap = new HashMap<>();
+                    withoutAttributesRecursively(
+                        nestedSourceMap,
+                        nestedTargetMap,
+                        attributesToBeRemoved,
+                        attributePrefix + sourceEntry.getKey() + "."
+                    );
+                    target.put((String) sourceEntry.getKey(), nestedTargetMap);
+                } else {
+                    target.put((String) sourceEntry.getKey(), sourceValue);
+                }
+            }
+        }
+
+        public TestDocument withOnlyAttributes(String... attributes) {
+            Map<String, Object> newContent = new HashMap<>();
+            for (String attribute : attributes) {
+                if (!attribute.contains(".")) {
+                    if (this.content.containsKey(attribute)) {
+                        newContent.put(attribute, this.content.get(attribute));
+                    }
+                } else {
+                    addAttributesRecursively(this.content, newContent, attribute.split("\\."), 0);
+                }
+            }
+
+            return new TestDocument(this.id, ImmutableMap.copyOf(newContent));
+        }
+
+        /*
+        public TestDocument withOnlyAttributes(Set<String> attributes) {
+            Map<String, Object> newContent = new HashMap<>();
+            for (String attri)
+            this.content.forEach((k, v) -> {
+                if (k.contains(".")) {
+                    addAttributesRecursively(this.content, newContent, k.split("\\."), 0);
+                } else {
+                    if (attributes.contains(k)) {
+                        newContent.put(k, v);
+                    }
+                }
+            });
+
+        }
+        */
+        public TestDocument applyTransform(DocumentTransformer transformerFunction) {
+            return transformerFunction.transform(this);
+        }
+
+        public TestDocument applyFieldTransform(String field, Function<Object, Object> transform) {
+            Object currentValue = content.get(field);
+            if (currentValue == null) {
+                return this;
+            }
+            Object newValue = transform.apply(currentValue);
+            if (newValue == currentValue) {
+                return this;
+            }
+
+            Map<String, Object> result = new HashMap<>(this.content);
+            result.put(field, newValue);
+
+            return new TestDocument(this.id, ImmutableMap.copyOf(result));
+        }
+
+        public String getUri(String index) {
+            return "/" + index + "/_doc/" + id;
+        }
+
+        @SuppressWarnings("unchecked")
+        private void addAttributesRecursively(
+            Map<?, ?> source,
+            Map<String, Object> target,
+            String[] attributePath,
+            int attributePathPosition
+        ) {
+            Object sourceObject = source.get(attributePath[attributePathPosition]);
+            if (sourceObject == null) {
+                return;
+            }
+            if (attributePathPosition == attributePath.length - 1) {
+                target.put(attributePath[attributePathPosition], sourceObject);
+            } else if (sourceObject instanceof Map<?, ?> sourceObjectMap) {
+                Object nextTarget = target.computeIfAbsent(attributePath[attributePathPosition], k -> new HashMap<>());
+                if (nextTarget instanceof Map<?, ?> nextTargetMap) {
+                    addAttributesRecursively(
+                        sourceObjectMap,
+                        (Map<String, Object>) nextTargetMap,
+                        attributePath,
+                        attributePathPosition + 1
+                    );
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    public interface DocumentTransformer {
+        TestDocument transform(TestDocument document);
+
+        static DocumentTransformer withoutAttributes(String... attributes) {
+            return (d) -> d.withoutAttributes(attributes);
+        }
+
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/TestData.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestData.java
@@ -70,12 +70,22 @@ public class TestData {
 
     public static final ImmutableSet<String> TEXT_FIELD_NAMES = ImmutableSet.of(
         "attr_text_1",
+        "attr_text_1.keyword",
         "attr_text_2",
+        "attr_text_2.keyword",
         "attr_text_termvectors",
+        "attr_text_termvectors.keyword",
         "attr_text_stored",
+        "attr_keyword",
+        "attr_keyword_doc_values_disabled",
+        "attr_text_doc_values_disabled",
+        "attr_text_doc_values_disabled_nullable",
         "attr_object.obj_attr_text_1",
+        "attr_object.obj_attr_text_1.keyword",
         "attr_object.obj_attr_text_2",
-        "attr_object.obj_attr_object.obj_obj_attr_text"
+        "attr_object.obj_attr_text_2.keyword",
+        "attr_object.obj_attr_object.obj_obj_attr_text",
+        "attr_object.obj_attr_object.obj_obj_attr_text.keyword"
     );
 
     private static final Cache<Key, TestData> cache;

--- a/src/integrationTest/java/org/opensearch/test/framework/TestIndex.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestIndex.java
@@ -36,18 +36,23 @@ public class TestIndex {
 
     private final String name;
     private final Settings settings;
+    private final TestData testData;
 
-    public TestIndex(String name, Settings settings) {
+    public TestIndex(String name, Settings settings, TestData testData) {
         this.name = name;
         this.settings = settings;
-
+        this.testData = testData;
     }
 
     public void create(Client client) {
-        client.admin().indices().create(new CreateIndexRequest(name).settings(settings)).actionGet();
+        if (testData != null) {
+            testData.createIndex(client, name, settings);
+        } else {
+            client.admin().indices().create(new CreateIndexRequest(name).settings(settings)).actionGet();
+        }
     }
 
-    public String getName() {
+    public String name() {
         return name;
     }
 
@@ -58,6 +63,7 @@ public class TestIndex {
     public static class Builder {
         private String name;
         private Settings.Builder settings = Settings.builder();
+        private TestData testData;
 
         public Builder name(String name) {
             this.name = name;
@@ -74,8 +80,13 @@ public class TestIndex {
             return this;
         }
 
+        public Builder data(TestData testData) {
+            this.testData = testData;
+            return this;
+        }
+
         public TestIndex build() {
-            return new TestIndex(name, settings.build());
+            return new TestIndex(name, settings.build(), testData);
         }
 
     }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -457,6 +457,10 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         }
 
         public Builder users(TestSecurityConfig.User... users) {
+            return this.users(Arrays.asList(users));
+        }
+
+        public Builder users(Collection<TestSecurityConfig.User> users) {
             for (TestSecurityConfig.User user : users) {
                 testSecurityConfig.user(user);
             }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -44,6 +44,7 @@ import java.util.stream.StreamSupport;
 import javax.net.ssl.SSLContext;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
@@ -434,6 +435,20 @@ public class TestRestClient implements AutoCloseable {
         public JsonNode bodyAsJsonNode() {
             try {
                 return DefaultObjectMapper.readTree(getBody());
+            } catch (IOException e) {
+                throw new RuntimeException("Cannot parse response body", e);
+            }
+        }
+
+        /**
+         * Parses the body as JSON and returns it as a simple Java Map.
+         * JSON objects become Map<String, Object>, JSON arrays become List<>.
+         * Other values are converted to the corresponding Java base types.
+         */
+        public Map<String, Object> bodyAsMap() {
+            try {
+                return DefaultObjectMapper.readValue(getBody(), new TypeReference<Map<String, Object>>() {
+                });
             } catch (IOException e) {
                 throw new RuntimeException("Cannot parse response body", e);
             }

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestDocumentMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestDocumentMatchers.java
@@ -1,0 +1,735 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.test.framework.matcher;
+
+import java.util.Base64;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.DiagnosingMatcher;
+
+import org.opensearch.test.framework.TestData;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+/**
+ * Matchers that can operate on responses of the OpenSearch REST APIs _search and _get; using various options like aggregations.
+ */
+public class RestDocumentMatchers {
+    @SafeVarargs
+    public static DiagnosingMatcher<HttpResponse> hasSearchHits(BaseMatcher<SearchResponseDocumentSet>... subMatchers) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Is the response body of a search request");
+
+                if (subMatchers.length > 0) {
+                    description.appendText(" where ");
+                }
+
+                for (BaseMatcher<?> subMatcher : subMatchers) {
+                    subMatcher.describeTo(description);
+                }
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse response)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                String contentType = response.getContentType() != null ? response.getContentType().toLowerCase() : "";
+
+                if (!(contentType.startsWith("application/json"))) {
+                    mismatchDescription.appendText("Response does not have the content type application/json: ")
+                        .appendValue(response.getContentType() + "; " + response.getHeaders());
+                    return false;
+                }
+
+                Map<String, Object> responseBody = response.bodyAsMap();
+                if (!(responseBody.get("hits") instanceof Map<?, ?> hits)) {
+                    mismatchDescription.appendText("Response does not have a hits attribute:\n").appendValue(response.getBody());
+                    return false;
+                }
+
+                if (!(hits.get("hits") instanceof Collection<?> searchHits)) {
+                    mismatchDescription.appendText("Response does not have a hits.hits attribute:\n").appendValue(response.getBody());
+                    return false;
+                }
+
+                SearchResponseDocumentSet responseDocumentSet = new SearchResponseDocumentSet(searchHits);
+
+                List<SearchResponseDocument> documents = searchHits.stream()
+                    .map(e -> new SearchResponseDocument((Map<?, ?>) e))
+                    .collect(Collectors.toUnmodifiableList());
+
+                boolean ok = true;
+
+                for (BaseMatcher<SearchResponseDocumentSet> subMatcher : subMatchers) {
+                    if (!subMatcher.matches(responseDocumentSet)) {
+                        subMatcher.describeMismatch(responseDocumentSet, mismatchDescription);
+                        mismatchDescription.appendText("\nResponse Body:\n").appendText(response.getBody());
+                        ok = false;
+                    }
+                }
+
+                return ok;
+
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<SearchResponseDocumentSet> whereDocumentSourceEquals(TestData.TestDocuments testDocuments) {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the _source attribute of all documents matches the reference");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof SearchResponseDocumentSet responseDocumentSet)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a SearchResponseDocumentSet");
+                    return false;
+                }
+
+                int errors = 0;
+
+                for (SearchResponseDocument document : responseDocumentSet.documents) {
+                    if (errors >= 10) {
+                        break;
+                    }
+
+                    TestData.TestDocument referenceDocument = testDocuments.get(document.id());
+                    if (referenceDocument == null) {
+                        mismatchDescription.appendText("Could not find document " + document.id() + " in reference documents\n");
+                        errors++;
+                        continue;
+                    }
+
+                    String testResult = compareValues(referenceDocument.content(), document.source(), "");
+
+                    if (testResult != null) {
+                        mismatchDescription.appendText("Source of document " + document.id() + " does not match reference:\n");
+                        mismatchDescription.appendText(testResult).appendText("\n");
+                        mismatchDescription.appendValue(document.source()).appendText("\n");
+                        mismatchDescription.appendValue(referenceDocument.content()).appendText("\n");
+                        errors++;
+                    }
+                }
+
+                return errors == 0;
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<SearchResponseDocumentSet> whereFieldsEquals(TestData.TestDocuments testDocuments) {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the fields attribute of all documents matches the reference");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof SearchResponseDocumentSet responseDocumentSet)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a SearchResponseDocument");
+                    return false;
+                }
+
+                int errors = 0;
+
+                for (SearchResponseDocument document : responseDocumentSet.documents) {
+                    if (errors >= 10) {
+                        break;
+                    }
+
+                    TestData.TestDocument referenceDocument = testDocuments.get(document.id());
+                    if (referenceDocument == null) {
+                        mismatchDescription.appendText("Could not find document " + document.id() + " in reference documents\n");
+                        errors++;
+                        continue;
+                    }
+
+                    Map<String, List<?>> fields = document.fields();
+                    if (fields == null) {
+                        mismatchDescription.appendText("Fields attribute missing\n");
+                        errors++;
+                        continue;
+                    }
+
+                    for (Map.Entry<String, List<?>> fieldEntry : fields.entrySet()) {
+                        String fieldName = fieldEntry.getKey();
+                        if (fieldName.endsWith(".keyword")) {
+                            fieldName = fieldName.substring(0, fieldName.length() - ".keyword".length());
+                        }
+
+                        Object referenceValue = referenceDocument.getAttributeByPath(fieldName.split("\\."));
+
+                        if (referenceValue == null) {
+                            mismatchDescription.appendText(
+                                "Document " + document.id() + " has unexpected field " + fieldEntry.getKey() + "\n"
+                            );
+                            errors++;
+                        } else if (!fieldEntry.getValue().isEmpty()) {
+                            Object fieldValue = fieldEntry.getValue().getFirst();
+                            String testResult = compareValues(referenceValue, fieldValue, "");
+                            if (testResult != null) {
+                                mismatchDescription.appendText(
+                                    "Document " + document.id() + " has unexpected value for field " + fieldEntry.getKey() + testResult
+                                );
+                                errors++;
+                            }
+                        }
+                    }
+                }
+
+                return errors == 0;
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<SearchResponseDocumentSet> emptyHits() {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("where the hits array is empty");
+
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof SearchResponseDocumentSet responseDocumentSet)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a SearchResponseDocument");
+                    return false;
+                }
+
+                if (!responseDocumentSet.documents.isEmpty()) {
+                    mismatchDescription.appendText("Search returned documents\n");
+                    return false;
+                }
+
+                return true;
+            }
+
+        };
+    }
+
+    @SafeVarargs
+    public static DiagnosingMatcher<HttpResponse> hasAggregation(String aggregationName, BaseMatcher<AggregationResult>... subMatchers) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Is a search request response with an aggregation");
+
+                if (subMatchers.length > 0) {
+                    description.appendText(" where ");
+                }
+
+                for (BaseMatcher<?> subMatcher : subMatchers) {
+                    subMatcher.describeTo(description);
+                }
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse response)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                String contentType = response.getContentType() != null ? response.getContentType().toLowerCase() : "";
+
+                if (!(contentType.startsWith("application/json"))) {
+                    mismatchDescription.appendText("Response does not have the content type application/json: ")
+                        .appendValue(response.getContentType() + "; " + response.getHeaders());
+                    return false;
+                }
+
+                Map<String, Object> responseBody = response.bodyAsMap();
+                if (!(responseBody.get("aggregations") instanceof Map<?, ?> aggregations)) {
+                    mismatchDescription.appendText("Response does not have a aggregations attribute:\n").appendValue(response.getBody());
+                    return false;
+                }
+
+                if (!(aggregations.get(aggregationName) instanceof Map<?, ?> aggregation)) {
+                    mismatchDescription.appendText("Response does not contain the aggregation " + aggregationName + ":\n")
+                        .appendValue(response.getBody());
+                    return false;
+                }
+
+                AggregationResult aggregationResult = AggregationResult.fromBucketsArray((List<?>) aggregation.get("buckets"));
+                boolean ok = true;
+                for (BaseMatcher<AggregationResult> subMatcher : subMatchers) {
+                    if (!subMatcher.matches(aggregationResult)) {
+                        subMatcher.describeMismatch(aggregationResult, mismatchDescription);
+                        mismatchDescription.appendText("\nResponse Body:\n").appendText(response.getBody());
+                        ok = false;
+                    }
+                }
+
+                return ok;
+
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<AggregationResult> whereBucketsEqual(Map<Object, Integer> expectedBuckets) {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the buckets match the expectation");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof AggregationResult aggregationResult)) {
+                    mismatchDescription.appendValue(item).appendText(" is not an AggregationResult");
+                    return false;
+                }
+
+                if (!aggregationResult.buckets.equals(expectedBuckets)) {
+                    mismatchDescription.appendText("Buckets do not match expected buckets ").appendValue(expectedBuckets).appendText("\n");
+                    return false;
+                }
+
+                return true;
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<AggregationResult> whereBucketsAreEmpty() {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the buckets object is empty");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof AggregationResult aggregationResult)) {
+                    mismatchDescription.appendValue(item).appendText(" is not an AggregationResult");
+                    return false;
+                }
+
+                if (!aggregationResult.buckets.isEmpty()) {
+                    mismatchDescription.appendText("Expected empty aggregation buckets, but buckets were found\n");
+                    return false;
+                }
+
+                return true;
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<AggregationResult> whereBucketsAreEmptyOrZero() {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the buckets object is empty or all buckets have doc_count=0");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof AggregationResult aggregationResult)) {
+                    mismatchDescription.appendValue(item).appendText(" is not an AggregationResult");
+                    return false;
+                }
+
+                if (aggregationResult.buckets.isEmpty()) {
+                    return true;
+                } else if (aggregationResult.buckets.values().stream().allMatch(v -> v == 0)) {
+                    return true;
+                } else {
+                    mismatchDescription.appendText("Expected empty aggregation buckets or doc_count=0 aggregation buckets\n");
+                    return false;
+                }
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<AggregationResult> whereNonEmptyBucketsExist() {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("where at least one bucket with doc_count != 0 exists");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof AggregationResult aggregationResult)) {
+                    mismatchDescription.appendValue(item).appendText(" is not an AggregationResult");
+                    return false;
+                }
+
+                if (aggregationResult.buckets.isEmpty()) {
+                    mismatchDescription.appendText("Aggregation does not have any buckets\n");
+                    return false;
+                } else if (aggregationResult.buckets.values().stream().allMatch(v -> v == 0)) {
+                    mismatchDescription.appendText("Aggregation only has doc_count=0 buckets\n");
+                    return false;
+                } else {
+                    return true;
+                }
+            }
+
+        };
+    }
+
+    @SafeVarargs
+    public static DiagnosingMatcher<HttpResponse> isTermVectorsResultWithFields(BaseMatcher<Set<String>>... subMatchers) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Is the response body of a term vectors request");
+
+                if (subMatchers.length > 0) {
+                    description.appendText(" where ");
+                }
+
+                for (BaseMatcher<?> subMatcher : subMatchers) {
+                    subMatcher.describeTo(description);
+                }
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse response)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                String contentType = response.getContentType() != null ? response.getContentType().toLowerCase() : "";
+
+                if (!(contentType.startsWith("application/json"))) {
+                    mismatchDescription.appendText("Response does not have the content type application/json: ")
+                        .appendValue(response.getContentType() + "; " + response.getHeaders());
+                    return false;
+                }
+
+                Map<String, Object> responseBody = response.bodyAsMap();
+                if (!(responseBody.get("term_vectors") instanceof Map<?, ?> termVectors)) {
+                    mismatchDescription.appendText("Response does not have a term_vectors attribute:\n").appendValue(response.getBody());
+                    return false;
+                }
+
+                Set<String> fields = termVectors.keySet().stream().map(String::valueOf).collect(Collectors.toSet());
+
+                boolean ok = true;
+
+                for (BaseMatcher<Set<String>> subMatcher : subMatchers) {
+                    if (!subMatcher.matches(fields)) {
+                        subMatcher.describeMismatch(fields, mismatchDescription);
+                        mismatchDescription.appendText("\nResponse Body:\n").appendText(response.getBody());
+                        ok = false;
+                    }
+                }
+
+                return ok;
+            }
+        };
+    }
+
+    public static DiagnosingMatcher<Set<String>> correspondingToDocument(TestData.TestDocument referenceDocument) {
+        return new DiagnosingMatcher<>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("the listed attribute names match the attributes given in the reference");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof Set<?> fieldsSet)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a SearchResponseDocument");
+                    return false;
+                }
+
+                Set<String> fieldsByReferenceDocument = textFieldsOfDocument(referenceDocument);
+
+                int errors = 0;
+
+                for (Object field : fieldsSet) {
+                    if (errors >= 10) {
+                        break;
+                    }
+
+                    String fieldName = (String) field;
+
+                    if (!fieldsByReferenceDocument.contains(fieldName)) {
+                        mismatchDescription.appendText("Encountered field " + fieldName + " which is not part of reference document\n");
+                        mismatchDescription.appendValue(referenceDocument.content()).appendText("\n");
+                        errors++;
+                        continue;
+                    }
+                }
+
+                for (String referenceDocumentField : fieldsByReferenceDocument) {
+                    if (errors >= 10) {
+                        break;
+                    }
+
+                    if (!fieldsSet.contains(referenceDocumentField)) {
+                        mismatchDescription.appendText("Term vectors result is missing field " + referenceDocumentField);
+                        mismatchDescription.appendValue(referenceDocument.content()).appendText("\n");
+                        errors++;
+                        continue;
+                    }
+                }
+
+                return errors == 0;
+            }
+
+            private Set<String> textFieldsOfDocument(TestData.TestDocument referenceDocument) {
+                return textFieldsOfDocument(referenceDocument.content(), "");
+            }
+
+            private Set<String> textFieldsOfDocument(Map<?, ?> referenceFields, String prefix) {
+                Set<String> result = new HashSet<>();
+
+                for (Map.Entry<?, ?> entry : referenceFields.entrySet()) {
+                    if (entry.getValue() instanceof Map<?, ?> object) {
+                        result.addAll(textFieldsOfDocument(object, prefix + entry.getKey() + "."));
+                    } else if (TestData.TEXT_FIELD_NAMES.contains(prefix + entry.getKey())) {
+                        result.add(prefix + entry.getKey());
+                        result.add(prefix + entry.getKey() + ".keyword");
+                    }
+                }
+
+                return result;
+            }
+
+        };
+    }
+
+    public static DiagnosingMatcher<HttpResponse> hasSource(TestData.TestDocument referenceDocument) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Has a _source attribute matching ").appendValue(referenceDocument);
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse response)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                String contentType = response.getContentType() != null ? response.getContentType().toLowerCase() : "";
+
+                if (!(contentType.startsWith("application/json"))) {
+                    mismatchDescription.appendText("Response does not have the content type application/json: ")
+                        .appendValue(response.getContentType() + "; " + response.getHeaders());
+                    return false;
+                }
+
+                Map<String, Object> responseBody = response.bodyAsMap();
+                if (!(responseBody.get("_source") instanceof Map<?, ?> actualSourceDocument)) {
+                    mismatchDescription.appendText("Response does not have a _source attribute:\n").appendValue(response.getBody());
+                    return false;
+                }
+
+                String testResult = compareValues(referenceDocument.content(), actualSourceDocument, "");
+                if (testResult != null) {
+                    mismatchDescription.appendText("Response _source does not match expected value:\n").appendText(testResult);
+                    return false;
+                }
+                return true;
+            }
+
+        };
+    }
+
+    public static class SearchResponseDocumentSet {
+        private final List<SearchResponseDocument> documents;
+
+        SearchResponseDocumentSet(List<SearchResponseDocument> documents) {
+            this.documents = documents;
+        }
+
+        SearchResponseDocumentSet(Collection<?> searchHits) {
+            this(searchHits.stream().map(e -> new SearchResponseDocument((Map<?, ?>) e)).toList());
+        }
+    }
+
+    public static class SearchResponseDocument {
+        private final Map<?, ?> content;
+
+        SearchResponseDocument(Map<?, ?> content) {
+            this.content = content;
+        }
+
+        String id() {
+            return (String) this.content.get("_id");
+        }
+
+        String index() {
+            return (String) this.content.get("_index");
+        }
+
+        Map<?, ?> source() {
+            return (Map<?, ?>) this.content.get("_source");
+        }
+
+        @SuppressWarnings("unchecked")
+        Map<String, List<?>> fields() {
+            return (Map<String, List<?>>) this.content.get("fields");
+        }
+    }
+
+    public static class AggregationResult {
+        private final Map<Object, Integer> buckets;
+
+        public AggregationResult(Map<Object, Integer> buckets) {
+            this.buckets = buckets;
+        }
+
+        static AggregationResult fromBucketsArray(List<?> bucketsArray) {
+            Map<Object, Integer> buckets = new LinkedHashMap<>();
+
+            for (Object bucket : bucketsArray) {
+                if (bucket instanceof Map<?, ?> bucketMap) {
+                    buckets.put(bucketMap.get("key"), (Integer) bucketMap.get("doc_count"));
+                }
+            }
+
+            return new AggregationResult(buckets);
+        }
+
+    }
+
+    /**
+     * Compares JSON object trees; normalizes values before comparing them, like encoding byte [] into base 64.
+     * If the object trees are equal, null is returned. If there are differences found, a string is returned
+     * which describes the differences.
+     */
+    public static String compareValues(Object expected, Object actual, String attributePath) {
+        if (expected instanceof Map<?, ?> expectedMap) {
+            if (actual instanceof Map<?, ?> actualMap) {
+                StringBuilder result = new StringBuilder();
+                int errors = 0;
+                for (Map.Entry<?, ?> expectedEntry : expectedMap.entrySet()) {
+                    String testResult = compareValues(
+                        expectedEntry.getValue(),
+                        actualMap.get(expectedEntry.getKey()),
+                        attributePath + "." + expectedEntry.getKey()
+                    );
+                    if (testResult != null) {
+                        result.append(testResult);
+                        errors++;
+                        if (errors > 3) {
+                            break;
+                        }
+                    }
+                }
+
+                for (Map.Entry<?, ?> actualEntry : actualMap.entrySet()) {
+                    if (!expectedMap.containsKey(actualEntry.getKey())) {
+                        result.append((attributePath.isEmpty() ? "" : (attributePath + ".")) + actualEntry.getKey() + ": not expected\n");
+                        errors++;
+                        if (errors > 3) {
+                            break;
+                        }
+                    }
+                }
+
+                if (errors == 0) {
+                    return null;
+                } else {
+                    return result.toString();
+                }
+
+            } else {
+                return attributePath + ": expected an object; is: " + actual + "\n";
+            }
+        } else if (expected instanceof List<?> expectedList) {
+            if (actual instanceof List<?> actualList) {
+                StringBuilder result = new StringBuilder();
+                int errors = 0;
+                for (int i = 0; i < expectedList.size() && errors < 3; i++) {
+                    Object expectedValue = expectedList.get(i);
+                    if (i >= actualList.size()) {
+                        result.append(attributePath + ": expected array member " + expectedValue + "; actual array has fewer elements\n");
+                        errors++;
+                        continue;
+                    }
+
+                    Object actualValue = actualList.get(i);
+                    String testResult = compareValues(expectedValue, actualValue, attributePath + "[" + i + "]");
+                    if (testResult != null) {
+                        result.append(testResult);
+                        errors++;
+                    }
+                }
+
+                if (actualList.size() > expectedList.size()) {
+                    result.append(
+                        attributePath
+                            + ": actual array has more members than expected: "
+                            + actualList.subList(expectedList.size(), actualList.size())
+                            + "\n"
+                    );
+                    errors++;
+                }
+
+                if (errors == 0) {
+                    return null;
+                } else {
+                    return result.toString();
+                }
+            } else {
+                return attributePath + ": expected an array; is: " + actual + "\n";
+            }
+        } else {
+            if (Objects.equals(normalizeValue(expected), normalizeValue(actual))) {
+                return null;
+            } else {
+                return attributePath + ": expected: " + normalizeValue(expected) + "; is: " + normalizeValue(actual);
+            }
+        }
+    }
+
+    private static Object normalizeValue(Object value) {
+        if (value instanceof byte[] bytes) {
+            return Base64.getEncoder().encodeToString(bytes);
+        } else {
+            return value;
+        }
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestDocumentMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestDocumentMatchers.java
@@ -525,7 +525,10 @@ public class RestDocumentMatchers {
                         result.addAll(textFieldsOfDocument(object, prefix + entry.getKey() + "."));
                     } else if (TestData.TEXT_FIELD_NAMES.contains(prefix + entry.getKey())) {
                         result.add(prefix + entry.getKey());
-                        result.add(prefix + entry.getKey() + ".keyword");
+
+                        if (TestData.TEXT_FIELD_NAMES.contains(prefix + entry.getKey() + ".keyword")) {
+                            result.add(prefix + entry.getKey() + ".keyword");
+                        }
                     }
                 }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
@@ -18,6 +18,35 @@ public class RestMatchers {
 
     private RestMatchers() {}
 
+    public static DiagnosingMatcher<HttpResponse> isOk() {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Response has status 200 OK");
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                HttpResponse response = (HttpResponse) item;
+
+                if (response.getStatusCode() == 200) {
+                    return true;
+                } else {
+                    mismatchDescription.appendText("Status is not 200 OK: ").appendValue(item);
+                    return false;
+                }
+
+            }
+
+        };
+    }
+
     public static DiagnosingMatcher<HttpResponse> isForbidden(String jsonPointer, String patternString) {
         return new DiagnosingMatcher<HttpResponse>() {
 


### PR DESCRIPTION
### Description

At the moment, the FLS/FM functionality is lacking test coverage. This is especially evident in the class `DlsFlsFilterLeafReader`: https://app.codecov.io/gh/opensearch-project/security/blob/main/src%2Fmain%2Fjava%2Forg%2Fopensearch%2Fsecurity%2Fconfiguration%2FDlsFlsFilterLeafReader.java

This PR introduces a new integration test with the goal to increase test coverage. It uses a test matrix of:

- different users with different FLS/FM configs
- different operations like get, search, aggregation, terms vectors

[Describe what this change achieves]
* Category: Test enhancement
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?: No changes

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
