### PR TITLE
[Resource Sharing] Adds a Resource Access Evaluator for standalone Resource access authorization

### DIFF
--- a/sample-resource-plugin/README.md
+++ b/sample-resource-plugin/README.md
@@ -10,11 +10,6 @@ Publish SPI to local maven before proceeding:
 ./gradlew clean :opensearch-security-spi:publishToMavenLocal
 ```
 
-System index feature must be enabled to prevent direct access to resource. Add the following setting in case it has not already been enabled.
-```yml
-plugins.security.system_indices.enabled: true
-```
-
 ## Features
 
 - Create, update, get, delete SampleResource, as well as share and revoke access to a resource.
@@ -58,12 +53,12 @@ plugins.security.system_indices.enabled: true
 
 4. **Interaction Rules**
     - If a **user is not the resource owner**, they must:
-        - Be assigned **a role with `sample_read_access`** permissions.
-        - **Have the resource shared with them** via the resource-sharing API.
+        - **Have the resource shared with them** via the resource-sharing API with appropriate action group.
     - A user **without** the necessary `sample-resource-plugin` cluster permissions:
         - **Cannot access the resource**, even if it is shared with them.
     - A user **with `sample-resource-plugin` permissions** but **without a shared resource**:
         - **Cannot access the resource**, since resource-level access control applies.
+    - Only resource-owners and super-admin can update the delete the resource.
 
 
 ## API Endpoints
@@ -104,7 +99,7 @@ The plugin exposes the following six API endpoints:
 
 ### 3. Delete Resource
 - **Endpoint:** `DELETE /_plugins/sample_resource_sharing/delete/{resource_id}`
-- **Description:** Deletes a specified resource owned by the requesting user.
+- **Description:** Deletes a specified resource owned by the requesting user. At present, only super-admins and resource-owner can delete the resource.
 - **Response:**
   ```json
   {
@@ -140,12 +135,14 @@ The plugin exposes the following six API endpoints:
 
 ### 5. Share Resource
 - **Endpoint:** `POST /_plugins/sample_resource_sharing/share/{resource_id}`
-- **Description:** Shares a resource with the intended entities. At present, only admin and resource owners can share the resource.
+- **Description:** Shares a resource with the intended entities. At present, only super-admins and resource-owner can share the resource.
 - **Request Body:**
   ```json
   {
     "share_with": {
-      "users": [ "sample_user" ]
+      "read_only": {
+        "users": [ "sample_user" ]
+      }
     }
   }
   ```
@@ -153,7 +150,7 @@ The plugin exposes the following six API endpoints:
   ```json
     {
       "share_with": {
-        "default": {
+        "read_only": {
           "users": [ "sample_user" ]
         }
       }
@@ -162,19 +159,25 @@ The plugin exposes the following six API endpoints:
 
 ### 6. Revoke Resource Access
 - **Endpoint:** `POST /_plugins/sample_resource_sharing/revoke/{resource_id}`
-- **Description:** Shares a resource with the intended entities. At present, only admin and resource owners can share the resource.
+- **Description:** Shares a resource with the intended entities. At present, only super-admins and resource-owner can revoke access to the resource.
 - **Request Body:**
   ```json
     {
       "entities_to_revoke": {
-        "users": [ "sample_user" ]
+        "read_only": {
+          "users": [ "sample_user" ]
+        }
       }
     }
   ```
 - **Response:**
   ```json
     {
-      "share_with" : { }
+      "share_with" : {
+        "read_only": {
+          "users" : [ ]
+        }
+      }
     }
   ```
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginFeatureDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginFeatureDisabledTests.java
@@ -34,6 +34,7 @@ import static org.opensearch.sample.SampleResourcePluginTestHelper.SAMPLE_RESOUR
 import static org.opensearch.sample.SampleResourcePluginTestHelper.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.SampleResourcePluginTestHelper.SHARED_WITH_USER;
 import static org.opensearch.sample.SampleResourcePluginTestHelper.revokeAccessPayload;
+import static org.opensearch.sample.SampleResourcePluginTestHelper.sampleReadOnlyAG;
 import static org.opensearch.sample.SampleResourcePluginTestHelper.shareWithPayload;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.security.resources.ResourceSharingIndexHandler.getSharingIndex;
@@ -76,7 +77,7 @@ public class SampleResourcePluginFeatureDisabledTests {
     }
 
     @Test
-    public void testNoResourceRestrictions() throws Exception {
+    public void testNoResourceRestrictions() {
         String resourceId;
         // create sample resource
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
@@ -133,7 +134,7 @@ public class SampleResourcePluginFeatureDisabledTests {
         try (TestRestClient client = cluster.getRestClient(SHARED_WITH_USER)) {
             HttpResponse updateResponse = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
-                shareWithPayload(SHARED_WITH_USER.getName())
+                shareWithPayload(SHARED_WITH_USER.getName(), sampleReadOnlyAG.name())
             );
             updateResponse.assertStatusCode(HttpStatus.SC_BAD_REQUEST);
         }
@@ -142,7 +143,7 @@ public class SampleResourcePluginFeatureDisabledTests {
         try (TestRestClient client = cluster.getRestClient(SHARED_WITH_USER)) {
             HttpResponse updateResponse = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
-                revokeAccessPayload(SHARED_WITH_USER.getName())
+                revokeAccessPayload(SHARED_WITH_USER.getName(), sampleReadOnlyAG.name())
             );
             updateResponse.assertStatusCode(HttpStatus.SC_BAD_REQUEST);
         }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginSecurityDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginSecurityDisabledTests.java
@@ -84,10 +84,16 @@ public class SampleResourcePluginSecurityDisabledTests extends SampleResourcePlu
             response = client.postJson(SAMPLE_RESOURCE_UPDATE_ENDPOINT + "/" + resourceId, sampleResourceUpdated);
             response.assertStatusCode(HttpStatus.SC_OK);
 
-            response = client.postJson(SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId, shareWithPayload(USER_ADMIN.getName()));
+            response = client.postJson(
+                SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
+                shareWithPayload(USER_ADMIN.getName(), sampleReadOnlyAG.name())
+            );
             assertNotImplementedResponse(response);
 
-            response = client.postJson(SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId, revokeAccessPayload(USER_ADMIN.getName()));
+            response = client.postJson(
+                SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
+                revokeAccessPayload(USER_ADMIN.getName(), sampleReadOnlyAG.name())
+            );
             assertNotImplementedResponse(response);
 
             response = client.delete(SAMPLE_RESOURCE_DELETE_ENDPOINT + "/" + resourceId);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginTestHelper.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/SampleResourcePluginTestHelper.java
@@ -27,12 +27,24 @@ public abstract class SampleResourcePluginTestHelper {
         "resource_sharing_test_user_limited_perms"
     ).roles(
         new TestSecurityConfig.Role("shared_role_limited_perms").clusterPermissions(
-            "cluster:admin/security/resource_access/*",
             "cluster:admin/sample-resource-plugin/get",
             "cluster:admin/sample-resource-plugin/create",
             "cluster:admin/sample-resource-plugin/share",
             "cluster:admin/sample-resource-plugin/revoke"
         )
+    );
+
+    protected static final TestSecurityConfig.ActionGroup sampleReadOnlyAG = new TestSecurityConfig.ActionGroup(
+        "sample_plugin_index_read_access",
+        TestSecurityConfig.ActionGroup.Type.INDEX,
+        "indices:data/read*",
+        "cluster:admin/sample-resource-plugin/get"
+    );
+    protected static final TestSecurityConfig.ActionGroup sampleAllAG = new TestSecurityConfig.ActionGroup(
+        "sample_plugin_index_all_access",
+        TestSecurityConfig.ActionGroup.Type.INDEX,
+        "indices:*",
+        "cluster:admin/sample-resource-plugin/*"
     );
 
     protected static final String SAMPLE_RESOURCE_CREATE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/create";
@@ -42,24 +54,28 @@ public abstract class SampleResourcePluginTestHelper {
     protected static final String SAMPLE_RESOURCE_SHARE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/share";
     protected static final String SAMPLE_RESOURCE_REVOKE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/revoke";
 
-    protected static String shareWithPayload(String user) {
+    protected static String shareWithPayload(String user, String accessLevel) {
         return """
             {
               "share_with": {
-                "users": ["%s"]
+                "%s" : {
+                    "users": ["%s"]
+                }
               }
             }
-            """.formatted(user);
+            """.formatted(accessLevel, user);
     }
 
-    protected static String revokeAccessPayload(String user) {
+    protected static String revokeAccessPayload(String user, String accessLevel) {
         return """
             {
               "entities_to_revoke": {
-                "users": ["%s"]
+                "%s" : {
+                    "users": ["%s"]
+                }
               }
             }
-            """.formatted(user);
+            """.formatted(accessLevel, user);
 
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/CreateResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/CreateResourceRequest.java
@@ -12,14 +12,17 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.sample.SampleResource;
 
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
 /**
  * Request object for CreateSampleResource transport action
  */
-public class CreateResourceRequest extends ActionRequest {
+public class CreateResourceRequest extends ActionRequest implements DocRequest {
 
     private final SampleResource resource;
 
@@ -46,5 +49,15 @@ public class CreateResourceRequest extends ActionRequest {
 
     public SampleResource getResource() {
         return this.resource;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return null;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/UpdateResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/UpdateResourceRequest.java
@@ -12,14 +12,17 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.sample.SampleResource;
 
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
 /**
  * Request object for UpdateResource transport action
  */
-public class UpdateResourceRequest extends ActionRequest {
+public class UpdateResourceRequest extends ActionRequest implements DocRequest {
 
     private final String resourceId;
     private final SampleResource resource;
@@ -54,5 +57,15 @@ public class UpdateResourceRequest extends ActionRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return resourceId;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/delete/DeleteResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/delete/DeleteResourceRequest.java
@@ -12,13 +12,16 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
 /**
  * Request object for DeleteSampleResource transport action
  */
-public class DeleteResourceRequest extends ActionRequest {
+public class DeleteResourceRequest extends ActionRequest implements DocRequest {
 
     private final String resourceId;
 
@@ -45,5 +48,15 @@ public class DeleteResourceRequest extends ActionRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return resourceId;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/get/GetResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/get/GetResourceRequest.java
@@ -12,13 +12,16 @@ import java.io.IOException;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
+
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
 /**
  * Request object for GetSampleResource transport action
  */
-public class GetResourceRequest extends ActionRequest {
+public class GetResourceRequest extends ActionRequest implements DocRequest {
 
     private final String resourceId;
 
@@ -45,5 +48,15 @@ public class GetResourceRequest extends ActionRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return resourceId;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
@@ -14,14 +14,17 @@ import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.security.spi.resources.sharing.Recipient;
 
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
 /**
  * Request object for revoking access to a sample resource
  */
-public class RevokeResourceAccessRequest extends ActionRequest {
+public class RevokeResourceAccessRequest extends ActionRequest implements DocRequest {
 
     String resourceId;
     Map<Recipient, Set<String>> entitiesToRevoke;
@@ -57,5 +60,15 @@ public class RevokeResourceAccessRequest extends ActionRequest {
 
     public Map<Recipient, Set<String>> getEntitiesToRevoke() {
         return entitiesToRevoke;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return resourceId;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
@@ -9,15 +9,13 @@
 package org.opensearch.sample.resource.actions.rest.revoke;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
@@ -27,26 +25,22 @@ import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 public class RevokeResourceAccessRequest extends ActionRequest implements DocRequest {
 
     String resourceId;
-    Map<Recipient, Set<String>> entitiesToRevoke;
+    ShareWith revokeAccess;
 
-    public RevokeResourceAccessRequest(String resourceId, Map<Recipient, Set<String>> entitiesToRevoke) {
+    public RevokeResourceAccessRequest(String resourceId, ShareWith entitiesToRevoke) {
         this.resourceId = resourceId;
-        this.entitiesToRevoke = entitiesToRevoke;
+        this.revokeAccess = entitiesToRevoke;
     }
 
     public RevokeResourceAccessRequest(StreamInput in) throws IOException {
         resourceId = in.readString();
-        entitiesToRevoke = in.readMap(key -> key.readEnum(Recipient.class), input -> input.readSet(StreamInput::readString));
+        revokeAccess = new ShareWith(in);
     }
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeString(resourceId);
-        out.writeMap(
-            entitiesToRevoke,
-            StreamOutput::writeEnum,
-            (streamOutput, strings) -> streamOutput.writeCollection(strings, StreamOutput::writeString)
-        );
+        revokeAccess.writeTo(out);
     }
 
     @Override
@@ -58,8 +52,8 @@ public class RevokeResourceAccessRequest extends ActionRequest implements DocReq
         return resourceId;
     }
 
-    public Map<Recipient, Set<String>> getEntitiesToRevoke() {
-        return entitiesToRevoke;
+    public ShareWith getEntitiesToRevoke() {
+        return revokeAccess;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
@@ -14,14 +14,17 @@ import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.security.spi.resources.sharing.Recipient;
 
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
 /**
  * Request object for sharing sample resource transport action
  */
-public class ShareResourceRequest extends ActionRequest {
+public class ShareResourceRequest extends ActionRequest implements DocRequest {
 
     private final String resourceId;
 
@@ -58,5 +61,15 @@ public class ShareResourceRequest extends ActionRequest {
 
     public Map<Recipient, Set<String>> getRecipients() {
         return recipients;
+    }
+
+    @Override
+    public String index() {
+        return RESOURCE_INDEX_NAME;
+    }
+
+    @Override
+    public String id() {
+        return resourceId;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
@@ -9,15 +9,13 @@
 package org.opensearch.sample.resource.actions.rest.share;
 
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.DocRequest;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
-import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
@@ -28,26 +26,22 @@ public class ShareResourceRequest extends ActionRequest implements DocRequest {
 
     private final String resourceId;
 
-    private final Map<Recipient, Set<String>> recipients;
+    private final ShareWith shareWithRecipients;
 
-    public ShareResourceRequest(String resourceId, Map<Recipient, Set<String>> recipients) {
+    public ShareResourceRequest(String resourceId, ShareWith shareWithRecipients) {
         this.resourceId = resourceId;
-        this.recipients = recipients;
+        this.shareWithRecipients = shareWithRecipients;
     }
 
     public ShareResourceRequest(StreamInput in) throws IOException {
         this.resourceId = in.readString();
-        this.recipients = in.readMap(key -> key.readEnum(Recipient.class), input -> input.readSet(StreamInput::readString));
+        this.shareWithRecipients = new ShareWith(in);
     }
 
     @Override
     public void writeTo(final StreamOutput out) throws IOException {
         out.writeString(this.resourceId);
-        out.writeMap(
-            recipients,
-            StreamOutput::writeEnum,
-            (streamOutput, strings) -> streamOutput.writeCollection(strings, StreamOutput::writeString)
-        );
+        shareWithRecipients.writeTo(out);
     }
 
     @Override
@@ -59,8 +53,8 @@ public class ShareResourceRequest extends ActionRequest implements DocRequest {
         return this.resourceId;
     }
 
-    public Map<Recipient, Set<String>> getRecipients() {
-        return recipients;
+    public ShareWith getShareWith() {
+        return shareWithRecipients;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/RevokeResourceAccessTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/RevokeResourceAccessTransportAction.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.sample.resource.actions.transport;
 
-import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,13 +20,11 @@ import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessRe
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessResponse;
 import org.opensearch.sample.resource.client.ResourceSharingClientAccessor;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
-import org.opensearch.security.spi.resources.sharing.Recipients;
 import org.opensearch.security.spi.resources.sharing.ShareWith;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
-import static org.opensearch.security.spi.resources.ResourceAccessLevels.PLACE_HOLDER;
 
 /**
  * Transport action for revoking resource access.
@@ -44,7 +40,7 @@ public class RevokeResourceAccessTransportAction extends HandledTransportAction<
     @Override
     protected void doExecute(Task task, RevokeResourceAccessRequest request, ActionListener<RevokeResourceAccessResponse> listener) {
         ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
-        ShareWith target = new ShareWith(Map.of(PLACE_HOLDER, new Recipients(request.getEntitiesToRevoke())));
+        ShareWith target = request.getEntitiesToRevoke();
         resourceSharingClient.revoke(request.getResourceId(), RESOURCE_INDEX_NAME, target, ActionListener.wrap(success -> {
             RevokeResourceAccessResponse response = new RevokeResourceAccessResponse(success.getShareWith());
             log.debug("Revoked resource access: {}", response.toString());

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/ShareResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/ShareResourceTransportAction.java
@@ -8,8 +8,6 @@
 
 package org.opensearch.sample.resource.actions.transport;
 
-import java.util.Map;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,13 +20,11 @@ import org.opensearch.sample.resource.actions.rest.share.ShareResourceRequest;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceResponse;
 import org.opensearch.sample.resource.client.ResourceSharingClientAccessor;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
-import org.opensearch.security.spi.resources.sharing.Recipients;
 import org.opensearch.security.spi.resources.sharing.ShareWith;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
-import static org.opensearch.security.spi.resources.ResourceAccessLevels.PLACE_HOLDER;
 
 /**
  * Transport action implementation for sharing a resource.
@@ -49,7 +45,7 @@ public class ShareResourceTransportAction extends HandledTransportAction<ShareRe
         }
 
         ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
-        ShareWith shareWith = new ShareWith(Map.of(PLACE_HOLDER, new Recipients(request.getRecipients())));
+        ShareWith shareWith = request.getShareWith();
         resourceSharingClient.share(request.getResourceId(), RESOURCE_INDEX_NAME, shareWith, ActionListener.wrap(sharing -> {
             ShareResourceResponse response = new ShareResourceResponse(sharing.getShareWith());
             log.debug("Shared resource: {}", response.toString());

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
@@ -9,10 +9,14 @@
 package org.opensearch.security.spi.resources.sharing;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import org.opensearch.core.common.io.stream.NamedWriteable;
 import org.opensearch.core.common.io.stream.StreamOutput;
@@ -36,6 +40,7 @@ import org.opensearch.core.xcontent.XContentParser;
  * @see org.opensearch.security.spi.resources.sharing.ShareWith
  */
 public class ResourceSharing implements ToXContentFragment, NamedWriteable {
+    private final Logger log = LogManager.getLogger(this.getClass());
 
     /**
      * The unique identifier of the resource and the resource sharing entry
@@ -77,18 +82,34 @@ public class ResourceSharing implements ToXContentFragment, NamedWriteable {
     public void share(String accessLevel, Recipients target) {
         if (shareWith == null) {
             shareWith = new ShareWith(Map.of(accessLevel, target));
+            return;
+        }
+        Recipients sharedWith = shareWith.atAccessLevel(accessLevel);
+        // sharedWith will be null when sharing at a new access-level
+        if (sharedWith == null) {
+            // update the ShareWith object
+            shareWith = shareWith.updateSharingInfo(accessLevel, target);
         } else {
-            Recipients sharedWith = shareWith.atAccessLevel(accessLevel);
             sharedWith.share(target);
         }
     }
 
     public void revoke(String accessLevel, Recipients target) {
         if (shareWith == null) {
-            // TODO log a warning that this is a noop
+            log.warn("Cannot revoke access as resource {} is not shared with anyone", this.resourceId);
             return;
+        }
+
+        Recipients sharedWith = shareWith.atAccessLevel(accessLevel);
+        // sharedWith will only be null if given access level doesn't exist in which case we log a warning message
+        if (sharedWith == null) {
+            log.warn(
+                "Cannot revoke access to {} for {} as the resource is not shared at accessLevel {}",
+                this.resourceId,
+                accessLevel,
+                target
+            );
         } else {
-            Recipients sharedWith = shareWith.atAccessLevel(accessLevel);
             sharedWith.revoke(target);
         }
     }
@@ -225,6 +246,9 @@ public class ResourceSharing implements ToXContentFragment, NamedWriteable {
      * @return set of access-levels which contain given nay of the targets
      */
     public Set<String> fetchAccessLevels(Recipient recipientType, Set<String> entities) {
+        if (shareWith == null) {
+            return Collections.emptySet();
+        }
         Set<String> matchingGroups = new HashSet<>();
         for (Map.Entry<String, Recipients> entry : shareWith.getSharingInfo().entrySet()) {
             String accessLevel = entry.getKey();

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -68,6 +68,10 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
         return sharingInfo.keySet();
     }
 
+    public Map<String, Recipients> getSharingInfo() {
+        return sharingInfo;
+    }
+
     public Recipients atAccessLevel(String accessLevel) {
         return sharingInfo.get(accessLevel);
     }

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -76,6 +76,14 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
         return sharingInfo.get(accessLevel);
     }
 
+    /**
+     * Adds a new entry in the sharingInfo map and returns the current object
+     */
+    public ShareWith updateSharingInfo(String accessLevel, Recipients target) {
+        sharingInfo.put(accessLevel, target);
+        return this;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();

--- a/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/EncryptionInTransitMigrationTests.java
@@ -43,7 +43,7 @@ public class EncryptionInTransitMigrationTests {
         .sslOnly(true)
         .nodeSpecificSettings(0, Map.of(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true))
         .nodeSpecificSettings(1, Map.of(ConfigConstants.SECURITY_CONFIG_SSL_DUAL_MODE_ENABLED, true))
-        .extectedNodeStartupCount(2)
+        .expectedNodeStartupCount(2)
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .build();
 

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -1082,7 +1082,7 @@ public class TestSecurityConfig {
             writeConfigToIndex(client, CType.ROLES, roles);
             writeConfigToIndex(client, CType.INTERNALUSERS, internalUsers);
             writeConfigToIndex(client, CType.ROLESMAPPING, rolesMapping);
-            writeEmptyConfigToIndex(client, CType.ACTIONGROUPS);
+            writeConfigToIndex(client, CType.ACTIONGROUPS, actionGroups);
             writeEmptyConfigToIndex(client, CType.TENANTS);
         } else {
             // Write raw configuration alternatively to the normal configuration

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -382,7 +382,7 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
             return this;
         }
 
-        public Builder extectedNodeStartupCount(int expectedNodeStartupCount) {
+        public Builder expectedNodeStartupCount(int expectedNodeStartupCount) {
             this.expectedNodeStartupCount = expectedNodeStartupCount;
             return this;
         }
@@ -480,6 +480,11 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
             for (TestSecurityConfig.User user : users) {
                 testSecurityConfig.user(user);
             }
+            return this;
+        }
+
+        public Builder actionGroups(TestSecurityConfig.ActionGroup... actionGroups) {
+            testSecurityConfig.actionGroups(actionGroups);
             return this;
         }
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1145,6 +1145,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final CompatConfig compatConfig = new CompatConfig(environment, transportPassiveAuthSetting);
 
+        rsIndexHandler = new ResourceSharingIndexHandler(localClient, threadPool);
         evaluator = new PrivilegesEvaluator(
             clusterService,
             clusterService::state,
@@ -1255,7 +1256,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             FeatureConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
             FeatureConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
         )) {
-            rsIndexHandler = new ResourceSharingIndexHandler(localClient, threadPool);
 
             ResourceAccessHandler resourceAccessHandler = new ResourceAccessHandler(threadPool, rsIndexHandler, adminDns);
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1156,7 +1156,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             settings,
             privilegesInterceptor,
             cih,
-            irr
+            irr,
+            resourcePluginInfo.getResourceIndices(),
+            rsIndexHandler
         );
 
         dlsFlsBaseContext = new DlsFlsBaseContext(evaluator, threadPool.getThreadContext(), adminDns);

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -408,13 +408,6 @@ public class PrivilegesEvaluator {
         }
 
         final Resolved requestedResolved = context.getResolvedRequest();
-        try {
-            if (resourceAccessEvaluator.evaluate(request, action0, context, presponse).isComplete()) {
-                return presponse;
-            }
-        } catch (IOException e) {
-            // Do nothing
-        }
 
         if (request instanceof BulkRequest && (Strings.isNullOrEmpty(user.getRequestedTenant()))) {
             // Shortcut for bulk actions. The details are checked on the lower level of the BulkShardRequests (Action
@@ -442,12 +435,7 @@ public class PrivilegesEvaluator {
             log.debug("RequestedResolved : {}", requestedResolved);
         }
 
-        // check snapshot/restore requests
-        if (snapshotRestoreEvaluator.evaluate(request, task, action0, clusterInfoHolder, presponse).isComplete()) {
-            return presponse;
-        }
-
-        // Security index access
+        // System index access
         if (systemIndexAccessEvaluator.evaluate(request, task, action0, requestedResolved, presponse, context, actionPrivileges, user)
             .isComplete()) {
             return presponse;
@@ -455,6 +443,20 @@ public class PrivilegesEvaluator {
 
         // Protected index access
         if (protectedIndexAccessEvaluator.evaluate(request, task, action0, requestedResolved, presponse, mappedRoles).isComplete()) {
+            return presponse;
+        }
+
+        // Protected Resources access
+        try {
+            if (resourceAccessEvaluator.evaluate(request, action0, context, presponse).isComplete()) {
+                return presponse;
+            }
+        } catch (IOException e) {
+            // Do nothing
+        }
+
+        // check snapshot/restore requests
+        if (snapshotRestoreEvaluator.evaluate(request, task, action0, clusterInfoHolder, presponse).isComplete()) {
             return presponse;
         }
 

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -1,0 +1,127 @@
+package org.opensearch.security.privileges;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.DocRequest;
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.security.auth.UserSubjectImpl;
+import org.opensearch.security.privileges.actionlevel.RoleBasedActionPrivileges;
+import org.opensearch.security.resources.ResourceSharingIndexHandler;
+import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.user.User;
+import org.opensearch.threadpool.ThreadPool;
+
+public class ResourceAccessEvaluator {
+    private final Set<String> resourceIndices;
+    private final ThreadContext threadContext;
+    private final ResourceSharingIndexHandler resourceSharingIndexHandler;
+
+    public ResourceAccessEvaluator(
+        Set<String> resourceIndices,
+        ThreadPool threadPool,
+        ResourceSharingIndexHandler resourceSharingIndexHandler
+    ) {
+        this.resourceIndices = resourceIndices;
+        this.threadContext = threadPool.getThreadContext();
+        this.resourceSharingIndexHandler = resourceSharingIndexHandler;
+    }
+
+    public PrivilegesEvaluatorResponse evaluate(
+        final ActionRequest request,
+        final String action,
+        final PrivilegesEvaluationContext context,
+        final PrivilegesEvaluatorResponse presponse
+    ) throws IOException {
+
+        if (!(request instanceof DocRequest)) {
+            return presponse;
+        }
+
+        final UserSubjectImpl userSubject = (UserSubjectImpl) this.threadContext.getPersistent(
+            ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER
+        );
+        final User user = (userSubject == null) ? null : userSubject.getUser();
+
+        if (user == null) {
+            presponse.allowed = false;
+            return presponse.markComplete();
+        }
+
+        // If user was super-admin, the request would have already been granted. So no need to check whether user is admin
+
+        if (request instanceof DocWriteRequest<?>) {
+            // check write permissions <- maybe punt it to the regular evaluator since it requires write permissions to the index
+        }
+
+        DocRequest req = (DocRequest) request;
+
+        // if requested index is not a resource sharing index, move on to the next evaluator
+        if (!resourceIndices.contains(req.index())) {
+            return presponse;
+        }
+
+        // Fetch the ResourceSharing document
+
+        CountDownLatch latch = new CountDownLatch(1);
+
+        Set<String> userRoles = new HashSet<>(user.getSecurityRoles());
+        Set<String> userBackendRoles = new HashSet<>(user.getRoles());
+
+        this.resourceSharingIndexHandler.fetchSharingInfo(req.index(), req.id(), ActionListener.wrap(document -> {
+            if (document == null) {
+                presponse.allowed = false; // TODO should we move this to next evaluator if no document is present, probs not since this
+                                           // index is protected
+                latch.countDown();
+                return;
+            }
+
+            // If document is public, action is allowed
+            // If user is the owner, action is allowed
+            if (document.isSharedWithEveryone() || document.isCreatedBy(user.getName())) {
+                presponse.allowed = true;
+                latch.countDown();
+                return;
+            }
+
+            Set<String> accessLevels = new HashSet<>();
+            accessLevels.addAll(document.fetchAccessLevels(Recipient.USERS, Set.of(user.getName())));
+            accessLevels.addAll(document.fetchAccessLevels(Recipient.ROLES, userRoles));
+            accessLevels.addAll(document.fetchAccessLevels(Recipient.BACKEND_ROLES, userBackendRoles));
+
+            if (accessLevels.isEmpty()) {
+                presponse.allowed = false;
+                latch.countDown();
+                return;
+            }
+
+            // Expand access-levels and check if any match the action supplied
+            if (context.getActionPrivileges() instanceof RoleBasedActionPrivileges roleBasedActionPrivileges) {
+                Set<String> actions = roleBasedActionPrivileges.flattenedActionGroups().resolve(accessLevels);
+                presponse.allowed = actions.contains(action);
+                latch.countDown();
+            } else {
+                // we don't yet support Plugins to access resources
+                presponse.allowed = false;
+                latch.countDown();
+            }
+
+        }, e -> {
+            presponse.allowed = false;
+            latch.countDown();
+        }));
+        try {
+            latch.await();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+
+        return presponse.markComplete();
+    }
+}

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -54,13 +54,19 @@ public class ResourceAccessEvaluator {
             return presponse.markComplete();
         }
 
+        DocRequest req = (DocRequest) request;
+
         // If user was super-admin, the request would have already been granted. So no need to check whether user is admin
 
-        if (request instanceof DocWriteRequest<?>) {
-            // check write permissions <- maybe punt it to the regular evaluator since it requires write permissions to the index
+        // Creation Request
+        // TODO Check if following is the correct way to identify the create request
+        if (request instanceof DocWriteRequest<?> && req.id() == null) {
+            // check write permissions
+            // TODO verif that this can be punted to the regular evaluator since it requires write permissions to the index
+            return presponse;
         }
 
-        DocRequest req = (DocRequest) request;
+
 
         // if requested index is not a resource sharing index, move on to the next evaluator
         if (!resourceIndices.contains(req.index())) {

--- a/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
@@ -323,7 +323,6 @@ public class SystemIndexAccessEvaluator {
                     );
                 }
                 presponse.allowed = false;
-                presponse.getMissingPrivileges();
                 presponse.markComplete();
             }
             return;

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
@@ -890,4 +890,8 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
             return statefulIndex != null ? statefulIndex.metadataVersion : 0;
         }
     };
+
+    public FlattenedActionGroups flattenedActionGroups() {
+        return actionGroups;
+    }
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -622,6 +622,7 @@ public class ResourceSharingIndexHandler {
                     );
                 }
 
+                assert sharingInfo != null;
                 for (String accessLevel : revokeAccess.accessLevels()) {
                     Recipients target = revokeAccess.atAccessLevel(accessLevel);
                     LOGGER.debug(
@@ -632,10 +633,9 @@ public class ResourceSharingIndexHandler {
                         accessLevel
                     );
 
-                    assert sharingInfo != null;
                     sharingInfo.revoke(accessLevel, target);
                 }
-                assert sharingInfo != null;
+
                 IndexRequest ir = client.prepareIndex(resourceSharingIndex)
                     .setId(sharingInfo.getResourceId())
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)

--- a/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/PrivilegesEvaluatorUnitTest.java
@@ -9,6 +9,7 @@
 package org.opensearch.security.privileges;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import com.google.common.collect.ImmutableList;
@@ -27,6 +28,7 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.configuration.ClusterInfoHolder;
 import org.opensearch.security.configuration.ConfigurationRepository;
 import org.opensearch.security.resolver.IndexResolverReplacer;
+import org.opensearch.security.resources.ResourceSharingIndexHandler;
 import org.opensearch.threadpool.ThreadPool;
 
 import org.mockito.Mock;
@@ -149,6 +151,9 @@ public class PrivilegesEvaluatorUnitTest {
     @Mock
     private ClusterState clusterState;
 
+    @Mock
+    private ResourceSharingIndexHandler resourceSharingIndexHandler;
+
     private Settings settings;
     private Supplier<ClusterState> clusterStateSupplier;
     private ThreadContext threadContext;
@@ -171,7 +176,9 @@ public class PrivilegesEvaluatorUnitTest {
             settings,
             privilegesInterceptor,
             clusterInfoHolder,
-            irr
+            irr,
+            Set.of(),
+            resourceSharingIndexHandler
         );
     }
 

--- a/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
@@ -33,6 +33,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.auditlog.NullAuditLog;
 import org.opensearch.security.configuration.ClusterInfoHolder;
+import org.opensearch.security.resources.ResourceSharingIndexHandler;
 import org.opensearch.security.securityconf.ConfigModel;
 import org.opensearch.security.securityconf.DynamicConfigModel;
 import org.opensearch.security.securityconf.impl.CType;
@@ -62,6 +63,8 @@ public class RestLayerPrivilegesEvaluatorTest {
     private DynamicConfigModel dynamicConfigModel;
     @Mock
     private ClusterInfoHolder clusterInfoHolder;
+    @Mock
+    private ResourceSharingIndexHandler resourceSharingIndexHandler;
 
     private static final User TEST_USER = new User("test_user");
 
@@ -167,7 +170,9 @@ public class RestLayerPrivilegesEvaluatorTest {
             Settings.EMPTY,
             null,
             clusterInfoHolder,
-            null
+            null,
+            Set.of(),
+            resourceSharingIndexHandler
         );
         privilegesEvaluator.onConfigModelChanged(configModel); // Defaults to the mocked config model
         privilegesEvaluator.onDynamicConfigModelChanged(dynamicConfigModel);


### PR DESCRIPTION
### Description
This PR adds a new privilege evaluator for evaluating access to a resource. #5281 introduced a way for plugin offload sharing and access evaluation to security plugin but that was done by requiring plugins to call verifyAccess method on their end. This leaves room for error. This new evaluator will filter all resource access requests through SecurityFilter class without requiring plugins to explicitly call verifyAccess method. It also adds support for access-levels instead of just the default one declared in the previous PR.

### Issues Resolved


### Testing
- Automated Tests

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
