### PR TITLE
Optimized runtime behavior of index matching during StatefulIndexPrivileges construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Replaced the standard distribution of BouncyCastle with BC-FIPS ([#5439](https://github.com/opensearch-project/security/pull/5439))
 * Introduced setting `plugins.security.privileges_evaluation.precomputed_privileges.enabled` ([#5465](https://github.com/opensearch-project/security/pull/5465))
 * Optimized wildcard matching runtime performance ([#5470](https://github.com/opensearch-project/security/pull/5470))
+* Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
@@ -696,6 +696,11 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                             continue;
                         }
 
+                        List<IndexAbstraction> matchingIndices = indexMatcher.matching(indices.values(), IndexAbstraction::getName);
+                        if (matchingIndices.isEmpty()) {
+                            continue;
+                        }
+
                         for (String permission : permissions) {
                             WildcardMatcher actionMatcher = WildcardMatcher.from(permission);
                             Collection<String> matchedActions = actionMatcher.getMatchAny(
@@ -703,21 +708,18 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                                 Collectors.toList()
                             );
 
-                            for (Map.Entry<String, IndexAbstraction> indicesEntry : indexMatcher.iterateMatching(
-                                indices.entrySet(),
-                                Map.Entry::getKey
-                            )) {
+                            for (IndexAbstraction index : matchingIndices) {
                                 for (String action : matchedActions) {
                                     CompactMapGroupBuilder.MapBuilder<
                                         String,
                                         DeduplicatingCompactSubSetBuilder.SubSetBuilder<String>> indexToRoles = actionToIndexToRoles
                                             .computeIfAbsent(action, k -> indexMapBuilder.createMapBuilder());
 
-                                    indexToRoles.get(indicesEntry.getKey()).add(roleName);
+                                    indexToRoles.get(index.getName()).add(roleName);
 
-                                    if (indicesEntry.getValue() instanceof IndexAbstraction.Alias) {
+                                    if (index instanceof IndexAbstraction.Alias) {
                                         // For aliases we additionally add the sub-indices to the privilege map
-                                        for (IndexMetadata subIndex : indicesEntry.getValue().getIndices()) {
+                                        for (IndexMetadata subIndex : index.getIndices()) {
                                             String subIndexName = subIndex.getIndex().getName();
                                             // We need to check whether the subIndex is part of the global indices
                                             // metadata map because that map has been filtered by relevantOnly().
@@ -732,7 +734,7 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                                                 log.debug(
                                                     "Ignoring member index {} of alias {}. This is usually the case because the index is closed or a data stream backing index.",
                                                     subIndexName,
-                                                    indicesEntry.getKey()
+                                                    index.getName()
                                                 );
                                             }
                                         }


### PR DESCRIPTION


### Description

This change moves the matching of index patterns from role configuration entries to a higher level during the construction of `StatefulIndexPrivileges` instances. This avoids that index pattern matching is repeated for each permission that is sourced from the role configuration. On clusters with many indices, this can provide a very significant performance improvement. In a simple micro benchmark (see comment below), we could observe computation times that showed a 85% reduction compared to the original code.

* Category: Enhancement
* Why these changes are required? For clusters with many indices and roles, runtime of index matching gets very significant.
* What is the old behavior before changes and new behavior after changes? No behavioral change

### Testing

- Existing unit and integration tests

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
