### PR TITLE
Handle subject in nested claim for JWT auth backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Restricting query optimization via star tree index for users with queries on indices with DLS/FLS/FieldMasked restrictions ([#5492](https://github.com/opensearch-project/security/pull/5492))
 * Handle subject in nested claim for JWT auth backends ([#5467](https://github.com/opensearch-project/security/pull/5467))
-  
+
 ### Bug Fixes
 
 * Fix compilation issue after change to Subject interface in core and bump to 3.2.0 ([#5423](https://github.com/opensearch-project/security/pull/5423))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimized wildcard matching runtime performance ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Restricting query optimization via star tree index for users with queries on indices with DLS/FLS/FieldMasked restrictions ([#5492](https://github.com/opensearch-project/security/pull/5492))
-
+* Handle subject in nested claim for JWT auth backends ([#5467](https://github.com/opensearch-project/security/pull/5467))
+  
 ### Bug Fixes
 
 * Fix compilation issue after change to Subject interface in core and bump to 3.2.0 ([#5423](https://github.com/opensearch-project/security/pull/5423))

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
@@ -66,11 +66,7 @@ public class JwtAuthenticationNestedClaimsTests {
         "jwt",
         BASIC_AUTH_DOMAIN_ORDER - 1
     ).jwtHttpAuthenticator(
-        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(CLAIM_USERNAME).rolesKey(NESTED_ROLES).build(
-            new HashMap<>(
-                Map.of(
-                    "noop", List.of("noop")
-                
+        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(CLAIM_USERNAME).rolesKey(NESTED_ROLES)
     ).backend("noop");
 
     @ClassRule

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
@@ -10,7 +10,6 @@
 package org.opensearch.security.http;
 
 import java.security.KeyPair;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +49,7 @@ public class JwtAuthenticationNestedClaimsTests {
     public static final List<String> USERNAME_CLAIM = List.of("preferred-username");
     public static final List<String> NESTED_ROLES = List.of("attributes", "roles");
     public static final List<String> NESTED_SUBJECT = List.of("attributes_sub", "sub");
+    public static final List<String> NESTED_SUBJECT_ATTRIBUTES_ONLY = List.of("attributes", "sub");
     public static final List<String> ROLES_CLAIM = List.of("all_access", "securitymanager");
 
     public static final String USER_SUPERHERO = "superhero";
@@ -57,12 +57,31 @@ public class JwtAuthenticationNestedClaimsTests {
     private static final String PUBLIC_KEY1 = new String(Base64.getEncoder().encode(KEY_PAIR1.getPublic().getEncoded()), US_ASCII);
     private static final String JWT_AUTH_HEADER = "jwt-auth";
 
+    // Token factory for regular subject + nested roles 
     private static final JwtAuthorizationHeaderFactory tokenFactory1 = new JwtAuthorizationHeaderFactory(
         KEY_PAIR1.getPrivate(),
         USERNAME_CLAIM,
         NESTED_ROLES,
         JWT_AUTH_HEADER
     );
+    
+    // Token factory for nested subject + nested roles
+    private static final JwtAuthorizationHeaderFactory tokenFactoryNestedSubjectAndRole = new JwtAuthorizationHeaderFactory(
+        KEY_PAIR1.getPrivate(),
+        NESTED_SUBJECT,
+        NESTED_ROLES,
+        JWT_AUTH_HEADER
+    );
+    
+    // Token factory for both subject and roles nested under same "attributes" only
+    private static final JwtAuthorizationHeaderFactory tokenFactoryAttributesOnly = new JwtAuthorizationHeaderFactory(
+        KEY_PAIR1.getPrivate(),
+        NESTED_SUBJECT_ATTRIBUTES_ONLY,
+        NESTED_ROLES,
+        JWT_AUTH_HEADER
+    );
+
+    // JWT domain for regular subject + nested roles 
     public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN = new TestSecurityConfig.AuthcDomain(
         "jwt",
         BASIC_AUTH_DOMAIN_ORDER - 1
@@ -70,17 +89,28 @@ public class JwtAuthenticationNestedClaimsTests {
         new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(USERNAME_CLAIM).rolesKey(NESTED_ROLES)
     ).backend("noop");
     
-    private static final JwtAuthorizationHeaderFactory tokenFactoryNestedSubjectAndRole = new JwtAuthorizationHeaderFactory(
-        KEY_PAIR1.getPrivate(),
-        NESTED_SUBJECT,
-        NESTED_ROLES,
-        JWT_AUTH_HEADER
-    );
+    // JWT domain for nested subject + nested roles
+    public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN_NESTED_SUBJECT = new TestSecurityConfig.AuthcDomain(
+        "jwt-nested",
+        BASIC_AUTH_DOMAIN_ORDER - 2
+    ).jwtHttpAuthenticator(
+        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(NESTED_SUBJECT).rolesKey(NESTED_ROLES)
+    ).backend("noop");
+    
+    // JWT domain for both subject and roles using "attributes" only
+    public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN_ATTRIBUTES_ONLY = new TestSecurityConfig.AuthcDomain(
+        "jwt-attributes-only",
+        BASIC_AUTH_DOMAIN_ORDER - 3
+    ).jwtHttpAuthenticator(
+        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(NESTED_SUBJECT_ATTRIBUTES_ONLY).rolesKey(NESTED_ROLES)
+    ).backend("noop");
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .anonymousAuth(false)
         .authc(JWT_AUTH_DOMAIN)
+        .authc(JWT_AUTH_DOMAIN_NESTED_SUBJECT)
+        .authc(JWT_AUTH_DOMAIN_ATTRIBUTES_ONLY)
         .build();
 
     @Rule
@@ -135,9 +165,9 @@ public class JwtAuthenticationNestedClaimsTests {
     
     @Test
     public void shouldAuthenticateWithNestedSubjectAndNestedRoles() {
-        // Create nested subject structure
+        // Create nested subject structure - the key should match NESTED_SUBJECT path
         Map<String, Object> attributesSub = new HashMap<>();
-        attributesSub.put("username", USER_SUPERHERO);
+        attributesSub.put("sub", USER_SUPERHERO);
         
         // Create nested roles structure
         Map<String, Object> attributes = new HashMap<>();
@@ -158,7 +188,173 @@ public class JwtAuthenticationNestedClaimsTests {
             String username = response.getTextFromJsonBody(POINTER_USERNAME);
             assertThat(username, equalTo(USER_SUPERHERO));
             
-            // But roles should still be extracted correctly
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(2));
+            assertThat(roles, containsInAnyOrder("all_access", "securitymanager"));
+        }
+    }
+    
+    @Test
+    public void shouldAuthenticateWithNestedSubjectAndSimpleRoles() {
+        // Create nested subject structure
+        Map<String, Object> attributesSub = new HashMap<>();
+        attributesSub.put("sub", USER_SUPERHERO);
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes_sub", attributesSub);
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SUPERHERO));
+            
+            // Should have no roles since they're not in the expected nested location
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(0));
+        }
+    }
+    
+    // Negative test cases
+    
+    @Test
+    public void shouldFailAuthenticationWithMissingNestedSubject() {
+        // Create nested roles structure but missing nested subject
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("roles", ROLES_CLAIM);
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes", attributes);
+        // Missing attributes_sub structure
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            // Should fail authentication due to missing subject
+            response.assertStatusCode(401);
+        }
+    }
+    
+    @Test
+    public void shouldFailAuthenticationWithWrongNestedSubjectStructure() {
+        // Create wrong nested subject structure
+        Map<String, Object> attributesSub = new HashMap<>();
+        attributesSub.put("wrong_key", USER_SUPERHERO);  // Wrong key, should be "sub"
+        
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("roles", ROLES_CLAIM);
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes_sub", attributesSub);
+        nestedClaims.put("attributes", attributes);
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            // Should fail authentication due to wrong subject structure
+            response.assertStatusCode(401);
+        }
+    }
+    
+    @Test
+    public void shouldAuthenticateWithMissingRolesButValidSubject() {
+        // Create nested subject structure but missing roles
+        Map<String, Object> attributesSub = new HashMap<>();
+        attributesSub.put("sub", USER_SUPERHERO);
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes_sub", attributesSub);
+        // Missing roles structure
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            // Should authenticate but with no roles
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SUPERHERO));
+            
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(0));
+        }
+    }
+    
+    @Test
+    public void shouldHandleWrongNestedRolesStructure() {
+        // Create nested subject structure with wrong roles structure
+        Map<String, Object> attributesSub = new HashMap<>();
+        attributesSub.put("sub", USER_SUPERHERO);
+        
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("wrong_roles_key", ROLES_CLAIM);  // Wrong key, should be "roles"
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes_sub", attributesSub);
+        nestedClaims.put("attributes", attributes);
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            // Should authenticate but with no roles due to wrong roles structure
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SUPERHERO));
+            
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(roles, hasSize(0));
+        }
+    }
+    
+    @Test
+    public void shouldFailAuthenticationWithCompletelyWrongTokenStructure() {
+        // Create completely wrong token structure
+        Map<String, Object> wrongClaims = new HashMap<>();
+        wrongClaims.put("completely", "wrong");
+        wrongClaims.put("structure", "invalid");
+        
+        Header header = tokenFactoryNestedSubjectAndRole.generateValidTokenWithCustomClaims(null, null, wrongClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            // Should fail authentication due to completely wrong structure
+            response.assertStatusCode(401);
+        }
+    }
+    
+    @Test
+    public void shouldAuthenticateWithBothSubjectAndRolesInAttributesOnly() {
+        // Create nested structure where both subject and roles are under "attributes"
+        // Subject path: attributes -> sub
+        // Roles path: attributes -> roles
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("sub", USER_SUPERHERO);
+        attributes.put("roles", ROLES_CLAIM);
+        
+        Map<String, Object> nestedClaims = new HashMap<>();
+        nestedClaims.put("attributes", attributes);
+        
+        // Use the token factory configured for attributes-only paths
+        Header header = tokenFactoryAttributesOnly.generateValidTokenWithCustomClaims(null, null, nestedClaims);
+        
+        try (TestRestClient client = cluster.getRestClient(header)) {
+            HttpResponse response = client.getAuthInfo();
+            
+            response.assertStatusCode(200);
+            String username = response.getTextFromJsonBody(POINTER_USERNAME);
+            assertThat(username, equalTo(USER_SUPERHERO));
+            
             List<String> roles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
             assertThat(roles, hasSize(2));
             assertThat(roles, containsInAnyOrder("all_access", "securitymanager"));

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
@@ -48,7 +48,8 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.BASIC
 public class JwtAuthenticationNestedClaimsTests {
 
     public static final List<String> CLAIM_USERNAME = List.of("preferred-username");
-    public static final List<String> CLAIM_ROLES = List.of("attributes", "roles");
+    public static final List<String> NESTED_ROLES = List.of("attributes", "roles");
+    public static final List<String> NESTED_SUBJECT = List.of("attributes_sub", "sub");
 
     public static final String USER_SUPERHERO = "superhero";
     private static final KeyPair KEY_PAIR1 = Keys.keyPairFor(SignatureAlgorithm.RS256);
@@ -58,14 +59,18 @@ public class JwtAuthenticationNestedClaimsTests {
     private static final JwtAuthorizationHeaderFactory tokenFactory1 = new JwtAuthorizationHeaderFactory(
         KEY_PAIR1.getPrivate(),
         CLAIM_USERNAME,
-        CLAIM_ROLES,
+        NESTED_ROLES,
         JWT_AUTH_HEADER
     );
     public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN = new TestSecurityConfig.AuthcDomain(
         "jwt",
         BASIC_AUTH_DOMAIN_ORDER - 1
     ).jwtHttpAuthenticator(
-        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(CLAIM_USERNAME).rolesKey(CLAIM_ROLES)
+        new JwtConfigBuilder().jwtHeader(JWT_AUTH_HEADER).signingKey(List.of(PUBLIC_KEY1)).subjectKey(CLAIM_USERNAME).rolesKey(NESTED_ROLES).build(
+            new HashMap<>(
+                Map.of(
+                    "noop", List.of("noop")
+                
     ).backend("noop");
 
     @ClassRule

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationNestedClaimsTests.java
@@ -47,7 +47,7 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.BASIC
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class JwtAuthenticationNestedClaimsTests {
 
-    public static final String CLAIM_USERNAME = "preferred-username";
+    public static final List<String> CLAIM_USERNAME = List.of("preferred-username");
     public static final List<String> CLAIM_ROLES = List.of("attributes", "roles");
 
     public static final String USER_SUPERHERO = "superhero";

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
@@ -68,7 +68,7 @@ import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searc
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class JwtAuthenticationTests {
 
-    public static final String CLAIM_USERNAME = "preferred-username";
+    public static final List<String> CLAIM_USERNAME = List.of("preferred-username");
     public static final List<String> CLAIM_ROLES = List.of("backend-user-roles");
 
     public static final String USER_SUPERHERO = "superhero";

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationWithUrlParamTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationWithUrlParamTests.java
@@ -50,7 +50,7 @@ import static org.opensearch.test.framework.audit.AuditMessagePredicate.userAuth
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class JwtAuthenticationWithUrlParamTests {
 
-    public static final String CLAIM_USERNAME = "preferred-username";
+    public static final List<String> CLAIM_USERNAME = List.of("preferred-username");
     public static final List<String> CLAIM_ROLES = List.of("backend-user-roles");
     public static final String POINTER_USERNAME = "/user_name";
 

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -36,7 +36,12 @@ class JwtAuthorizationHeaderFactory {
 
     private final String headerName;
 
-    public JwtAuthorizationHeaderFactory(PrivateKey privateKey, List<String> usernameClaimName, List<String> rolesClaimName, String headerName) {
+    public JwtAuthorizationHeaderFactory(
+        PrivateKey privateKey,
+        List<String> usernameClaimName,
+        List<String> rolesClaimName,
+        String headerName
+    ) {
         this.privateKey = requireNonNull(privateKey, "Private key is required");
         this.usernameClaimName = requireNonNull(usernameClaimName, "Username claim name is required");
         this.rolesClaimName = requireNonNull(rolesClaimName, "Roles claim name is required.");

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -67,27 +67,26 @@ class JwtAuthorizationHeaderFactory {
         ImmutableMap.Builder<String, Object> builder = new ImmutableMap.Builder();
         // Handle username claim
         if (StringUtils.isNoneEmpty(username)) {
-            if (usernameClaimName instanceof List && !((List<?>) usernameClaimName).isEmpty()) {
-                // Handle nested username claim
-                List<String> usernamePath = (List<String>) usernameClaimName;
-                Map<String, Object> nestedUserMap = new HashMap<>();
-                Map<String, Object> currentUserMap = nestedUserMap;
+            if (usernameClaimName.size() == 1) {
+                // Simple case - no nesting
+                builder.put(usernameClaimName.get(0), username);
+            } else {
+                // Handle nested claims
+                Map<String, Object> nestedMap = new HashMap<>();
+                Map<String, Object> currentMap = nestedMap;
 
-                // Build the nested structure for username
-                for (int i = 0; i < usernamePath.size() - 1; i++) {
+                // Build the nested structure
+                for (int i = 0; i < usernameClaimName.size() - 1; i++) {
                     Map<String, Object> nextMap = new HashMap<>();
-                    currentUserMap.put(usernamePath.get(i), nextMap);
-                    currentUserMap = nextMap;
+                    currentMap.put(usernameClaimName.get(i), nextMap);
+                    currentMap = nextMap;
                 }
 
                 // Add the username at the deepest level
-                currentUserMap.put(usernamePath.get(usernamePath.size() - 1), username);
+                currentMap.put(usernameClaimName.get(usernameClaimName.size() - 1), username);
 
-                // Add the entire nested username structure to the builder
-                builder.putAll(nestedUserMap);
-            } else {
-                // Simple case - no nesting for username
-                builder.put(usernameClaimName.toString(), username);
+                // Add the entire nested structure to the builder
+                builder.putAll(nestedMap);
             }
         }
 

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -118,7 +118,6 @@ class JwtAuthorizationHeaderFactory {
     }
 
     Header generateValidTokenWithCustomClaims(String username, String[] roles, Map<String, Object> additionalClaims) {
-        // requireNonNull(username, "Username is required"); not required as username can be null
         requireNonNull(additionalClaims, "Custom claims are required");
         Map<String, Object> claims = new HashMap<>(customClaimsMap(username, roles));
         claims.putAll(additionalClaims);

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -118,7 +118,7 @@ class JwtAuthorizationHeaderFactory {
     }
 
     Header generateValidTokenWithCustomClaims(String username, String[] roles, Map<String, Object> additionalClaims) {
-        requireNonNull(username, "Username is required");
+        // requireNonNull(username, "Username is required"); not required as username can be null
         requireNonNull(additionalClaims, "Custom claims are required");
         Map<String, Object> claims = new HashMap<>(customClaimsMap(username, roles));
         claims.putAll(additionalClaims);

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthorizationHeaderFactory.java
@@ -151,7 +151,7 @@ class JwtAuthorizationHeaderFactory {
         requireNonNull(username, "Username is required");
         Date now = new Date(1000);
         String token = Jwts.builder()
-            .setClaims(Map.of(usernameClaimName, username))
+            .setClaims(customClaimsMap(username, null))
             .setIssuer(ISSUER)
             .setSubject(subject(username))
             .setAudience(AUDIENCE)
@@ -167,7 +167,7 @@ class JwtAuthorizationHeaderFactory {
         requireNonNull(username, "Username is required");
         Date now = new Date();
         String token = Jwts.builder()
-            .setClaims(Map.of(usernameClaimName, username))
+            .setClaims(customClaimsMap(username, null))
             .setIssuer(ISSUER)
             .setSubject(subject(username))
             .setAudience(AUDIENCE)

--- a/src/integrationTest/java/org/opensearch/test/framework/JwtConfigBuilder.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/JwtConfigBuilder.java
@@ -21,7 +21,7 @@ public class JwtConfigBuilder {
     private String jwtHeader;
     private String jwtUrlParameter;
     private List<String> signingKeys;
-    private String subjectKey;
+    private List<String> subjectKey;
     private List<String> rolesKey;
 
     public JwtConfigBuilder jwtHeader(String jwtHeader) {
@@ -40,6 +40,11 @@ public class JwtConfigBuilder {
     }
 
     public JwtConfigBuilder subjectKey(String subjectKey) {
+        this.subjectKey = List.of(subjectKey);
+        return this;
+    }
+
+    public JwtConfigBuilder subjectKey(List<String> subjectKey) {
         this.subjectKey = subjectKey;
         return this;
     }
@@ -66,7 +71,7 @@ public class JwtConfigBuilder {
         if (isNoneBlank(jwtUrlParameter)) {
             builder.put("jwt_url_parameter", jwtUrlParameter);
         }
-        if (isNoneBlank(subjectKey)) {
+        if (subjectKey != null && !subjectKey.isEmpty()) {
             builder.put("subject_key", subjectKey);
         }
         if (rolesKey != null && !rolesKey.isEmpty()) {

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -187,9 +187,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     @VisibleForTesting
     public String extractSubject(JWTClaimsSet claims) {
         String subject = claims.getSubject();
-        log.warn("subject is '{}' ", subject);
-        log.warn("subjectKey is '{}' ", subjectKey);
-        log.warn("claims is '{}' ", claims);
 
         if (subjectKey != null && !subjectKey.isEmpty()) {
             Object subjectObject = null;
@@ -206,7 +203,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
                 }
             }
 
-            log.warn("subjectObject is '{}' ", subjectObject);
 
             if (subjectObject == null) {
                 log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);
@@ -237,7 +233,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             return new String[0];
         }
 
-        log.warn("rolesKey is '{}' ", rolesKey);
         Object rolesObject = null;
         Map<String, Object> claimsMap = claims.getClaims();
         for (int i = 0; i < rolesKey.size(); i++) {
@@ -262,7 +257,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             return new String[0];
         }
 
-        log.warn("rolesObject is '{}' ", rolesObject);
         String[] roles = String.valueOf(rolesObject).split(",");
 
         // We expect a String or Collection. If we find something else, convert to

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -261,7 +261,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             );
             return new String[0];
         }
-        
+
         log.warn("rolesObject is '{}' ", rolesObject);
         String[] roles = String.valueOf(rolesObject).split(",");
 

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -203,7 +203,6 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
                 }
             }
 
-
             if (subjectObject == null) {
                 log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);
                 return null;

--- a/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/AbstractHTTPJwtAuthenticator.java
@@ -60,7 +60,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
     private final String jwtHeaderName;
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
-    private final String subjectKey;
+    private final List<String> subjectKey;
     private final List<String> rolesKey;
     private final List<String> requiredAudience;
     private final String requiredIssuer;
@@ -73,7 +73,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         jwtHeaderName = settings.get("jwt_header", AUTHORIZATION);
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.getAsList("roles_key");
-        subjectKey = settings.get("subject_key");
+        subjectKey = settings.getAsList("subject_key");
         clockSkewToleranceSeconds = settings.getAsInt("jwt_clock_skew_tolerance_seconds", DEFAULT_CLOCK_SKEW_TOLERANCE_SECONDS);
         requiredAudience = settings.getAsList("required_audience");
         requiredIssuer = settings.get("required_issuer");
@@ -183,12 +183,30 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
         return jwtToken;
     }
 
+    @SuppressWarnings("unchecked")
     @VisibleForTesting
     public String extractSubject(JWTClaimsSet claims) {
         String subject = claims.getSubject();
+        log.warn("subject is '{}' ", subject);
+        log.warn("subjectKey is '{}' ", subjectKey);
+        log.warn("claims is '{}' ", claims);
 
-        if (subjectKey != null) {
-            Object subjectObject = claims.getClaim(subjectKey);
+        if (subjectKey != null && !subjectKey.isEmpty()) {
+            Object subjectObject = null;
+            Map<String, Object> claimsMap = claims.getClaims();
+            // This loop is necessary for nested claim traversal
+            for (int i = 0; i < subjectKey.size(); i++) {
+                if (i == subjectKey.size() - 1) {
+                    subjectObject = claimsMap.get(subjectKey.get(i));
+                } else if (claimsMap.get(subjectKey.get(i)) instanceof Map) {
+                    claimsMap = (Map<String, Object>) claimsMap.get(subjectKey.get(i));
+                } else {
+                    log.warn("Failed to get subject from JWT claims with subject_key '{}'.", subjectKey);
+                    return null;
+                }
+            }
+
+            log.warn("subjectObject is '{}' ", subjectObject);
 
             if (subjectObject == null) {
                 log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);
@@ -219,6 +237,7 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             return new String[0];
         }
 
+        log.warn("rolesKey is '{}' ", rolesKey);
         Object rolesObject = null;
         Map<String, Object> claimsMap = claims.getClaims();
         for (int i = 0; i < rolesKey.size(); i++) {
@@ -242,7 +261,8 @@ public abstract class AbstractHTTPJwtAuthenticator implements HTTPAuthenticator 
             );
             return new String[0];
         }
-
+        
+        log.warn("rolesObject is '{}' ", rolesObject);
         String[] roles = String.valueOf(rolesObject).split(",");
 
         // We expect a String or Collection. If we find something else, convert to

--- a/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -267,12 +267,12 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                         node,
                         node.getClass()
                     );
-                    return subject;  // Return default subject on error
+                    return null;  // Subject cannot be extracted from the configured path
                 }
                 node = map.get(key);
                 if (node == null) {                                      // key missing
                     log.warn("Failed to find '{}' in JWT claims while following subject_key path {}.", key, subjectKey);
-                    return subject;  // Return default subject on error
+                    return null;  // Subject cannot be extracted from the configured path
                 }
             }
             // ── 2. Interpret the leaf value ────────────────────────────────────────────

--- a/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticator.java
@@ -65,7 +65,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
     private final boolean isDefaultAuthHeader;
     private final String jwtUrlParameter;
     private final List<String> rolesKey;
-    private final String subjectKey;
+    private final List<String> subjectKey;
     private final List<String> requiredAudience;
     private final String requireIssuer;
 
@@ -79,7 +79,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         jwtHeaderName = settings.get("jwt_header", AUTHORIZATION);
         isDefaultAuthHeader = AUTHORIZATION.equalsIgnoreCase(jwtHeaderName);
         rolesKey = settings.getAsList("roles_key");
-        subjectKey = settings.get("subject_key");
+        subjectKey = settings.getAsList("subject_key");
         requiredAudience = settings.getAsList("required_audience");
         requireIssuer = settings.get("required_issuer");
 
@@ -178,7 +178,7 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
                     assertValidAudienceClaim(claims);
                 }
 
-                final String subject = extractSubject(claims, request);
+                final String subject = extractSubject(claims);
 
                 if (subject == null) {
                     log.error("No subject found in JWT token");
@@ -253,25 +253,41 @@ public class HTTPJwtAuthenticator implements HTTPAuthenticator {
         return "jwt";
     }
 
-    protected String extractSubject(final Claims claims, final SecurityRequest request) {
+    protected String extractSubject(final Claims claims) {
         String subject = claims.getSubject();
-        if (subjectKey != null) {
-            // try to get roles from claims, first as Object to avoid having to catch the ExpectedTypeException
-            Object subjectObject = claims.get(subjectKey, Object.class);
-            if (subjectObject == null) {
-                log.warn("Failed to get subject from JWT claims, check if subject_key '{}' is correct.", subjectKey);
-                return null;
+        if (subjectKey != null && !subjectKey.isEmpty()) {
+            // ── 1. Traverse the nested structure ───────────────────────────────────────
+            Object node = claims;                                        // start at root
+            for (String key : subjectKey) {
+                if (!(node instanceof Map<?, ?> map)) {                  // unexpected shape
+                    log.warn(
+                        "While following subject_key path {}, expected a JSON object before '{}', but found '{}' ({}).",
+                        subjectKey,
+                        key,
+                        node,
+                        node.getClass()
+                    );
+                    return subject;  // Return default subject on error
+                }
+                node = map.get(key);
+                if (node == null) {                                      // key missing
+                    log.warn("Failed to find '{}' in JWT claims while following subject_key path {}.", key, subjectKey);
+                    return subject;  // Return default subject on error
+                }
             }
-            // We expect a String. If we find something else, convert to String but issue a warning
-            if (!(subjectObject instanceof String)) {
+            // ── 2. Interpret the leaf value ────────────────────────────────────────────
+            if (node instanceof String str) {
+                return str.trim();
+            } else {                                                     // something odd
                 log.warn(
-                    "Expected type String for roles in the JWT for subject_key {}, but value was '{}' ({}). Will convert this value to String.",
+                    "Expected a String at the end of subject_key path {}, but found '{}' ({}). Converting to String.",
                     subjectKey,
-                    subjectObject,
-                    subjectObject.getClass()
+                    node,
+                    node.getClass()
                 );
+                return String.valueOf(node).trim();
             }
-            subject = String.valueOf(subjectObject);
+
         }
         return subject;
     }

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -314,7 +314,7 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     public void testSubjectAndRolesInNestedClaim() {
         Settings settings = Settings.builder()
             .put("openid_connect_url", mockIdpServer.getDiscoverUri())
-            .putList("subject_key", TestJwts.NESTED_MCCOY_SUBJECT)
+            .putList("subject_key", TestJwts.NESTED_ROLES_AND_SUBJECT_CLAIM)
             .putList("roles_key", TestJwts.NESTED_ROLES_CLAIM)
             .put("required_issuer", TestJwts.TEST_ISSUER)
             .put("required_audience", TestJwts.TEST_AUDIENCE)

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByOpenIdConnectAuthenticatorTest.java
@@ -286,6 +286,56 @@ public class HTTPJwtKeyByOpenIdConnectAuthenticatorTest {
     }
 
     @Test
+    public void testSubjectInNestedClaim() {
+        Settings settings = Settings.builder()
+            .put("openid_connect_url", mockIdpServer.getDiscoverUri())
+            .putList("subject_key", TestJwts.NESTED_MCCOY_SUBJECT)
+            .put("roles_key", TestJwts.ROLES_CLAIM)
+            .put("required_issuer", TestJwts.TEST_ISSUER)
+            .put("required_audience", TestJwts.TEST_AUDIENCE)
+            .build();
+
+        HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(
+            new FakeRestRequest(
+                ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_NESTED_SUBJECT_OCT_1),
+                new HashMap<String, String>()
+            ).asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNotNull(creds);
+        assertThat(creds.getUsername(), Matchers.is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getBackendRoles(), Matchers.is(TestJwts.TEST_ROLES));
+    }
+
+    @Test
+    public void testSubjectAndRolesInNestedClaim() {
+        Settings settings = Settings.builder()
+            .put("openid_connect_url", mockIdpServer.getDiscoverUri())
+            .putList("subject_key", TestJwts.NESTED_MCCOY_SUBJECT)
+            .putList("roles_key", TestJwts.NESTED_ROLES_CLAIM)
+            .put("required_issuer", TestJwts.TEST_ISSUER)
+            .put("required_audience", TestJwts.TEST_AUDIENCE)
+            .build();
+
+        HTTPJwtKeyByOpenIdConnectAuthenticator jwtAuth = new HTTPJwtKeyByOpenIdConnectAuthenticator(settings, null);
+
+        AuthCredentials creds = jwtAuth.extractCredentials(
+            new FakeRestRequest(
+                ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_NESTED_ROLES_AND_SUBJECT_OCT_1),
+                new HashMap<String, String>()
+            ).asSecurityRequest(),
+            null
+        );
+
+        Assert.assertNotNull(creds);
+        assertThat(creds.getUsername(), Matchers.is(TestJwts.MCCOY_SUBJECT));
+        assertThat(creds.getBackendRoles(), Matchers.is(TestJwts.TEST_ROLES));
+    }
+
+    @Test
     public void testExp() {
         Settings settings = Settings.builder().put("openid_connect_url", mockIdpServer.getDiscoverUri()).build();
 

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
@@ -11,11 +11,11 @@
 
 package org.opensearch.security.auth.http.jwt.keybyoidc;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Arrays;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -121,7 +121,7 @@ class TestJwts {
     @SuppressWarnings("unchecked")
     static JWTClaimsSet create(String subject, String audience, String issuer, Object... moreClaims) {
         JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
-    
+
         if (subject != null) {
             claimsBuilder.subject(String.valueOf(subject));
         }
@@ -143,10 +143,10 @@ class TestJwts {
                     if (!pathParts.isEmpty()) {
                         String topLevelKey = String.valueOf(pathParts.get(0));
                         @SuppressWarnings("unchecked")
-                        Map<String, Object> currentMap = topLevelClaims.containsKey(topLevelKey) 
+                        Map<String, Object> currentMap = topLevelClaims.containsKey(topLevelKey)
                             ? (Map<String, Object>) topLevelClaims.get(topLevelKey)
                             : new HashMap<>();
-                        
+
                         if (!topLevelClaims.containsKey(topLevelKey)) {
                             topLevelClaims.put(topLevelKey, currentMap);
                         }
@@ -157,7 +157,7 @@ class TestJwts {
                             Map<String, Object> nextMap = currentMap.containsKey(key)
                                 ? (Map<String, Object>) currentMap.get(key)
                                 : new HashMap<>();
-                            
+
                             if (!currentMap.containsKey(key)) {
                                 currentMap.put(key, nextMap);
                             }

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Arrays;
 
 import com.google.common.collect.ImmutableSet;
 

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
@@ -154,7 +154,6 @@ class TestJwts {
                         // Navigate to the correct nested level
                         for (int j = 1; j < pathParts.size() - 1; j++) {
                             String key = String.valueOf(pathParts.get(j));
-                            @SuppressWarnings("unchecked")
                             Map<String, Object> nextMap = currentMap.containsKey(key)
                                 ? (Map<String, Object>) currentMap.get(key)
                                 : new HashMap<>();

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
@@ -33,12 +33,14 @@ import static com.nimbusds.jwt.JWTClaimNames.NOT_BEFORE;
 class TestJwts {
     static final String ROLES_CLAIM = "roles";
     static final List<String> NESTED_ROLES_CLAIM = List.of("attributes", "roles");
+    static final List<String> NESTED_ROLES_AND_SUBJECT_CLAIM = List.of("attributes", "sub");
     static final Set<String> TEST_ROLES = ImmutableSet.of("role1", "role2");
     static final String TEST_ROLES_STRING = String.join(",", TEST_ROLES);
 
     static final String TEST_AUDIENCE = "TestAudience";
 
     static final String MCCOY_SUBJECT = "Leonard McCoy";
+    static final List<String> NESTED_MCCOY_SUBJECT = List.of("attributes_sub", "sub");
 
     static final String TEST_ISSUER = "TestIssuer";
 
@@ -46,12 +48,32 @@ class TestJwts {
 
     static final JWTClaimsSet MC_COY_2 = create(MCCOY_SUBJECT, TEST_AUDIENCE, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
 
+    static final JWTClaimsSet MC_COY_NESTED_SUBJECT = create(
+        null,
+        TEST_AUDIENCE,
+        TEST_ISSUER,
+        NESTED_MCCOY_SUBJECT,
+        MCCOY_SUBJECT,
+        ROLES_CLAIM,
+        TEST_ROLES_STRING
+    );
+
     static final JWTClaimsSet MC_COY_NESTED_ROLES = create(
         MCCOY_SUBJECT,
         TEST_AUDIENCE,
         TEST_ISSUER,
         NESTED_ROLES_CLAIM,
         TEST_ROLES_STRING
+    );
+
+    static final JWTClaimsSet MC_COY_NESTED_ROLES_AND_SUBJECT = create(
+        null,
+        TEST_AUDIENCE,
+        TEST_ISSUER,
+        NESTED_ROLES_CLAIM,
+        TEST_ROLES_STRING,
+        NESTED_ROLES_AND_SUBJECT_CLAIM,
+        MCCOY_SUBJECT
     );
 
     static final JWTClaimsSet MC_COY_NO_AUDIENCE = create(MCCOY_SUBJECT, null, TEST_ISSUER, ROLES_CLAIM, TEST_ROLES_STRING);
@@ -71,8 +93,9 @@ class TestJwts {
     static final String MC_COY_SIGNED_OCT_1 = createSigned(MC_COY, TestJwk.OCT_1);
 
     static final String MC_COY_SIGNED_OCT_2 = createSigned(MC_COY_2, TestJwk.OCT_2);
-
+    static final String MC_COY_SIGNED_NESTED_SUBJECT_OCT_1 = createSigned(MC_COY_NESTED_SUBJECT, TestJwk.OCT_1);
     static final String MC_COY_SIGNED_NESTED_ROLES_OCT_1 = createSigned(MC_COY_NESTED_ROLES, TestJwk.OCT_1);
+    static final String MC_COY_SIGNED_NESTED_ROLES_AND_SUBJECT_OCT_1 = createSigned(MC_COY_NESTED_ROLES_AND_SUBJECT, TestJwk.OCT_1);
     static final String MC_COY_SIGNED_NO_AUDIENCE_OCT_1 = createSigned(MC_COY_NO_AUDIENCE, TestJwk.OCT_1);
     static final String MC_COY_SIGNED_NO_ISSUER_OCT_1 = createSigned(MC_COY_NO_ISSUER, TestJwk.OCT_1);
 
@@ -96,8 +119,11 @@ class TestJwts {
 
     static JWTClaimsSet create(String subject, String audience, String issuer, Object... moreClaims) {
         JWTClaimsSet.Builder claimsBuilder = new JWTClaimsSet.Builder();
+        // Handle only simple subject case
+        if (subject != null) {
+            claimsBuilder.subject(String.valueOf(subject));
+        }
 
-        claimsBuilder.subject(subject);
         if (audience != null) {
             claimsBuilder.audience(audience);
         }


### PR DESCRIPTION
### Description

This PR abstracts the `subject ` configuration from jwt-backed auth backends to handle a list as config to get sub within nested claims of a JWT payload.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement of https://github.com/opensearch-project/security/pull/5355
### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/5430

Supported Nested claims 

```
Standard structure with top-level subject:
{
    "sub": "Leonard McCoy",
    "aud": "TestAudience",
    "iss": "TestIssuer",
    "roles": "role1,role2"
}

Standard structure with top-level subject with nested structures for roles:
{
    "sub": "Leonard McCoy",
    "aud": "TestAudience",
    "iss": "TestIssuer",
    "attributes": {
        "roles": "role1,role2"
    }
}

Nested subject under attributes:
{
    "aud": "TestAudience",
    "iss": "TestIssuer",
    "attributes": {
        "roles": "role1,role2",
        "sub": "Leonard McCoy"
    }
}

Separate nested structures for subject and roles:
{
    "attributes_sub": {
        "sub": "Leonard McCoy"
    },
    "aud": "TestAudience",
    "iss": "TestIssuer",
    "attributes": {
        "roles": "role1,role2"
    }
}
```

### Testing 
####  Unit Tests added 
Added in `HTTPJwtKeyByOpenIdConnectAuthenticatorTest`
- testSubjectInNestedClaim
- testSubjectAndRolesInNestedClaim
<img width="191" height="129" alt="Unit Tests Result" src="https://github.com/user-attachments/assets/3486e3e7-dbe9-447f-a32e-9cbb1a54bfde" />

#### Integ Tests added 
Added in `JwtAuthenticationNestedClaimsTests`
- shouldAuthenticateWithNestedRolesClaim
- shouldAuthenticateWithNestedSubjectAndNestedRoles
- shouldAuthenticateWithNestedSubjectAndSimpleRoles
- shouldFailAuthenticationWithCompletelyWrongTokenStructure 
- shouldFailAuthenticationWithMissingNestedSubject
- shouldFailAuthenticationWithWrongNestedSubjectStructure
- shouldHandleMissingNestedRolesClaim
- shouldHandleWrongNestedRolesStructure
<img width="191" height="129" alt="Integ Tests Result" src="https://github.com/user-attachments/assets/71774bd0-cd62-40d4-b432-91b2febd83fe" />


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
