### PR TITLE
Integrate search-relevance functionalities with security plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Github workflow for changelog verification ([#5318](https://github.com/opensearch-project/security/pull/5318))
 - Register cluster settings listener for `plugins.security.cache.ttl_minutes` ([#5324](https://github.com/opensearch-project/security/pull/5324))
 - Add flush cache endpoint for individual user ([#5337](https://github.com/opensearch-project/security/pull/5337))
+- Integrate search-relevance functionalities with security plugin ([#5376](https://github.com/opensearch-project/security/pull/5376))
 
 ### Changed
 - Use extendedPlugins in integrationTest framework for sample resource plugin testing ([#5322](https://github.com/opensearch-project/security/pull/5322))

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -471,3 +471,24 @@ ltr_full_access:
     reserved: true
     cluster_permissions:
       - cluster:admin/ltr/*
+
+# Allow users to use all Search Relevance functionalities
+search_relevance_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/search_relevance/*'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/mappings/get'
+        - 'indices:data/read/search*'
+
+# Allow users to read Search Relevance resources
+search_relevance_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/opensearch/search_relevance/experiment/get'
+    - 'cluster:admin/opensearch/search_relevance/judgment/get'
+    - 'cluster:admin/opensearch/search_relevance/queryset/get'
+    - 'cluster:admin/opensearch/search_relevance/search_configuration/get'

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -74,7 +74,9 @@ public class SecuritySettingsConfigurer {
         ".geospatial-ip2geo-data*",
         ".plugins-flow-framework-config",
         ".plugins-flow-framework-templates",
-        ".plugins-flow-framework-state"
+        ".plugins-flow-framework-state",
+        ".plugins-search-relevance-experiment",
+        ".plugins-search-relevance-judgment-cache"
     );
     static final Integer DEFAULT_PASSWORD_MIN_LENGTH = 8;
     static String ADMIN_PASSWORD = "";


### PR DESCRIPTION
### Description
Adds search-relevance related roles to the plugin: 
 - read only
 - full access.

Adds search-relevance system indices to demo scripts:
- `.plugins-search-relevance-experiment`
- `.plugins-search-relevance-judgment-cache`

### Issues Resolved
This is a new feature for 3.1 release, no backfort

### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
