### PR TITLE
Migrate SslContextHandler to SSLContext

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -85,7 +85,7 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                     @Override
                     public Optional<String> sslProvider() {
                         return sslSettingsManager.sslConfiguration(CertType.TRANSPORT)
-                            .map(config -> config.sslParameters().provider().name());
+                            .map(config -> config.sslParameters().provider().getName());
                     }
 
                     @Override
@@ -141,7 +141,7 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                 return Optional.of(new SecureHttpTransportParameters() {
                     @Override
                     public Optional<String> sslProvider() {
-                        return sslSettingsManager.sslConfiguration(CertType.HTTP).map(config -> config.sslParameters().provider().name());
+                        return sslSettingsManager.sslConfiguration(CertType.HTTP).map(config -> config.sslParameters().provider().getName());
                     }
 
                     @Override

--- a/src/main/java/org/opensearch/security/ssl/SslConfiguration.java
+++ b/src/main/java/org/opensearch/security/ssl/SslConfiguration.java
@@ -95,12 +95,7 @@ public class SslConfiguration {
                 Set<X500Principal> issuerDns = keyStoreConfiguration.getIssuerDns();
                 KeyManagerFactory kmFactory = keyStoreConfiguration.createKeyManagerFactory(validateCertificates);
                 TrustManagerFactory tmFactory = trustStoreConfiguration.createTrustManagerFactory(validateCertificates, issuerDns);
-
-
-                SSLContext sslContext = SSLContext.getInstance("TLS", sslParameters.provider().name());
-//                String.valueOf(provider.getName())
-
-
+                SSLContext sslContext = SSLContext.getInstance("TLS", sslParameters.provider());
                 sslContext.init(kmFactory.getKeyManagers(), tmFactory.getTrustManagers(), null);
 
                 SSLSessionContext serverSessionContext;

--- a/src/main/java/org/opensearch/security/ssl/SslConfiguration.java
+++ b/src/main/java/org/opensearch/security/ssl/SslConfiguration.java
@@ -96,7 +96,12 @@ public class SslConfiguration {
                 KeyManagerFactory kmFactory = keyStoreConfiguration.createKeyManagerFactory(validateCertificates);
                 TrustManagerFactory tmFactory = trustStoreConfiguration.createTrustManagerFactory(validateCertificates, issuerDns);
                 SSLContext sslContext = SSLContext.getInstance("TLS", sslParameters.provider());
-                sslContext.init(kmFactory.getKeyManagers(), tmFactory.getTrustManagers(), null);
+
+                if (tmFactory != null) {
+                    sslContext.init(kmFactory.getKeyManagers(), tmFactory.getTrustManagers(), null);
+                } else {
+                    sslContext.init(kmFactory.getKeyManagers(), null, null);
+                }
 
                 SSLSessionContext serverSessionContext;
                 if (!isClient) {

--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -88,6 +88,14 @@ public class SslContextHandler {
         engine.setEnabledCipherSuites(sslConfiguration.ciphers());
         engine.setEnabledProtocols(sslConfiguration.allowedProtocols());
         engine.setUseClientMode(isClient);
+
+        SSLParameters sslParameters = engine.getSSLParameters();
+        sslParameters.setApplicationProtocols(new String[]{
+                ApplicationProtocolNames.HTTP_2,
+                ApplicationProtocolNames.HTTP_1_1
+        });
+        engine.setSSLParameters(sslParameters);
+
         if (!isClient) {
             switch (sslConfiguration.sslParameters().clientAuth()) {
                 case ClientAuth.NONE:
@@ -105,12 +113,6 @@ public class SslContextHandler {
                 default:
                     throw new IllegalStateException("Unexpected value: " + sslConfiguration.sslParameters().clientAuth());
             }
-            SSLParameters sslParameters = sslContext.getDefaultSSLParameters();
-            sslParameters.setApplicationProtocols(new String[]{
-                    ApplicationProtocolNames.HTTP_2,
-                    ApplicationProtocolNames.HTTP_1_1
-            });
-            engine.setSSLParameters(sslParameters);
         }
         return engine;
     }

--- a/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
@@ -12,6 +12,7 @@
 package org.opensearch.security.ssl.config;
 
 import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -69,6 +70,19 @@ public class SslParameters {
     public SslProvider provider() {
         return provider;
     }
+
+//    public Provider provider(){
+//        switch (provider) {
+//            case SslProvider.JDK:
+//                break;
+//            case SslProvider.OPENSSL:
+//                break;
+//            case SslProvider.OPENSSL_REFCNT:
+//                break;
+//            default:
+//                throw new IllegalStateException("Unexpected value: " + provider);
+//        }
+//    }
 
     public List<String> allowedCiphers() {
         return ciphers;

--- a/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
+++ b/src/main/java/org/opensearch/security/ssl/config/SslParameters.java
@@ -13,6 +13,7 @@ package org.opensearch.security.ssl.config;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
+import java.security.Security;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -67,22 +68,13 @@ public class SslParameters {
         return clientAuth;
     }
 
-    public SslProvider provider() {
-        return provider;
+    public Provider provider(){
+        return switch (provider) {
+            case SslProvider.JDK -> Security.getProvider("SunJSSE");
+            case SslProvider.OPENSSL, SslProvider.OPENSSL_REFCNT ->
+                    throw new IllegalStateException("OpenSSL providers not configurable or supported: " + provider);
+        };
     }
-
-//    public Provider provider(){
-//        switch (provider) {
-//            case SslProvider.JDK:
-//                break;
-//            case SslProvider.OPENSSL:
-//                break;
-//            case SslProvider.OPENSSL_REFCNT:
-//                break;
-//            default:
-//                throw new IllegalStateException("Unexpected value: " + provider);
-//        }
-//    }
 
     public List<String> allowedCiphers() {
         return ciphers;

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
@@ -12,6 +12,8 @@
 package org.opensearch.security.ssl;
 
 import java.nio.file.Path;
+import java.security.Provider;
+import java.security.Security;
 import java.util.List;
 import java.util.Locale;
 
@@ -30,6 +32,7 @@ import org.opensearch.security.ssl.config.CertType;
 import io.netty.handler.ssl.ClientAuth;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.security.OpenSearchSecurityPlugin.tryAddSecurityProvider;
 import static org.opensearch.security.ssl.CertificatesUtils.privateKeyToPemObject;
 import static org.opensearch.security.ssl.CertificatesUtils.writePemContent;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_HTTP_CLIENTAUTH_MODE;
@@ -65,6 +68,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        tryAddSecurityProvider();
         writeCertificates("ca_http_certificate.pem", "access_http_certificate.pem", "access_http_certificate_pk.pem");
         writeCertificates("ca_transport_certificate.pem", "access_transport_certificate.pem", "access_transport_certificate_pk.pem");
     }
@@ -270,7 +274,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::isServer)
+                .map(SslContextHandler::isClient)
                 .orElse(false)
 
         );
@@ -311,7 +315,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::isServer)
+                .map(SslContextHandler::isClient)
                 .orElse(false)
 
         );
@@ -354,7 +358,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::isServer)
+                .map(SslContextHandler::isClient)
                 .orElse(false)
 
         );
@@ -420,7 +424,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::isServer)
+                .map(SslContextHandler::isClient)
                 .orElse(false)
 
         );

--- a/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslSettingsManagerTest.java
@@ -28,7 +28,6 @@ import org.opensearch.env.TestEnvironment;
 import org.opensearch.security.ssl.config.CertType;
 
 import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.SslContext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.ssl.CertificatesUtils.privateKeyToPemObject;
@@ -231,7 +230,7 @@ public class SslSettingsManagerTest extends RandomizedTest {
 
         assertThat(
             "Built Server SSL context for HTTP",
-            sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::sslContext).map(SslContext::isServer).orElse(false)
+            sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::isServer).orElse(false)
         );
     }
 
@@ -265,15 +264,13 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Server SSL context for Transport",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isServer)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
         );
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isClient)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );
@@ -303,20 +300,18 @@ public class SslSettingsManagerTest extends RandomizedTest {
 
         assertThat(
             "Built Server SSL context for HTTP",
-            sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::sslContext).map(SslContext::isServer).orElse(false)
+            sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::isServer).orElse(false)
         );
         assertThat(
             "Built Server SSL context for Transport",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isServer)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
         );
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isClient)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );
@@ -352,16 +347,14 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Server SSL context for Transport",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isServer)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isClient)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );
@@ -420,16 +413,14 @@ public class SslSettingsManagerTest extends RandomizedTest {
         assertThat(
             "Built Server SSL context for Transport",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isServer)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );
         assertThat(
             "Built Client SSL context for Transport Client",
             sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT)
-                .map(SslContextHandler::sslContext)
-                .map(SslContext::isClient)
+                .map(SslContextHandler::isServer)
                 .orElse(false)
 
         );


### PR DESCRIPTION
### Description
Refactor ahead of #5258 with the goals of moving from a netty [ssl context implementation](https://netty.io/4.1/api/io/netty/handler/ssl/SslContext.html) to the more generic[ javax SSLContext](https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLContext.html).

These changes move the ssl context implementation which `SslContextHandler` wraps from the netty implementation to javax with the goal of keeping all functionality unchanged.

### Issues Resolved
Component of #5258 - Does not completely resolve this issue.

### Testing
Update existing unit test suites.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
