### PR TITLE
Remove accessUnixDomainSocket from plugin-security.policy

### DIFF
--- a/plugin-security.policy
+++ b/plugin-security.policy
@@ -77,8 +77,6 @@ grant {
 
   //Enable this permission to debug unauthorized de-serialization attempt
   //permission java.io.SerializablePermission "enableSubstitution";
-
-  permission java.net.NetPermission "accessUnixDomainSocket";
 };
 
 grant codeBase "${codebase.netty-common}" {


### PR DESCRIPTION
### Description

Removes this line from the policy file that was added in the [previous PR](https://github.com/opensearch-project/security/pull/5263) to fix the build. This line may not be necessary outside of core libraries.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
