### PR TITLE
Bug fix: Fixing stale cache issue post snapshot restore

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -870,6 +870,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     }
                 }
             }.toListener());
+
+            indexModule.addIndexEventListener(cr);
         }
     }
 

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -15,7 +15,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import com.fasterxml.jackson.databind.InjectableValues;
@@ -34,17 +36,22 @@ import org.opensearch.action.support.PlainActionFuture;
 import org.opensearch.cluster.ClusterChangedEvent;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.ClusterStateUpdateTask;
+import org.opensearch.cluster.RestoreInProgress;
 import org.opensearch.cluster.block.ClusterBlocks;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
+import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.Priority;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
@@ -63,6 +70,7 @@ import org.opensearch.transport.client.IndicesAdminClient;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.OngoingStubbing;
 
@@ -82,9 +90,11 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -170,6 +180,20 @@ public class ConfigurationRepositoryTest {
     }
 
     private ConfigurationRepository createConfigurationRepository(Settings settings) {
+        return new ConfigurationRepository(
+            settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX),
+            settings,
+            path,
+            threadPool,
+            localClient,
+            clusterService,
+            auditLog,
+            securityIndexHandler,
+            configurationLoaderSecurity7
+        );
+    }
+
+    private ConfigurationRepository createConfigurationRepository(Settings settings, ThreadPool threadPool) {
         return new ConfigurationRepository(
             settings.get(ConfigConstants.SECURITY_CONFIG_INDEX_NAME, ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX),
             settings,
@@ -567,6 +591,57 @@ public class ConfigurationRepositoryTest {
         ConfigurationMap result = configurationRepository.getConfigurationsFromIndex(CType.values(), false, false);
 
         assertThat(result.size(), is(CType.values().size()));
+    }
+
+    @Test
+    public void afterIndexShardStarted_whenSecurityIndexUpdated() throws InterruptedException, TimeoutException {
+        Settings settings = Settings.builder().build();
+        IndexShard indexShard = mock(IndexShard.class);
+        ShardRouting shardRouting = mock(ShardRouting.class);
+        ShardId shardId = mock(ShardId.class);
+        Index index = mock(Index.class);
+        ClusterState mockClusterState = mock(ClusterState.class);
+        RestoreInProgress mockRestore = mock(RestoreInProgress.class);
+        RestoreInProgress.Entry mockEntry = mock(RestoreInProgress.Entry.class);
+        ExecutorService executorService = mock(ExecutorService.class);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        ConfigurationRepository configurationRepository = spy(createConfigurationRepository(settings, threadPool));
+
+        // Setup mock behavior
+        when(indexShard.shardId()).thenReturn(shardId);
+        when(shardId.getIndex()).thenReturn(index);
+        when(index.getName()).thenReturn(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX);
+        when(indexShard.routingEntry()).thenReturn(shardRouting);
+        when(clusterService.state()).thenReturn(mockClusterState);
+        when(mockClusterState.custom(RestoreInProgress.TYPE)).thenReturn(mockRestore);
+        when(threadPool.generic()).thenReturn(executorService);
+
+        // when replica shard updated
+        when(shardRouting.primary()).thenReturn(false);
+        configurationRepository.afterIndexShardStarted(indexShard);
+        verify(executorService, never()).execute(any());
+        verify(configurationRepository, never()).reloadConfiguration(any());
+
+        // when primary shard updated
+        doReturn(true).when(configurationRepository).reloadConfiguration(any());
+        when(shardRouting.primary()).thenReturn(true);
+        when(mockRestore.iterator()).thenReturn(Collections.singletonList(mockEntry).iterator());
+        when(mockEntry.indices()).thenReturn(Collections.singletonList(ConfigConstants.OPENDISTRO_SECURITY_DEFAULT_CONFIG_INDEX));
+        ArgumentCaptor<Runnable> successRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        configurationRepository.afterIndexShardStarted(indexShard);
+        verify(executorService).execute(successRunnableCaptor.capture());
+        successRunnableCaptor.getValue().run();
+        verify(configurationRepository).reloadConfiguration(CType.values());
+
+        // When there is error in checking if restored from snapshot
+        Mockito.reset(configurationRepository, executorService);
+        ArgumentCaptor<Runnable> errorRunnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        when(clusterService.state()).thenThrow(new RuntimeException("ClusterState exception"));
+        when(shardRouting.primary()).thenReturn(true);
+        configurationRepository.afterIndexShardStarted(indexShard);
+        verify(executorService).execute(errorRunnableCaptor.capture());
+        errorRunnableCaptor.getValue().run();
+        verify(configurationRepository, never()).reloadConfiguration(any());
     }
 
     void assertClusterState(final ArgumentCaptor<ClusterStateUpdateTask> clusterStateUpdateTaskCaptor) throws Exception {


### PR DESCRIPTION
### Description
Bug fix: Fixing stale cache issue post snapshot restore

Currently when a snapshot is restored on a domain including security index, the security index is updated but the in memory cache is not updated or reloaded with data from security index. Due to this AuthNZ for API requests and dashboard access is incorrect. It can either provide access when it shouldn't or deny access when it shouldn't

This change address this issue by adding a listener to index shard update events which reloads the cache with data from security index. This ensures cache is always updated when security index is updated

### Issues Resolved
[[Bug] Stale cache post snapshot restore](https://github.com/opensearch-project/security/issues/5308)

### Testing
- Tested with a local snapshot repository. Took a snapshot of current security index data. Made new changes to index by creating a new role with certain index permissions and mapping the role to existing user. Restored the snapshot and verified
    - API call to access index data which the new role had permissions was not accessible (before it was accessible because cache wasn't updated)
    - Verified cache and security index holds same data

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
