### PR TITLE
Client certificate setting bypasses password requirements #4378

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -103,6 +103,8 @@ public class BackendRegistry {
     private Cache<AuthCredentials, User> userCache; // rest standard
     private Cache<String, User> restImpersonationCache; // used for rest impersonation
     private Cache<User, Set<String>> restRoleCache; //
+    private static final String OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER = "X-opensearch-product-origin";
+    private static final String OPENSEARCH_PRODUCT_DASHBOARD_ORIGIN = "opensearch-dashboards";
 
     private void createCaches() {
         userCache = CacheBuilder.newBuilder()
@@ -362,6 +364,16 @@ public class BackendRegistry {
                         ac,
                         request
                     );
+                }
+                
+                if ( request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER)!= null && request.header(OPENSEARCH_PRODUCT_ORIGIN_HTTP_HEADER).equals(OPENSEARCH_PRODUCT_DASHBOARD_ORIGIN) && authDomain.getBackend().getClass().getName().equals(InternalAuthenticationBackend.class.getName())   ) {
+                	log.error("Cannot authenticate rest user because  user authentication failed from browser.");
+                    auditLog.logFailedLogin(ac.getUsername(), true, null, request);
+                    request.queueForSending(
+                        new SecurityResponse(SC_FORBIDDEN, "Cannot authenticate user because authentication failed from browser login via HTTP")
+                    );
+                    return false;
+                	
                 }
                 continue;
             }


### PR DESCRIPTION
Signed-off-by: Asif Bashar <asif.bashar@gmail.com>

### Description
[Describe what this change achieves]
* Category  Bug fix
* Why these changes are required? 
* #4378 
* When client authentication certificate is set as required in opensearch.yaml , and opensearch_dashboards.yml has "alwaysPresentCertficate" : true, browser login to dashboard does not validate password and allows login with any user/password. This allows for any user to view dashboard.

config.yaml example below

config:
dynamic:
authc:
basic_internal_auth_domain:
authentication_backend:
type: intern
description: Authenticate via HTTP Basic against internal users database
http_authenticator:
challenge: true
type: basic
http_enabled: true
order: 4
transport_enabled: true
clientcert_auth_domain:
authentication_backend:
type: noop
description: Authenticate via SSL client certificates
http_authenticator:
challenge: false
config:
username_attribute: ''
type: clientcert
http_enabled: true
order: 2
transport_enabled: false
* What is the old behavior before changes and new behavior after changes?
With this fix any password from browser  will not  let user login when above conditions are configured.


### Issues Resolved
https://github.com/opensearch-project/security/issues/4378

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
N/A
### Testing
manual testing

### Check List
- [ N/A] New functionality includes testing
- [ N/A] New functionality has been documented
- N/A[ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [N/A ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
