### PR TITLE
Easing debugging for security not initialized error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Introduced new, performance-optimized implementation for tenant privileges ([#5339](https://github.com/opensearch-project/security/pull/5339))
 - Performance improvements: Immutable user object ([#5212](https://github.com/opensearch-project/security/pull/5212))
 - Include mapped roles when setting userInfo in ThreadContext ([#5369](https://github.com/opensearch-project/security/pull/5369))
+- Adds details for debugging Security not initialized error([#5370](https://github.com/opensearch-project/security/pull/5370))
 
 ### Dependencies
 - Bump `guava_version` from 33.4.6-jre to 33.4.8-jre ([#5284](https://github.com/opensearch-project/security/pull/5284))

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1143,7 +1143,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         userService = new UserService(cs, cr, passwordHasher, settings, localClient);
 
         final XFFResolver xffResolver = new XFFResolver(threadPool);
-        backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool);
+        backendRegistry = new BackendRegistry(settings, adminDns, xffResolver, auditLog, threadPool, cih);
         backendRegistry.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         tokenManager = new SecurityTokenManager(cs, threadPool, userService);
 
@@ -1181,7 +1181,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             cr.subscribeOnChange(configMap -> { ((DlsFlsValveImpl) dlsFlsValve).updateConfiguration(cr.getConfiguration(CType.ROLES)); });
         }
 
-        sf = new SecurityFilter(settings, evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, compatConfig, irr, xffResolver);
+        sf = new SecurityFilter(settings, evaluator, adminDns, dlsFlsValve, auditLog, threadPool, cs, cih, compatConfig, irr, xffResolver);
 
         final String principalExtractorClass = settings.get(SSLConfigConstants.SECURITY_SSL_TRANSPORT_PRINCIPAL_EXTRACTOR_CLASS, null);
 

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -61,6 +61,7 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auth.blocking.ClientBlockRegistry;
 import org.opensearch.security.auth.internal.NoOpAuthenticationBackend;
 import org.opensearch.security.configuration.AdminDNs;
+import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityRequestChannel;
 import org.opensearch.security.filter.SecurityResponse;
@@ -101,6 +102,7 @@ public class BackendRegistry {
     private final AuditLog auditLog;
     private final ThreadPool threadPool;
     private final UserInjector userInjector;
+    private final ClusterInfoHolder clusterInfoHolder;
     private int ttlInMin;
     private Cache<AuthCredentials, User> userCache; // rest standard
     private Cache<String, User> restImpersonationCache; // used for rest impersonation
@@ -152,13 +154,15 @@ public class BackendRegistry {
         final AdminDNs adminDns,
         final XFFResolver xffResolver,
         final AuditLog auditLog,
-        final ThreadPool threadPool
+        final ThreadPool threadPool,
+        final ClusterInfoHolder clusterInfoHolder
     ) {
         this.adminDns = adminDns;
         this.opensearchSettings = settings;
         this.xffResolver = xffResolver;
         this.auditLog = auditLog;
         this.threadPool = threadPool;
+        this.clusterInfoHolder = clusterInfoHolder;
         this.userInjector = new UserInjector(settings, threadPool, auditLog, xffResolver);
         this.restAuthDomains = Collections.emptySortedSet();
         this.ipAuthFailureListeners = Collections.emptyList();
@@ -275,8 +279,12 @@ public class BackendRegistry {
         }
 
         if (!isInitialized()) {
-            log.error("Not yet initialized (you may need to run securityadmin)");
-            request.queueForSending(new SecurityResponse(SC_SERVICE_UNAVAILABLE, "OpenSearch Security not initialized."));
+            StringBuilder error = new StringBuilder("OpenSearch Security not initialized.");
+            if (!clusterInfoHolder.hasClusterManager()) {
+                error.append(String.format(" %s", ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT));
+            }
+            log.error("{} (you may need to run securityadmin)", error.toString());
+            request.queueForSending(new SecurityResponse(SC_SERVICE_UNAVAILABLE, error.toString()));
             return false;
         }
 

--- a/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
+++ b/src/main/java/org/opensearch/security/configuration/ClusterInfoHolder.java
@@ -36,6 +36,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 
 public class ClusterInfoHolder implements ClusterStateListener {
+    public static final String CLUSTER_MANAGER_NOT_PRESENT = "Cluster manager not present";
 
     protected final Logger log = LogManager.getLogger(this.getClass());
     private volatile DiscoveryNodes nodes = null;
@@ -92,5 +93,12 @@ public class ClusterInfoHolder implements ClusterStateListener {
 
     public String getClusterName() {
         return this.clusterName;
+    }
+
+    public Boolean hasClusterManager() {
+        if (nodes != null) {
+            return nodes.getClusterManagerNode() != null;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -79,6 +79,7 @@ import org.opensearch.security.auth.RolesInjector;
 import org.opensearch.security.auth.UserInjector;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.configuration.AdminDNs;
+import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.configuration.CompatConfig;
 import org.opensearch.security.configuration.DlsFlsRequestValve;
 import org.opensearch.security.http.XFFResolver;
@@ -107,6 +108,7 @@ public class SecurityFilter implements ActionFilter {
     private final AuditLog auditLog;
     private final ThreadContext threadContext;
     private final ClusterService cs;
+    private final ClusterInfoHolder clusterInfoHolder;
     private final CompatConfig compatConfig;
     private final IndexResolverReplacer indexResolverReplacer;
     private final XFFResolver xffResolver;
@@ -122,6 +124,7 @@ public class SecurityFilter implements ActionFilter {
         AuditLog auditLog,
         ThreadPool threadPool,
         ClusterService cs,
+        final ClusterInfoHolder clusterInfoHolder,
         final CompatConfig compatConfig,
         final IndexResolverReplacer indexResolverReplacer,
         final XFFResolver xffResolver
@@ -132,6 +135,7 @@ public class SecurityFilter implements ActionFilter {
         this.auditLog = auditLog;
         this.threadContext = threadPool.getThreadContext();
         this.cs = cs;
+        this.clusterInfoHolder = clusterInfoHolder;
         this.compatConfig = compatConfig;
         this.indexResolverReplacer = indexResolverReplacer;
         this.xffResolver = xffResolver;
@@ -362,10 +366,14 @@ public class SecurityFilter implements ActionFilter {
             final PrivilegesEvaluator eval = evalp;
 
             if (!eval.isInitialized()) {
-                log.error("OpenSearch Security not initialized for {}", action);
-                listener.onFailure(
-                    new OpenSearchSecurityException("OpenSearch Security not initialized for " + action, RestStatus.SERVICE_UNAVAILABLE)
-                );
+                StringBuilder error = new StringBuilder("OpenSearch Security not initialized for ");
+                error.append(action);
+                if (!clusterInfoHolder.hasClusterManager()) {
+                    error.append(String.format(". %s", ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT));
+                }
+
+                log.error(error.toString());
+                listener.onFailure(new OpenSearchSecurityException(error.toString(), RestStatus.SERVICE_UNAVAILABLE));
                 return;
             }
 

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -307,7 +307,11 @@ public class PrivilegesEvaluator {
         Set<String> injectedRoles
     ) {
         if (!isInitialized()) {
-            throw new OpenSearchSecurityException("OpenSearch Security is not initialized.");
+            StringBuilder error = new StringBuilder("OpenSearch Security is not initialized.");
+            if (!clusterInfoHolder.hasClusterManager()) {
+                error.append(String.format(" %s", ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT));
+            }
+            throw new OpenSearchSecurityException(error.toString());
         }
 
         TransportAddress caller = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_REMOTE_ADDRESS);
@@ -319,7 +323,11 @@ public class PrivilegesEvaluator {
     public PrivilegesEvaluatorResponse evaluate(PrivilegesEvaluationContext context) {
 
         if (!isInitialized()) {
-            throw new OpenSearchSecurityException("OpenSearch Security is not initialized.");
+            StringBuilder error = new StringBuilder("OpenSearch Security is not initialized.");
+            if (!clusterInfoHolder.hasClusterManager()) {
+                error.append(String.format(" %s", ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT));
+            }
+            throw new OpenSearchSecurityException(error.toString());
         }
 
         String action0 = context.getAction();

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -273,6 +273,8 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             eventBus.post(audit == null ? defaultAuditConfig : audit);
         }
 
+        log.debug("Dispatched config update notification to different subscribers");
+
         initialized.set(true);
     }
 

--- a/src/test/java/org/opensearch/security/configuration/ClusterInfoHolderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ClusterInfoHolderTest.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.configuration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterChangedEvent;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.node.DiscoveryNodes;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ClusterInfoHolderTest {
+
+    private ClusterInfoHolder clusterInfoHolder;
+
+    @Mock
+    private ClusterChangedEvent mockEvent;
+
+    @Mock
+    private ClusterState mockClusterState;
+
+    @Mock
+    private DiscoveryNodes mockNodes;
+
+    @Mock
+    private DiscoveryNode mockNode;
+
+    private static final String TEST_CLUSTER_NAME = "test-cluster";
+
+    @Before
+    public void setUp() {
+        clusterInfoHolder = new ClusterInfoHolder(TEST_CLUSTER_NAME);
+        when(mockEvent.state()).thenReturn(mockClusterState);
+        when(mockClusterState.nodes()).thenReturn(mockNodes);
+    }
+
+    @Test
+    public void testInitialState() {
+        assertFalse("Should not be initialized initially", clusterInfoHolder.isInitialized());
+        assertNull("Should not have cluster manager status initially", clusterInfoHolder.isLocalNodeElectedClusterManager());
+        assertEquals("Should have correct cluster name", TEST_CLUSTER_NAME, clusterInfoHolder.getClusterName());
+    }
+
+    @Test
+    public void testClusterChanged_NodesChanged() {
+        // Execute
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Verify
+        assertTrue("Should be initialized after nodes change", clusterInfoHolder.isInitialized());
+    }
+
+    @Test
+    public void testClusterChanged_LocalNodeClusterManager() {
+        // Setup
+        when(mockEvent.localNodeClusterManager()).thenReturn(Boolean.TRUE);
+
+        // Execute
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Verify
+        assertTrue("Should be cluster manager", clusterInfoHolder.isLocalNodeElectedClusterManager());
+    }
+
+    @Test
+    public void testClusterChanged_NotLocalNodeClusterManager() {
+        // Setup
+        when(mockEvent.localNodeClusterManager()).thenReturn(false);
+
+        // Execute
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Verify
+        assertFalse("Should not be cluster manager", clusterInfoHolder.isLocalNodeElectedClusterManager());
+    }
+
+    @Test
+    public void testGetMinNodeVersion_WhenNotInitialized() {
+        assertNull("Should return null when not initialized", clusterInfoHolder.getMinNodeVersion());
+    }
+
+    @Test
+    public void testGetMinNodeVersion_WhenInitialized() {
+        // Setup
+        Version expectedVersion = Version.CURRENT;
+        when(mockNodes.getMinNodeVersion()).thenReturn(expectedVersion);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Execute & Verify
+        assertEquals("Should return correct min version", expectedVersion, clusterInfoHolder.getMinNodeVersion());
+    }
+
+    @Test
+    public void testHasNode_WhenNotInitialized() {
+        assertNull("Should return null when not initialized", clusterInfoHolder.hasNode(mockNode));
+    }
+
+    @Test
+    public void testHasNode_WhenNodeExists() {
+        // Setup
+        when(mockNodes.nodeExists(mockNode)).thenReturn(true);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Execute & Verify
+        assertTrue("Should return true when node exists", clusterInfoHolder.hasNode(mockNode));
+    }
+
+    @Test
+    public void testHasNode_WhenNodeDoesNotExist() {
+        // Setup
+        when(mockNodes.nodeExists(mockNode)).thenReturn(false);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Execute & Verify
+        assertFalse("Should return false when node doesn't exist", clusterInfoHolder.hasNode(mockNode));
+    }
+
+    @Test
+    public void testHasClusterManager_WhenNotInitialized() {
+        assertFalse("Should return false when not initialized", clusterInfoHolder.hasClusterManager());
+    }
+
+    @Test
+    public void testHasClusterManager_WhenClusterManagerExists() {
+        // Setup
+        when(mockNodes.getClusterManagerNode()).thenReturn(mockNode);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Execute & Verify
+        assertTrue("Should return true when cluster manager exists", clusterInfoHolder.hasClusterManager());
+    }
+
+    @Test
+    public void testHasClusterManager_WhenNoClusterManager() {
+        // Setup
+        when(mockNodes.getClusterManagerNode()).thenReturn(null);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        // Execute & Verify
+        assertFalse("Should return false when no cluster manager", clusterInfoHolder.hasClusterManager());
+    }
+
+    @Test
+    public void testGetClusterManagerNotPresentStatus() {
+        assertEquals("Should return correct status message", "Cluster manager not present", ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT);
+    }
+
+    @Test
+    public void testMultipleClusterChanges() {
+        // First change
+        when(mockEvent.nodesChanged()).thenReturn(true);
+        when(mockEvent.localNodeClusterManager()).thenReturn(true);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        assertTrue("Should be initialized", clusterInfoHolder.isInitialized());
+        assertTrue("Should be cluster manager", clusterInfoHolder.isLocalNodeElectedClusterManager());
+
+        // Second change
+        when(mockEvent.nodesChanged()).thenReturn(false);
+        when(mockEvent.localNodeClusterManager()).thenReturn(false);
+        clusterInfoHolder.clusterChanged(mockEvent);
+
+        assertTrue("Should still be initialized", clusterInfoHolder.isInitialized());
+        assertFalse("Should not be cluster manager anymore", clusterInfoHolder.isLocalNodeElectedClusterManager());
+    }
+}

--- a/src/test/java/org/opensearch/security/filter/SecurityFilterTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityFilterTests.java
@@ -26,6 +26,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.AdminDNs;
+import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.configuration.CompatConfig;
 import org.opensearch.security.configuration.DlsFlsRequestValve;
 import org.opensearch.security.http.XFFResolver;
@@ -84,6 +85,7 @@ public class SecurityFilterTests {
             mock(AuditLog.class),
             mock(ThreadPool.class),
             mock(ClusterService.class),
+            mock(ClusterInfoHolder.class),
             mock(CompatConfig.class),
             mock(IndexResolverReplacer.class),
             mock(XFFResolver.class)
@@ -107,6 +109,7 @@ public class SecurityFilterTests {
             auditLog,
             new ThreadPool(Settings.builder().put("node.name", "mock").build()),
             mock(ClusterService.class),
+            mock(ClusterInfoHolder.class),
             mock(CompatConfig.class),
             mock(IndexResolverReplacer.class),
             mock(XFFResolver.class)

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -218,7 +218,6 @@ public class PrivilegesEvaluatorUnitTest {
         assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized."));
 
         when(clusterInfoHolder.hasClusterManager()).thenReturn(false);
-        when(ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT).thenReturn("Cluster manager not present");
         exception = assertThrows(
                 OpenSearchSecurityException.class,
                 () -> privilegesEvaluator.evaluate(null)

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -9,17 +9,39 @@
 package org.opensearch.security.privileges;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.configuration.ClusterInfoHolder;
+import org.opensearch.security.configuration.ConfigurationRepository;
+import org.opensearch.security.resolver.IndexResolverReplacer;
+import org.opensearch.threadpool.ThreadPool;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.privileges.PrivilegesEvaluator.DNFOF_MATCHER;
 import static org.opensearch.security.privileges.PrivilegesEvaluator.isClusterPerm;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class PrivilegesEvaluatorUnitTest {
 
     private static final List<String> allowedDnfof = ImmutableList.of(
@@ -97,6 +119,63 @@ public class PrivilegesEvaluatorUnitTest {
         "indices:monitor/upgrade"
     );
 
+    @Mock
+    private ClusterService clusterService;
+
+    @Mock
+    private ThreadPool threadPool;
+
+    @Mock
+    private ConfigurationRepository configurationRepository;
+
+    @Mock
+    private IndexNameExpressionResolver resolver;
+
+    @Mock
+    private AuditLog auditLog;
+
+    @Mock
+    private PrivilegesInterceptor privilegesInterceptor;
+
+    @Mock
+    private ClusterInfoHolder clusterInfoHolder;
+
+    @Mock
+    private IndexResolverReplacer irr;
+
+    @Mock
+    private NamedXContentRegistry namedXContentRegistry;
+
+    @Mock
+    private ClusterState clusterState;
+
+    private Settings settings;
+    private Supplier<ClusterState> clusterStateSupplier;
+    private ThreadContext threadContext;
+    private PrivilegesEvaluator privilegesEvaluator;
+
+    @Before
+    public void setUp() {
+        settings = Settings.builder().build();
+        clusterStateSupplier = () -> clusterState;
+        threadContext = new ThreadContext(Settings.EMPTY);
+
+        privilegesEvaluator = new PrivilegesEvaluator(
+            clusterService,
+            clusterStateSupplier,
+            threadPool,
+            threadContext,
+            configurationRepository,
+            resolver,
+            auditLog,
+            settings,
+            privilegesInterceptor,
+            clusterInfoHolder,
+            irr,
+            namedXContentRegistry
+        );
+    }
+
     @Test
     public void testClusterPerm() {
         String multiSearchTemplate = "indices:data/read/msearch/template";
@@ -127,5 +206,23 @@ public class PrivilegesEvaluatorUnitTest {
         for (final String permission : allowedDnfof) {
             assertThat(DNFOF_MATCHER.test(permission), equalTo(true));
         }
+    }
+
+    @Test
+    public void testEvaluate_NotInitialized_ExceptionThrown() {
+        when(clusterInfoHolder.hasClusterManager()).thenReturn(true);
+        OpenSearchSecurityException exception = assertThrows(
+                OpenSearchSecurityException.class,
+                () -> privilegesEvaluator.evaluate(null)
+        );
+        assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized."));
+
+        when(clusterInfoHolder.hasClusterManager()).thenReturn(false);
+        when(ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT).thenReturn("Cluster manager not present");
+        exception = assertThrows(
+                OpenSearchSecurityException.class,
+                () -> privilegesEvaluator.evaluate(null)
+        );
+        assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized. Cluster manager not present"));
     }
 }

--- a/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
@@ -115,7 +115,6 @@ public class RestLayerPrivilegesEvaluatorTest {
         assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized."));
 
         when(clusterInfoHolder.hasClusterManager()).thenReturn(false);
-        when(ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT).thenReturn("Cluster manager not present");
         exception = assertThrows(OpenSearchSecurityException.class, () -> restPrivilegesEvaluator.evaluate(TEST_USER, "route_name", null));
         assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized. Cluster manager not present"));
     }

--- a/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
@@ -32,6 +32,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.auditlog.NullAuditLog;
+import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.securityconf.ConfigModel;
 import org.opensearch.security.securityconf.DynamicConfigModel;
 import org.opensearch.security.securityconf.impl.CType;
@@ -59,6 +60,8 @@ public class RestLayerPrivilegesEvaluatorTest {
     private ConfigModel configModel;
     @Mock
     private DynamicConfigModel dynamicConfigModel;
+    @Mock
+    private ClusterInfoHolder clusterInfoHolder;
 
     private static final User TEST_USER = new User("test_user");
 
@@ -104,11 +107,17 @@ public class RestLayerPrivilegesEvaluatorTest {
     public void testEvaluate_NotInitialized_NullModel_ExceptionThrown() {
         PrivilegesEvaluator privilegesEvaluator = createPrivilegesEvaluator(null);
         RestLayerPrivilegesEvaluator restPrivilegesEvaluator = new RestLayerPrivilegesEvaluator(privilegesEvaluator);
-        final OpenSearchSecurityException exception = assertThrows(
+        when(clusterInfoHolder.hasClusterManager()).thenReturn(true);
+        OpenSearchSecurityException exception = assertThrows(
             OpenSearchSecurityException.class,
             () -> restPrivilegesEvaluator.evaluate(TEST_USER, "route_name", null)
         );
         assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized."));
+
+        when(clusterInfoHolder.hasClusterManager()).thenReturn(false);
+        when(ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT).thenReturn("Cluster manager not present");
+        exception = assertThrows(OpenSearchSecurityException.class, () -> restPrivilegesEvaluator.evaluate(TEST_USER, "route_name", null));
+        assertThat(exception.getMessage(), equalTo("OpenSearch Security is not initialized. Cluster manager not present"));
     }
 
     @Test
@@ -158,7 +167,7 @@ public class RestLayerPrivilegesEvaluatorTest {
             new NullAuditLog(),
             Settings.EMPTY,
             null,
-            null,
+            clusterInfoHolder,
             null,
             null
         );


### PR DESCRIPTION
### Description

If security index is not created during node bootup and if any API call is made we receive generic error `OpenSearch Security is not initialized`. Security index may not be created for various number of reasons but commonly seen due to master not initialized. To ease the debugging and fixing the issue, adding more details to error statement and possible cause will help. This PR starts with one of the possible cause, it can be extended in future appropriately

Future adding few debug lines to ease debugging during issues

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved
Easing debugging and fixing error 

### Testing
To minic the scenario added this setting in opensearch.yml `node.roles: [data, ingest]` to have no master node. Then made API calls to reproduce the error

```
curl -X GET "https://localhost:9200/my-index-000001/_search?pretty"  -H 'Content-Type: application/json' -u '<>:<>' --insecure

OpenSearch Security is not initialized. Cluster manager not present
```

**Earlier**
```
curl -X GET "https://localhost:9200/my-index-000001/_search?pretty"  -H 'Content-Type: application/json' -u '<>:<>' --insecure

OpenSearch Security is not initialized
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
