### PR TITLE
Jwt nested subs

### DIFF
--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -194,7 +194,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             // This loop is necessary for nested claim traversal
             for (int i = 0; i < subjectKey.size(); i++) {
                 if (i == subjectKey.size() - 1) {
-                    
                     subjectObject = claimsMap.get(subjectKey.get(i));
                 } else if (claimsMap.get(subjectKey.get(i)) instanceof Map) {
                     claimsMap = (Map<String, Object>) claimsMap.get(subjectKey.get(i));

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -60,7 +60,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final String jwtHeaderName;
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
-    private final String subjectKey;
+    private final List<String> subjectKey;
     private final List<String> rolesKey;
     private final List<String> requiredAudience;
     private final String requiredIssuer;
@@ -73,7 +73,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         jwtHeaderName = settings.get("jwt_header", AUTHORIZATION);
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.getAsList("roles_key");
-        subjectKey = settings.get("subject_key");
+        subjectKey = settings.getAsList("subject_key");
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
         requiredAudience = settings.getAsList("required_audience");
         requiredIssuer = settings.get("required_issuer");
@@ -182,13 +182,27 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
 
         return jwtToken;
     }
-
+    
+    @SuppressWarnings("unchecked")
     @VisibleForTesting
     public String extractSubject(JWTClaimsSet claims) {
         String subject = claims.getSubject();
 
         if (subjectKey != null) {
-            Object subjectObject = claims.getClaim(subjectKey);
+            Object subjectObject = null;
+            Map<String, Object> claimsMap = claims.getClaims();
+            // This loop is necessary for nested claim traversal
+            for (int i = 0; i < subjectKey.size(); i++) {
+                if (i == subjectKey.size() - 1) {
+                    
+                    subjectObject = claimsMap.get(subjectKey.get(i));
+                } else if (claimsMap.get(subjectKey.get(i)) instanceof Map) {
+                    claimsMap = (Map<String, Object>) claimsMap.get(subjectKey.get(i));
+                } else {
+                    log.warn("Failed to get subject from JWT claims with subject_key '{}'.", subjectKey);
+                    return null;
+                }
+            }            
 
             if (subjectObject == null) {
                 log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);


### PR DESCRIPTION
### Description

This PR abstracts the `subject_key ` configuration from jwt-backed auth backends to handle a list as config to get sub within nested claims of a JWT payload.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement of https://github.com/opensearch-project/security/pull/5355
### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/5430



### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
