### PR TITLE
Fix dependabot_pr workflow

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ steps.github_app_token.outputs.token }}
+          ref: ${{ github.head_ref }}
 
       # See please https://docs.gradle.org/8.10/userguide/upgrading_version_8.html#minimum_daemon_jvm_version
       - name: Set up JDK 21


### PR DESCRIPTION
### Description

This PR fixes the error seen on https://github.com/opensearch-project/security/actions/runs/15144109381/job/42575432746?pr=5352

```
Run stefanzweifel/git-auto-commit-action@v5
Started: bash /home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v5/entrypoint.sh
INPUT_REPOSITORY value: .
INPUT_STATUS_OPTIONS: 
INPUT_FILE_PATTERN: .
INPUT_BRANCH value: dependabot/gradle/org.springframework.kafka-spring-kafka-test-3.3.6
From https://github.com/opensearch-project/security
 * [new branch]      1.0                -> origin/1.0
 * [new branch]      1.1                -> origin/1.1
 * [new branch]      1.2                -> origin/1.2
 * [new branch]      1.3                -> origin/1.3
 * [new branch]      1.x                -> origin/1.x
 * [new branch]      2.0                -> origin/2.0
 * [new branch]      2.1                -> origin/2.1
 * [new branch]      2.10               -> origin/2.10
 * [new branch]      2.11               -> origin/2.11
 * [new branch]      2.12               -> origin/2.12
 * [new branch]      2.13               -> origin/2.13
 * [new branch]      2.14               -> origin/2.14
 * [new branch]      2.15               -> origin/2.15
 * [new branch]      2.16               -> origin/2.16
 * [new branch]      2.17               -> origin/2.17
 * [new branch]      2.18               -> origin/2.18
 * [new branch]      2.19               -> origin/2.19
 * [new branch]      2.2                -> origin/2.2
 * [new branch]      2.3                -> origin/2.3
 * [new branch]      2.4                -> origin/2.4
 * [new branch]      2.5                -> origin/2.5
 * [new branch]      2.6                -> origin/2.6
 * [new branch]      2.7                -> origin/2.7
 * [new branch]      2.8                -> origin/2.8
 * [new branch]      2.9                -> origin/2.9
 * [new branch]      2.x                -> origin/2.x
 * [new branch]      3.0                -> origin/3.0
 * [new branch]      backport/backport-2995-to-2.9 -> origin/backport/backport-2995-to-2.9
 * [new branch]      backport/backport-3062-to-2.x -> origin/backport/backport-3062-to-2.x
 * [new branch]      backport/backport-3082-to-2.x -> origin/backport/backport-3082-to-2.x
 * [new branch]      backport/backport-3338-to-2.x -> origin/backport/backport-3338-to-2.x
 * [new branch]      backport/backport-3431-to-2.x -> origin/backport/backport-3431-to-2.x
 * [new branch]      backport/backport-3460-to-2.11 -> origin/backport/backport-3460-to-2.11
 * [new branch]      backport/backport-3526-to-2.x -> origin/backport/backport-3526-to-2.x
 * [new branch]      backport/backport-3532-to-2.x -> origin/backport/backport-3532-to-2.x
 * [new branch]      backport/backport-3951-to-2.11 -> origin/backport/backport-3951-to-2.11
 * [new branch]      backport/backport-3951-to-2.9 -> origin/backport/backport-3951-to-2.9
 * [new branch]      backport/backport-4418-to-2.x -> origin/backport/backport-4418-to-2.x
 * [new branch]      backport/backport-4641-to-2.x -> origin/backport/backport-4641-to-2.x
 * [new branch]      backport/backport-4839-to-2.18 -> origin/backport/backport-4839-to-2.18
 * [new branch]      backport/backport-5116-to-2.x -> origin/backport/backport-5116-to-2.x
 * [new branch]      backport/backport-5281-to-3.0 -> origin/backport/backport-5281-to-3.0
 * [new branch]      dependabot/gradle/kafka_version-3.9.1 -> origin/dependabot/gradle/kafka_version-3.9.1
 * [new branch]      dependabot/gradle/org.springframework.kafka-spring-kafka-test-3.3.6 -> origin/dependabot/gradle/org.springframework.kafka-spring-kafka-test-3.3.6
 * [new branch]      feature/api-tokens -> origin/feature/api-tokens
 * [new branch]      feature/extensions -> origin/feature/extensions
 * [new branch]      opendistro-0.10    -> origin/opendistro-0.10
 * [new branch]      opendistro-0.9     -> origin/opendistro-0.9
 * [new branch]      opendistro-1.0     -> origin/opendistro-1.0
 * [new branch]      opendistro-1.1     -> origin/opendistro-1.1
 * [new branch]      opendistro-1.10    -> origin/opendistro-1.10
 * [new branch]      opendistro-1.11    -> origin/opendistro-1.11
 * [new branch]      opendistro-1.12    -> origin/opendistro-1.12
 * [new branch]      opendistro-1.13    -> origin/opendistro-1.13
 * [new branch]      opendistro-1.2     -> origin/opendistro-1.2
 * [new branch]      opendistro-1.3     -> origin/opendistro-1.3
 * [new branch]      opendistro-1.4     -> origin/opendistro-1.4
 * [new branch]      opendistro-1.5     -> origin/opendistro-1.5
 * [new branch]      opendistro-1.6     -> origin/opendistro-1.6
 * [new branch]      opendistro-1.7     -> origin/opendistro-1.7
 * [new branch]      opendistro-1.8     -> origin/opendistro-1.8
 * [new branch]      opendistro-1.9     -> origin/opendistro-1.9
 * [new branch]      publish-resource-sharing-spi -> origin/publish-resource-sharing-spi
 * [new branch]      task/publish-resource-sharing-spi -> origin/task/publish-resource-sharing-spi
 * [new tag]         3.0.0.0            -> 3.0.0.0
error: Your local changes to the following files would be overwritten by checkout:
	CHANGELOG.md
Please commit your changes or stash them before you switch branches.
Aborting
Error: Invalid status code: 1
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v5/index.js:17:19)
    at ChildProcess.emit (node:events:5[24](https://github.com/opensearch-project/security/actions/runs/15144109381/job/42575432746?pr=5352#step:10:25):28)
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:304:5) {
  code: 1
}
Error: Invalid status code: 1
    at ChildProcess.<anonymous> (/home/runner/work/_actions/stefanzweifel/git-auto-commit-action/v5/index.js:17:19)
    at ChildProcess.emit (node:events:524:[28](https://github.com/opensearch-project/security/actions/runs/15144109381/job/42575432746?pr=5352#step:10:29))
    at maybeClose (node:internal/child_process:1104:16)
    at ChildProcess._handle.onexit (node:internal/child_process:[30](https://github.com/opensearch-project/security/actions/runs/15144109381/job/42575432746?pr=5352#step:10:31)4:5)
```

This now follows the recommended setup from https://github.com/stefanzweifel/git-auto-commit-action

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
