### PR TITLE
Include mapped roles when setting userInfo in ThreadContext

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -279,13 +279,13 @@ public class PrivilegesEvaluator {
         return configModel != null && dcm != null && actionPrivileges.get() != null;
     }
 
-    private void setUserInfoInThreadContext(User user) {
+    private void setUserInfoInThreadContext(User user, Set<String> mappedRoles) {
         if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
             StringJoiner joiner = new StringJoiner("|");
             // Escape any pipe characters in the values before joining
             joiner.add(escapePipe(user.getName()));
             joiner.add(escapePipe(String.join(",", user.getRoles())));
-            joiner.add(escapePipe(String.join(",", user.getSecurityRoles())));
+            joiner.add(escapePipe(String.join(",", mappedRoles)));
 
             String requestedTenant = user.getRequestedTenant();
             if (!Strings.isNullOrEmpty(requestedTenant)) {
@@ -357,7 +357,7 @@ public class PrivilegesEvaluator {
             context.setMappedRoles(mappedRoles);
         }
 
-        setUserInfoInThreadContext(user);
+        setUserInfoInThreadContext(user, mappedRoles);
 
         final boolean isDebugEnabled = log.isDebugEnabled();
         if (isDebugEnabled) {


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/security/pull/5212 the user object was made immutable after instantiation. With the immutability, there were a [few lines removed](https://github.com/opensearch-project/security/pull/5212/files#diff-e746c76b234a31b6f95d428b7c40dabf805b609b110c560902c967db8f83fa7aL354-R354) to temporarily add the mapped roles before setting the userInfo into the threadcontext. This PR adds them back in.

This PR explicitly passes the mapped roles 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bugfix

### Issues Resolved

Fixes issues seen in AD and SAP plugin tests w/ security

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
