### PR TITLE
Use extendedPlugins in integrationTest framework for sample resource plugin testing

### DIFF
--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRestAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRestAction.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.opensearch.core.common.Strings;
@@ -72,7 +71,7 @@ public class RevokeResourceAccessRestAction extends BaseRestHandler {
             throw new IllegalArgumentException("entities_to_revoke is required and cannot be empty");
         }
 
-        Map<Recipient, Set<String>> entitiesToRevoke = source.entrySet()
+        Map<Recipient, Collection<String>> entitiesToRevoke = source.entrySet()
             .stream()
             .filter(entry -> entry.getValue() instanceof Collection<?>)
             .collect(

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
@@ -9,7 +9,12 @@
 package org.opensearch.security.spi.resources.sharing;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -36,6 +41,8 @@ import org.opensearch.core.xcontent.XContentParser;
  */
 public class ResourceSharing implements ToXContentFragment, NamedWriteable {
 
+    private String docId;
+
     /**
      * The index where the resource is defined
      */
@@ -61,6 +68,14 @@ public class ResourceSharing implements ToXContentFragment, NamedWriteable {
         this.resourceId = resourceId;
         this.createdBy = createdBy;
         this.shareWith = shareWith;
+    }
+
+    public String getDocId() {
+        return docId;
+    }
+
+    public void setDocId(String docId) {
+        this.docId = docId;
     }
 
     public String getSourceIdx() {
@@ -93,6 +108,21 @@ public class ResourceSharing implements ToXContentFragment, NamedWriteable {
 
     public void setShareWith(ShareWith shareWith) {
         this.shareWith = shareWith;
+    }
+
+    public void share(String accessLevel, Map<String, List<String>> target) {
+        if (shareWith == null) {
+            Map<Recipient, Collection<String>> recipients = new HashMap<>();
+            target.forEach((key, value) -> { recipients.put(Recipient.valueOf(key.toUpperCase(Locale.ROOT)), value); });
+            SharedWithActionGroup sharedWith = new SharedWithActionGroup(
+                accessLevel,
+                new SharedWithActionGroup.ActionGroupRecipients(recipients)
+            );
+            shareWith = new ShareWith(Set.of(sharedWith));
+        } else {
+            SharedWithActionGroup sharedWith = shareWith.atAccessLevel(accessLevel);
+            sharedWith.share(target);
+        }
     }
 
     @Override

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -57,6 +57,15 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
         return sharedWithActionGroups;
     }
 
+    public SharedWithActionGroup atAccessLevel(String accessLevel) {
+        for (SharedWithActionGroup sharedWithActionGroup : sharedWithActionGroups) {
+            if (sharedWithActionGroup.getActionGroup().equals(accessLevel)) {
+                return sharedWithActionGroup;
+            }
+        }
+        return null;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/SharedWithActionGroup.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/SharedWithActionGroup.java
@@ -9,8 +9,10 @@
 package org.opensearch.security.spi.resources.sharing;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -57,6 +59,13 @@ public class SharedWithActionGroup implements ToXContentFragment, NamedWriteable
         return actionGroupRecipients;
     }
 
+    public void share(Map<String, List<String>> target) {
+        for (String recipientType : target.keySet()) {
+            Collection<String> recipients = actionGroupRecipients.getRecipientsByType(Recipient.valueOf(recipientType));
+            recipients.addAll(target.get(recipientType));
+        }
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.field(actionGroup);
@@ -100,9 +109,9 @@ public class SharedWithActionGroup implements ToXContentFragment, NamedWriteable
      */
     public static class ActionGroupRecipients implements ToXContentFragment, NamedWriteable {
 
-        private final Map<Recipient, Set<String>> recipients;
+        private final Map<Recipient, Collection<String>> recipients;
 
-        public ActionGroupRecipients(Map<Recipient, Set<String>> recipients) {
+        public ActionGroupRecipients(Map<Recipient, Collection<String>> recipients) {
             if (recipients == null) {
                 throw new IllegalArgumentException("Recipients map cannot be null");
             }
@@ -113,8 +122,15 @@ public class SharedWithActionGroup implements ToXContentFragment, NamedWriteable
             this.recipients = in.readMap(key -> key.readEnum(Recipient.class), input -> input.readSet(StreamInput::readString));
         }
 
-        public Map<Recipient, Set<String>> getRecipients() {
+        public Map<Recipient, Collection<String>> getRecipients() {
             return recipients;
+        }
+
+        public Collection<String> getRecipientsByType(Recipient recipientType) {
+            if (!recipients.containsKey(recipientType)) {
+                recipients.put(recipientType, new HashSet<>());
+            }
+            return recipients.get(recipientType);
         }
 
         @Override
@@ -123,7 +139,7 @@ public class SharedWithActionGroup implements ToXContentFragment, NamedWriteable
         }
 
         public static ActionGroupRecipients fromXContent(XContentParser parser) throws IOException {
-            Map<Recipient, Set<String>> recipients = new HashMap<>();
+            Map<Recipient, Collection<String>> recipients = new HashMap<>();
 
             XContentParser.Token token;
             while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -157,7 +173,7 @@ public class SharedWithActionGroup implements ToXContentFragment, NamedWriteable
             if (recipients.isEmpty()) {
                 return builder;
             }
-            for (Map.Entry<Recipient, Set<String>> entry : recipients.entrySet()) {
+            for (Map.Entry<Recipient, Collection<String>> entry : recipients.entrySet()) {
                 builder.array(entry.getKey().getName(), entry.getValue().toArray());
             }
             return builder;

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -11,7 +11,7 @@ package org.opensearch.security.resources;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -165,7 +165,7 @@ public class ResourceSharingIndexHandler {
             IndexRequest ir = client.prepareIndex(resourceSharingIndex)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .setSource(entry.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS))
-                .setOpType(DocWriteRequest.OpType.CREATE) // only create if an entry doesn't exist
+                .setOpType(DocWriteRequest.OpType.CREATE)
                 .request();
 
             ActionListener<IndexResponse> irListener = ActionListener.wrap(
@@ -400,6 +400,7 @@ public class ResourceSharingIndexHandler {
                         ) {
                             parser.nextToken();
                             ResourceSharing resourceSharing = ResourceSharing.fromXContent(parser);
+                            resourceSharing.setDocId(hit.getId());
 
                             LOGGER.debug(
                                 "Successfully fetched document from {} matching resource_id: {} and source_idx: {}",
@@ -497,6 +498,7 @@ public class ResourceSharingIndexHandler {
      * @param listener        Listener to be notified when the operation completes
      * @throws RuntimeException if there's an error during the update operation
      */
+    @SuppressWarnings("unchecked")
     public void updateResourceSharingInfo(
         String resourceId,
         String sourceIdx,
@@ -520,16 +522,15 @@ public class ResourceSharingIndexHandler {
         }
 
         StepListener<ResourceSharing> fetchDocListener = new StepListener<>();
-        StepListener<Boolean> updateScriptListener = new StepListener<>();
         StepListener<ResourceSharing> updatedSharingListener = new StepListener<>();
 
         // Fetch resource sharing doc
         fetchResourceSharingDocument(sourceIdx, resourceId, fetchDocListener);
 
         // build update script
-        fetchDocListener.whenComplete(currentSharingInfo -> {
+        fetchDocListener.whenComplete(sharingInfo -> {
             // Check if user can share. At present only the resource creator and admin is allowed to share the resource
-            if (!isAdmin && currentSharingInfo != null && !currentSharingInfo.getCreatedBy().getCreator().equals(requestUserName)) {
+            if (!isAdmin && sharingInfo != null && !sharingInfo.getCreatedBy().getCreator().equals(requestUserName)) {
 
                 LOGGER.error("User {} is not authorized to share resource {}", requestUserName, resourceId);
                 listener.onFailure(
@@ -540,63 +541,25 @@ public class ResourceSharingIndexHandler {
                 );
             }
 
-            Script updateScript = new Script(ScriptType.INLINE, "painless", """
-                if (ctx._source.share_with == null) {
-                    ctx._source.share_with = [:];
-                }
-
-                for (def entry : params.shareWith.entrySet()) {
-                    def actionGroupName = entry.getKey();
-                    def newActionGroup = entry.getValue();
-
-                    if (!ctx._source.share_with.containsKey(actionGroupName)) {
-                        def newActionGroupEntry = [:];
-                        for (def field : newActionGroup.entrySet()) {
-                            if (field.getValue() != null && !field.getValue().isEmpty()) {
-                                newActionGroupEntry[field.getKey()] = new HashSet(field.getValue());
-                            }
-                        }
-                        ctx._source.share_with[actionGroupName] = newActionGroupEntry;
-                    } else {
-                        def existingActionGroup = ctx._source.share_with[actionGroupName];
-
-                        for (def field : newActionGroup.entrySet()) {
-                            def fieldName = field.getKey();
-                            def newValues = field.getValue();
-
-                            if (newValues != null && !newValues.isEmpty()) {
-                                if (!existingActionGroup.containsKey(fieldName)) {
-                                    existingActionGroup[fieldName] = new HashSet();
-                                }
-
-                                for (def value : newValues) {
-                                    if (!existingActionGroup[fieldName].contains(value)) {
-                                        existingActionGroup[fieldName].add(value);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                """, Collections.singletonMap("shareWith", shareWithMap));
-
-            updateByQueryResourceSharing(sourceIdx, resourceId, updateScript, updateScriptListener);
-
-        }, listener::onFailure);
-
-        // Build & return the updated ResourceSharing
-        updateScriptListener.whenComplete(success -> {
-            if (!success) {
-                LOGGER.error("Failed to update resource sharing info for resource {}", resourceId);
-                listener.onResponse(null);
-                return;
+            for (String accessLevel : shareWithMap.keySet()) {
+                Map<String, List<String>> target = (Map<String, List<String>>) shareWithMap.get(accessLevel);
+                assert sharingInfo != null;
+                sharingInfo.share(accessLevel, target);
             }
-            // TODO check if this should be replaced by Java in-memory computation (current intuition is that it will be more memory
-            // intensive to do it in java)
-            fetchResourceSharingDocument(sourceIdx, resourceId, updatedSharingListener);
-        }, listener::onFailure);
 
-        updatedSharingListener.whenComplete(listener::onResponse, listener::onFailure);
+            IndexRequest ir = client.prepareIndex(resourceSharingIndex)
+                .setId(sharingInfo.getDocId())
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .setSource(sharingInfo.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS))
+                .setOpType(DocWriteRequest.OpType.INDEX)
+                .request();
+
+            ActionListener<IndexResponse> irListener = ActionListener.wrap(idxResponse -> {
+                LOGGER.info("Successfully updated {} entry for resource {} in index {}.", resourceSharingIndex, resourceId, sourceIdx);
+                fetchResourceSharingDocument(sourceIdx, resourceId, listener);
+            }, (failResponse) -> { LOGGER.error(failResponse.getMessage()); });
+            client.index(ir, irListener);
+        }, listener::onFailure);
     }
 
     /**
@@ -686,7 +649,7 @@ public class ResourceSharingIndexHandler {
                 }
 
                 Map<String, Object> revoke = new HashMap<>();
-                for (Map.Entry<Recipient, Set<String>> entry : revokeAccess.getRecipients().entrySet()) {
+                for (Map.Entry<Recipient, Collection<String>> entry : revokeAccess.getRecipients().entrySet()) {
                     revoke.put(entry.getKey().getName(), new ArrayList<>(entry.getValue()));
                 }
                 List<String> actionGroupsToUse = (actionGroups != null) ? new ArrayList<>(actionGroups) : new ArrayList<>();

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -539,6 +539,7 @@ public class ResourceSharingIndexHandler {
                         RestStatus.FORBIDDEN
                     )
                 );
+                return;
             }
 
             for (String accessLevel : shareWithMap.keySet()) {
@@ -556,7 +557,7 @@ public class ResourceSharingIndexHandler {
 
             ActionListener<IndexResponse> irListener = ActionListener.wrap(idxResponse -> {
                 LOGGER.info("Successfully updated {} entry for resource {} in index {}.", resourceSharingIndex, resourceId, sourceIdx);
-                fetchResourceSharingDocument(sourceIdx, resourceId, listener);
+                listener.onResponse(sharingInfo);
             }, (failResponse) -> { LOGGER.error(failResponse.getMessage()); });
             client.index(ir, irListener);
         }, listener::onFailure);


### PR DESCRIPTION
### Description

This PR takes advantage of the changes in https://github.com/opensearch-project/OpenSearch/pull/16908 to setup the integrationTests in the sample-resource-plugin using extendedPlugins instead of the workaround that was introduced.

This PR also does a little refactoring on the `share` flow to modify sharing info of a resource in memory instead of painless which was failing for me locally in testing.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Refactoring

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
