### PR TITLE
Bump com.github.spotbugs from 5.2.5 to 6.3.0 and checkstyle to 10.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `org.eclipse.platform:org.eclipse.equinox.common` from 3.20.0 to 3.20.100 ([#5402](https://github.com/opensearch-project/security/pull/5402))
 - Bump `spring_version` from 6.2.7 to 6.2.8 ([#5403](https://github.com/opensearch-project/security/pull/5403))
 - Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#5401](https://github.com/opensearch-project/security/pull/5401))
+- Bump `com.github.spotbugs` from 5.2.5 to 6.3.0 and checkstyle to 10.25.0 ([#5409](https://github.com/opensearch-project/security/pull/5409))
 
 
 ### Deprecated

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ plugins {
     id 'com.netflix.nebula.ospackage' version "11.11.2"
     id "org.gradle.test-retry" version "1.6.2"
     id 'eclipse'
-    id "com.github.spotbugs" version "5.2.5"
+    id "com.github.spotbugs" version "6.2.0"
     id "com.google.osdetector" version "1.7.3"
 }
 
@@ -376,7 +376,7 @@ jacocoTestReport {
 }
 
 checkstyle {
-    toolVersion "10.3.3"
+    toolVersion "10.25.0"
     showViolations true
     configDirectory.set(rootProject.file("checkstyle/"))
 }
@@ -474,6 +474,9 @@ configurations {
             // for spotless transitive dependency CVE
             force "org.eclipse.platform:org.eclipse.core.runtime:3.33.100"
             force "org.eclipse.platform:org.eclipse.equinox.common:3.20.100"
+            force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+            force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
+            force "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
 
             // For integrationTest
             force "org.apache.httpcomponents:httpclient:4.5.14"

--- a/build.gradle
+++ b/build.gradle
@@ -477,6 +477,7 @@ configurations {
             force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
             force "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
             force "org.apache.httpcomponents.core5:httpcore5-h2:${versions.httpcore5}"
+            force "org.codehaus.plexus:plexus-utils:3.3.0"
 
             // For integrationTest
             force "org.apache.httpcomponents:httpclient:4.5.14"


### PR DESCRIPTION
### Description

Bump com.github.spotbugs from 5.2.5 to 6.3.0 and checkstyle to 10.25.0

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Resolves https://github.com/advisories/GHSA-73m2-qfq3-56cx

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
