### PR TITLE
Remove beta1 qualifier in more locations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ import groovy.json.JsonBuilder
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 
@@ -24,7 +24,7 @@ buildscript {
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
 
-        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-beta1-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
 
         kafka_version  = '3.7.1'
         open_saml_version = '5.1.4'

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,9 +44,9 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
         opensearch_group = "org.opensearch"
-        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-beta1-SNAPSHOT')
+        common_utils_version = System.getProperty("common_utils.version", '3.0.0.0-SNAPSHOT')
         jackson_version = System.getProperty("jackson_version", "2.15.2")
     }
     repositories {

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -37,9 +37,9 @@ ext {
     projectSubstitutions = [:]
     licenseFile = rootProject.file('LICENSE.txt')
     noticeFile = rootProject.file('NOTICE.txt')
-    opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
-    buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
+    buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 
     version_tokens = opensearch_version.tokenize('-')
     opensearch_build = version_tokens[0] + '.0'

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 ext {
-    opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+    opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
 }
 
 repositories {


### PR DESCRIPTION
### Description

This PR removes all instances of the beta1 qualifier on the main branch.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

Related to https://github.com/opensearch-project/security/pull/5300

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
