### PR TITLE
Allow for secure LDAP password settings

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/sink/ExternalOpenSearchSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/ExternalOpenSearchSink.java
@@ -31,8 +31,8 @@ import org.opensearch.security.support.PemKeyReader;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public final class ExternalOpenSearchSink extends AuditLogSink {
 

--- a/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
@@ -50,7 +50,7 @@ import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class WebhookSink extends AuditLogSink {
 

--- a/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -82,8 +82,8 @@ import org.ldaptive.ssl.CredentialConfigFactory;
 import org.ldaptive.ssl.SslConfig;
 import org.ldaptive.ssl.ThreadLocalTLSSocketFactory;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
@@ -300,7 +300,7 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 configureSSL(config, settings, configPath);
 
                 final String bindDn = settings.get(ConfigConstants.LDAP_BIND_DN, null);
-                final String password = settings.get(ConfigConstants.LDAP_PASSWORD, null);
+                final String password = ConfigConstants.LDAP_PASSWORD.getSetting(settings, null);
 
                 if (isDebugEnabled) {
                     log.debug("bindDn {}, password {}", bindDn, password != null && password.length() > 0 ? "****" : "<not set>");
@@ -564,13 +564,13 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 }
 
                 PrivateKey authenticationKey = PemKeyReader.loadKeyFromStream(
-                    settings.get(ConfigConstants.LDAPS_PEMKEY_PASSWORD),
+                    ConfigConstants.LDAPS_PEMKEY_PASSWORD.getSetting(settings),
                     PemKeyReader.resolveStream(ConfigConstants.LDAPS_PEMKEY_CONTENT, settings)
                 );
 
                 if (authenticationKey == null) {
                     authenticationKey = PemKeyReader.loadKeyFromFile(
-                        settings.get(ConfigConstants.LDAPS_PEMKEY_PASSWORD),
+                        ConfigConstants.LDAPS_PEMKEY_PASSWORD.getSetting(settings),
                         PemKeyReader.resolve(ConfigConstants.LDAPS_PEMKEY_FILEPATH, settings, configPath, enableClientAuth)
                     );
                 }

--- a/src/main/java/org/opensearch/security/auth/ldap/util/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/util/ConfigConstants.java
@@ -11,6 +11,8 @@
 
 package org.opensearch.security.auth.ldap.util;
 
+import org.opensearch.security.setting.SecurableLegacySetting;
+
 public final class ConfigConstants {
 
     public static final String LDAP_AUTHC_USERBASE = "userbase";
@@ -40,7 +42,6 @@ public final class ConfigConstants {
 
     public static final String LDAP_HOSTS = "hosts";
     public static final String LDAP_BIND_DN = "bind_dn";
-    public static final String LDAP_PASSWORD = "password";
     public static final String LDAP_FAKE_LOGIN_ENABLED = "fakelogin_enabled";
     public static final String LDAP_SEARCH_ALL_BASES = "search_all_bases";
 
@@ -64,7 +65,6 @@ public final class ConfigConstants {
 
     public static final String LDAPS_PEMKEY_FILEPATH = "pemkey_filepath";
     public static final String LDAPS_PEMKEY_CONTENT = "pemkey_content";
-    public static final String LDAPS_PEMKEY_PASSWORD = "pemkey_password";
     public static final String LDAPS_PEMCERT_FILEPATH = "pemcert_filepath";
     public static final String LDAPS_PEMCERT_CONTENT = "pemcert_content";
     public static final String LDAPS_PEMTRUSTEDCAS_FILEPATH = "pemtrustedcas_filepath";
@@ -92,6 +92,10 @@ public final class ConfigConstants {
 
     public static final String LDAP_POOL_PRUNING_PERIOD = "pool.pruning_period";
     public static final String LDAP_POOL_IDLE_TIME = "pool.idle_time";
+
+    // legacy unsecure and secure settings
+    public static final SecurableLegacySetting LDAP_PASSWORD = new SecurableLegacySetting("password");
+    public static final SecurableLegacySetting LDAPS_PEMKEY_PASSWORD = new SecurableLegacySetting("pemkey_password");
 
     private ConfigConstants() {
 

--- a/src/main/java/org/opensearch/security/auth/ldap2/LDAPConnectionFactoryFactory.java
+++ b/src/main/java/org/opensearch/security/auth/ldap2/LDAPConnectionFactoryFactory.java
@@ -184,7 +184,7 @@ public class LDAPConnectionFactoryFactory {
         BindConnectionInitializer result = new BindConnectionInitializer();
 
         String bindDn = settings.get(ConfigConstants.LDAP_BIND_DN, null);
-        String password = settings.get(ConfigConstants.LDAP_PASSWORD, null);
+        String password = ConfigConstants.LDAP_PASSWORD.getSetting(settings);
 
         if (password != null && password.length() == 0) {
             password = null;

--- a/src/main/java/org/opensearch/security/setting/SecurableLegacySetting.java
+++ b/src/main/java/org/opensearch/security/setting/SecurableLegacySetting.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.setting;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.settings.SecureSetting;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.settings.SecureString;
+
+/**
+ * Wrapper for legacy settings that support a secure variant located in the Keystore.
+ * <p>
+ * Secure name is the insecure name with "_secure" appended to it.
+ */
+public class SecurableLegacySetting {
+    private static final Logger LOG = LogManager.getLogger(SecurableLegacySetting.class);
+
+    public static final String SECURE_SUFFIX = "_secure";
+
+    public final String insecurePropertyName;
+
+    public final String propertyName;
+
+    public final String defaultValue;
+
+    public SecurableLegacySetting(String insecurePropertyName) {
+        this(insecurePropertyName, null);
+    }
+
+    public SecurableLegacySetting(String insecurePropertyName, String defaultValue) {
+        this(insecurePropertyName, String.format("%s%s", insecurePropertyName, SECURE_SUFFIX), defaultValue);
+    }
+
+    public SecurableLegacySetting(String insecurePropertyName, String propertyName, String defaultValue) {
+        super();
+        this.insecurePropertyName = insecurePropertyName;
+        this.propertyName = propertyName;
+        this.defaultValue = defaultValue;
+    }
+
+    public Setting<SecureString> asSetting() {
+        final Setting<SecureString> fallback = new InsecureFallbackStringSetting(this.insecurePropertyName, this.propertyName);
+        return SecureSetting.secureString(this.propertyName, fallback);
+    }
+
+    public Setting<SecureString> asInsecureSetting() {
+        return new InsecureFallbackStringSetting(this.insecurePropertyName, this.propertyName);
+    }
+
+    public String getSetting(Settings settings) {
+        return this.getSetting(settings, this.defaultValue);
+    }
+
+    public String getSetting(Settings settings, String defaultValue) {
+        return Optional.of(this.asSetting().get(settings)).filter(ss -> ss.length() > 0).map(SecureString::toString).orElse(defaultValue);
+    }
+
+    /**
+     * Alternative to InsecureStringSetting, which doesn't raise an exception if allow_insecure_settings is false, but
+     * instead log.WARNs the violation. This is to appease a potential cyclic dependency between commons-utils
+     */
+    private static class InsecureFallbackStringSetting extends Setting<SecureString> {
+        private final String name;
+        private final String secureName;
+
+        private InsecureFallbackStringSetting(String name, String secureName) {
+            super(name, "", s -> new SecureString(s.toCharArray()), Property.Deprecated, Property.Filtered, Property.NodeScope);
+            this.name = name;
+            this.secureName = secureName;
+        }
+
+        public SecureString get(Settings settings) {
+            if (this.exists(settings)) {
+                LOG.warn(
+                    "Setting [{}] has a secure counterpart [{}] which should be used instead. Allowing use of {} for legacy setups",
+                    this.name,
+                    this.secureName,
+                    this.name
+                );
+            }
+
+            return super.get(settings);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
+++ b/src/main/java/org/opensearch/security/ssl/DefaultSecurityKeyStore.java
@@ -89,18 +89,18 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_CLIENT_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_CLIENT_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_SERVER_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_SERVER_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_CLIENT_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_CLIENT_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_SERVER_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_SERVER_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class DefaultSecurityKeyStore implements SecurityKeyStore {
 

--- a/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslCertificatesLoader.java
@@ -23,8 +23,8 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.settings.SecureSetting;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
+import org.opensearch.security.setting.SecurableLegacySetting;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SECURE_SUFFIX;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_PASSWORD;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_TYPE;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.KEYSTORE_ALIAS;
@@ -99,7 +99,7 @@ public class SslCertificatesLoader {
     }
 
     private char[] resolvePassword(final String legacyPasswordSettings, final Settings settings, final String defaultPassword) {
-        final var securePasswordSetting = String.format("%s%s", legacyPasswordSettings, SECURE_SUFFIX);
+        final var securePasswordSetting = String.format("%s%s", legacyPasswordSettings, SecurableLegacySetting.SECURE_SUFFIX);
         final var securePassword = SecureSetting.secureString(securePasswordSetting, null).get(settings);
         final var legacyPassword = settings.get(legacyPasswordSettings, defaultPassword);
         if (!securePassword.isEmpty() && legacyPassword != null && !legacyPassword.equals(defaultPassword)) {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -47,7 +47,7 @@ import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.ssl.transport.PrincipalExtractor.Type;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD;
 
 public class SSLRequestHelper {
 

--- a/src/main/java/org/opensearch/security/util/SettingsBasedSSLConfigurator.java
+++ b/src/main/java/org/opensearch/security/util/SettingsBasedSSLConfigurator.java
@@ -47,8 +47,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class SettingsBasedSSLConfigurator {
     private static final Logger log = LogManager.getLogger(SettingsBasedSSLConfigurator.class);

--- a/src/main/java/org/opensearch/security/util/SettingsBasedSSLConfiguratorV4.java
+++ b/src/main/java/org/opensearch/security/util/SettingsBasedSSLConfiguratorV4.java
@@ -48,8 +48,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.security.support.PemKeyReader;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class SettingsBasedSSLConfiguratorV4 {
     private static final Logger log = LogManager.getLogger(SettingsBasedSSLConfigurator.class);

--- a/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestClientCert.java
+++ b/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestClientCert.java
@@ -154,7 +154,7 @@ public class LdapBackendTestClientCert {
             .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,dc=example,dc=com")
             .put(ConfigConstants.LDAP_AUTHC_USERNAME_ATTRIBUTE, "uid")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=ldapbinder,ou=people,dc=example,dc=com")
-            .put(ConfigConstants.LDAP_PASSWORD, "ldapbinder")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "ldapbinder")
             .put("path.home", ".")
             .build();
 

--- a/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -116,7 +116,7 @@ public class LdapBackendTestNewStyleConfig {
             .put("users.u1.search", "(uid={0})")
             .put("users.u1.base", "ou=people,o=TEST")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-            .put(ConfigConstants.LDAP_PASSWORD, "spocksecret")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "spocksecret")
             .build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend(settings, null).authenticate(
@@ -134,7 +134,7 @@ public class LdapBackendTestNewStyleConfig {
             .put("users.u1.search", "(uid={0})")
             .put("users.u1.base", "ou=people,o=TEST")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-            .put(ConfigConstants.LDAP_PASSWORD, "wrong")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "wrong")
             .build();
 
         new LDAPAuthenticationBackend(settings, null).authenticate(

--- a/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestClientCert2.java
+++ b/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestClientCert2.java
@@ -156,7 +156,7 @@ public class LdapBackendTestClientCert2 {
             .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,dc=example,dc=com")
             .put(ConfigConstants.LDAP_AUTHC_USERNAME_ATTRIBUTE, "uid")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=ldapbinder,ou=people,dc=example,dc=com")
-            .put(ConfigConstants.LDAP_PASSWORD, "ldapbinder")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "ldapbinder")
             .put("path.home", ".")
             .build();
 

--- a/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestNewStyleConfig2.java
+++ b/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestNewStyleConfig2.java
@@ -138,7 +138,7 @@ public class LdapBackendTestNewStyleConfig2 {
             .put("users.u1.search", "(uid={0})")
             .put("users.u1.base", "ou=people,o=TEST")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-            .put(ConfigConstants.LDAP_PASSWORD, "spocksecret")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "spocksecret")
             .build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend2(settings, null).authenticate(
@@ -156,7 +156,7 @@ public class LdapBackendTestNewStyleConfig2 {
                 .put("users.u1.search", "(uid={0})")
                 .put("users.u1.base", "ou=people,o=TEST")
                 .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-                .put(ConfigConstants.LDAP_PASSWORD, "wrong")
+                .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "wrong")
                 .build();
 
             new LDAPAuthenticationBackend2(settings, null).authenticate(

--- a/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestOldStyleConfig2.java
+++ b/src/test/java/org/opensearch/security/auth/ldap2/LdapBackendTestOldStyleConfig2.java
@@ -154,7 +154,7 @@ public class LdapBackendTestOldStyleConfig2 {
             .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
             .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,o=TEST")
             .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-            .put(ConfigConstants.LDAP_PASSWORD, "spocksecret")
+            .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "spocksecret")
             .build();
 
         final LdapUser user = (LdapUser) new LDAPAuthenticationBackend2(settings, null).authenticate(
@@ -171,7 +171,7 @@ public class LdapBackendTestOldStyleConfig2 {
                 .put(ConfigConstants.LDAP_AUTHC_USERSEARCH, "(uid={0})")
                 .put(ConfigConstants.LDAP_AUTHC_USERBASE, "ou=people,o=TEST")
                 .put(ConfigConstants.LDAP_BIND_DN, "cn=Captain Spock,ou=people,o=TEST")
-                .put(ConfigConstants.LDAP_PASSWORD, "wrong")
+                .put(ConfigConstants.LDAP_PASSWORD.insecurePropertyName, "wrong")
                 .build();
 
             new LDAPAuthenticationBackend2(settings, null).authenticate(

--- a/src/test/java/org/opensearch/security/sanity/tests/SecurityRestTestCase.java
+++ b/src/test/java/org/opensearch/security/sanity/tests/SecurityRestTestCase.java
@@ -28,8 +28,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_KEYSTORE_PASSWORD;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_ENABLED;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_KEYSTORE_FILEPATH;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_PEMCERT_FILEPATH;

--- a/src/test/java/org/opensearch/security/setting/SecurableLegacySettingTest.java
+++ b/src/test/java/org/opensearch/security/setting/SecurableLegacySettingTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.setting;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.MockSecureSettings;
+import org.opensearch.common.settings.Settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class SecurableLegacySettingTest {
+    private final String settingName = "test.setting";
+    private final SecurableLegacySetting secureSetting = new SecurableLegacySetting(settingName);
+
+    @Test
+    public void testSettingNames() {
+        assertThat(secureSetting.propertyName, is(settingName + SecurableLegacySetting.SECURE_SUFFIX));
+        assertThat(secureSetting.insecurePropertyName, is(settingName));
+    }
+
+    @Test
+    public void testGetSecureSetting() {
+        final var mockSecureSettings = new MockSecureSettings();
+
+        mockSecureSettings.setString(secureSetting.propertyName, "test-password");
+        final var settings = Settings.builder().setSecureSettings(mockSecureSettings).build();
+        final var password = secureSetting.getSetting(settings);
+        assertThat(password, is("test-password"));
+    }
+
+    @Test
+    public void testGetInsecureSetting() {
+        final var settings = Settings.builder().put(settingName, "test-password").build();
+        final var password = secureSetting.getSetting(settings);
+        assertThat(password, is("test-password"));
+    }
+
+    @Test
+    public void testShouldFavorSecureOverInsecureSetting() {
+        final var mockSecureSettings = new MockSecureSettings();
+        mockSecureSettings.setString(secureSetting.propertyName, "secure-password");
+        final var settings = Settings.builder()
+            .setSecureSettings(mockSecureSettings)
+            .put(secureSetting.insecurePropertyName, "insecure-password")
+            .build();
+        final var password = secureSetting.getSetting(settings);
+        assertThat(password, is("secure-password"));
+    }
+}

--- a/src/test/java/org/opensearch/security/ssl/SSLTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SSLTest.java
@@ -63,12 +63,12 @@ import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_KEYPASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_PEMKEY_PASSWORD;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_KEYPASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_KEYSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_PEMKEY_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 @SuppressWarnings({ "resource", "unchecked" })
 public class SSLTest extends SingleClusterTest {

--- a/src/test/java/org/opensearch/security/ssl/SecureSSLSettingsTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SecureSSLSettingsTest.java
@@ -7,46 +7,11 @@ package org.opensearch.security.ssl;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.opensearch.common.settings.MockSecureSettings;
-import org.opensearch.common.settings.Settings;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_HTTP_PEMKEY_PASSWORD;
-
 public class SecureSSLSettingsTest {
     @Test
     public void testGetSettings() {
         final var settings = SecureSSLSettings.getSecureSettings();
         Assert.assertNotNull(settings);
         Assert.assertTrue(settings.size() > 0);
-    }
-
-    @Test
-    public void testGetSecureSetting() {
-        final var mockSecureSettings = new MockSecureSettings();
-        mockSecureSettings.setString(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.propertyName, "test-password");
-        final var settings = Settings.builder().setSecureSettings(mockSecureSettings).build();
-        final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        assertThat(password, is("test-password"));
-    }
-
-    @Test
-    public void testGetInsecureSetting() {
-        final var settings = Settings.builder().put(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.insecurePropertyName, "test-password").build();
-        final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        assertThat(password, is("test-password"));
-    }
-
-    @Test
-    public void testShouldFavorSecureOverInsecureSetting() {
-        final var mockSecureSettings = new MockSecureSettings();
-        mockSecureSettings.setString(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.propertyName, "secure-password");
-        final var settings = Settings.builder()
-            .setSecureSettings(mockSecureSettings)
-            .put(SECURITY_SSL_HTTP_PEMKEY_PASSWORD.insecurePropertyName, "insecure-password")
-            .build();
-        final var password = SECURITY_SSL_HTTP_PEMKEY_PASSWORD.getSetting(settings);
-        assertThat(password, is("secure-password"));
     }
 }

--- a/src/test/java/org/opensearch/security/util/SettingsBasedSSLConfiguratorV4Test.java
+++ b/src/test/java/org/opensearch/security/util/SettingsBasedSSLConfiguratorV4Test.java
@@ -71,7 +71,7 @@ import org.opensearch.security.util.SettingsBasedSSLConfiguratorV4.SSLConfig;
 
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.opensearch.security.ssl.SecureSSLSettings.SSLSetting.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
+import static org.opensearch.security.ssl.SecureSSLSettings.SECURITY_SSL_TRANSPORT_TRUSTSTORE_PASSWORD;
 
 public class SettingsBasedSSLConfiguratorV4Test {
 


### PR DESCRIPTION
### Description
* Category: Enhancement
* Why these changes are required: To allow for secure storage of LDAP password settings
* What is the old behavior before changes and new behavior after changes
    * Before - settings for ldap `password` and `pem_password` were only configurable in an insecure manner (plaintext in yml or via cli / env variables)
    * After - Settings can now be acquired from the keystore (or still provided in an insecure manner, for which a warning will be shown in the logs, prompting the administrator to migrate to the secure versions)

If this PR is approved, i plan to submit similar PRs for the other secure settings using the `SecurableLegacySetting` class:
* OIDC: `pemkey_password, client_secret, passphrase` (https://docs.opensearch.org/docs/latest/security/authentication-backends/openid-connect/)
* JWT: `signing_key` (https://docs.opensearch.org/docs/latest/security/authentication-backends/jwt/)
* SAML: `signature_private_key_password, exchange_key, pemkey_password` (https://docs.opensearch.org/docs/latest/security/authentication-backends/saml/)


### Issues Resolved
* Related to (extension and refactor of) #2296 (for which I'm the original author)

Is this a backport: no

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end: no

### Testing
* Unit tests updated for LDAP password (with insecure legacy setting and secure setting)
* There is currently no existing test for pemkey_password

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
    - To be completed in another PR on opensearch-project/documentation-website repo once this PR is approved
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR - **N/A**
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md) - **N/A**
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
