### PR TITLE
[3.1 backport] Introduced setting for disabling denormalized privilege data structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased 3.1.x]
 ### Added
 
+* Introduced setting `plugins.security.privileges_evaluation.precomputed_privileges.enabled` ([#5483](https://github.com/opensearch-project/security/pull/5483))
 
 ### Changed
 

--- a/src/integrationTest/java/org/opensearch/security/privileges/ActionPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/ActionPrivilegesTest.java
@@ -960,6 +960,26 @@ public class ActionPrivilegesTest {
             );
             assertThat(resultForIndexNotCoveredByAlias, isForbidden());
         }
+
+        @Test
+        public void statefulDisabled() throws Exception {
+            SecurityDynamicConfiguration<RoleV7> roles = SecurityDynamicConfiguration.fromYaml(
+                "test_role:\n" + "  index_permissions:\n" + "  - index_patterns: ['test_*']\n" + "    allowed_actions: ['indices:*']",
+                CType.ROLES
+            );
+            Map<String, IndexAbstraction> metadata = indices("test_1", "test_2", "test_3")//
+                .build()
+                .getIndicesLookup();
+
+            ActionPrivileges subject = new ActionPrivileges(
+                roles,
+                FlattenedActionGroups.EMPTY,
+                Map::of,
+                Settings.builder().put(ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED.getKey(), false).build()
+            );
+            subject.updateStatefulIndexPrivileges(metadata, 1);
+            assertEquals(0, subject.getEstimatedStatefulIndexByteSize());
+        }
     }
 
     /**

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
@@ -51,6 +51,7 @@ import org.opensearch.index.query.MatchNoneQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.security.privileges.ActionPrivileges;
 import org.opensearch.security.privileges.PrivilegesConfigurationValidationException;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.PrivilegesEvaluationException;
@@ -537,7 +538,13 @@ public class DocumentPrivilegesTest {
                 roleConfig,
                 statefulness == Statefulness.STATEFUL ? INDEX_METADATA.getIndicesLookup() : Map.of(),
                 xContentRegistry,
-                Settings.builder().put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll).build()
+                Settings.builder()
+                    .put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll)
+                    .put(
+                        ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED.getKey(),
+                        statefulness == Statefulness.STATEFUL || statefulness == Statefulness.NON_STATEFUL
+                    )
+                    .build()
             );
         }
     }
@@ -852,7 +859,13 @@ public class DocumentPrivilegesTest {
                 roleConfig,
                 statefulness == Statefulness.STATEFUL ? INDEX_METADATA.getIndicesLookup() : Map.of(),
                 xContentRegistry,
-                Settings.builder().put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll).build()
+                Settings.builder()
+                    .put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll)
+                    .put(
+                        ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED.getKey(),
+                        statefulness == Statefulness.STATEFUL || statefulness == Statefulness.NON_STATEFUL
+                    )
+                    .build()
             );
         }
     }
@@ -1104,7 +1117,13 @@ public class DocumentPrivilegesTest {
                 roleConfig,
                 statefulness == Statefulness.STATEFUL ? INDEX_METADATA.getIndicesLookup() : Map.of(),
                 xContentRegistry,
-                Settings.builder().put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll).build()
+                Settings.builder()
+                    .put("plugins.security.dfm_empty_overrides_all", this.dfmEmptyOverridesAll)
+                    .put(
+                        ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED.getKey(),
+                        statefulness == Statefulness.STATEFUL || statefulness == Statefulness.NON_STATEFUL
+                    )
+                    .build()
             );
         }
 
@@ -1231,7 +1250,8 @@ public class DocumentPrivilegesTest {
      */
     static enum Statefulness {
         STATEFUL,
-        NON_STATEFUL
+        NON_STATEFUL,
+        DISABLED
     }
 
     /**

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2131,6 +2131,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             // Privileges evaluation
             settings.add(ActionPrivileges.PRECOMPUTED_PRIVILEGES_MAX_HEAP_SIZE);
+            settings.add(ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED);
 
             // Resource Sharing
             settings.add(

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/AbstractRuleBasedPrivileges.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.security.privileges.ActionPrivileges;
 import org.opensearch.security.privileges.IndexPattern;
 import org.opensearch.security.privileges.PrivilegesConfigurationValidationException;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
@@ -91,6 +92,11 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
      */
     private final boolean dfmEmptyOverridesAll;
 
+    /**
+     * Corresponds to the setting plugins.security.privileges_evaluation.precomputed_privileges.enabled
+     */
+    private final boolean statefulIndexEnabled;
+
     public AbstractRuleBasedPrivileges(
         SecurityDynamicConfiguration<RoleV7> roles,
         Map<String, IndexAbstraction> indexMetadata,
@@ -101,7 +107,8 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
         this.roleToRuleFunction = roleToRuleFunction;
         this.staticRules = new StaticRules<>(roles, roleToRuleFunction);
         this.dfmEmptyOverridesAll = settings.getAsBoolean(ConfigConstants.SECURITY_DFM_EMPTY_OVERRIDES_ALL, false);
-        this.statefulRules = new StatefulRules<>(roles, indexMetadata, roleToRuleFunction);
+        this.statefulIndexEnabled = ActionPrivileges.PRECOMPUTED_PRIVILEGES_ENABLED.get(settings);
+        this.statefulRules = this.statefulIndexEnabled ? new StatefulRules<>(roles, indexMetadata, roleToRuleFunction) : null;
     }
 
     /**
@@ -524,6 +531,10 @@ abstract class AbstractRuleBasedPrivileges<SingleRule, JoinedRule extends Abstra
         throws PrivilegesEvaluationException;
 
     synchronized void updateIndices(Map<String, IndexAbstraction> indexMetadata) {
+        if (!this.statefulIndexEnabled) {
+            return;
+        }
+
         StatefulRules<SingleRule> statefulRules = this.statefulRules;
 
         if (statefulRules == null || !statefulRules.indexMetadata.keySet().equals(indexMetadata.keySet())) {


### PR DESCRIPTION
### Description

Backport from https://github.com/opensearch-project/security/pull/5465

This introduces the setting `plugins.security.privileges_evaluation.precomputed_privileges.enabled` which can be used to disable the creation of denormalized privilege data structures. It is enabled by default to provide the best action throughput. It can make sense to disable the setting when it is seen that the initialisation process takes so much time/resources that it negatively affects the cluster performance (like observed in #5464) . This come at the price of a reduced action throughput.

* Category: Enhancement
* Why these changes are required? Operational safety
* What is the old behavior before changes and new behavior after changes? No behavioral changes.

### Testing

- Unit testing

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
