### PR TITLE
[3.1] Fix CHANGELOG on 3.1 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,4 +29,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Security
 
-[Unreleased 3.x]: https://github.com/opensearch-project/security/compare/3.0...main
+[Unreleased 3.1.x]: https://github.com/opensearch-project/security/compare/3.1...main


### PR DESCRIPTION
### Description

Fixes the changelog_verifier workflow on the 3.1 branch.

The link at the bottom is wrong to compute the changes for the next unreleased 3.1.x. Ideally it should be from the last released tag (in this case 3.1.0) to the head of the 3.1 branch, but the tag does not yet exist.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
