### PR TITLE
Replace the standard distribution of BouncyCastle with BC-FIPS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,9 @@ buildscript {
         guava_version = '33.4.8-jre'
         jaxb_version = '2.3.9'
         spring_version = '6.2.8'
-        bouncycastle_version = '1.81'
+        bc_fips_version = '2.0.0'
+        bcpkix_fips_version = '2.0.7'
+        bcutil_fips_version = '2.0.3'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -536,8 +538,9 @@ allprojects {
         integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
         integrationTestImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
         integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-        integrationTestImplementation "org.bouncycastle:bc-fips:2.0.0"
-        integrationTestImplementation "org.bouncycastle:bcpkix-fips:2.0.7"
+        integrationTestImplementation "org.bouncycastle:bc-fips:${bc_fips_version}"
+        integrationTestImplementation "org.bouncycastle:bcpkix-fips:${bcpkix_fips_version}"
+        integrationTestImplementation "org.bouncycastle:bcutil-fips:${bcutil_fips_version}"
         integrationTestImplementation('org.awaitility:awaitility:4.3.0') {
             exclude(group: 'org.hamcrest', module: 'hamcrest')
         }
@@ -653,8 +656,9 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.9.0'
-    implementation "org.bouncycastle:bc-fips:2.0.0"
-    implementation "org.bouncycastle:bcpkix-fips:2.0.7"
+    implementation "org.bouncycastle:bc-fips:${bc_fips_version}"
+    implementation "org.bouncycastle:bcpkix-fips:${bcpkix_fips_version}"
+    implementation "org.bouncycastle:bcutil-fips:${bcutil_fips_version}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
     implementation 'com.rfksystems:blake2b:2.0.0'
@@ -757,9 +761,9 @@ dependencies {
     testImplementation('org.awaitility:awaitility:4.3.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
-    testImplementation "org.bouncycastle:bc-fips:2.0.0"
-    testImplementation "org.bouncycastle:bcpkix-fips:2.0.7"
-
+    testImplementation "org.bouncycastle:bc-fips:${bc_fips_version}"
+    testImplementation "org.bouncycastle:bcpkix-fips:${bcpkix_fips_version}"
+    testImplementation "org.bouncycastle:bcutil-fips:${bcutil_fips_version}"
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // Kafka test execution

--- a/build.gradle
+++ b/build.gradle
@@ -536,8 +536,8 @@ allprojects {
         integrationTestImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
         integrationTestImplementation "org.apache.logging.log4j:log4j-jul:${versions.log4j}"
         integrationTestImplementation 'org.hamcrest:hamcrest:2.2'
-        integrationTestImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
-        integrationTestImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
+        integrationTestImplementation "org.bouncycastle:bc-fips:2.0.0"
+        integrationTestImplementation "org.bouncycastle:bcpkix-fips:2.0.7"
         integrationTestImplementation('org.awaitility:awaitility:4.3.0') {
             exclude(group: 'org.hamcrest', module: 'hamcrest')
         }
@@ -641,12 +641,6 @@ tasks.integrationTest.finalizedBy(jacocoTestReport) // report is always generate
 //run the integrationTest task before the check task
 check.dependsOn integrationTest
 
-configurations.all {
-    exclude group:"org.bouncycastle", module: "bc-fips"
-    exclude group:"org.bouncycastle", module:"bctls-fips"
-    exclude group:"org.bouncycastle", module:"bcutil-fips"
-    exclude group:"org.bouncycastle", module:"bcpkix-fips"
-}
 
 dependencies {
     implementation project(path: ":${rootProject.name}-spi", configuration: 'shadow')
@@ -659,7 +653,8 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.9.0'
-    implementation "org.bouncycastle:bcprov-jdk18on:${bouncycastle_version}"
+    implementation "org.bouncycastle:bc-fips:2.0.0"
+    implementation "org.bouncycastle:bcpkix-fips:2.0.7"
     implementation 'org.ldaptive:ldaptive:1.2.3'
     implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
     implementation 'com.rfksystems:blake2b:2.0.0'
@@ -720,7 +715,6 @@ dependencies {
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.5'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     runtimeOnly 'org.checkerframework:checker-qual:3.49.4'
-    runtimeOnly "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
     runtimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
@@ -763,8 +757,8 @@ dependencies {
     testImplementation('org.awaitility:awaitility:4.3.0') {
         exclude(group: 'org.hamcrest', module: 'hamcrest')
     }
-    testImplementation "org.bouncycastle:bcpkix-jdk18on:${bouncycastle_version}"
-    testImplementation "org.bouncycastle:bcutil-jdk18on:${bouncycastle_version}"
+    testImplementation "org.bouncycastle:bc-fips:2.0.0"
+    testImplementation "org.bouncycastle:bcpkix-fips:2.0.7"
 
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'

--- a/src/integrationTest/java/org/opensearch/test/framework/certificate/CertificatesIssuerFactory.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/certificate/CertificatesIssuerFactory.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 
-
 import static org.opensearch.test.framework.certificate.AlgorithmKit.ecdsaSha256withEcdsa;
 import static org.opensearch.test.framework.certificate.AlgorithmKit.rsaSha256withRsa;
 

--- a/src/integrationTest/java/org/opensearch/test/framework/certificate/CertificatesIssuerFactory.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/certificate/CertificatesIssuerFactory.java
@@ -12,7 +12,8 @@ package org.opensearch.test.framework.certificate;
 import java.security.Provider;
 import java.util.Optional;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+
 
 import static org.opensearch.test.framework.certificate.AlgorithmKit.ecdsaSha256withEcdsa;
 import static org.opensearch.test.framework.certificate.AlgorithmKit.rsaSha256withRsa;
@@ -30,7 +31,7 @@ class CertificatesIssuerFactory {
 
     }
 
-    private static final Provider DEFAULT_SECURITY_PROVIDER = new BouncyCastleProvider();
+    private static final Provider DEFAULT_SECURITY_PROVIDER = new BouncyCastleFipsProvider();;
 
     /**
     * @see {@link #rsaBaseCertificateIssuer(Provider)}

--- a/src/test/java/org/opensearch/security/ssl/CertificatesRule.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificatesRule.java
@@ -45,7 +45,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
@@ -53,7 +53,7 @@ import org.opensearch.common.collect.Tuple;
 
 public class CertificatesRule extends ExternalResource {
 
-    private final static BouncyCastleProvider BOUNCY_CASTLE_PROVIDER = new BouncyCastleProvider();
+    private final static BouncyCastleFipsProvider BOUNCY_CASTLE_FIPS_PROVIDER = new BouncyCastleFipsProvider();
 
     private final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -128,7 +128,7 @@ public class CertificatesRule extends ExternalResource {
     }
 
     public KeyPair generateKeyPair() throws NoSuchAlgorithmException {
-        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", BOUNCY_CASTLE_PROVIDER);
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA", BOUNCY_CASTLE_FIPS_PROVIDER);
         generator.initialize(4096);
         return generator.generateKeyPair();
     }
@@ -180,7 +180,7 @@ public class CertificatesRule extends ExternalResource {
             endDate
         ).addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
             .addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyCertSign | KeyUsage.cRLSign))
-            .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BOUNCY_CASTLE_PROVIDER).build(parentKeyPair.getPrivate()));
+            .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BOUNCY_CASTLE_FIPS_PROVIDER).build(parentKeyPair.getPrivate()));
         // CS-ENFORCE-SINGLE
     }
 
@@ -303,7 +303,7 @@ public class CertificatesRule extends ExternalResource {
             )
             .addExtension(Extension.extendedKeyUsage, true, new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth))
             .addExtension(Extension.subjectAlternativeName, false, new DERSequence(sans.toArray(sans.toArray(new ASN1Encodable[0]))))
-            .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BOUNCY_CASTLE_PROVIDER).build(parentKeyPair.getPrivate()));
+            .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider(BOUNCY_CASTLE_FIPS_PROVIDER).build(parentKeyPair.getPrivate()));
         // CS-ENFORCE-SINGLE
         return Tuple.tuple(keyPair.getPrivate(), certificate);
     }


### PR DESCRIPTION
### Description
This change replaces the standard distribution of BouncyCastle with BC-FIPS

### Issues Resolved
https://github.com/opensearch-project/security/issues/5438

### Testing
Relying on the existing tests

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
