### PR TITLE
Refactor JWT Vendor to take a claims builder and rename oboEnabled to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Moved OpenSAML jars to a Shadow Jar configuration to facilitate its use in FIPS enabled environments ([#5400](https://github.com/opensearch-project/security/pull/5404))
 - Fix compilation issue after change to Subject interface in core and bump to 3.2.0 ([#5423](https://github.com/opensearch-project/security/pull/5423))
+- Refactor JWT Vender to take a claims builder and rename oboEnabled to enabled ([#5436](https://github.com/opensearch-project/security/pull/5436))
 
 ### Dependencies
 - Bump `org.eclipse.platform:org.eclipse.core.runtime` from 3.33.0 to 3.33.100 ([#5400](https://github.com/opensearch-project/security/pull/5400))

--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -62,7 +62,6 @@ public class OnBehalfOfJwtAuthenticationTest {
     static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
     private static final String CREATE_OBO_TOKEN_PATH = "_plugins/_security/api/generateonbehalfoftoken";
-    private static Boolean oboEnabled = true;
     private static final String signingKey = Base64.getEncoder()
         .encodeToString(
             "jwt signing key for an on behalf of token authentication backend for testing of OBO authentication".getBytes(
@@ -118,7 +117,7 @@ public class OnBehalfOfJwtAuthenticationTest {
         .roles(HOST_MAPPING_ROLE, ROLE_WITH_OBO_PERM);
 
     private static OnBehalfOfConfig defaultOnBehalfOfConfig() {
-        return new OnBehalfOfConfig().oboEnabled(oboEnabled).signingKey(signingKey).encryptionKey(encryptionKey);
+        return new OnBehalfOfConfig().enabled(true).signingKey(signingKey).encryptionKey(encryptionKey);
     }
 
     @ClassRule
@@ -155,7 +154,7 @@ public class OnBehalfOfJwtAuthenticationTest {
     }
 
     @Test
-    public void shouldNotAuthenticateWithATemperedOBOToken() {
+    public void shouldNotAuthenticateWithATamperedOBOToken() {
         String oboToken = generateOboToken(ADMIN_USER_NAME, DEFAULT_PASSWORD);
         oboToken = oboToken.substring(0, oboToken.length() - 1); // tampering the token
         Header adminOboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
@@ -242,11 +241,11 @@ public class OnBehalfOfJwtAuthenticationTest {
         authenticateWithOboToken(oboHeader, OBO_USER_NAME_WITH_PERM, HttpStatus.SC_OK);
 
         // Disable OBO via config and see that the authenticator doesn't authorize
-        patchOnBehalfOfConfig(defaultOnBehalfOfConfig().oboEnabled(false));
+        patchOnBehalfOfConfig(defaultOnBehalfOfConfig().enabled(false));
         authenticateWithOboToken(oboHeader, OBO_USER_NAME_WITH_PERM, HttpStatus.SC_UNAUTHORIZED);
 
         // Reenable OBO via config and see that the authenticator is working again
-        patchOnBehalfOfConfig(defaultOnBehalfOfConfig().oboEnabled(true));
+        patchOnBehalfOfConfig(defaultOnBehalfOfConfig().enabled(true));
         authenticateWithOboToken(oboHeader, OBO_USER_NAME_WITH_PERM, HttpStatus.SC_OK);
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/OnBehalfOfConfig.java
@@ -18,12 +18,12 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
 public class OnBehalfOfConfig implements ToXContentObject {
-    private Boolean oboEnabled;
+    private Boolean enabled;
     private String signing_key;
     private String encryption_key;
 
-    public OnBehalfOfConfig oboEnabled(Boolean oboEnabled) {
-        this.oboEnabled = oboEnabled;
+    public OnBehalfOfConfig enabled(Boolean enabled) {
+        this.enabled = enabled;
         return this;
     }
 
@@ -40,7 +40,7 @@ public class OnBehalfOfConfig implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder xContentBuilder, ToXContent.Params params) throws IOException {
         xContentBuilder.startObject();
-        xContentBuilder.field("enabled", oboEnabled);
+        xContentBuilder.field("enabled", enabled);
         xContentBuilder.field("signing_key", signing_key);
         if (StringUtils.isNoneBlank(encryption_key)) {
             xContentBuilder.field("encryption_key", encryption_key);

--- a/src/main/java/org/opensearch/security/authtoken/jwt/claims/JwtClaimsBuilder.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/claims/JwtClaimsBuilder.java
@@ -15,6 +15,12 @@ import java.util.Date;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 
+/**
+ * Builder for creating JWT claims.
+ *
+ * This class builds a claims set with standard claims such as issued_at, not before time, subject, issuer, audience,
+ * expiration time, and custom claims.
+ */
 public class JwtClaimsBuilder {
     private final JWTClaimsSet.Builder builder;
 

--- a/src/main/java/org/opensearch/security/authtoken/jwt/claims/JwtClaimsBuilder.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/claims/JwtClaimsBuilder.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.authtoken.jwt.claims;
+
+import java.util.Date;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+
+public class JwtClaimsBuilder {
+    private final JWTClaimsSet.Builder builder;
+
+    public JwtClaimsBuilder() {
+        this.builder = new JWTClaimsSet.Builder();
+    }
+
+    public JwtClaimsBuilder issueTime(Date issueTime) {
+        builder.issueTime(issueTime);
+        return this;
+    }
+
+    public JwtClaimsBuilder notBeforeTime(Date notBeforeTime) {
+        builder.notBeforeTime(notBeforeTime);
+        return this;
+    }
+
+    public JwtClaimsBuilder subject(String subject) {
+        builder.subject(subject);
+        return this;
+    }
+
+    public JwtClaimsBuilder issuer(String issuer) {
+        builder.issuer(issuer);
+        return this;
+    }
+
+    public JwtClaimsBuilder audience(String audience) {
+        builder.audience(audience);
+        return this;
+    }
+
+    public JwtClaimsBuilder issuedAt(Date issuedAt) {
+        builder.issueTime(issuedAt);
+        return this;
+    }
+
+    public JwtClaimsBuilder expirationTime(Date expirationTime) {
+        builder.expirationTime(expirationTime);
+        return this;
+    }
+
+    public JwtClaimsBuilder addCustomClaim(String claimName, String value) {
+        builder.claim(claimName, value);
+        return this;
+    }
+
+    public JWTClaimsSet build() {
+        return builder.build();
+    }
+
+}

--- a/src/main/java/org/opensearch/security/authtoken/jwt/claims/OBOJwtClaimsBuilder.java
+++ b/src/main/java/org/opensearch/security/authtoken/jwt/claims/OBOJwtClaimsBuilder.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.authtoken.jwt.claims;
+
+import java.util.List;
+
+import org.opensearch.security.authtoken.jwt.EncryptionDecryptionUtil;
+
+public class OBOJwtClaimsBuilder extends JwtClaimsBuilder {
+    private final EncryptionDecryptionUtil encryptionDecryptionUtil;
+
+    public OBOJwtClaimsBuilder(String encryptionKey) {
+        super();
+        this.encryptionDecryptionUtil = new EncryptionDecryptionUtil(encryptionKey);
+    }
+
+    public OBOJwtClaimsBuilder addRoles(List<String> roles) {
+        final String listOfRoles = String.join(",", roles);
+        this.addCustomClaim("er", encryptionDecryptionUtil.encrypt(listOfRoles));
+        return this;
+    }
+
+    public OBOJwtClaimsBuilder addBackendRoles(Boolean includeBackendRoles, List<String> backendRoles) {
+        if (includeBackendRoles && backendRoles != null) {
+            final String listOfBackendRoles = String.join(",", backendRoles);
+            this.addCustomClaim("br", listOfBackendRoles);
+        }
+        return this;
+    }
+}

--- a/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
+++ b/src/main/java/org/opensearch/security/http/OnBehalfOfAuthenticator.java
@@ -63,15 +63,14 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
 
     private final JwtParser jwtParser;
     private final String encryptionKey;
-    private final Boolean oboEnabled;
+    private final Boolean enabled;
     private final String clusterName;
 
     private final EncryptionDecryptionUtil encryptionUtil;
 
     @SuppressWarnings("removal")
     public OnBehalfOfAuthenticator(Settings settings, String clusterName) {
-        String oboEnabledSetting = settings.get("enabled", "true");
-        oboEnabled = Boolean.parseBoolean(oboEnabledSetting);
+        enabled = settings.getAsBoolean("enabled", Boolean.TRUE);
         encryptionKey = settings.get("encryption_key");
 
         final SecurityManager sm = System.getSecurityManager();
@@ -165,7 +164,7 @@ public class OnBehalfOfAuthenticator implements HTTPAuthenticator {
     }
 
     private AuthCredentials extractCredentials0(final SecurityRequest request) {
-        if (!oboEnabled) {
+        if (!enabled) {
             log.debug("On-behalf-of authentication is disabled");
             return null;
         }

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -450,7 +450,7 @@ public class ConfigV7 {
 
     public static class OnBehalfOfSettings {
         @JsonProperty("enabled")
-        private Boolean oboEnabled = Boolean.FALSE;
+        private Boolean enabled = Boolean.FALSE;
         @JsonProperty("signing_key")
         private String signingKey;
         @JsonProperty("encryption_key")
@@ -465,12 +465,12 @@ public class ConfigV7 {
             }
         }
 
-        public Boolean getOboEnabled() {
-            return oboEnabled;
+        public Boolean isEnabled() {
+            return enabled;
         }
 
-        public void setOboEnabled(Boolean oboEnabled) {
-            this.oboEnabled = oboEnabled;
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
         }
 
         public String getSigningKey() {
@@ -491,7 +491,7 @@ public class ConfigV7 {
 
         @Override
         public String toString() {
-            return "OnBehalfOfSettings [ enabled=" + oboEnabled + ", signing_key=" + signingKey + ", encryption_key=" + encryptionKey + "]";
+            return "OnBehalfOfSettings [ enabled=" + enabled + ", signing_key=" + signingKey + ", encryption_key=" + encryptionKey + "]";
         }
     }
 

--- a/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
+++ b/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
@@ -12,8 +12,10 @@
 package org.opensearch.security.identity;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
+import com.google.common.io.BaseEncoding;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,16 +38,15 @@ import org.opensearch.security.user.User;
 import org.opensearch.security.user.UserService;
 import org.opensearch.threadpool.ThreadPool;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -75,11 +76,14 @@ public class SecurityTokenManagerTest {
 
     @After
     public void after() {
-        verifyNoMoreInteractions(cs);
-        verifyNoMoreInteractions(threadPool);
         verifyNoMoreInteractions(userService);
     }
 
+    final static String signingKey =
+        "This is my super safe signing key that no one will ever be able to guess. It's would take billions of years and the world's most powerful quantum computer to crack";
+    final static String signingKeyB64Encoded = BaseEncoding.base64().encode(signingKey.getBytes(StandardCharsets.UTF_8));
+
+    @Test
     public void onConfigModelChanged_oboNotSupported() {
         final ConfigModel configModel = mock(ConfigModel.class);
 
@@ -92,7 +96,7 @@ public class SecurityTokenManagerTest {
     @Test
     public void onDynamicConfigModelChanged_JwtVendorEnabled() {
         final ConfigModel configModel = mock(ConfigModel.class);
-        final DynamicConfigModel mockConfigModel = createMockJwtVendorInTokenManager();
+        final DynamicConfigModel mockConfigModel = createMockJwtVendorInTokenManager(true);
 
         tokenManager.onConfigModelChanged(configModel);
 
@@ -114,8 +118,12 @@ public class SecurityTokenManagerTest {
     }
 
     /** Creates the jwt vendor and returns a mock for validation if needed */
-    private DynamicConfigModel createMockJwtVendorInTokenManager() {
-        final Settings settings = Settings.builder().put("enabled", true).build();
+    private DynamicConfigModel createMockJwtVendorInTokenManager(boolean includeEncryptionKey) {
+        final Settings settings = Settings.builder()
+            .put("enabled", true)
+            .put("signing_key", signingKeyB64Encoded)
+            .put("encryption_key", (includeEncryptionKey ? "1234567890" : null))
+            .build();
         final DynamicConfigModel dcm = mock(DynamicConfigModel.class);
         when(dcm.getDynamicOnBehalfOfSettings()).thenReturn(settings);
         doAnswer((invocation) -> jwtVendor).when(tokenManager).createJwtVendor(settings);
@@ -207,11 +215,9 @@ public class SecurityTokenManagerTest {
         tokenManager.onConfigModelChanged(configModel);
         when(configModel.mapSecurityRoles(any(), any())).thenReturn(Set.of());
 
-        createMockJwtVendorInTokenManager();
+        createMockJwtVendorInTokenManager(true);
 
-        when(jwtVendor.createJwt(any(), anyString(), anyString(), anyLong(), any(), any(), anyBoolean())).thenThrow(
-            new RuntimeException("foobar")
-        );
+        when(jwtVendor.createJwt(any(), any(), any(), any())).thenThrow(new RuntimeException("foobar"));
         final OpenSearchSecurityException exception = assertThrows(
             OpenSearchSecurityException.class,
             () -> tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 450L))
@@ -233,15 +239,102 @@ public class SecurityTokenManagerTest {
         tokenManager.onConfigModelChanged(configModel);
         when(configModel.mapSecurityRoles(any(), any())).thenReturn(Set.of());
 
-        createMockJwtVendorInTokenManager();
+        createMockJwtVendorInTokenManager(true);
 
         final ExpiringBearerAuthToken authToken = mock(ExpiringBearerAuthToken.class);
-        when(jwtVendor.createJwt(any(), anyString(), anyString(), anyLong(), any(), any(), anyBoolean())).thenReturn(authToken);
+        when(jwtVendor.createJwt(any(), any(), any(), any())).thenReturn(authToken);
         final AuthToken returnedToken = tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 450L));
 
         assertThat(returnedToken, equalTo(authToken));
 
         verify(cs).getClusterName();
         verify(threadPool).getThreadContext();
+    }
+
+    @Test
+    public void testCreateJwtWithNegativeExpiry() {
+        doAnswer(invocation -> true).when(tokenManager).issueOnBehalfOfTokenAllowed();
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("Jon"));
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        final ConfigModel configModel = mock(ConfigModel.class);
+        tokenManager.onConfigModelChanged(configModel);
+        when(configModel.mapSecurityRoles(any(), any())).thenReturn(Set.of());
+
+        createMockJwtVendorInTokenManager(true);
+
+        final Throwable exception = assertThrows(RuntimeException.class, () -> {
+            try {
+                final AuthToken returnedToken = tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", -300L));
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: The expiration time should be a positive integer"));
+    }
+
+    @Test
+    public void testCreateJwtWithExceededExpiry() throws Exception {
+        doAnswer(invocation -> new ClusterName("cluster17")).when(cs).getClusterName();
+        doAnswer(invocation -> true).when(tokenManager).issueOnBehalfOfTokenAllowed();
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("Jon"));
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        final ConfigModel configModel = mock(ConfigModel.class);
+        tokenManager.onConfigModelChanged(configModel);
+        when(configModel.mapSecurityRoles(any(), any())).thenReturn(Set.of());
+
+        createMockJwtVendorInTokenManager(true);
+
+        tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 90000000L));
+        // Expiry is a hint, the max value is controlled by the JwtVendor and reduced as is seen fit.
+        ArgumentCaptor<Long> longCaptor = ArgumentCaptor.forClass(Long.class);
+        verify(jwtVendor).createJwt(any(), any(), any(), longCaptor.capture());
+
+        assertThat(600L, equalTo(longCaptor.getValue()));
+    }
+
+    @Test
+    public void testCreateJwtWithBadEncryptionKey() {
+        doAnswer(invocation -> true).when(tokenManager).issueOnBehalfOfTokenAllowed();
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("Jon"));
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        final ConfigModel configModel = mock(ConfigModel.class);
+        tokenManager.onConfigModelChanged(configModel);
+        when(configModel.mapSecurityRoles(any(), any())).thenReturn(Set.of());
+
+        createMockJwtVendorInTokenManager(false);
+
+        final Throwable exception = assertThrows(RuntimeException.class, () -> {
+            try {
+                tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 90000000L));
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: encryption_key cannot be null"));
+    }
+
+    @Test
+    public void testCreateJwtWithBadRoles() {
+        doAnswer(invocation -> true).when(tokenManager).issueOnBehalfOfTokenAllowed();
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("Jon"));
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        final ConfigModel configModel = mock(ConfigModel.class);
+        tokenManager.onConfigModelChanged(configModel);
+        when(configModel.mapSecurityRoles(any(), any())).thenReturn(null);
+
+        createMockJwtVendorInTokenManager(true);
+
+        final Throwable exception = assertThrows(RuntimeException.class, () -> {
+            try {
+                tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 90000000L));
+            } catch (final Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: Roles cannot be null"));
     }
 }

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
@@ -111,7 +111,7 @@ public class ConfigV7Test {
         ConfigV7.OnBehalfOfSettings oboSettings;
 
         oboSettings = new ConfigV7.OnBehalfOfSettings();
-        assertThat(Boolean.FALSE, is(oboSettings.getOboEnabled()));
+        assertThat(Boolean.FALSE, is(oboSettings.isEnabled()));
         Assert.assertNull(oboSettings.getSigningKey());
         Assert.assertNull(oboSettings.getEncryptionKey());
     }


### PR DESCRIPTION
### Description

This is a small refactor ahead of https://github.com/cwperks/security/pull/56 to make the JWTVendor more flexible. Currently the JWTVendor is tailor made for On-Behalf-Of tokens, but will be re-used for API Tokens and needs more flexibility. This PR adds a notion of a JWTClaimsBuilder to build the claims set for different types of tokens issued by the security plugin. This PR adds an OBOJwtClaimsSetBuilder for building the claims set of an OBO token.

It also has a small refactor of `onoEnabled` -> `enabled` since its clear in context what the variable is enabling.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
