### PR TITLE
DlsFlsFilterLeafReader::termVectors implementation causes assertion errors for users with FLS/FM active

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -492,6 +492,11 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     public TermVectors termVectors() throws IOException {
         return new TermVectors() {
             @Override
+            public void prefetch(int docID) throws IOException {
+                in.termVectors().prefetch(docID);
+            }
+
+            @Override
             public Fields get(int docID) throws IOException {
                 final Fields fields = in.termVectors().get(docID);
 
@@ -513,7 +518,7 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
                             return null;
                         }
 
-                        return wrapTerms(field, in.terms(field));
+                        return wrapTerms(field, fields.terms(field));
 
                     }
 


### PR DESCRIPTION
### Description

Fixes

```
2025-04-01 13:19:40 opensearch[data_0][get][T#3] WARN  RunnerThreadGroup:570 - Uncaught exception in thread: Thread[#301,opensearch[data_0][get][T#3],5,TGRP-FlsFmIntegrationTests]
java.lang.AssertionError: null
	at __randomizedtesting.SeedInfo.seed([756AD321ED0B3FEE]:0) ~[?:?]
	at org.opensearch.action.termvectors.TermVectorsWriter.writeTermWithDocsAndPos(TermVectorsWriter.java:213) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.termvectors.TermVectorsWriter.setFields(TermVectorsWriter.java:139) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.termvectors.TermVectorsResponse.setFields(TermVectorsResponse.java:414) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:161) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.index.termvectors.TermVectorsService.getTermVectors(TermVectorsService.java:97) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:148) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.termvectors.TransportTermVectorsAction.shardOperation(TransportTermVectorsAction.java:62) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.support.single.shard.TransportSingleShardAction.lambda$asyncShardOperation$0(TransportSingleShardAction.java:131) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.ActionRunnable.lambda$supply$0(ActionRunnable.java:74) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.action.ActionRunnable$2.doRun(ActionRunnable.java:89) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:994) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at org.opensearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:52) ~[opensearch-3.0.0-beta1-SNAPSHOT.jar:3.0.0-beta1-SNAPSHOT]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
```

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/5238

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
See please https://github.com/opensearch-project/OpenSearch/pull/17446

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
