### PR TITLE
[Resource Sharing] Adds a Share API to fetch and update sharing information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Restricting query optimization via star tree index for users with queries on indices with DLS/FLS/FieldMasked restrictions ([#5492](https://github.com/opensearch-project/security/pull/5492))
 * Handle subject in nested claim for JWT auth backends ([#5467](https://github.com/opensearch-project/security/pull/5467))
+* [Resource Sharing] Adds a Share API to fetch and update sharing information ([#5459](https://github.com/opensearch-project/security/pull/5459))
 
 ### Bug Fixes
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/ShareApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/ShareApiTests.java
@@ -120,7 +120,7 @@ public class ShareApiTests {
             // non-permission user cannot list shared resources,
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.get(
-                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_index=" + RESOURCE_INDEX_NAME
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_INDEX_NAME
                 );
                 response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
@@ -138,7 +138,7 @@ public class ShareApiTests {
             // non-permission user can now list shared_with resources by calling share API
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.get(
-                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_index=" + RESOURCE_INDEX_NAME
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_INDEX_NAME
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.bodyAsJsonNode().get("sharing_info").get("resource_id").asText(), equalTo(adminResId));

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/ShareApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/ShareApiTests.java
@@ -1,0 +1,207 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.spi.resources.sharing.Recipients;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
+import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * This test file tests the share API defined by the security plugin.
+ * Resource access control feature and system index protection are assumed to be enabled
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({ ShareApiTests.RoutesTests.class })
+public class ShareApiTests {
+    /**
+     * Base test class providing shared cluster setup and teardown
+     */
+    public static abstract class BaseTests {
+        @ClassRule
+        public static LocalCluster cluster = newCluster(true, true);
+
+        @After
+        public void clearIndices() {
+            try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+                client.delete(RESOURCE_INDEX_NAME);
+                client.delete(RESOURCE_SHARING_INDEX);
+            }
+        }
+    }
+
+    /**
+     * Tests exercising the share API endpoints, GET, PUT & PATCH
+     */
+    @RunWith(RandomizedRunner.class)
+    @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+    public static class RoutesTests extends BaseTests {
+        private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+        private String adminResId;
+
+        @Before
+        public void setup() {
+            adminResId = api.createSampleResourceAs(USER_ADMIN);
+            api.awaitSharingEntry();
+        }
+
+        @Test
+        public void testPutSharingInfo() {
+            // non-permission user cannot share resource
+            try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.putJson(
+                    SECURITY_SHARE_ENDPOINT,
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyAG.name(), NO_ACCESS_USER.getName())
+                );
+                response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
+            }
+
+            // a sharing entry should be created successfully since admin has access to share API
+            try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                TestRestClient.HttpResponse response = client.putJson(
+                    SECURITY_SHARE_ENDPOINT,
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleAllAG.name(), LIMITED_ACCESS_USER.getName())
+                );
+                response.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(response.getBody(), containsString(LIMITED_ACCESS_USER.getName()));
+                assertThat(response.getBody(), not(containsString(NO_ACCESS_USER.getName())));
+            }
+
+            // non-permission user will now have access to directly call share API
+            try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.putJson(
+                    SECURITY_SHARE_ENDPOINT,
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyAG.name(), NO_ACCESS_USER.getName())
+                );
+                response.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(response.getBody(), containsString(NO_ACCESS_USER.getName()));
+            }
+        }
+
+        @Test
+        public void testGetSharingInfo() {
+            // non-permission user cannot list shared resources,
+            try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.get(
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_index=" + RESOURCE_INDEX_NAME
+                );
+                response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
+            }
+
+            // a sharing entry should be created successfully since admin has access to share API
+            try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                TestRestClient.HttpResponse response = client.putJson(
+                    SECURITY_SHARE_ENDPOINT,
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleAllAG.name(), FULL_ACCESS_USER.getName())
+                );
+                response.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(response.getBody(), containsString(FULL_ACCESS_USER.getName()));
+            }
+
+            // non-permission user can now list shared_with resources by calling share API
+            try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.get(
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_index=" + RESOURCE_INDEX_NAME
+                );
+                response.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(response.bodyAsJsonNode().get("sharing_info").get("resource_id").asText(), equalTo(adminResId));
+            }
+        }
+
+        @Test
+        public void testPatchSharingInfo() {
+            Map<Recipient, Set<String>> recs = new HashMap<>();
+            Set<String> users = new HashSet<>();
+            users.add(FULL_ACCESS_USER.getName());
+            recs.put(Recipient.USERS, users);
+            Recipients recipients = new Recipients(recs);
+
+            TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
+            patchSharingInfoPayloadBuilder.resourceId(adminResId).resourceIndex(RESOURCE_INDEX_NAME).share(recipients, sampleAllAG.name());
+
+            // full-access user cannot share with itself since user doesn't have permission to share
+            try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
+            }
+
+            // a sharing entry should be created successfully since admin has access to share API
+            try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(response.getBody(), containsString(FULL_ACCESS_USER.getName()));
+            }
+
+            // limited access user will not be able to call patch endpoint
+            try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
+            }
+
+            // full-access user will now be able to patch and grant access to limited access user
+            // they can also shoot themselves in the foot and remove own access
+            try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+                // add limited user
+                users.add(LIMITED_ACCESS_USER.getName());
+                patchSharingInfoPayloadBuilder.share(recipients, sampleAllAG.name());
+                // remove self
+                Set<String> revokedUsers = new HashSet<>();
+                revokedUsers.add(FULL_ACCESS_USER.getName());
+                recs.put(Recipient.USERS, revokedUsers);
+                recipients = new Recipients(recs);
+                patchSharingInfoPayloadBuilder.revoke(recipients, sampleAllAG.name());
+
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_OK);
+            }
+
+            // limited access user will now be able to call patch endpoint, but full-access won't
+            try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_OK);
+            }
+            try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+                TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+                response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
+            }
+        }
+    }
+
+}

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -212,7 +212,7 @@ public final class TestUtils {
         return """
             {
               "resource_id": "%s",
-              "resource_index": "%s",
+              "resource_type": "%s",
               "share_with": {
                 "%s" : {
                     "users": ["%s"]
@@ -280,7 +280,7 @@ public final class TestUtils {
             return """
                 {
                   "resource_id": "%s",
-                  "resource_index": "%s",
+                  "resource_type": "%s",
                   "patch":{
                       "add": {
                         %s

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -281,13 +281,11 @@ public final class TestUtils {
                 {
                   "resource_id": "%s",
                   "resource_type": "%s",
-                  "patch":{
-                      "add": {
-                        %s
-                      },
-                      "revoke": {
-                        %s
-                      }
+                  "add": {
+                    %s
+                  },
+                  "revoke": {
+                    %s
                   }
                 }
                 """.formatted(resourceId, resourceIndex, allShares, allRevokes);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -282,7 +282,7 @@ public final class TestUtils {
                   "resource_id": "%s",
                   "resource_index": "%s",
                   "patch":{
-                      "share_with": {
+                      "add": {
                         %s
                       },
                       "revoke": {

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/Recipients.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/Recipients.java
@@ -60,16 +60,22 @@ public class Recipients implements ToXContentFragment, NamedWriteable {
     public void share(Recipients target) {
         Map<Recipient, Set<String>> targetRecipients = target.getRecipients();
         for (Recipient recipientType : targetRecipients.keySet()) {
-            Set<String> updatedRecipients = recipients.get(recipientType);
-            updatedRecipients.addAll(targetRecipients.get(recipientType));
+            if (!recipients.containsKey(recipientType)) { // will not be present in case of very first share
+                recipients.put(recipientType, targetRecipients.get(recipientType));
+            } else {
+                Set<String> updatedRecipients = recipients.get(recipientType);
+                updatedRecipients.addAll(targetRecipients.get(recipientType));
+            }
         }
     }
 
     public void revoke(Recipients target) {
         Map<Recipient, Set<String>> targetRecipients = target.getRecipients();
         for (Recipient recipientType : targetRecipients.keySet()) {
-            Set<String> updatedRecipients = recipients.get(recipientType);
-            updatedRecipients.removeAll(targetRecipients.get(recipientType));
+            if (recipients.containsKey(recipientType)) { // no need to revoke if access was not granted in first place
+                Set<String> updatedRecipients = recipients.get(recipientType);
+                updatedRecipients.removeAll(targetRecipients.get(recipientType));
+            }
         }
     }
 
@@ -117,7 +123,7 @@ public class Recipients implements ToXContentFragment, NamedWriteable {
 
     @Override
     public String toString() {
-        return "{" + recipients + '}';
+        return recipients.toString();
     }
 
     @Override

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -155,7 +155,7 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
      * Returns a new ShareWith by revoking recipients based on another ShareWith.
      */
     public ShareWith revoke(ShareWith other) {
-        if (other == null || other.isPrivate()) {
+        if (this.sharingInfo.isEmpty() || other == null || other.isPrivate()) {
             return this;
         }
         Map<String, Recipients> updated = new HashMap<>(this.sharingInfo);

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -131,4 +131,42 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
     public String toString() {
         return "ShareWith " + sharingInfo;
     }
+
+    /**
+     * Returns a new ShareWith by merging this and another ShareWith (adding recipients).
+     */
+    public ShareWith add(ShareWith other) {
+        if (other == null || other.isPrivate()) {
+            return this;
+        }
+        Map<String, Recipients> updated = new HashMap<>(this.sharingInfo);
+        for (var entry : other.sharingInfo.entrySet()) {
+            String level = entry.getKey();
+            Recipients patchRecipients = entry.getValue();
+            updated.merge(level, patchRecipients, (orig, patchRec) -> {
+                orig.share(patchRec);
+                return orig;
+            });
+        }
+        return new ShareWith(updated);
+    }
+
+    /**
+     * Returns a new ShareWith by revoking recipients based on another ShareWith.
+     */
+    public ShareWith revoke(ShareWith other) {
+        if (other == null || other.isPrivate()) {
+            return this;
+        }
+        Map<String, Recipients> updated = new HashMap<>(this.sharingInfo);
+        for (var entry : other.sharingInfo.entrySet()) {
+            String level = entry.getKey();
+            Recipients revokeRecipients = entry.getValue();
+            updated.computeIfPresent(level, (lvl, orig) -> {
+                orig.revoke(revokeRecipients);
+                return orig;
+            });
+        }
+        return new ShareWith(updated);
+    }
 }

--- a/spi/src/test/java/org/opensearch/security/spi/resources/ShareWithTests.java
+++ b/spi/src/test/java/org/opensearch/security/spi/resources/ShareWithTests.java
@@ -14,7 +14,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.Test;
 
 import org.opensearch.common.xcontent.XContentFactory;
@@ -31,11 +30,13 @@ import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import org.mockito.Mockito;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -62,16 +63,16 @@ public class ShareWithTests {
 
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
-        MatcherAssert.assertThat(shareWith, notNullValue());
+        assertThat(shareWith, notNullValue());
         Recipients readOnly = shareWith.atAccessLevel("read_only");
-        MatcherAssert.assertThat(readOnly, notNullValue());
+        assertThat(readOnly, notNullValue());
 
         Map<Recipient, Set<String>> recipients = readOnly.getRecipients();
-        MatcherAssert.assertThat(recipients, notNullValue());
-        MatcherAssert.assertThat(recipients.get(Recipient.USERS).size(), is(1));
-        MatcherAssert.assertThat(recipients.get(Recipient.USERS), contains("user1"));
-        MatcherAssert.assertThat(recipients.get(Recipient.ROLES).size(), is(0));
-        MatcherAssert.assertThat(recipients.get(Recipient.BACKEND_ROLES).size(), is(0));
+        assertThat(recipients, notNullValue());
+        assertThat(recipients.get(Recipient.USERS).size(), is(1));
+        assertThat(recipients.get(Recipient.USERS), contains("user1"));
+        assertThat(recipients.get(Recipient.ROLES).size(), is(0));
+        assertThat(recipients.get(Recipient.BACKEND_ROLES).size(), is(0));
     }
 
     @Test
@@ -81,9 +82,9 @@ public class ShareWithTests {
 
         ShareWith result = ShareWith.fromXContent(parser);
 
-        MatcherAssert.assertThat(result, notNullValue());
-        MatcherAssert.assertThat(result.isPrivate(), is(true));
-        MatcherAssert.assertThat(result.isPublic(), is(false));
+        assertThat(result, notNullValue());
+        assertThat(result.isPrivate(), is(true));
+        assertThat(result.isPublic(), is(false));
     }
 
     @Test
@@ -110,22 +111,22 @@ public class ShareWithTests {
 
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
-        MatcherAssert.assertThat(shareWith, notNullValue());
+        assertThat(shareWith, notNullValue());
 
         Recipients defaultAccessLevel = shareWith.atAccessLevel("default");
 
         Recipients readOnly = shareWith.atAccessLevel("read-only");
 
-        MatcherAssert.assertThat(defaultAccessLevel, notNullValue());
-        MatcherAssert.assertThat(readOnly, notNullValue());
+        assertThat(defaultAccessLevel, notNullValue());
+        assertThat(readOnly, notNullValue());
 
-        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.USERS).size(), is(2));
-        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.ROLES).size(), is(1));
-        MatcherAssert.assertThat(defaultAccessLevel.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
+        assertThat(defaultAccessLevel.getRecipientsByType(Recipient.USERS).size(), is(2));
+        assertThat(defaultAccessLevel.getRecipientsByType(Recipient.ROLES).size(), is(1));
+        assertThat(defaultAccessLevel.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
 
-        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.USERS).size(), is(1));
-        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.ROLES).size(), is(1));
-        MatcherAssert.assertThat(readOnly.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
+        assertThat(readOnly.getRecipientsByType(Recipient.USERS).size(), is(1));
+        assertThat(readOnly.getRecipientsByType(Recipient.ROLES).size(), is(1));
+        assertThat(readOnly.getRecipientsByType(Recipient.BACKEND_ROLES).size(), is(1));
     }
 
     @Test
@@ -136,9 +137,9 @@ public class ShareWithTests {
 
         ShareWith result = ShareWith.fromXContent(mockParser);
 
-        MatcherAssert.assertThat(result, notNullValue());
-        MatcherAssert.assertThat(result.isPrivate(), is(true));
-        MatcherAssert.assertThat(result.isPublic(), is(false));
+        assertThat(result, notNullValue());
+        assertThat(result.isPrivate(), is(true));
+        assertThat(result.isPublic(), is(false));
     }
 
     @Test
@@ -155,8 +156,8 @@ public class ShareWithTests {
 
         String expected = "{\"actionGroup1\":{\"users\":[\"bleh\"]}}";
 
-        MatcherAssert.assertThat(expected.length(), equalTo(result.length()));
-        MatcherAssert.assertThat(expected, equalTo(result));
+        assertThat(expected.length(), equalTo(result.length()));
+        assertThat(expected, equalTo(result));
     }
 
     @Test
@@ -206,8 +207,8 @@ public class ShareWithTests {
 
         ShareWith shareWith = ShareWith.fromXContent(parser);
 
-        MatcherAssert.assertThat(shareWith.isPrivate(), is(true));
-        MatcherAssert.assertThat(shareWith.isPublic(), is(false));
+        assertThat(shareWith.isPrivate(), is(true));
+        assertThat(shareWith.isPublic(), is(false));
     }
 
     @Test
@@ -241,7 +242,7 @@ public class ShareWithTests {
         // existing level merged
         verify(orig, times(1)).share(patchRec);
         // new level added
-        MatcherAssert.assertThat(result.atAccessLevel("write"), equalTo(patchRec));
+        assertThat(result.atAccessLevel("write"), equalTo(patchRec));
     }
 
     @Test
@@ -260,7 +261,25 @@ public class ShareWithTests {
         // revoke called on existing
         verify(orig, times(1)).revoke(revokeRec);
         // non-existing level noop
-        MatcherAssert.assertThat(result.atAccessLevel("write"), nullValue());
+        assertThat(result.atAccessLevel("write"), nullValue());
+    }
+
+    @Test
+    public void testRevoke_NonExisting() {
+        ShareWith base = new ShareWith(new HashMap<>());
+        Recipients revokeRec = mock(Recipients.class);
+        Map<String, Recipients> revokeMap = new HashMap<>();
+        revokeMap.put("read", revokeRec);
+        revokeMap.put("write", revokeRec);
+        ShareWith revokeSw = new ShareWith(revokeMap);
+
+        assertThat(base.getSharingInfo().size(), is(0));
+
+        ShareWith result = base.revoke(revokeSw);
+        // revoke called on existing
+        assertThat("Revoke on empty base should return the same object", result, sameInstance(base));
+        // assert no levels were added or removed
+        assertThat(result.getSharingInfo().size(), is(0));
     }
 
     @Test

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -692,7 +692,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 );
 
                 // Resource sharing API to update sharing info
-                if (settings.getAsBoolean(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT)) {
+                if (settings.getAsBoolean(
+                    ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
+                    OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
+                )) {
                     handlers.add(new ShareRestAction());
                 }
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -181,6 +181,9 @@ import org.opensearch.security.resources.ResourceAccessHandler;
 import org.opensearch.security.resources.ResourceIndexListener;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.resources.ResourceSharingIndexHandler;
+import org.opensearch.security.resources.api.share.ShareAction;
+import org.opensearch.security.resources.api.share.ShareRestAction;
+import org.opensearch.security.resources.api.share.ShareTransportAction;
 import org.opensearch.security.rest.DashboardsInfoAction;
 import org.opensearch.security.rest.SecurityConfigUpdateAction;
 import org.opensearch.security.rest.SecurityHealthAction;
@@ -687,8 +690,11 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     )
                 );
 
-                log.debug("Added {} rest handler(s)", handlers.size());
+                // Resource sharing API to update sharing info
+                handlers.add(new ShareRestAction());
+
             }
+            log.debug("Added {} rest handler(s)", handlers.size());
         }
 
         return handlers;
@@ -714,6 +720,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 actions.add(new ActionHandler<>(CertificatesActionType.INSTANCE, TransportCertificatesInfoNodesAction.class));
             }
             actions.add(new ActionHandler<>(WhoAmIAction.INSTANCE, TransportWhoAmIAction.class));
+
+            // transport action to handle sharing info update
+            actions.add(new ActionHandler<>(ShareAction.INSTANCE, ShareTransportAction.class));
         }
         return actions;
     }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -240,6 +240,7 @@ import static org.opensearch.security.privileges.dlsfls.FieldMasking.Config.BLAK
 import static org.opensearch.security.resources.ResourceSharingIndexHandler.getSharingIndex;
 import static org.opensearch.security.setting.DeprecatedSettings.checkForDeprecatedSetting;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_SSL_CERTIFICATES_HOT_RELOAD_ENABLED;
@@ -691,7 +692,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 );
 
                 // Resource sharing API to update sharing info
-                handlers.add(new ShareRestAction());
+                if (settings.getAsBoolean(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT)) {
+                    handlers.add(new ShareRestAction());
+                }
 
             }
             log.debug("Added {} rest handler(s)", handlers.size());
@@ -722,7 +725,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             actions.add(new ActionHandler<>(WhoAmIAction.INSTANCE, TransportWhoAmIAction.class));
 
             // transport action to handle sharing info update
-            actions.add(new ActionHandler<>(ShareAction.INSTANCE, ShareTransportAction.class));
+            if (settings.getAsBoolean(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT)) {
+                actions.add(new ActionHandler<>(ShareAction.INSTANCE, ShareTransportAction.class));
+            }
+
         }
         return actions;
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -68,6 +68,8 @@ public class Utils {
     @Deprecated
     public final static String LEGACY_PLUGIN_API_ROUTE_PREFIX = LEGACY_PLUGIN_ROUTE_PREFIX + "/api";
 
+    public final static String PLUGIN_API_RESOURCE_ROUTE_PREFIX = PLUGIN_API_ROUTE_PREFIX + "/resource";
+
     public final static String OPENDISTRO_API_DEPRECATION_MESSAGE =
         "[_opendistro/_security] is a deprecated endpoint path. Please use _plugins/_security instead.";
 

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -19,6 +19,7 @@ import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
 import org.opensearch.security.resources.ResourceAccessHandler;
 import org.opensearch.security.support.ConfigConstants;
 
@@ -98,8 +99,8 @@ public class ResourceAccessEvaluator {
         );
         if (!isResourceSharingFeatureEnabled) return false;
         if (!(request instanceof DocRequest docRequest)) return false;
-        if (docRequest.id() == null) {
-            log.debug("Request id is null, request is of type {}", docRequest.getClass().getName());
+        if (Strings.isNullOrEmpty(docRequest.id())) {
+            log.debug("Request id is blank or null, request is of type {}", docRequest.getClass().getName());
             return false;
         }
         // if requested index is not a resource sharing index, move on to the regular evaluator

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -220,13 +220,13 @@ public class ResourceAccessHandler {
      * A final resource-sharing object will be returned upon successful application of the patch to the index record
      * @param resourceId    id of the resource whose sharing info is to be updated
      * @param resourceIndex name of the resource index
-     * @param patchContent  the patch to be applied
+     * @param patch  the patch to be applied
      * @param listener      listener to be notified of final resource sharing record
      */
     public void patchSharingInfo(
         @NonNull String resourceId,
         @NonNull String resourceIndex,
-        @NonNull Map<String, Object> patchContent,
+        @NonNull Map<String, ShareWith> patch,
         ActionListener<ResourceSharing> listener
     ) {
         final UserSubjectImpl userSubject = (UserSubjectImpl) threadContext.getPersistent(
@@ -250,14 +250,14 @@ public class ResourceAccessHandler {
             user.getName(),
             resourceId,
             resourceIndex,
-            patchContent.toString()
+            patch.toString()
         );
 
-        this.resourceSharingIndexHandler.patchSharingInfo(resourceId, resourceIndex, patchContent, ActionListener.wrap(sharingInfo -> {
-            LOGGER.debug("Successfully patched sharing info for resource {} with {}", resourceId, patchContent.toString());
+        this.resourceSharingIndexHandler.patchSharingInfo(resourceId, resourceIndex, patch, ActionListener.wrap(sharingInfo -> {
+            LOGGER.debug("Successfully patched sharing info for resource {} with {}", resourceId, patch.toString());
             listener.onResponse(sharingInfo);
         }, e -> {
-            LOGGER.error("Failed to patched sharing info for resource {} with {}: {}", resourceId, patchContent.toString(), e.getMessage());
+            LOGGER.error("Failed to patched sharing info for resource {} with {}: {}", resourceId, patch.toString(), e.getMessage());
             listener.onFailure(e);
         }));
 

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -13,6 +13,7 @@ package org.opensearch.security.resources;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -21,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -56,6 +58,7 @@ public class ResourceAccessHandler {
     private final AdminDNs adminDNs;
     private final PrivilegesEvaluator privilegesEvaluator;
 
+    @Inject
     public ResourceAccessHandler(
         final ThreadPool threadPool,
         final ResourceSharingIndexHandler resourceSharingIndexHandler,
@@ -207,6 +210,92 @@ public class ResourceAccessHandler {
             LOGGER.error("Error while checking permission for user {} on resource {}: {}", user.getName(), resourceId, e.getMessage());
             listener.onFailure(e);
         }));
+    }
+
+    /**
+     * Patches the sharing info. It could be either or all 3 of the following possibilities:
+     * 1. Revoke access                 - remove op
+     * 2. Upgrade or downgrade access   - move op
+     * 3. Share with new entity         - add op
+     * A final resource-sharing object will be returned upon successful application of the patch to the index record
+     * @param resourceId    id of the resource whose sharing info is to be updated
+     * @param resourceIndex name of the resource index
+     * @param patchContent  the patch to be applied
+     * @param listener      listener to be notified of final resource sharing record
+     */
+    public void patchSharingInfo(
+        @NonNull String resourceId,
+        @NonNull String resourceIndex,
+        @NonNull Map<String, Object> patchContent,
+        ActionListener<ResourceSharing> listener
+    ) {
+        final UserSubjectImpl userSubject = (UserSubjectImpl) threadContext.getPersistent(
+            ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER
+        );
+        final User user = (userSubject == null) ? null : userSubject.getUser();
+
+        if (user == null) {
+            LOGGER.warn("No authenticated user found. Failed to patch resource sharing info {}", resourceId);
+            listener.onFailure(
+                new OpenSearchStatusException(
+                    "No authenticated user found. Failed to patch resource sharing info " + resourceId,
+                    RestStatus.UNAUTHORIZED
+                )
+            );
+            return;
+        }
+
+        LOGGER.debug(
+            "User {} is updating sharing info for resource {} in index {} with {}",
+            user.getName(),
+            resourceId,
+            resourceIndex,
+            patchContent.toString()
+        );
+
+        this.resourceSharingIndexHandler.patchSharingInfo(resourceId, resourceIndex, patchContent, ActionListener.wrap(sharingInfo -> {
+            LOGGER.debug("Successfully patched sharing info for resource {} with {}", resourceId, patchContent.toString());
+            listener.onResponse(sharingInfo);
+        }, e -> {
+            LOGGER.error("Failed to patched sharing info for resource {} with {}: {}", resourceId, patchContent.toString(), e.getMessage());
+            listener.onFailure(e);
+        }));
+
+    }
+
+    /**
+     * Get sharing info for this record
+     * @param resourceId    id of the resource whose sharing info is to be fetched
+     * @param resourceIndex name of the resource index
+     * @param listener      listener to be notified of final resource sharing record
+     */
+    public void getSharingInfo(@NonNull String resourceId, @NonNull String resourceIndex, ActionListener<ResourceSharing> listener) {
+        final UserSubjectImpl userSubject = (UserSubjectImpl) threadContext.getPersistent(
+            ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER
+        );
+        final User user = (userSubject == null) ? null : userSubject.getUser();
+
+        if (user == null) {
+            LOGGER.warn("No authenticated user found. Failed to fetch resource sharing info {}", resourceId);
+            listener.onFailure(
+                new OpenSearchStatusException(
+                    "No authenticated user found. Failed to fetch resource sharing info " + resourceId,
+                    RestStatus.UNAUTHORIZED
+                )
+            );
+            return;
+        }
+
+        LOGGER.debug("User {} is fetching sharing info for resource {} in index {}", user.getName(), resourceId, resourceIndex);
+
+        this.resourceSharingIndexHandler.fetchSharingInfo(resourceIndex, resourceId, ActionListener.wrap(sharingInfo -> {
+            LOGGER.debug("Successfully fetched sharing info for resource {} in index {}", resourceId, resourceIndex);
+            listener.onResponse(sharingInfo);
+        }, e -> {
+            LOGGER.error("Failed to fetched sharing info for resource {} in index {}: {}", resourceId, resourceIndex, e.getMessage());
+            listener.onFailure(e);
+        }));
+
     }
 
     /**

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -10,6 +10,7 @@
 package org.opensearch.security.resources;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -598,11 +599,11 @@ public class ResourceSharingIndexHandler {
         sharingInfoListener.whenComplete(resourceSharing -> {
             ShareWith updatedShareWith = resourceSharing.getShareWith();
             if (updatedShareWith == null) {
-                updatedShareWith = add;
-            } else if (add != null) {
+                updatedShareWith = new ShareWith(new HashMap<>());
+            }
+            if (add != null) {
                 updatedShareWith = updatedShareWith.add(add);
             }
-
             if (revoke != null) {
                 updatedShareWith = updatedShareWith.revoke(revoke);
             }

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -580,8 +580,8 @@ public class ResourceSharingIndexHandler {
     private ShareWith applyPatch(@Nullable ShareWith existing, Map<String, ShareWith> patches) {
         ShareWith base = existing == null ? new ShareWith(new HashMap<>()) : existing;
         // update new share-with info
-        if (patches.containsKey("share_with")) {
-            base = base.add(patches.get("share_with"));
+        if (patches.containsKey("add")) {
+            base = base.add(patches.get("add"));
         }
         // revoke any access
         if (patches.containsKey("revoke")) {

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.share;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * This class represents the action type for sharing resource.
+ *
+ */
+public class ShareAction extends ActionType<ShareResponse> {
+
+    public static final ShareAction INSTANCE = new ShareAction();
+
+    public static final String NAME = "cluster:admin/security/resource/share";
+
+    private ShareAction() {
+        super(NAME, ShareResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -1,0 +1,219 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.share;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.action.DocRequest;
+import org.opensearch.common.xcontent.LoggingDeprecationHandler;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.spi.resources.sharing.ShareWith;
+
+import joptsimple.internal.Strings;
+
+/**
+ * This class represents a request to share access to a resource.
+ *
+ */
+public class ShareRequest extends ActionRequest implements DocRequest {
+
+    @JsonProperty("resource_id")
+    private final String resourceId;
+    @JsonProperty("resource_index")
+    private final String resourceIndex;
+    @JsonProperty("share_with")
+    private final ShareWith shareWith;
+    @JsonProperty("patch")
+    private final Map<String, Object> patch;
+
+    private final RestRequest.Method method;
+
+    /**
+     * Private constructor to enforce usage of Builder
+     */
+    private ShareRequest(Builder builder) {
+        this.resourceId = builder.resourceId;
+        this.resourceIndex = builder.resourceIndex;
+        this.shareWith = builder.shareWith;
+        this.patch = builder.patch;
+        this.method = builder.method;
+    }
+
+    /**
+     * Static factory method to initialize ShareRequest from a Map.
+     */
+    @SuppressWarnings("unchecked")
+    public static ShareRequest from(Map<String, Object> source) throws IOException {
+        Builder builder = new Builder();
+
+        builder.method((RestRequest.Method) source.get("method"));
+
+        builder.resourceId((String) source.get("resource_id"));
+
+        builder.resourceIndex((String) source.get("resource_index"));
+
+        if (source.containsKey("share_with")) {
+            builder.shareWith((Map<String, Object>) source.get("share_with"));
+        }
+
+        if (source.containsKey("patch")) {
+            builder.patch((Map<String, Object>) source.get("patch"));
+        }
+
+        return builder.build();
+    }
+
+    public ShareRequest(StreamInput in) throws IOException {
+        super(in);
+        this.resourceId = in.readString();
+        this.resourceIndex = in.readString();
+        this.shareWith = in.readOptionalWriteable(ShareWith::new);
+        this.patch = in.readMap();
+        this.method = in.readEnum(RestRequest.Method.class);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(resourceId);
+        out.writeString(resourceIndex);
+        if (shareWith != null) {
+            shareWith.writeTo(out);
+        }
+        if (patch != null) {
+            out.writeString(patch.toString());
+        }
+        out.writeEnum(method);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        var arv = new ActionRequestValidationException();
+        if (Strings.isNullOrEmpty(resourceIndex) || Strings.isNullOrEmpty(resourceId)) {
+            arv.addValidationError("resource_id and resource_index must be present");
+            throw arv;
+        }
+
+        // no further check needed in case of GET
+        if (method == RestRequest.Method.GET) {
+            return null;
+        }
+        // either of shareWith or patch must be present in the request
+        if (shareWith == null && (patch == null || patch.isEmpty())) {
+            String message = method == RestRequest.Method.PATCH ? "Patch" : "ShareWith";
+            arv.addValidationError(message + " is required");
+            throw arv;
+        }
+        return null;
+    }
+
+    public ShareWith getShareWith() {
+        return shareWith;
+    }
+
+    public Map<String, Object> getPatch() {
+        return patch;
+    }
+
+    public RestRequest.Method getMethod() {
+        return method;
+    }
+
+    /**
+     * Get the index that this request operates on
+     *
+     * @return the index
+     */
+    @Override
+    public String index() {
+        return resourceIndex;
+    }
+
+    /**
+     * Get the id of the document for this request
+     *
+     * @return the id
+     */
+    @Override
+    public String id() {
+        return resourceId;
+    }
+
+    /**
+     * Builder for ShareRequest
+     */
+    public static class Builder {
+        private String resourceId;
+        private String resourceIndex;
+        private ShareWith shareWith;
+        private Map<String, Object> patch;
+        private RestRequest.Method method;
+
+        public void resourceId(String resourceId) {
+            this.resourceId = resourceId;
+        }
+
+        public void resourceIndex(String resourceIndex) {
+            this.resourceIndex = resourceIndex;
+        }
+
+        public void shareWith(Map<String, Object> source) {
+            try {
+                this.shareWith = parseShareWith(source);
+            } catch (Exception e) {
+                this.shareWith = null;
+            }
+        }
+
+        public void shareWith(ShareWith shareWith) {
+            this.shareWith = shareWith;
+        }
+
+        public void patch(Map<String, Object> patch) {
+            this.patch = patch;
+        }
+
+        public void method(RestRequest.Method method) {
+            this.method = method;
+        }
+
+        public ShareRequest build() {
+            return new ShareRequest(this);
+        }
+
+        private ShareWith parseShareWith(Map<String, Object> source) throws IOException {
+            if (source == null || source.isEmpty()) {
+                throw new IllegalArgumentException("share_with is required and cannot be empty");
+            }
+
+            String jsonString = XContentFactory.jsonBuilder().map(source).toString();
+
+            try (
+                XContentParser parser = XContentType.JSON.xContent()
+                    .createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, jsonString)
+            ) {
+
+                return ShareWith.fromXContent(parser);
+            } catch (IllegalArgumentException e) {
+                throw new IllegalArgumentException("Invalid share_with structure: " + e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -60,8 +60,8 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         this.resourceId = in.readString();
         this.resourceIndex = in.readString();
         this.shareWith = in.readOptionalWriteable(ShareWith::new);
-        this.add = new ShareWith(in);
-        this.revoke = new ShareWith(in);
+        this.add = in.readOptionalWriteable(ShareWith::new);
+        this.revoke = in.readOptionalWriteable(ShareWith::new);
     }
 
     @Override
@@ -69,15 +69,9 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         out.writeEnum(method);
         out.writeString(resourceId);
         out.writeString(resourceIndex);
-        if (shareWith != null) {
-            shareWith.writeTo(out);
-        }
-        if (add != null) {
-            add.writeTo(out);
-        }
-        if (revoke != null) {
-            revoke.writeTo(out);
-        }
+        out.writeOptionalWriteable(shareWith);
+        out.writeOptionalWriteable(add);
+        out.writeOptionalWriteable(revoke);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -88,9 +88,16 @@ public class ShareRequest extends ActionRequest implements DocRequest {
             return null;
         }
         // either of shareWith or patch must be present in the request
-        if (shareWith == null && (patch == null || patch.isEmpty())) {
-            String message = method == RestRequest.Method.PATCH ? "Patch" : "ShareWith";
-            arv.addValidationError(message + " is required");
+        if (shareWith == null && method == RestRequest.Method.PUT) {
+            arv.addValidationError("share_with is required");
+            throw arv;
+        }
+        if (method == RestRequest.Method.PATCH) {
+            if (patch == null || patch.isEmpty()) {
+                arv.addValidationError("patch is required");
+            } else if (!patch.containsKey("add") && !patch.containsKey("revoke")) {
+                arv.addValidationError("patch must not be empty");
+            }
             throw arv;
         }
         return null;
@@ -175,7 +182,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
                 if (tok == XContentParser.Token.FIELD_NAME) {
                     String field = parser.currentName();
                     parser.nextToken();
-                    if ("share_with".equals(field) || "revoke".equals(field)) {
+                    if ("add".equals(field) || "revoke".equals(field)) {
                         map.put(field, ShareWith.fromXContent(parser));
                     } else {
                         parser.skipChildren();

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -33,7 +33,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
 
     @JsonProperty("resource_id")
     private final String resourceId;
-    @JsonProperty("resource_index")
+    @JsonProperty("resource_type")
     private final String resourceIndex;
     @JsonProperty("share_with")
     private final ShareWith shareWith;
@@ -79,7 +79,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
     public ActionRequestValidationException validate() {
         var arv = new ActionRequestValidationException();
         if (Strings.isNullOrEmpty(resourceIndex) || Strings.isNullOrEmpty(resourceId)) {
-            arv.addValidationError("resource_id and resource_index must be present");
+            arv.addValidationError("resource_id and resource_type must be present");
             throw arv;
         }
 
@@ -95,10 +95,11 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         if (method == RestRequest.Method.PATCH) {
             if (patch == null || patch.isEmpty()) {
                 arv.addValidationError("patch is required");
+                throw arv;
             } else if (!patch.containsKey("add") && !patch.containsKey("revoke")) {
                 arv.addValidationError("patch must not be empty");
+                throw arv;
             }
-            throw arv;
         }
         return null;
     }
@@ -203,7 +204,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
                             case "resource_id":
                                 this.resourceId(parser.text());
                                 break;
-                            case "resource_index":
+                            case "resource_type":
                                 this.resourceIndex(parser.text());
                                 break;
                             case "share_with":

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareResponse.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareResponse.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.share;
+
+import java.io.IOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.security.spi.resources.sharing.ResourceSharing;
+
+/**
+ * This class is used to represent the response of a {@link ShareRequest}.
+ *
+ */
+public class ShareResponse extends ActionResponse implements ToXContentObject {
+
+    private final ResourceSharing resourceSharing;
+
+    public ShareResponse(final StreamInput in) throws IOException {
+        this.resourceSharing = in.readNamedWriteable(ResourceSharing.class);
+    }
+
+    public ShareResponse(ResourceSharing resourceSharing) {
+        this.resourceSharing = resourceSharing;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeNamedWriteable(resourceSharing);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("sharing_info", resourceSharing);
+        return builder.endObject();
+    }
+
+    @Override
+    public String toString() {
+        return "ShareResponse [resourceSharing=" + resourceSharing + "]";
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.share;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestRequest.Method.PATCH;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.security.dlic.rest.api.Responses.badRequest;
+import static org.opensearch.security.dlic.rest.api.Responses.ok;
+import static org.opensearch.security.dlic.rest.api.Responses.response;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_RESOURCE_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
+/**
+ * This class implements the share REST API for resource access management.
+ * It provides endpoints for sharing a resource.
+ *
+ */
+public class ShareRestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(ShareRestAction.class);
+
+    private final static Set<String> allowedPatchOperations = Set.of("share_with", "revoke");
+
+    public ShareRestAction() {}
+
+    @Override
+    public List<Route> routes() {
+        return addRoutesPrefix(
+            ImmutableList.of(new Route(PUT, "/share"), new Route(GET, "/share"), new Route(PATCH, "/share")),
+            PLUGIN_API_RESOURCE_ROUTE_PREFIX
+        );
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getName();
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        // These two params will only be present with GET request
+        String resId = request.param("resource_id");
+        String resourceIndex = request.param("resource_index");
+
+        Map<String, Object> source = new HashMap<>();
+        if (request.hasContent()) {
+            try (XContentParser parser = request.contentParser()) {
+                source = parser.map();
+            }
+        }
+
+        if (!Strings.isNullOrEmpty(resId)) {
+            source.put("resource_id", resId);
+        }
+        if (!Strings.isNullOrEmpty(resourceIndex)) {
+            source.put("resource_index", resourceIndex);
+        }
+
+        source.put("method", request.method());
+
+        ShareRequest sharingInfoUpdateRequest = ShareRequest.from(source);
+
+        return channel -> {
+            // TODO confirm the validation here for patch Operations
+            Map<String, Object> patch = sharingInfoUpdateRequest.getPatch();
+            if (patch != null && !allowedPatchOperations.containsAll(patch.keySet())) {
+                badRequest(channel, "Invalid patch operation supplied. Allowed ops: " + allowedPatchOperations);
+            }
+
+            client.executeLocally(ShareAction.INSTANCE, sharingInfoUpdateRequest, new ActionListener<>() {
+
+                @Override
+                public void onResponse(ShareResponse response) {
+                    ok(channel, response::toXContent);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    LOGGER.debug(e.getMessage(), e);
+                    handleError(channel, e);
+                }
+
+            });
+        };
+    }
+
+    private void handleError(RestChannel channel, Exception e) {
+        String message = e.getMessage();
+        if (e instanceof OpenSearchStatusException ex) {
+            response(channel, ex.status(), message);
+        } else {
+            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
@@ -44,7 +44,7 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 public class ShareRestAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(ShareRestAction.class);
 
-    private final static Set<String> ALLOWED_PATCH_OPERATIONS = Set.of("share_with", "revoke");
+    private final static Set<String> ALLOWED_PATCH_OPERATIONS = Set.of("add", "revoke");
 
     public ShareRestAction() {}
 
@@ -65,7 +65,7 @@ public class ShareRestAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
         // These two params will only be present with GET request
         String resourceId = request.param("resource_id");
-        String resourceIndex = request.param("resource_index");
+        String resourceIndex = request.param("resource_type");
 
         ShareRequest.Builder builder = new ShareRequest.Builder();
         builder.method(request.method());

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
@@ -10,8 +10,6 @@ package org.opensearch.security.resources.api.share;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import org.apache.logging.log4j.LogManager;
@@ -24,13 +22,11 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.security.spi.resources.sharing.ShareWith;
 import org.opensearch.transport.client.node.NodeClient;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.PATCH;
 import static org.opensearch.rest.RestRequest.Method.PUT;
-import static org.opensearch.security.dlic.rest.api.Responses.badRequest;
 import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.api.Responses.response;
 import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_RESOURCE_ROUTE_PREFIX;
@@ -43,8 +39,6 @@ import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
  */
 public class ShareRestAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(ShareRestAction.class);
-
-    private final static Set<String> ALLOWED_PATCH_OPERATIONS = Set.of("add", "revoke");
 
     public ShareRestAction() {}
 
@@ -84,11 +78,6 @@ public class ShareRestAction extends BaseRestHandler {
         ShareRequest shareRequest = builder.build();
 
         return channel -> {
-            Map<String, ShareWith> patchMap = shareRequest.getPatch();
-            if (patchMap != null && !ALLOWED_PATCH_OPERATIONS.containsAll(patchMap.keySet())) {
-                badRequest(channel, "Invalid patch operations: " + patchMap.keySet());
-                return;
-            }
             client.executeLocally(
                 ShareAction.INSTANCE,
                 shareRequest,

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
@@ -98,6 +98,7 @@ public class ShareRestAction extends BaseRestHandler {
     }
 
     private void handleError(RestChannel channel, Exception e) {
+        LOGGER.error("Error while processing request", e);
         String message = e.getMessage();
         if (e instanceof OpenSearchStatusException ex) {
             response(channel, ex.status(), message);

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareTransportAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareTransportAction.java
@@ -45,7 +45,13 @@ public class ShareTransportAction extends HandledTransportAction<ShareRequest, S
                 resourceAccessHandler.getSharingInfo(request.id(), request.index(), sharingInfoListener);
                 return;
             case PATCH:
-                resourceAccessHandler.patchSharingInfo(request.id(), request.index(), request.getPatch(), sharingInfoListener);
+                resourceAccessHandler.patchSharingInfo(
+                    request.id(),
+                    request.index(),
+                    request.getAdd(),
+                    request.getRevoke(),
+                    sharingInfoListener
+                );
                 break;
             case PUT:
                 resourceAccessHandler.share(request.id(), request.index(), request.getShareWith(), sharingInfoListener);

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareTransportAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareTransportAction.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.share;
+
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.spi.resources.sharing.ResourceSharing;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+/**
+ * Transport action for handling resource access requests.
+ */
+public class ShareTransportAction extends HandledTransportAction<ShareRequest, ShareResponse> {
+    private final ResourceAccessHandler resourceAccessHandler;
+
+    @Inject
+    public ShareTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ResourceAccessHandler resourceAccessHandler
+    ) {
+        super(ShareAction.NAME, transportService, actionFilters, ShareRequest::new);
+        this.resourceAccessHandler = resourceAccessHandler;
+    }
+
+    @Override
+    protected void doExecute(Task task, ShareRequest request, ActionListener<ShareResponse> listener) {
+
+        ActionListener<ResourceSharing> sharingInfoListener = ActionListener.wrap(
+            resourceSharing -> listener.onResponse(new ShareResponse(resourceSharing)),
+            listener::onFailure
+        );
+        switch (request.getMethod()) {
+            case GET:
+                resourceAccessHandler.getSharingInfo(request.id(), request.index(), sharingInfoListener);
+                return;
+            case PATCH:
+                resourceAccessHandler.patchSharingInfo(request.id(), request.index(), request.getPatch(), sharingInfoListener);
+                break;
+            case PUT:
+                resourceAccessHandler.share(request.id(), request.index(), request.getShareWith(), sharingInfoListener);
+                break;
+        }
+
+    }
+
+}

--- a/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
+++ b/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
@@ -9,7 +9,6 @@
 package org.opensearch.security.resources;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
@@ -332,26 +331,27 @@ public class ResourceAccessHandlerTest {
     public void testPatchSharingInfoSuccess() {
         User user = new User("user1", ImmutableSet.of(), ImmutableSet.of(), null, ImmutableMap.of(), false);
         injectUser(user);
-        Map<String, ShareWith> patch = Map.of("op", new ShareWith(ImmutableMap.of()));
+        ShareWith add = new ShareWith(ImmutableMap.of());
+        ShareWith revoke = new ShareWith(ImmutableMap.of());
 
         ResourceSharing doc = mock(ResourceSharing.class);
         doAnswer(inv -> {
-            ActionListener<ResourceSharing> l = inv.getArgument(3);
+            ActionListener<ResourceSharing> l = inv.getArgument(4);
             l.onResponse(doc);
             return null;
-        }).when(sharingIndexHandler).patchSharingInfo(eq(RESOURCE_ID), eq(INDEX), eq(patch), any());
+        }).when(sharingIndexHandler).patchSharingInfo(eq(RESOURCE_ID), eq(INDEX), eq(add), eq(revoke), any());
 
         ActionListener<ResourceSharing> listener = mock(ActionListener.class);
-        handler.patchSharingInfo(RESOURCE_ID, INDEX, patch, listener);
+        handler.patchSharingInfo(RESOURCE_ID, INDEX, add, revoke, listener);
 
         verify(listener).onResponse(doc);
     }
 
     @Test
     public void testPatchSharingInfoFailsIfNoUser() {
-        Map<String, ShareWith> patch = Map.of("op", new ShareWith(ImmutableMap.of()));
+        ShareWith x = new ShareWith(ImmutableMap.of());
         ActionListener<ResourceSharing> listener = mock(ActionListener.class);
-        handler.patchSharingInfo(RESOURCE_ID, INDEX, patch, listener);
+        handler.patchSharingInfo(RESOURCE_ID, INDEX, x, x, listener);
 
         verify(listener).onFailure(any(OpenSearchStatusException.class));
     }

--- a/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
+++ b/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
@@ -332,7 +332,7 @@ public class ResourceAccessHandlerTest {
     public void testPatchSharingInfoSuccess() {
         User user = new User("user1", ImmutableSet.of(), ImmutableSet.of(), null, ImmutableMap.of(), false);
         injectUser(user);
-        Map<String, Object> patch = Map.of("op", "add");
+        Map<String, ShareWith> patch = Map.of("op", new ShareWith(ImmutableMap.of()));
 
         ResourceSharing doc = mock(ResourceSharing.class);
         doAnswer(inv -> {
@@ -349,7 +349,7 @@ public class ResourceAccessHandlerTest {
 
     @Test
     public void testPatchSharingInfoFailsIfNoUser() {
-        Map<String, Object> patch = Map.of("op", "remove");
+        Map<String, ShareWith> patch = Map.of("op", new ShareWith(ImmutableMap.of()));
         ActionListener<ResourceSharing> listener = mock(ActionListener.class);
         handler.patchSharingInfo(RESOURCE_ID, INDEX, patch, listener);
 


### PR DESCRIPTION
### Description

Adds a new `/share` API to support sharing of resources by dashboard component. It supports three methods:
1. GET `/_plugins/_security/api/resource/share` - requires two query params `?resource_id=<id>&resource_type=<name>` to be present.
    1. fetches the current sharing information for the requested resource
2. PUT `/_plugins/_security/api/resource/share` 
```json
{
  "resource_id": "%s",
  "resource_type": "%s",
  "share_with": {
    "%s" : {
        "users": ["%s"]
    }
  }
}
```
   1. Creates or update (overrides) any existing sharing information.
3. PATCH `/_plugins/_security/api/resource/share`
```json
{
  "resource_id": "%s",
  "resource_type": "%s",
  "add": {
    %s
  },
  "revoke": {
    %s
  }
}
``` 
  1. Patches existing sharing info:
     1. `add` block contains information of entities and levels at which to share
     2. `revoke` block contains information of entities and levels at which to revoke

The structure for PUT and PATCH request content' sharing block must look like:
```json
 {
    "READ_ONLY": {
      "users": ["user1", "user2"],
      "roles": ["viewer_role"],
      "backend_roles": ["data_analyst"]
    },
    "READ_WRITE": {
      "users": ["admin_user"],
      "roles": ["editor_role"],
      "backend_roles": ["content_manager"]
    }
  }
```

* Category - Enhancement
* Why these changes are required?
   *  Sets up base for future dashboard component to directly invoke share apis when loading and updating sharing info.


### Issues Resolved
TBD



Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
TBD

### Testing
Integration testing

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
