### PR TITLE
[2.19] Fix CVE-2025-53864, CVE-2025-48734

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.19.x]
 
 ### Maintenance
-- Bump `kafka_version` from 3.7.1 to 3.9.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))
 - Bump `com.nimbusds:nimbus-jose-jwt:9.48` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))
 - Bump `checkstyle` from 10.3.3 to 10.26.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Maintenance
 - Bump `kafka_version` from 3.7.1 to 3.9.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))
 - Bump `com.nimbusds:nimbus-jose-jwt:9.48` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))
-- Bump `commons-validator:commons-validator:1.9.0` from 1.9.0 to 1.10.0 ([#5480](https://github.com/opensearch-project/security/pull/5480))
+- Bump `checkstyle` from 10.3.3 to 10.26.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))~~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# CHANGELOG
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to the [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
+
+## [Unreleased 2.19.x]
+
+### Maintenance
+- Bump `kafka_version` from 3.7.1 to 4.0.0 ([#5480](https://github.com/opensearch-project/security/pull/5480))
+- Bump `com.nimbusds:nimbus-jose-jwt:10.0.2` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 2.19.x]
 
 ### Maintenance
-- Bump `kafka_version` from 3.7.1 to 4.0.0 ([#5480](https://github.com/opensearch-project/security/pull/5480))
+- Bump `kafka_version` from 3.7.1 to 3.9.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))
 - Bump `com.nimbusds:nimbus-jose-jwt:10.0.2` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Maintenance
 - Bump `kafka_version` from 3.7.1 to 3.9.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))
-- Bump `com.nimbusds:nimbus-jose-jwt:10.0.2` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))
+- Bump `com.nimbusds:nimbus-jose-jwt:9.48` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))
+- Bump `commons-validator:commons-validator:1.9.0` from 1.9.0 to 1.10.0 ([#5480](https://github.com/opensearch-project/security/pull/5480))

--- a/build.gradle
+++ b/build.gradle
@@ -692,7 +692,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-group-coordinator:${kafka_version}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
-    testImplementation 'commons-validator:commons-validator:1.10.0'
+    testImplementation 'commons-validator:commons-validator:1.9.0'
     testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
-        kafka_version  = '3.9.1'
+        kafka_version  = '3.7.1'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -593,7 +593,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.9.0'
     implementation "org.bouncycastle:bcprov-jdk18on:${versions.bouncycastle}"
     implementation 'org.ldaptive:ldaptive:1.2.3'
-    implementation 'com.nimbusds:nimbus-jose-jwt:9.48'
+    implementation 'com.nimbusds:nimbus-jose-jwt:10.0.2'
     implementation 'com.rfksystems:blake2b:2.0.0'
     implementation 'com.password4j:password4j:1.8.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -692,7 +692,7 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-group-coordinator:${kafka_version}"
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
-    testImplementation 'commons-validator:commons-validator:1.9.0'
+    testImplementation 'commons-validator:commons-validator:1.10.0'
     testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
     testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
-        kafka_version  = '4.0.0'
+        kafka_version  = '3.9.1'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'

--- a/build.gradle
+++ b/build.gradle
@@ -496,6 +496,9 @@ configurations {
             force "org.eclipse.platform:org.eclipse.core.runtime:3.32.0"
             force "org.eclipse.platform:org.eclipse.equinox.common:3.19.200"
 
+            // for checkstyle
+            force "org.codehaus.plexus:plexus-utils:3.1.1"
+
             // For integrationTest
             force "org.apache.httpcomponents:httpclient-cache:4.5.14"
             force "org.apache.httpcomponents:httpclient:4.5.14"

--- a/build.gradle
+++ b/build.gradle
@@ -383,7 +383,7 @@ jacocoTestReport {
 }
 
 checkstyle {
-    toolVersion "10.3.3"
+    toolVersion "10.26.1"
     configDirectory.set(rootProject.file("checkstyle/"))
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
-        kafka_version  = '3.7.1'
+        kafka_version  = '4.0.0'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'


### PR DESCRIPTION
### Description

CVE-2025-53864:
Bump nimbus-jose-jwt 9.48 -> 10.0.2

CVE-2025-48734
Bump checkstyle 10.3.3 -> 10.26.1

Additionally forcing plexus-utils:3.1.1 to resolve dependency conflict with new checkstyle version (wants 3.3.0).

### Issues Resolved
Above CVEs.

### Testing
N/A

### Check List
~~- [ ] New functionality includes testing~~
~~- [ ] New functionality has been documented~~
~~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~~
~~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~~
~~- [ ] Commits are signed per the DCO using --signoff~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
