### PR TITLE
[2.19] Quick fix for tenant privilege performance issues

### DIFF
--- a/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/ConfigModelV7.java
@@ -1029,9 +1029,11 @@ public class ConfigModelV7 extends ConfigModel {
     private class TenantHolder {
 
         private SetMultimap<String, Tuple<String, Boolean>> tenantsMM = null;
+        private final ImmutableSet<String> allDefinedTenantNames;
 
         public TenantHolder(SecurityDynamicConfiguration<RoleV7> roles, SecurityDynamicConfiguration<TenantV7> definedTenants) {
             final Set<Future<Tuple<String, Set<Tuple<String, Boolean>>>>> futures = new HashSet<>(roles.getCEntries().size());
+            this.allDefinedTenantNames = ImmutableSet.copyOf(definedTenants.getCEntries().keySet());
 
             final ExecutorService execs = Executors.newFixedThreadPool(10);
 
@@ -1053,7 +1055,7 @@ public class ConfigModelV7 extends ConfigModel {
 
                                     // find Wildcarded tenant patterns
                                     List<String> matchingTenants = WildcardMatcher.from(tenant.getTenant_patterns())
-                                        .getMatchAny(definedTenants.getCEntries().keySet(), Collectors.toList());
+                                        .getMatchAny(allDefinedTenantNames, Collectors.toList());
                                     for (String matchingTenant : matchingTenants) {
                                         tuples.add(
                                             new Tuple<String, Boolean>(
@@ -1146,7 +1148,7 @@ public class ConfigModelV7 extends ConfigModel {
                         // Indeed, because we don't have control over what will be
                         // passed on as values of users' attributes, we have to make
                         // sure that we don't allow them to select tenants that do not exist.
-                        if (ConfigModelV7.this.tenants.getCEntries().keySet().contains(tenant)) {
+                        if (this.allDefinedTenantNames.contains(tenant)) {
                             result.put(tenant, rw);
                         }
                     }


### PR DESCRIPTION
### Description

This is a minimal quick fix to solve the performance issues described in https://github.com/opensearch-project/security/issues/5342 and https://github.com/opensearch-project/security/issues/5129 also for OpenSearch 2.19.

It won't be as fast as the implementation in #5350, as it still requires loops. Still, micro benchmarks on `ConfigModelV7.mapTenants()` show a huge improvement (10 threads, 10000 iterations):

- 2.19.1 release version: 2.14 ms per call
- This change: 0.065 ms per call

This can be achieved by avoiding calls to `SecurityDynamicConfiguration.getCEntries()` which will always copy the config `HashMap` in a synchronized block - thus very strongly limiting the concurrency on the particular node.


* Category: Performance improvement
* Why these changes are required? Performance issues on clusters with many tenants
* What is the old behavior before changes and new behavior after changes? None

### Issues Resolved

Fixes https://github.com/opensearch-project/security/issues/5342
Fixes https://github.com/opensearch-project/security/issues/5129

Related fix for 3.0: https://github.com/opensearch-project/security/pull/5350

### Testing

- Existing integration tests

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
