### PR TITLE
Add forecast roles and permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Add flush cache endpoint for individual user ([#5337](https://github.com/opensearch-project/security/pull/5337))
 - Handle roles in nested claim for JWT auth backends ([#5355](https://github.com/opensearch-project/security/pull/5355))
 - Integrate search-relevance functionalities with security plugin ([#5376](https://github.com/opensearch-project/security/pull/5376))
+- Add forecast roles and permissions ([#5386](https://github.com/opensearch-project/security/pull/5386))
 
 ### Changed
 - Use extendedPlugins in integrationTest framework for sample resource plugin testing ([#5322](https://github.com/opensearch-project/security/pull/5322))

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -460,17 +460,17 @@ query_insights_full_access:
 
 # Allow users to execute read only LTR actions
 ltr_read_access:
-    reserved: true
-    cluster_permissions:
-      - cluster:admin/ltr/caches/stats
-      - cluster:admin/ltr/featurestore/list
-      - cluster:admin/ltr/stats
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/caches/stats
+    - cluster:admin/ltr/featurestore/list
+    - cluster:admin/ltr/stats
 
 # Allow users to execute all LTR actions
 ltr_full_access:
-    reserved: true
-    cluster_permissions:
-      - cluster:admin/ltr/*
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/*
 
 # Allow users to use all Search Relevance functionalities
 search_relevance_full_access:
@@ -492,3 +492,45 @@ search_relevance_read_access:
     - 'cluster:admin/opensearch/search_relevance/judgment/get'
     - 'cluster:admin/opensearch/search_relevance/queryset/get'
     - 'cluster:admin/opensearch/search_relevance/search_configuration/get'
+
+# Allow users to read Forecast resources
+forecast_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/forecaster/info'
+    - 'cluster:admin/plugin/forecast/forecaster/stats'
+    - 'cluster:admin/plugin/forecast/forecaster/suggest'
+    - 'cluster:admin/plugin/forecast/forecaster/validate'
+    - 'cluster:admin/plugin/forecast/forecasters/get'
+    - 'cluster:admin/plugin/forecast/forecasters/info'
+    - 'cluster:admin/plugin/forecast/forecasters/search'
+    - 'cluster:admin/plugin/forecast/result/topForecasts'
+    - 'cluster:admin/plugin/forecast/tasks/search'
+  index_permissions:
+    - index_patterns:
+        - 'opensearch-forecast-result*'
+      allowed_actions:
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+
+# Allows users to use all Forecasting functionality
+forecast_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/*'
+    - 'cluster:admin/settings/update'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mapping/get'
+        - 'indices:admin/mapping/put'
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+        - 'indices:data/read/field_caps*'
+        - 'indices:data/read/search'
+        - 'indices:data/write*'
+        - 'indices_monitor'


### PR DESCRIPTION
### Description
Add forecast roles and indices; format roles.yml

* Added `forecast_read_access` and `forecast_full_access` roles in `config/roles.yml` to support the forecasting feature.
* Registered forecasting system indices within the AD plugin: [TimeSeriesAnalyticsPlugin.java](https://github.com/opensearch-project/anomaly-detection/blob/main/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java#L1722)](https://github.com/opensearch-project/anomaly-detection/blob/main/src/main/java/org/opensearch/timeseries/TimeSeriesAnalyticsPlugin.java#L1722).
* Formatted `config/roles.yml` using `check-permissions-order.js` to satisfy code hygiene CI requirements; this formatting affected the `ltr` role but did not change any actual content


Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
Not a backport.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
Yes, https://github.com/opensearch-project/security-dashboards-plugin/pull/2253

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
