### PR TITLE
[Backport 3.0] Added getter for originalRequest field in IndexResolverReplacer.Resovled

### DIFF
--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -500,6 +500,10 @@ public class IndexResolverReplacer {
             return allIndices;
         }
 
+        public Set<String> getOriginalRequested() {
+            return originalRequested;
+        }
+
         public Set<String> getAllIndicesResolved(ClusterService clusterService, IndexNameExpressionResolver resolver) {
             return getAllIndicesResolved(clusterService::state, resolver);
         }


### PR DESCRIPTION
Backporting to 3.0

This getter is necessary for anyone building a custom plugin on top of OS security plugin and wants to do some analysis on originalRequested field.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).