### PR TITLE
Register cluster settings listener for `plugins.security.cache.ttl_minutes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 - [Resource Permissions] Introduces Centralized Resource Access Control Framework ([#5281](https://github.com/opensearch-project/security/pull/5281))
 - Github workflow for changelog verification ([#5318](https://github.com/opensearch-project/security/pull/5318))
+- Register cluster settings listener for `plugins.security.cache.ttl_minutes` ([#5324](https://github.com/opensearch-project/security/pull/5324))
 
 ### Changed
 

--- a/src/integrationTest/java/org/opensearch/security/SecuritySettingsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecuritySettingsTests.java
@@ -1,0 +1,49 @@
+package org.opensearch.security;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.awaitility.Awaitility;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class SecuritySettingsTests {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_ADMIN)
+        .build();
+
+    @Test
+    public void testTtlInMinCanBeUpdatedDynamically() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse updateResponse = client.putJson("_cluster/settings", """
+                    {
+                        "persistent": { },
+                        "transient": {
+                            "plugins.security.cache.ttl_minutes": "1440"
+                        }
+                    }
+                """);
+
+            updateResponse.assertStatusCode(200);
+            Awaitility.await().untilAsserted(() -> {
+                TestRestClient.HttpResponse response = client.get("_plugins/_security/health");
+                assertThat(response.getBody(), containsString("\"" + ConfigConstants.SECURITY_CACHE_TTL_MINUTES + "\":1440"));
+            });
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/SecuritySettingsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecuritySettingsTests.java
@@ -1,3 +1,11 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
 package org.opensearch.security;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1139,6 +1139,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final XFFResolver xffResolver = new XFFResolver(threadPool);
         backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool);
+        backendRegistry.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         tokenManager = new SecurityTokenManager(cs, threadPool, userService);
 
         final CompatConfig compatConfig = new CompatConfig(environment, transportPassiveAuthSetting);
@@ -1484,7 +1485,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(Setting.boolSetting(ConfigConstants.SECURITY_DISABLED, false, Property.NodeScope, Property.Filtered));
 
-            settings.add(Setting.intSetting(ConfigConstants.SECURITY_CACHE_TTL_MINUTES, 60, 0, Property.NodeScope, Property.Filtered));
+            settings.add(SecuritySettings.CACHE_TTL_SETTING);
 
             // Security
             settings.add(

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -203,6 +203,10 @@ public class BackendRegistry {
         return initialized;
     }
 
+    public int getTtlInMin() {
+        return ttlInMin;
+    }
+
     public void invalidateCache() {
         userCache.invalidateAll();
         restImpersonationCache.invalidateAll();

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -30,7 +30,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -107,13 +106,6 @@ public class BackendRegistry {
     private Cache<User, Set<String>> restRoleCache; //
 
     private void createCaches() {
-        Map<AuthCredentials, User> existingUserCache = new HashMap<>();
-        Map<String, User> existingRestImpersonationCache = new HashMap<>();
-        Map<User, Set<String>> existingRestRoleCache = new HashMap<>();
-        if (userCache != null) {
-            existingUserCache.putAll(userCache.asMap());
-        }
-
         userCache = CacheBuilder.newBuilder()
             .expireAfterWrite(ttlInMin, TimeUnit.MINUTES)
             .removalListener(new RemovalListener<AuthCredentials, User>() {
@@ -123,14 +115,6 @@ public class BackendRegistry {
                 }
             })
             .build();
-
-        if (!existingUserCache.isEmpty()) {
-            userCache.putAll(existingUserCache);
-        }
-
-        if (restImpersonationCache != null) {
-            existingRestImpersonationCache.putAll(restImpersonationCache.asMap());
-        }
 
         restImpersonationCache = CacheBuilder.newBuilder()
             .expireAfterWrite(ttlInMin, TimeUnit.MINUTES)
@@ -142,14 +126,6 @@ public class BackendRegistry {
             })
             .build();
 
-        if (!existingRestImpersonationCache.isEmpty()) {
-            restImpersonationCache.putAll(existingRestImpersonationCache);
-        }
-
-        if (restRoleCache != null) {
-            restRoleCache.putAll(existingRestRoleCache);
-        }
-
         restRoleCache = CacheBuilder.newBuilder()
             .expireAfterWrite(ttlInMin, TimeUnit.MINUTES)
             .removalListener(new RemovalListener<User, Set<String>>() {
@@ -159,10 +135,6 @@ public class BackendRegistry {
                 }
             })
             .build();
-
-        if (!existingRestRoleCache.isEmpty()) {
-            restRoleCache.putAll(existingRestRoleCache);
-        }
     }
 
     public void registerClusterSettingsChangeListener(final ClusterSettings clusterSettings) {

--- a/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityHealthAction.java
@@ -49,6 +49,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.OPENDISTRO_API_DEP
 import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_ROUTE_PREFIX;
 import static org.opensearch.security.dlic.rest.support.Utils.addDeprecatedRoutesPrefix;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+import static org.opensearch.security.support.SecuritySettings.CACHE_TTL_SETTING;
 
 public class SecurityHealthAction extends BaseRestHandler {
     private static final List<Route> routes = addRoutesPrefix(
@@ -108,6 +109,10 @@ public class SecurityHealthAction extends BaseRestHandler {
                     builder.field("message", message);
                     builder.field("mode", mode);
                     builder.field("status", status);
+                    // TODO Consider a separate settings API
+                    builder.startObject("settings");
+                    builder.field(CACHE_TTL_SETTING.getKey(), registry.getTtlInMin());
+                    builder.endObject();
                     builder.endObject();
                     response = new BytesRestResponse(restStatus, builder);
 

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -33,7 +33,7 @@ public class SecuritySettings {
         60,
         0,
         Setting.Property.NodeScope,
-        Setting.Property.Filtered
+        Setting.Property.Dynamic
     ); // Not filtered
 
 }

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -28,4 +28,12 @@ public class SecuritySettings {
         Setting.Property.Dynamic
     ); // Not filtered
 
+    public static final Setting<Integer> CACHE_TTL_SETTING = Setting.intSetting(
+        ConfigConstants.SECURITY_CACHE_TTL_MINUTES,
+        60,
+        0,
+        Setting.Property.NodeScope,
+        Setting.Property.Filtered
+    ); // Not filtered
+
 }


### PR DESCRIPTION
### Description

This PR registers a cluster settings listener for the `plugins.security.cache.ttl_minutes` setting that will allow it to be changed dynamically.

Updating this setting will not persist across reboots and this will only last as long as the OpenSearch process remains up. To update this setting more permanently requires modifying the setting in `opensearch.yml`

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
