### PR TITLE
Allow integrationTestFramework to use new constructor of Node that accepts pluginInfos

### DIFF
--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -63,6 +63,8 @@ configurations.all {
         force 'org.apache.httpcomponents:httpclient:4.5.14'
         force 'org.apache.httpcomponents:httpcore:4.4.16'
         force 'commons-codec:commons-codec:1.18.0'
+        force 'org.hamcrest:hamcrest:2.2'
+        force 'org.mockito:mockito-core:5.17.0'
     }
 }
 

--- a/src/integrationTest/java/org/opensearch/node/PluginAwareNode.java
+++ b/src/integrationTest/java/org/opensearch/node/PluginAwareNode.java
@@ -30,17 +30,13 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.opensearch.common.settings.Settings;
-import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
 
 public class PluginAwareNode extends Node {
 
     private final boolean clusterManagerEligible;
 
-    public PluginAwareNode(
-        boolean clusterManagerEligible,
-        final Settings preparedSettings,
-        final Collection<Class<? extends Plugin>> plugins
-    ) {
+    public PluginAwareNode(boolean clusterManagerEligible, final Settings preparedSettings, final Collection<PluginInfo> plugins) {
         super(
             InternalSettingsPreparer.prepareEnvironment(preparedSettings, Collections.emptyMap(), null, () -> System.getenv("HOSTNAME")),
             plugins,

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -47,6 +47,7 @@ import org.junit.rules.ExternalResource;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
 import org.opensearch.security.action.configupdate.ConfigUpdateRequest;
 import org.opensearch.security.action.configupdate.ConfigUpdateResponse;
@@ -84,6 +85,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
     private boolean sslOnly;
 
     private final List<Class<? extends Plugin>> plugins;
+    private final List<PluginInfo> additionalPlugins;
     private final ClusterManager clusterManager;
     private final TestSecurityConfig testSecurityConfig;
     private Map<Integer, Settings> nodeSpecificOverride;
@@ -107,6 +109,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         Settings nodeOverride,
         ClusterManager clusterManager,
         List<Class<? extends Plugin>> plugins,
+        List<PluginInfo> additionalPlugins,
         TestCertificates testCertificates,
         List<LocalCluster> clusterDependencies,
         Map<String, LocalCluster> remotes,
@@ -116,6 +119,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         Integer expectedNodeStartupCount
     ) {
         this.plugins = plugins;
+        this.additionalPlugins = additionalPlugins;
         this.testCertificates = testCertificates;
         this.clusterManager = clusterManager;
         this.testSecurityConfig = testSgConfig;
@@ -247,6 +251,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
                 clusterManager,
                 nodeSettingsSupplier,
                 plugins,
+                additionalPlugins,
                 testCertificates,
                 expectedNodeStartupCount
             );
@@ -326,6 +331,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         private boolean sslOnly = false;
         private Integer expectedNodeStartupCount;
         private final List<Class<? extends Plugin>> plugins = new ArrayList<>();
+        private final List<PluginInfo> additionalPlugins = new ArrayList<>();
         private Map<String, LocalCluster> remoteClusters = new HashMap<>();
         private List<LocalCluster> clusterDependencies = new ArrayList<>();
         private List<TestIndex> testIndices = new ArrayList<>();
@@ -419,6 +425,16 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
         @SafeVarargs
         public final Builder plugin(Class<? extends Plugin>... plugins) {
             this.plugins.addAll(List.of(plugins));
+
+            return this;
+        }
+
+        /**
+         * Adds additional plugins to the cluster
+         */
+        @SafeVarargs
+        public final Builder plugin(PluginInfo... plugins) {
+            this.additionalPlugins.addAll(List.of(plugins));
 
             return this;
         }
@@ -584,6 +600,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
                     settings,
                     clusterManager,
                     plugins,
+                    additionalPlugins,
                     testCertificates,
                     clusterDependencies,
                     remoteClusters,

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -54,6 +54,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
@@ -63,6 +64,7 @@ import org.opensearch.core.common.Strings;
 import org.opensearch.http.BindHttpException;
 import org.opensearch.node.PluginAwareNode;
 import org.opensearch.plugins.Plugin;
+import org.opensearch.plugins.PluginInfo;
 import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.ClusterManager.NodeSettings;
 import org.opensearch.transport.BindTransportException;
@@ -94,7 +96,8 @@ public class LocalOpenSearchCluster {
     private final String clusterName;
     private final ClusterManager clusterManager;
     private final NodeSettingsSupplier nodeSettingsSupplier;
-    private final List<Class<? extends Plugin>> additionalPlugins;
+    private final List<Class<? extends Plugin>> plugins;
+    private final List<PluginInfo> additionalPlugins;
     private final List<Node> nodes = new ArrayList<>();
     private final TestCertificates testCertificates;
     private final Integer expectedNodeStartupCount;
@@ -112,13 +115,15 @@ public class LocalOpenSearchCluster {
         String clusterName,
         ClusterManager clusterManager,
         NodeSettingsSupplier nodeSettingsSupplier,
-        List<Class<? extends Plugin>> additionalPlugins,
+        List<Class<? extends Plugin>> plugins,
+        List<PluginInfo> additionalPlugins,
         TestCertificates testCertificates,
         Integer expectedNodeStartCount
     ) {
         this.clusterName = clusterName;
         this.clusterManager = clusterManager;
         this.nodeSettingsSupplier = nodeSettingsSupplier;
+        this.plugins = plugins;
         this.additionalPlugins = additionalPlugins;
         this.testCertificates = testCertificates;
         this.expectedNodeStartupCount = expectedNodeStartCount;
@@ -426,8 +431,24 @@ public class LocalOpenSearchCluster {
 
         CompletableFuture<StartStage> start() {
             CompletableFuture<StartStage> completableFuture = new CompletableFuture<>();
-            final Collection<Class<? extends Plugin>> mergedPlugins = nodeSettings.pluginsWithAddition(additionalPlugins);
-            this.node = new PluginAwareNode(nodeSettings.containRole(NodeRole.CLUSTER_MANAGER), getOpenSearchSettings(), mergedPlugins);
+            final Collection<Class<? extends Plugin>> mergedPlugins = nodeSettings.pluginsWithAddition(plugins);
+            final List<PluginInfo> classpathPlugins = mergedPlugins.stream()
+                .map(
+                    p -> new PluginInfo(
+                        p.getName(),
+                        "classpath plugin",
+                        "NA",
+                        Version.CURRENT,
+                        "1.8",
+                        p.getName(),
+                        null,
+                        Collections.emptyList(),
+                        false
+                    )
+                )
+                .toList();
+            classpathPlugins.addAll(additionalPlugins);
+            this.node = new PluginAwareNode(nodeSettings.containRole(NodeRole.CLUSTER_MANAGER), getOpenSearchSettings(), classpathPlugins);
 
             new Thread(new Runnable() {
 


### PR DESCRIPTION
### Description

This PR reacts to changes in core from https://github.com/opensearch-project/OpenSearch/pull/16908 that changed the constructor of Node.java to take a collection of PluginInfo instead of a simple list of classes to allow the integration tests to be more flexible and ultimately allow defining extended plugins within tests.

This change is needed to fix a compilation error due to the change in core and the security plugin's integrationTest framework.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
