### PR TITLE
Fix compilation issue after change to Subject interface in core

### DIFF
--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
@@ -59,7 +59,7 @@ import org.opensearch.sample.resource.actions.transport.UpdateResourceTransportA
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginAction;
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginRestAction;
 import org.opensearch.sample.secure.actions.transport.SecurePluginTransportAction;
-import org.opensearch.sample.utils.RunAsSubjectClient;
+import org.opensearch.sample.utils.PluginClient;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -78,7 +78,7 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
     private static final Logger log = LogManager.getLogger(SampleResourcePlugin.class);
     private boolean isResourceSharingEnabled = false;
 
-    private RunAsSubjectClient pluginClient;
+    private PluginClient pluginClient;
 
     public SampleResourcePlugin(final Settings settings) {
         isResourceSharingEnabled = settings.getAsBoolean(OPENSEARCH_RESOURCE_SHARING_ENABLED, OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT);
@@ -98,7 +98,7 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
-        this.pluginClient = new RunAsSubjectClient(client);
+        this.pluginClient = new PluginClient(client);
         return List.of(pluginClient);
     }
 

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/secure/actions/transport/SecurePluginTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/secure/actions/transport/SecurePluginTransportAction.java
@@ -24,7 +24,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginAction;
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginRequest;
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginResponse;
-import org.opensearch.sample.utils.RunAsSubjectClient;
+import org.opensearch.sample.utils.PluginClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
@@ -35,12 +35,10 @@ import org.opensearch.transport.client.Client;
 public class SecurePluginTransportAction extends HandledTransportAction<SecurePluginRequest, SecurePluginResponse> {
     private static final Logger log = LogManager.getLogger(SecurePluginTransportAction.class);
 
-    // TODO Get RunAsClient
-
     private final Client pluginClient;
 
     @Inject
-    public SecurePluginTransportAction(TransportService transportService, ActionFilters actionFilters, RunAsSubjectClient pluginClient) {
+    public SecurePluginTransportAction(TransportService transportService, ActionFilters actionFilters, PluginClient pluginClient) {
         super(SecurePluginAction.NAME, transportService, actionFilters, SecurePluginRequest::new);
         this.pluginClient = pluginClient;
     }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/PluginClient.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/PluginClient.java
@@ -1,12 +1,12 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-
-package org.opensearch.security.systemindex.sampleplugin;
+package org.opensearch.sample.utils;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -21,20 +21,19 @@ import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.FilterClient;
 
 /**
- * Implementation of client that will run transport actions in a stashed context and inject the name of the provided
- * subject into the context.
+ * A special client for executing transport actions as this plugin's system subject.
  */
-public class RunAsSubjectClient extends FilterClient {
+public class PluginClient extends FilterClient {
 
-    private static final Logger logger = LogManager.getLogger(RunAsSubjectClient.class);
+    private static final Logger logger = LogManager.getLogger(PluginClient.class);
 
     private Subject subject;
 
-    public RunAsSubjectClient(Client delegate) {
+    public PluginClient(Client delegate) {
         super(delegate);
     }
 
-    public RunAsSubjectClient(Client delegate, Subject subject) {
+    public PluginClient(Client delegate, Subject subject) {
         super(delegate);
         this.subject = subject;
     }
@@ -49,11 +48,13 @@ public class RunAsSubjectClient extends FilterClient {
         Request request,
         ActionListener<Response> listener
     ) {
+        if (subject == null) {
+            throw new IllegalStateException("PluginClient is not initialized.");
+        }
         try (ThreadContext.StoredContext ctx = threadPool().getThreadContext().newStoredContext(false)) {
             subject.runAs(() -> {
                 logger.info("Running transport action with subject: {}", subject.getPrincipal().getName());
                 super.doExecute(action, request, ActionListener.runBefore(listener, ctx::restore));
-                return null;
             });
         } catch (RuntimeException e) {
             throw e;

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestBulkIndexDocumentIntoMixOfSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestBulkIndexDocumentIntoMixOfSystemIndexAction.java
@@ -34,9 +34,9 @@ import static org.opensearch.security.systemindex.sampleplugin.SystemIndexPlugin
 public class RestBulkIndexDocumentIntoMixOfSystemIndexAction extends BaseRestHandler {
 
     private final Client client;
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
-    public RestBulkIndexDocumentIntoMixOfSystemIndexAction(Client client, RunAsSubjectClient pluginClient) {
+    public RestBulkIndexDocumentIntoMixOfSystemIndexAction(Client client, PluginClient pluginClient) {
         this.client = client;
         this.pluginClient = pluginClient;
     }

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestBulkIndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestBulkIndexDocumentIntoSystemIndexAction.java
@@ -34,9 +34,9 @@ import static org.opensearch.rest.RestRequest.Method.PUT;
 public class RestBulkIndexDocumentIntoSystemIndexAction extends BaseRestHandler {
 
     private final Client client;
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
-    public RestBulkIndexDocumentIntoSystemIndexAction(Client client, RunAsSubjectClient pluginClient) {
+    public RestBulkIndexDocumentIntoSystemIndexAction(Client client, PluginClient pluginClient) {
         this.client = client;
         this.pluginClient = pluginClient;
     }

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestGetOnSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestGetOnSystemIndexAction.java
@@ -27,9 +27,9 @@ import static org.opensearch.rest.RestRequest.Method.GET;
 
 public class RestGetOnSystemIndexAction extends BaseRestHandler {
 
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
-    public RestGetOnSystemIndexAction(RunAsSubjectClient pluginClient) {
+    public RestGetOnSystemIndexAction(PluginClient pluginClient) {
         this.pluginClient = pluginClient;
     }
 

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestSearchOnSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestSearchOnSystemIndexAction.java
@@ -29,9 +29,9 @@ import static org.opensearch.rest.RestRequest.Method.GET;
 
 public class RestSearchOnSystemIndexAction extends BaseRestHandler {
 
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
-    public RestSearchOnSystemIndexAction(RunAsSubjectClient pluginClient) {
+    public RestSearchOnSystemIndexAction(PluginClient pluginClient) {
         this.pluginClient = pluginClient;
     }
 

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/RestUpdateOnSystemIndexAction.java
@@ -27,9 +27,9 @@ import static org.opensearch.rest.RestRequest.Method.PUT;
 
 public class RestUpdateOnSystemIndexAction extends BaseRestHandler {
 
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
-    public RestUpdateOnSystemIndexAction(RunAsSubjectClient pluginClient) {
+    public RestUpdateOnSystemIndexAction(PluginClient pluginClient) {
         this.pluginClient = pluginClient;
     }
 

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/SystemIndexPlugin1.java
@@ -45,7 +45,7 @@ import org.opensearch.watcher.ResourceWatcherService;
 public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, IdentityAwarePlugin {
     public static final String SYSTEM_INDEX_1 = ".system-index1";
 
-    private RunAsSubjectClient pluginClient;
+    private PluginClient pluginClient;
 
     private Client client;
 
@@ -64,7 +64,7 @@ public class SystemIndexPlugin1 extends Plugin implements SystemIndexPlugin, Ide
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         this.client = client;
-        this.pluginClient = new RunAsSubjectClient(client);
+        this.pluginClient = new PluginClient(client);
         return List.of(pluginClient);
     }
 

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/TransportIndexDocumentIntoSystemIndexAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/TransportIndexDocumentIntoSystemIndexAction.java
@@ -30,14 +30,14 @@ public class TransportIndexDocumentIntoSystemIndexAction extends HandledTranspor
     AcknowledgedResponse> {
 
     private final Client client;
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
     @Inject
     public TransportIndexDocumentIntoSystemIndexAction(
         final TransportService transportService,
         final ActionFilters actionFilters,
         final Client client,
-        final RunAsSubjectClient pluginClient
+        final PluginClient pluginClient
     ) {
         super(IndexDocumentIntoSystemIndexAction.NAME, transportService, actionFilters, IndexDocumentIntoSystemIndexRequest::new);
         this.client = client;

--- a/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/TransportRunClusterHealthAction.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/sampleplugin/TransportRunClusterHealthAction.java
@@ -26,14 +26,14 @@ import org.opensearch.transport.client.Client;
 public class TransportRunClusterHealthAction extends HandledTransportAction<RunClusterHealthRequest, AcknowledgedResponse> {
 
     private final Client client;
-    private final RunAsSubjectClient pluginClient;
+    private final PluginClient pluginClient;
 
     @Inject
     public TransportRunClusterHealthAction(
         final TransportService transportService,
         final ActionFilters actionFilters,
         final Client client,
-        final RunAsSubjectClient pluginClient
+        final PluginClient pluginClient
     ) {
         super(RunClusterHealthAction.NAME, transportService, actionFilters, RunClusterHealthRequest::new);
         this.client = client;

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -167,8 +167,8 @@ import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
 import org.opensearch.security.http.NonSslHttpServerTransport;
 import org.opensearch.security.http.XFFResolver;
-import org.opensearch.security.identity.ContextProvidingPluginSubject;
 import org.opensearch.security.identity.NoopPluginSubject;
+import org.opensearch.security.identity.SecurePluginSubject;
 import org.opensearch.security.identity.SecurityTokenManager;
 import org.opensearch.security.privileges.PrivilegesEvaluationException;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
@@ -2294,7 +2294,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     public PluginSubject getPluginSubject(Plugin plugin) {
         PluginSubject subject;
         if (!client && !disabled && !SSLConfig.isSslOnlyMode()) {
-            subject = new ContextProvidingPluginSubject(threadPool, settings, plugin);
+            subject = new SecurePluginSubject(threadPool, settings, plugin);
             String pluginPrincipal = subject.getPrincipal().getName();
             URL resource = plugin.getClass().getClassLoader().getResource("plugin-additional-permissions.yml");
             RoleV7 pluginPermissions;

--- a/src/main/java/org/opensearch/security/auth/UserSubjectImpl.java
+++ b/src/main/java/org/opensearch/security/auth/UserSubjectImpl.java
@@ -10,8 +10,8 @@
 package org.opensearch.security.auth;
 
 import java.security.Principal;
-import java.util.concurrent.Callable;
 
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.identity.NamedPrincipal;
 import org.opensearch.identity.UserSubject;
@@ -42,10 +42,10 @@ public class UserSubjectImpl implements UserSubject {
     }
 
     @Override
-    public <T> T runAs(Callable<T> callable) throws Exception {
+    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
             threadPool.getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);
-            return callable.call();
+            r.run();
         }
     }
 

--- a/src/main/java/org/opensearch/security/identity/NoopPluginSubject.java
+++ b/src/main/java/org/opensearch/security/identity/NoopPluginSubject.java
@@ -12,8 +12,8 @@
 package org.opensearch.security.identity;
 
 import java.security.Principal;
-import java.util.concurrent.Callable;
 
+import org.opensearch.common.CheckedRunnable;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.identity.NamedPrincipal;
 import org.opensearch.identity.PluginSubject;
@@ -33,9 +33,9 @@ public class NoopPluginSubject implements PluginSubject {
     }
 
     @Override
-    public <T> T runAs(Callable<T> callable) throws Exception {
+    public <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
         try (ThreadContext.StoredContext ctx = threadPool.getThreadContext().stashContext()) {
-            return callable.call();
+            r.run();
         }
     }
 }

--- a/src/test/java/org/opensearch/security/identity/SecurePluginSubjectTests.java
+++ b/src/test/java/org/opensearch/security/identity/SecurePluginSubjectTests.java
@@ -26,7 +26,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_USER;
 import static org.junit.Assert.assertNull;
 
-public class ContextProvidingPluginSubjectTests {
+public class SecurePluginSubjectTests {
     static class TestIdentityAwarePlugin extends Plugin implements IdentityAwarePlugin {
 
     }
@@ -41,7 +41,7 @@ public class ContextProvidingPluginSubjectTests {
 
         final User pluginUser = new User(pluginPrincipal);
 
-        ContextProvidingPluginSubject subject = new ContextProvidingPluginSubject(threadPool, Settings.EMPTY, testPlugin);
+        SecurePluginSubject subject = new SecurePluginSubject(threadPool, Settings.EMPTY, testPlugin);
 
         assertThat(subject.getPrincipal().getName(), equalTo(pluginPrincipal));
 


### PR DESCRIPTION
### Description

Fix compilation issue after change to Subject interface in core

Interface changed in https://github.com/opensearch-project/OpenSearch/pull/18570 to use a CheckedRunnable to avoid throwing a generic Exception with using Callable. 

This PR also renames a few classes for maintainability. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
