### PR TITLE
Automatically add dependabot label to dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,13 @@ updates:
       # For all packages, ignore all major versions to minimize breaking issues
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+    labels:
+      - "dependabot"
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"
+      - "dependencies"


### PR DESCRIPTION
### Description

The dependabot-changelog-helper GHA expects the `dependabot` label on dependabot PRs. Currently the `Update the changelog` step in `dependabot_pr.yml` workflow is failing silently bc this label is absent

```
Run dangoslen/dependabot-changelog-helper@v4
Label 'dependabot' not found in pull request labels
```

ref: https://github.com/opensearch-project/security/actions/runs/15109843244/job/42484278169?pr=5345

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
