### PR TITLE
fixing dependabot changelog pull_request workflow

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,5 +1,5 @@
 name: Dependabot PR actions
-on: pull_request
+on: pull_request_target
 
 jobs:
   dependabot:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 - Corrections in DlsFlsFilterLeafReader regarding PointVales and object valued attributes ([#5303](https://github.com/opensearch-project/security/pull/5303))
 - Fix issue computing diffs in compliance audit log when writing to security index ([#5279](https://github.com/opensearch-project/security/pull/5279))
+- Fixing dependabot broken pull_request workflow for changelog update ([#5331](https://github.com/opensearch-project/security/pull/5331))
 
 ### Security
 


### PR DESCRIPTION
### Description
Fixing  [dependabot](https://github.com/apps/dependabot) broken pull_request workflow for changelog update 
### What changed?
For GitHub Actions workflows initiated by Dependabot (github.actor == "dependabot[bot]") using the pull_request, pull_request_review, pull_request_review_comment, and push events:
secrets are inaccessible , which cause

Dependabot_pr worklow is faling with error : [Error: Input required and not supplied: app_id](https://github.com/opensearch-project/security/actions/runs/14965211943/job/42033842830)
ref : https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
###  Fix for broken pull_request workflow
For workflows that are triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permission and secrets
### Issues Resolved
 https://github.com/opensearch-project/security/pull/5326


Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
