### PR TITLE
[2.19] Use SecurityDynamicConfig.exists to determine if tenant exists to avoid copy on every call to mapTenants

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -1146,7 +1146,7 @@ public class ConfigModelV7 extends ConfigModel {
                         // Indeed, because we don't have control over what will be
                         // passed on as values of users' attributes, we have to make
                         // sure that we don't allow them to select tenants that do not exist.
-                        if (ConfigModelV7.this.tenants.getCEntries().keySet().contains(tenant)) {
+                        if (ConfigModelV7.this.tenants.exists(tenant)) {
                             result.put(tenant, rw);
                         }
                     }


### PR DESCRIPTION
### Description

This PR contains an optimization for multi-tenancy. ConfigModelV7.TenantHolder.mapTenants is called on every request and in a cluster with a large number of tenants, the current logic to determine if the candidate tenant name (after attr replacement) is an actual tenant can be expensive due to copying all tenants in memory within the implementation of [getCEntries](https://github.com/opensearch-project/security/blob/2.19/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java#L286-L291).

Opening this in draft because there may be an issue with concurrent modification after this change, but adding a tenant is a seldom action compared to copying the list of tenants on every request.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
