### PR TITLE
add missing cluster:monitor permission

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -520,6 +520,7 @@ forecast_full_access:
   cluster_permissions:
     - 'cluster:admin/plugin/forecast/*'
     - 'cluster:admin/settings/update'
+    - 'cluster_monitor'
   index_permissions:
     - index_patterns:
         - '*'

--- a/release-notes/opensearch-security.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-security.release-notes-3.1.0.0.md
@@ -19,6 +19,7 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.1.0
 * Include mapped roles when setting userInfo in ThreadContext ([#5369](https://github.com/opensearch-project/security/pull/5369))
 * Adds details for debugging Security not initialized error([#5370](https://github.com/opensearch-project/security/pull/5370))
 * [Resource Sharing] Store resource sharing info in indices that map 1-to-1 with resource index ([#5358](https://github.com/opensearch-project/security/pull/5358))
+* add missing cluster:monitor permission ([#5405](https://github.com/opensearch-project/security/pull/5405))
 
 ### Removed
 * Removed unused support for custom User object serialization ([#5339](https://github.com/opensearch-project/security/pull/5339))


### PR DESCRIPTION
### Description
* adds required permission for creating a cross-cluster forecaster

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
No.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
No, it doesn't.

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
