### PR TITLE
Corrections in DlsFlsFilterLeafReader regarding PointVales and object valued attributes

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/TestData.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestData.java
@@ -174,6 +174,8 @@ public class TestData {
                   "attr_int": {"type": "integer"},
                   "attr_double": {"type": "double"},
                   "attr_binary": {"type": "binary", "doc_values": true},
+                  "attr_geo_point_string": {"type": "geo_point"},
+                  "attr_geo_point_string_stored": {"type": "geo_point", "store": true, "doc_values": false},
                   "attr_text_termvectors": {
                     "type": "text",
                     "term_vector": "with_positions_offsets_payloads",
@@ -348,6 +350,8 @@ public class TestData {
         builder.put("attr_int", random.nextInt(10000));
         builder.put("attr_double", random.nextDouble());
         builder.put("attr_binary", randomBinaryValue(random));
+        builder.put("attr_geo_point_string", randomGeoPointString(random));
+        builder.put("attr_geo_point_string_stored", randomGeoPointString(random));
         builder.put(
             "attr_object",
             ImmutableMap.of(
@@ -392,6 +396,10 @@ public class TestData {
             random.nextBytes(binary);
             return Base64.getEncoder().encodeToString(binary);
         }
+    }
+
+    private String randomGeoPointString(Random random) {
+        return random.nextDouble(-90, 90) + "," + random.nextDouble(-180, 180);
     }
 
     private static String randomId(Random random) {
@@ -629,6 +637,10 @@ public class TestData {
                 return null;
             }
         }
+
+        public Set<String> allIds() {
+            return this.documents.keySet();
+        }
     }
 
     public static class TestDocument {
@@ -652,6 +664,14 @@ public class TestData {
             return (String) this.content.get("attr_text_1");
         }
 
+        public String attrText2() {
+            return (String) this.content.get("attr_text_2");
+        }
+
+        public String attrKeyword() {
+            return (String) this.content.get("attr_keyword");
+        }
+
         public String attrKeywordDocValuesDisabled() {
             return (String) this.content.get("attr_keyword_doc_values_disabled");
         }
@@ -662,6 +682,10 @@ public class TestData {
 
         public String sourceIp() {
             return (String) this.content.get("source_ip");
+        }
+
+        public String attrGeoPointString() {
+            return (String) this.content.get("attr_geo_point_string");
         }
 
         public Object getAttributeByPath(String... attributes) {

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
@@ -94,4 +94,100 @@ public class RestMatchers {
             }
         };
     }
+
+    public static DiagnosingMatcher<HttpResponse> isBadRequest(String jsonPointer, String patternString) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Response has status 400 Bad Request with a JSON response that has the value ")
+                    .appendValue(patternString)
+                    .appendText(" at ")
+                    .appendValue(jsonPointer);
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                HttpResponse response = (HttpResponse) item;
+
+                if (response.getStatusCode() != 400) {
+                    mismatchDescription.appendText("Status is not 400 Bad Request: ").appendText("\n").appendValue(item);
+                    return false;
+                }
+
+                try {
+                    String value = response.getTextFromJsonBody(jsonPointer);
+
+                    if (value == null) {
+                        mismatchDescription.appendText("Could not find value at " + jsonPointer).appendText("\n").appendValue(item);
+                        return false;
+                    }
+
+                    if (value.contains(patternString)) {
+                        return true;
+                    } else {
+                        mismatchDescription.appendText("Value at " + jsonPointer + " does not match pattern: " + patternString + "\n")
+                            .appendValue(item);
+                        return false;
+                    }
+                } catch (Exception e) {
+                    mismatchDescription.appendText("Parsing request body failed with " + e).appendText("\n").appendValue(item);
+                    return false;
+                }
+            }
+        };
+    }
+
+    public static DiagnosingMatcher<HttpResponse> isInternalServerError(String jsonPointer, String patternString) {
+        return new DiagnosingMatcher<HttpResponse>() {
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Response has status 500 Internal Server Error with a JSON response that has the value ")
+                    .appendValue(patternString)
+                    .appendText(" at ")
+                    .appendValue(jsonPointer);
+            }
+
+            @Override
+            protected boolean matches(Object item, Description mismatchDescription) {
+                if (!(item instanceof HttpResponse)) {
+                    mismatchDescription.appendValue(item).appendText(" is not a HttpResponse");
+                    return false;
+                }
+
+                HttpResponse response = (HttpResponse) item;
+
+                if (response.getStatusCode() != 500) {
+                    mismatchDescription.appendText("Status is not 500 Internal Server Error: ").appendText("\n").appendValue(item);
+                    return false;
+                }
+
+                try {
+                    String value = response.getTextFromJsonBody(jsonPointer);
+
+                    if (value == null) {
+                        mismatchDescription.appendText("Could not find value at " + jsonPointer).appendText("\n").appendValue(item);
+                        return false;
+                    }
+
+                    if (value.contains(patternString)) {
+                        return true;
+                    } else {
+                        mismatchDescription.appendText("Value at " + jsonPointer + " does not match pattern: " + patternString + "\n")
+                            .appendValue(item);
+                        return false;
+                    }
+                } catch (Exception e) {
+                    mismatchDescription.appendText("Parsing request body failed with " + e).appendText("\n").appendValue(item);
+                    return false;
+                }
+            }
+        };
+    }
 }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -486,7 +486,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         }
 
         DlsFlsProcessedConfig config = this.dlsFlsProcessedConfig.get();
-        return config.getFieldPrivileges().getRestriction(privilegesEvaluationContext, index).isAllowed(field);
+        return config.getFieldPrivileges().getRestriction(privilegesEvaluationContext, index).isAllowedRecursive(field);
     }
 
     private static InternalAggregation aggregateBuckets(InternalAggregation aggregation) {

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilter.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilter.java
@@ -115,8 +115,8 @@ class FlsDocumentFilter {
                 queuedFieldName = null;
 
                 if (metaFields.contains(fullQueuedFieldName)
-                    || flsRule.isAllowed(fullQueuedFieldName)
-                    || (startOfObjectOrArray && flsRule.isObjectAllowed(fullQueuedFieldName))) {
+                    || flsRule.isAllowedAssumingParentsAreAllowed(fullQueuedFieldName)
+                    || (startOfObjectOrArray && flsRule.isObjectAllowedAssumingParentsAreAllowed(fullQueuedFieldName))) {
                     generator.writeFieldName(parser.currentName());
                     fullCurrentName = fullQueuedFieldName;
                 } else {

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/FlsStoredFieldVisitor.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/FlsStoredFieldVisitor.java
@@ -85,7 +85,9 @@ public class FlsStoredFieldVisitor extends StoredFieldVisitor {
 
     @Override
     public Status needsField(FieldInfo fieldInfo) throws IOException {
-        return metaFields.contains(fieldInfo.name) || flsRule.isAllowed(fieldInfo.name) ? delegate.needsField(fieldInfo) : Status.NO;
+        return metaFields.contains(fieldInfo.name) || flsRule.isAllowedRecursive(fieldInfo.name)
+            ? delegate.needsField(fieldInfo)
+            : Status.NO;
     }
 
     @Override


### PR DESCRIPTION

### Description

This fixes and cleans up DlsFlsFilterLeafReader logic related to field mappins based on PointValues and object valued attributes.

* Category: Bug fix
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Testing

- Integration testing

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
