### PR TITLE
Add Shikhar Jain (GH: shikharj05) as a maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @derek-ho @nibix @peternied @RyanL1997 @reta @willyborankin
+* @cwperks @DarshitChanpura @derek-ho @nibix @peternied @RyanL1997 @reta @shikharj05 @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
+| Shikhar Jain     | [shikharj05](https://github.com/shikharj05)           | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Independent |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
 | Nils Bandener    | [nibix](https://github.com/nibix)                     | Eliatra     |


### PR DESCRIPTION
I have nominated and maintainers have agreed to add @shikharj05 as a co-maintainer of the security repo.

@shikharj05 has made many valuable contributions and given insightful comments on reviews and GH issues over the last few years.
 
Shikhar is an avid PR reviewer and has reviewed a total of 127 PRs (including open and closed) - a great quality of a maintainer :).
 
See all PRs where Shikhar has engaged as a commenter: https://github.com/opensearch-project/security/pulls?q=is%3Apr+commenter%3Ashikharj05
 
Some notable PR reviews include:
 
- Replace BouncyCastle's OpenBSDBCrypt use with password4j for password hashing and verification: https://github.com/opensearch-project/security/pull/4381
- Add support for ipv6 ip address in user injection: https://github.com/opensearch-project/security/pull/4399
- Add initial changes to expose an endpoint for auth failure listener get call: https://github.com/opensearch-project/security/pull/4641
- Refactor SSL Configuration: https://github.com/opensearch-project/security/pull/4671
 
Shikhar also routinely opens up issues on the Security repo with valuable feature requests and reports of deficiencies (8 in total):
 
- See issues submitted by Shikhar here: https://github.com/opensearch-project/security/issues?q=is%3Aissue+author%3Ashikharj05
 
Shikhar's first issue opened was in May 2022. Notable issue submissions include:
 
- Details about the race condition on bootstrap that could lead to partial cache initialization: https://github.com/opensearch-project/security/issues/3204
- Feature request on IP-based rate limiter to allow additional config to get original IP of request if proxied: https://github.com/opensearch-project/security/issues/4262
- Audit log fails to log the request if the request is invalid: https://github.com/opensearch-project/security/issues/1849
 
Shikhar regularly contributes to conversation on Github issues (including RFCs):
 
- Insight on the RFC around Resource Sharing + Authorization: https://github.com/opensearch-project/security/issues/4500#issuecomment-2199256868
- Engaged on the RFC around scheduled job security model: https://github.com/opensearch-project/security/issues/2905#issuecomment-1639812625
- Insight into ser/de issue post 2.11: https://github.com/opensearch-project/security/issues/4521#issuecomment-2207876738
- Help a community member understand security config options around dashboards read only role: https://github.com/opensearch-project/security/issues/4626#issuecomment-2284801155
 
See all issues where Shikhar has engaged as a commenter: https://github.com/opensearch-project/security/issues?q=is%3Aissue+commenter%3Ashikharj05
 
Shikhar has 12 contributions on main and has additional changes open for review as well. Here are some highlights:
 
- Allow same certificate during hot reload: https://github.com/opensearch-project/security/pull/1798
- Refactor SafeSerializationUtils for better performance: https://github.com/opensearch-project/security/pull/4973
- Deprecate opendistro API paths: https://github.com/opensearch-project/security/pull/5102
- Remove whitelist settings in favor of allowlist: https://github.com/opensearch-project/security/pull/5224
- Escape pipe character for injected user: https://github.com/opensearch-project/security/pull/5175
- Improve coverage of ConfigurationRepository class: https://github.com/opensearch-project/security/pull/5206
 
See all code contributions (Open + Closed) from Shikhar here: https://github.com/opensearch-project/security/commits?author=shikharj05
 
Additionally, Shikhar is active in the community and has given a talk at OpenSearch Con SF on attribute-based access control (ABAC):https://www.youtube.com/watch?v=zB4Mnue8mi0