### PR TITLE
[Backport 2.19] Only log Invalid Authorization header when HTTP Basic auth challenge is called (#5377)

### DIFF
--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -76,6 +76,7 @@ import org.greenrobot.eventbus.Subscribe;
 import static org.apache.http.HttpStatus.SC_FORBIDDEN;
 import static org.apache.http.HttpStatus.SC_SERVICE_UNAVAILABLE;
 import static org.apache.http.HttpStatus.SC_UNAUTHORIZED;
+import static org.opensearch.security.http.HTTPBasicAuthenticator.BASIC_TYPE;
 import static com.amazon.dlic.auth.http.saml.HTTPSamlAuthenticator.SAML_TYPE;
 
 public class BackendRegistry {
@@ -311,8 +312,8 @@ public class BackendRegistry {
                         if (!authDomain.getHttpAuthenticator().getType().equals(SAML_TYPE)) {
                             auditLog.logFailedLogin("<NONE>", false, null, request);
                         }
-                        if (isTraceEnabled) {
-                            log.trace("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                        if (authDomain.getHttpAuthenticator().getType().equals(BASIC_TYPE)) {
+                            log.warn("No 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                         }
                         notifyIpAuthFailureListeners(request, authCredentials);
                         request.queueForSending(restResponse.get());

--- a/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/HTTPBasicAuthenticator.java
@@ -47,6 +47,8 @@ public class HTTPBasicAuthenticator implements HTTPAuthenticator {
 
     protected final Logger log = LogManager.getLogger(this.getClass());
 
+    public static final String BASIC_TYPE = "basic";
+
     public HTTPBasicAuthenticator(final Settings settings, final Path configPath) {
 
     }
@@ -78,6 +80,6 @@ public class HTTPBasicAuthenticator implements HTTPAuthenticator {
 
     @Override
     public String getType() {
-        return "basic";
+        return BASIC_TYPE;
     }
 }

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -39,10 +39,8 @@ import org.opensearch.security.user.AuthCredentials;
 public class HTTPHelper {
 
     public static AuthCredentials extractCredentials(String authorizationHeader, Logger log) {
-
         if (authorizationHeader != null) {
             if (!authorizationHeader.trim().toLowerCase().startsWith("basic ")) {
-                log.warn("No 'Basic Authorization' header, send 401 and 'WWW-Authenticate Basic'");
                 return null;
             } else {
 
@@ -75,7 +73,7 @@ public class HTTPHelper {
                 }
 
                 if (username == null || password == null) {
-                    log.warn("Invalid 'Authorization' header, send 401 and 'WWW-Authenticate Basic'");
+                    log.warn("Invalid 'Authorization' header for HTTP Basic auth");
                     return null;
                 } else {
                     return new AuthCredentials(username, password.getBytes(StandardCharsets.UTF_8)).markComplete();


### PR DESCRIPTION
(cherry picked from commit 9e6047f99da4df3404e2d52f3afe4e49e508c3a5)

Backport of #5377 to 2.19.