### PR TITLE
[3.1 Backport] Optimizations and simplifications for WildcardMatcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ### Dependencies
+* Optimized wildcard matching runtime performance ([#5470](https://github.com/opensearch-project/security/pull/5470))
+
+### Maintenance
 - Bump `org.eclipse.platform:org.eclipse.core.runtime` from 3.33.0 to 3.33.100 ([#5400](https://github.com/opensearch-project/security/pull/5400))
 - Bump `org.eclipse.platform:org.eclipse.equinox.common` from 3.20.0 to 3.20.100 ([#5402](https://github.com/opensearch-project/security/pull/5402))
 - Bump `spring_version` from 6.2.7 to 6.2.8 ([#5403](https://github.com/opensearch-project/security/pull/5403))

--- a/src/integrationTest/java/org/opensearch/security/support/WildcardMatcherTest.java
+++ b/src/integrationTest/java/org/opensearch/security/support/WildcardMatcherTest.java
@@ -1,0 +1,244 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.support;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Parameterized.class)
+public class WildcardMatcherTest {
+    boolean ignoreCase;
+
+    @Test
+    public void any() {
+        WildcardMatcher subject = applyCase(WildcardMatcher.ANY);
+        assertTrue(subject.test("any_string"));
+        assertTrue(subject.test(""));
+        assertTrue(subject.matchAny("any_string"));
+        assertTrue(subject.matchAny(Arrays.asList("any_string")));
+        assertTrue(subject.matchAny(Stream.of("any_string")));
+        assertEquals("*", subject.toString());
+    }
+
+    @Test
+    public void none() {
+        WildcardMatcher subject = applyCase(WildcardMatcher.NONE);
+        assertFalse(subject.test("any_string"));
+        assertFalse(subject.test(""));
+        assertFalse(subject.matchAny("any_string"));
+        assertFalse(subject.matchAny(Arrays.asList("any_string")));
+        assertFalse(subject.matchAny(Stream.of("any_string")));
+        assertEquals("<NONE>", subject.toString());
+    }
+
+    @Test
+    public void anyFromStar() {
+        assertSame(WildcardMatcher.ANY, applyCase(WildcardMatcher.from("*")));
+    }
+
+    @Test
+    public void noneFromNull() {
+        assertSame(WildcardMatcher.NONE, applyCase(WildcardMatcher.from()));
+        assertSame(WildcardMatcher.NONE, applyCase(WildcardMatcher.from((String) null)));
+    }
+
+    @Test
+    public void exact() {
+        String base = "exact_string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from(base));
+        assertTrue(subject instanceof WildcardMatcher.Exact);
+        assertTrue(subject.test(base));
+        assertFalse(subject.test(base + "_x"));
+        assertEquals(ignoreCase, subject.test(base.toUpperCase()));
+        assertTrue(subject.matchAny(base));
+        assertTrue(subject.matchAny(base, "foo"));
+        assertFalse(subject.matchAny("foo"));
+        assertTrue(subject.matchAny(Arrays.asList(base, "foo")));
+        assertFalse(subject.matchAny(Arrays.asList("foo")));
+        assertEquals(base, subject.toString());
+        assertEquals(applyCase(WildcardMatcher.from(base)), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(base + "x")), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(base + "*")), subject);
+        assertEquals(Arrays.asList(base), subject.getMatchAny(Arrays.asList(base, "other"), Collectors.toList()));
+    }
+
+    @Test
+    public void prefix() {
+        String base = "prefix_string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from(base + "*"));
+        assertTrue(subject instanceof WildcardMatcher.PrefixMatcher);
+        assertTrue(subject.test(base + "_more"));
+        assertTrue(subject.test(base));
+        assertFalse(subject.test(base.substring(0, 5)));
+        assertFalse(subject.test("more_" + base));
+        assertEquals(ignoreCase, subject.test(base.toUpperCase()));
+        assertEquals(ignoreCase, subject.test(base.toUpperCase() + "_more"));
+        assertTrue(subject.matchAny(base));
+        assertTrue(subject.matchAny(base, "foo"));
+        assertFalse(subject.matchAny("foo"));
+        assertEquals(base + "*", subject.toString());
+        assertEquals(applyCase(WildcardMatcher.from(subject.toString())), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(subject.toString() + "x")), subject);
+        assertEquals(
+            Arrays.asList(base, base + "_more"),
+            subject.getMatchAny(Arrays.asList(base, base + "_more", "other"), Collectors.toList())
+        );
+        assertEquals(
+            Arrays.asList(base, base + "_more"),
+            StreamSupport.stream(subject.iterateMatching(Arrays.asList(base, base + "_more", "other")).spliterator(), false).toList()
+        );
+        assertEquals(Arrays.asList(base, base + "_more"), subject.matching(Arrays.asList(base, base + "_more", "other")));
+    }
+
+    @Test
+    public void contains() {
+        String base = "contains_string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from("*" + base + "*"));
+        assertTrue(subject instanceof WildcardMatcher.ContainsMatcher);
+        assertTrue(subject.test(base));
+        assertTrue(subject.test(base + "_a"));
+        assertTrue(subject.test("a_" + base));
+        assertTrue(subject.test("a_" + base + "_a"));
+        assertFalse(subject.test("string".substring(0, 5)));
+        assertEquals(ignoreCase, subject.test(base.toUpperCase()));
+        assertEquals(ignoreCase, subject.test("a_" + base.toUpperCase() + "_a"));
+        assertEquals("*" + base + "*", subject.toString());
+        assertEquals(applyCase(WildcardMatcher.from(subject.toString())), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(subject.toString() + "x")), subject);
+    }
+
+    @Test
+    public void simple() {
+        String base1 = "my";
+        String base2 = "string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from(base1 + "*" + base2 + "*"));
+        assertTrue(subject instanceof WildcardMatcher.SimpleMatcher);
+        assertTrue(subject.test(base1 + base2));
+        assertTrue(subject.test(base1 + "_x_" + base2));
+        assertTrue(subject.test(base1 + "_x_" + base2 + "_y"));
+        assertFalse(subject.test("x_" + base1 + base2));
+        assertEquals(ignoreCase, subject.test(base1 + base2.toUpperCase()));
+    }
+
+    @Test
+    public void simple_withQuestionMark() {
+        String base = "string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from("?" + base));
+        assertTrue(subject instanceof WildcardMatcher.SimpleMatcher);
+        assertFalse(subject.test(base));
+        assertTrue(subject.test("." + base));
+        assertFalse(subject.test(".." + base));
+        assertFalse(subject.test("." + base + "."));
+        assertEquals(ignoreCase, subject.test("." + base.toUpperCase()));
+    }
+
+    @Test
+    public void simple_withQuestionMarkAndStar() {
+        String base1 = "my";
+        String base2 = "string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from(base1 + "?" + base2 + "*"));
+        assertTrue(subject instanceof WildcardMatcher.SimpleMatcher);
+        assertFalse(subject.test(base1 + base2));
+        assertTrue(subject.test(base1 + "_" + base2));
+        assertTrue(subject.test(base1 + "_" + base2 + "_y"));
+        assertFalse(subject.test("x_" + base1 + base2));
+        assertEquals(ignoreCase, subject.test(base1 + "_" + base2.toUpperCase()));
+    }
+
+    @Test
+    public void simple_questionMark() {
+        WildcardMatcher subject = applyCase(WildcardMatcher.from("?"));
+        assertTrue(subject instanceof WildcardMatcher.SimpleMatcher);
+        assertFalse(subject.test(""));
+        assertTrue(subject.test("."));
+        assertFalse(subject.test(".."));
+    }
+
+    @Test
+    public void regex() {
+        String base1 = "my";
+        String base2 = "string";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from("/" + base1 + ".*" + base2 + "./"));
+        assertTrue(subject instanceof WildcardMatcher.RegexMatcher);
+        assertFalse(subject.test(base1 + base2));
+        assertTrue(subject.test(base1 + base2 + "x"));
+        assertTrue(subject.test(base1 + "_x_" + base2 + "x"));
+        assertFalse(subject.test("x_" + base1 + base2 + "x"));
+        assertEquals(ignoreCase, subject.test(base1 + base2.toUpperCase() + "x"));
+        assertEquals("/" + base1 + ".*" + base2 + "./", subject.toString());
+        assertEquals(applyCase(WildcardMatcher.from(subject.toString())), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(subject.toString() + "x")), subject);
+    }
+
+    @Test
+    public void combined() {
+        String base1 = "string";
+        String base2 = "other";
+        WildcardMatcher subject = applyCase(WildcardMatcher.from(base1 + "*", base2));
+        assertTrue(subject instanceof WildcardMatcher.MatcherCombiner);
+        assertTrue(subject.test(base1 + "_more"));
+        assertTrue(subject.test(base1));
+        assertTrue(subject.test(base2));
+        assertFalse(subject.test(base2 + "_more"));
+        assertEquals(ignoreCase, subject.test(base1.toUpperCase()));
+        assertEquals(ignoreCase, subject.test(base1.toUpperCase() + "_more"));
+        assertEquals(ignoreCase, subject.test(base2.toUpperCase()));
+        assertEquals("[" + base1 + "*, " + base2 + "]", subject.toString());
+        assertEquals(applyCase(WildcardMatcher.from(base1 + "*", base2)), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(base1 + "*", base2, "x")), subject);
+        assertNotEquals(applyCase(WildcardMatcher.from(base1 + "*")), subject);
+    }
+
+    @Test
+    public void concat() {
+        String base1 = "string";
+        String base2 = "other";
+        WildcardMatcher subject1 = applyCase(WildcardMatcher.from(base1 + "*"));
+        assertSame(subject1, subject1.concat(Collections.emptyList()));
+        WildcardMatcher subject2 = subject1.concat(Collections.singleton(applyCase(WildcardMatcher.from(base2))));
+        assertTrue(subject2 instanceof WildcardMatcher.MatcherCombiner);
+        assertTrue(subject2.test(base1));
+        assertTrue(subject2.test(base2));
+        assertFalse(subject2.test(base2 + "_more"));
+    }
+
+    public WildcardMatcherTest(boolean ignoreCase) {
+        this.ignoreCase = ignoreCase;
+    }
+
+    @Parameterized.Parameters(name = "ignoreCase: {0}")
+    public static Collection<Object[]> params() {
+        return Arrays.asList(new Object[] { false }, new Object[] { true });
+    }
+
+    private WildcardMatcher applyCase(WildcardMatcher wildcardMatcher) {
+        if (ignoreCase) {
+            return wildcardMatcher.ignoreCase();
+        } else {
+            return wildcardMatcher;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditMessage.java
@@ -64,7 +64,7 @@ public final class AuditMessage {
     private static final Logger log = LogManager.getLogger(AuditMessage.class);
 
     // clustername and cluster uuid
-    private static final WildcardMatcher AUTHORIZATION_HEADER = WildcardMatcher.from("Authorization", false);
+    private static final WildcardMatcher AUTHORIZATION_HEADER = WildcardMatcher.from("Authorization").ignoreCase();
     private static final String SENSITIVE_KEY = "password";
     private static final String SENSITIVE_REPLACEMENT_VALUE = "__SENSITIVE__";
 

--- a/src/main/java/org/opensearch/security/rest/SecurityWhoAmIAction.java
+++ b/src/main/java/org/opensearch/security/rest/SecurityWhoAmIAction.java
@@ -111,7 +111,7 @@ public class SecurityWhoAmIAction extends BaseRestHandler {
 
                         final String dn = sslInfo.getPrincipal();
                         final boolean isAdmin = adminDns.isAdminDN(dn);
-                        final boolean isNodeCertificateRequest = dn != null && WildcardMatcher.from(nodesDn, true).matchAny(dn);
+                        final boolean isNodeCertificateRequest = dn != null && WildcardMatcher.from(nodesDn).ignoreCase().matchAny(dn);
 
                         builder.startObject();
                         builder.field("dn", dn);

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -382,7 +382,9 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
             return this.configuration.getCEntries()
                 .entrySet()
                 .stream()
-                .collect(ImmutableMap.toImmutableMap(Entry::getKey, entry -> WildcardMatcher.from(entry.getValue().getNodesDn(), false)));
+                .collect(
+                    ImmutableMap.toImmutableMap(Entry::getKey, entry -> WildcardMatcher.from(entry.getValue().getNodesDn()).ignoreCase())
+                );
         }
     }
 }

--- a/src/main/java/org/opensearch/security/support/WildcardMatcher.java
+++ b/src/main/java/org/opensearch/security/support/WildcardMatcher.java
@@ -26,12 +26,12 @@
 
 package org.opensearch.security.support;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang3.StringUtils;
 
 public abstract class WildcardMatcher implements Predicate<String> {
 
@@ -62,21 +63,6 @@ public abstract class WildcardMatcher implements Predicate<String> {
         }
 
         @Override
-        public boolean matchAll(Stream<String> candidates) {
-            return true;
-        }
-
-        @Override
-        public boolean matchAll(Collection<String> candidates) {
-            return true;
-        }
-
-        @Override
-        public boolean matchAll(String[] candidates) {
-            return true;
-        }
-
-        @Override
         public <T extends Collection<String>> T getMatchAny(Stream<String> candidates, Collector<String, ?, T> collector) {
             return candidates.collect(collector);
         }
@@ -84,6 +70,11 @@ public abstract class WildcardMatcher implements Predicate<String> {
         @Override
         public boolean test(String candidate) {
             return true;
+        }
+
+        @Override
+        public WildcardMatcher ignoreCase() {
+            return this;
         }
 
         @Override
@@ -110,21 +101,6 @@ public abstract class WildcardMatcher implements Predicate<String> {
         }
 
         @Override
-        public boolean matchAll(Stream<String> candidates) {
-            return false;
-        }
-
-        @Override
-        public boolean matchAll(Collection<String> candidates) {
-            return false;
-        }
-
-        @Override
-        public boolean matchAll(String[] candidates) {
-            return false;
-        }
-
-        @Override
         public <T extends Collection<String>> T getMatchAny(Stream<String> candidates, Collector<String, ?, T> collector) {
             return Stream.<String>empty().collect(collector);
         }
@@ -145,36 +121,49 @@ public abstract class WildcardMatcher implements Predicate<String> {
         }
 
         @Override
+        public WildcardMatcher ignoreCase() {
+            return this;
+        }
+
+        @Override
         public String toString() {
             return "<NONE>";
         }
     };
 
-    public static WildcardMatcher from(String pattern, boolean caseSensitive) {
+    public static WildcardMatcher from(String pattern) {
         if (pattern == null) {
             return NONE;
         } else if (pattern.equals("*")) {
             return ANY;
         } else if (pattern.startsWith("/") && pattern.endsWith("/")) {
-            return new RegexMatcher(pattern, caseSensitive);
-        } else if (pattern.indexOf('?') >= 0 || pattern.indexOf('*') >= 0) {
-            return caseSensitive ? new SimpleMatcher(pattern) : new CasefoldingMatcher(pattern, SimpleMatcher::new);
+            return new RegexMatcher(pattern, true);
         } else {
-            return caseSensitive ? new Exact(pattern) : new CasefoldingMatcher(pattern, Exact::new);
+            int star = pattern.indexOf('*');
+            int questionmark = pattern.indexOf('?');
+
+            if (star == -1 && questionmark == -1) {
+                // This is just a string constant
+                return new Exact(pattern, true);
+            } else if (star == pattern.length() - 1 && questionmark == -1) {
+                // Simple prefix pattern: "a*"
+                return new PrefixMatcher(pattern, true);
+            } else if (pattern.length() > 1 && questionmark == -1 && star == 0 && pattern.indexOf('*', 1) == pattern.length() - 1) {
+                // Simple contains pattern: "*a*"
+                return new ContainsMatcher(pattern, true);
+            } else {
+                return new SimpleMatcher(pattern);
+            }
         }
     }
 
-    public static WildcardMatcher from(String pattern) {
-        return from(pattern, true);
-    }
-
     // This may in future use more optimized techniques to combine multiple WildcardMatchers in a single automaton
-    public static <T> WildcardMatcher from(Stream<T> stream, boolean caseSensitive) {
+    public static <T> WildcardMatcher from(Stream<T> stream) {
         Collection<WildcardMatcher> matchers = stream.map(t -> {
             if (t == null) {
                 return NONE;
             } else if (t instanceof String) {
-                return WildcardMatcher.from(((String) t), caseSensitive);
+                return WildcardMatcher.from((String) t);
             } else if (t instanceof WildcardMatcher) {
                 return ((WildcardMatcher) t);
             }
@@ -189,58 +178,47 @@ public abstract class WildcardMatcher implements Predicate<String> {
         return new MatcherCombiner(matchers);
     }
 
-    public static <T> WildcardMatcher from(Collection<T> collection, boolean caseSensitive) {
+    public static <T> WildcardMatcher from(Collection<T> collection) {
         if (collection == null || collection.isEmpty()) {
             return NONE;
         } else if (collection.size() == 1) {
             T t = collection.stream().findFirst().get();
             if (t instanceof String) {
-                return from(((String) t), caseSensitive);
+                return from((String) t);
             } else if (t instanceof WildcardMatcher) {
                 return ((WildcardMatcher) t);
             }
             throw new UnsupportedOperationException("WildcardMatcher can't be constructed from " + t.getClass().getSimpleName());
         }
-        return from(collection.stream(), caseSensitive);
-    }
-
-    public static WildcardMatcher from(String[] patterns, boolean caseSensitive) {
-        if (patterns == null || patterns.length == 0) {
-            return NONE;
-        } else if (patterns.length == 1) {
-            return from(patterns[0], caseSensitive);
-        }
-        return from(Arrays.stream(patterns), caseSensitive);
-    }
-
-    public static WildcardMatcher from(Stream<String> patterns) {
-        return from(patterns, true);
-    }
-
-    public static WildcardMatcher from(Collection<?> patterns) {
-        return from(patterns, true);
+        return from(collection.stream());
     }
 
     public static WildcardMatcher from(String... patterns) {
-        return from(patterns, true);
+        if (patterns == null || patterns.length == 0) {
+            return NONE;
+        } else if (patterns.length == 1) {
+            return from(patterns[0]);
+        }
+        return from(Arrays.stream(patterns));
     }
 
-    public WildcardMatcher concat(Stream<WildcardMatcher> matchers) {
-        return new MatcherCombiner(Stream.concat(matchers, Stream.of(this)).collect(ImmutableSet.toImmutableSet()));
-    }
+    /**
+     * This is the main matching method of this class. Use this to match a single string against the particular matcher.
+     * Returns true if it matches, false otherwise.
+     */
+    @Override
+    public abstract boolean test(String s);
+
+    /**
+     * This converts this WildcardMatcher into an instance that ignores case.
+     */
+    public abstract WildcardMatcher ignoreCase();
 
     public WildcardMatcher concat(Collection<WildcardMatcher> matchers) {
         if (matchers.isEmpty()) {
             return this;
         }
-        return concat(matchers.stream());
-    }
-
-    public WildcardMatcher concat(WildcardMatcher... matchers) {
-        if (matchers.length == 0) {
-            return this;
-        }
-        return concat(Arrays.stream(matchers));
+        return new MatcherCombiner(Stream.concat(matchers.stream(), Stream.of(this)).collect(ImmutableSet.toImmutableSet()));
     }
 
     public boolean matchAny(Stream<String> candidates) {
@@ -255,18 +233,6 @@ public abstract class WildcardMatcher implements Predicate<String> {
         return matchAny(Arrays.stream(candidates));
     }
 
-    public boolean matchAll(Stream<String> candidates) {
-        return candidates.allMatch(this);
-    }
-
-    public boolean matchAll(Collection<String> candidates) {
-        return matchAll(candidates.stream());
-    }
-
-    public boolean matchAll(String[] candidates) {
-        return matchAll(Arrays.stream(candidates));
-    }
-
     public <T extends Collection<String>> T getMatchAny(Stream<String> candidates, Collector<String, ?, T> collector) {
         return candidates.filter(this).collect(collector);
     }
@@ -279,14 +245,26 @@ public abstract class WildcardMatcher implements Predicate<String> {
         return getMatchAny(Arrays.stream(candidate), collector);
     }
 
-    public Optional<WildcardMatcher> findFirst(final String candidate) {
-        return Optional.ofNullable(test(candidate) ? this : null);
-    }
-
+    /**
+     * Returns an Iterable that can be used to iterate through all matching elements from the given candidates param.
+     * The matching elements are computed on the fly when you are iterating. This means that this function performs
+     * in a very space efficient way. However, if you repeatedly iterate through the returned Iterable, matching will be
+     * performed again and again. If you want to have pre-computed results, use the function matching().
+     */
     public Iterable<String> iterateMatching(Iterable<String> candidates) {
         return iterateMatching(candidates, Function.identity());
     }
 
+    /**
+     * Returns an Iterable that can be used to iterate through all matching elements from the given candidates param.
+     * The matching elements are computed on the fly when you are iterating. This means that this function performs
+     * in a very space efficient way. However, if you repeatedly iterate through the returned Iterable, matching will be
+     * performed again and again. If you want to have pre-computed results, use the function matching().
+     * <p>
+     * This function can iterate through any type of object. The toStringFunction() parameter will be internally used
+     * to convert the object into a string on which the matching can be performed. This is typically a getName() function
+     * or something similar.
+     */
     public <E> Iterable<E> iterateMatching(Iterable<E> candidates, Function<E, String> toStringFunction) {
         return new Iterable<E>() {
 
@@ -332,8 +310,34 @@ public abstract class WildcardMatcher implements Predicate<String> {
         };
     }
 
+    /**
+     * Returns a list with the elements from the given candidates that match this pattern.
+     */
+    public List<String> matching(Collection<String> candidates) {
+        return matching(candidates, Function.identity());
+    }
+
+    /**
+     * Returns a list with the elements from the given candidates that match this pattern.
+     <p>
+     * This function can iterate through any type of object. The toStringFunction() parameter will be internally used
+     * to convert the object into a string on which the matching can be performed. This is typically a getName() function
+     * or something similar.
+     */
+    public <E> List<E> matching(Collection<E> candidates, Function<E, String> toStringFunction) {
+        List<E> result = new ArrayList<>(Math.min(candidates.size(), 20));
+
+        for (E candidate : candidates) {
+            if (test(toStringFunction.apply(candidate))) {
+                result.add(candidate);
+            }
+        }
+
+        return result;
+    }
+
     public static List<WildcardMatcher> matchers(Collection<String> patterns) {
-        return patterns.stream().map(p -> WildcardMatcher.from(p, true)).collect(Collectors.toList());
+        return patterns.stream().map(WildcardMatcher::from).collect(Collectors.toList());
     }
 
     public static List<String> getAllMatchingPatterns(final Collection<WildcardMatcher> matchers, final String candidate) {
@@ -348,82 +352,43 @@ public abstract class WildcardMatcher implements Predicate<String> {
         return pattern == null || !(pattern.contains("*") || pattern.contains("?") || (pattern.startsWith("/") && pattern.endsWith("/")));
     }
 
-    //
-    // --- Implementation specializations ---
-    //
-    // Casefolding matcher - sits on top of case-sensitive matcher
-    // and proxies toLower() of input string to the wrapped matcher
-    private static final class CasefoldingMatcher extends WildcardMatcher {
+    /**
+     * Matches a constant value.
+     */
+    static final class Exact extends AbstractSimpleWildcardMatcher {
 
-        private final WildcardMatcher inner;
+        private final boolean caseSensitive;
 
-        public CasefoldingMatcher(String pattern, Function<String, WildcardMatcher> simpleWildcardMatcher) {
-            this.inner = simpleWildcardMatcher.apply(pattern.toLowerCase());
+        private Exact(String pattern, boolean caseSensitive) {
+            super(pattern);
+            this.caseSensitive = caseSensitive;
         }
 
         @Override
         public boolean test(String candidate) {
-            return inner.test(candidate.toLowerCase());
+            if (this.caseSensitive) {
+                return pattern.equals(candidate);
+            } else {
+                return pattern.equalsIgnoreCase(candidate);
+            }
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            CasefoldingMatcher that = (CasefoldingMatcher) o;
-            return inner.equals(that.inner);
-        }
-
-        @Override
-        public int hashCode() {
-            return inner.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return inner.toString();
+        public WildcardMatcher ignoreCase() {
+            return new Exact(this.pattern, false);
         }
     }
 
-    public static final class Exact extends WildcardMatcher {
-
-        private final String pattern;
-
-        private Exact(String pattern) {
-            this.pattern = pattern;
-        }
-
-        @Override
-        public boolean test(String candidate) {
-            return pattern.equals(candidate);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Exact that = (Exact) o;
-            return pattern.equals(that.pattern);
-        }
-
-        @Override
-        public int hashCode() {
-            return pattern.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return pattern;
-        }
-    }
-
-    // RegexMatcher uses JDK Pattern to test for matching,
-    // assumes "/<regex>/" strings as input pattern
-    private static final class RegexMatcher extends WildcardMatcher {
+    /**
+     * Represents full regex patterns, which can be identified by a leading and trailing /.
+     * Uses the JDK Pattern class under the hood.
+     */
+    static final class RegexMatcher extends AbstractSimpleWildcardMatcher {
 
         private final Pattern pattern;
 
         private RegexMatcher(String pattern, boolean caseSensitive) {
+            super(pattern);
             Preconditions.checkArgument(pattern.length() > 1 && pattern.startsWith("/") && pattern.endsWith("/"));
             final String stripSlashesPattern = pattern.substring(1, pattern.length() - 1);
             this.pattern = caseSensitive
@@ -437,33 +402,17 @@ public abstract class WildcardMatcher implements Predicate<String> {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            RegexMatcher that = (RegexMatcher) o;
-            return pattern.pattern().equals(that.pattern.pattern());
-        }
-
-        @Override
-        public int hashCode() {
-            return pattern.pattern().hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return "/" + pattern.pattern() + "/";
+        public WildcardMatcher ignoreCase() {
+            return new RegexMatcher(super.pattern, false);
         }
     }
 
     // Simple implementation of WildcardMatcher matcher with * and ? without
     // using exlicit stack or recursion (as long as we don't need sub-matches it does work)
     // allows us to save on resources and heap allocations unless Regex is required
-    private static final class SimpleMatcher extends WildcardMatcher {
-
-        private final String pattern;
-
+    static class SimpleMatcher extends AbstractSimpleWildcardMatcher {
         SimpleMatcher(String pattern) {
-            this.pattern = pattern;
+            super(pattern);
         }
 
         @Override
@@ -493,54 +442,115 @@ public abstract class WildcardMatcher implements Predicate<String> {
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            SimpleMatcher that = (SimpleMatcher) o;
-            return pattern.equals(that.pattern);
-        }
+        public WildcardMatcher ignoreCase() {
+            return new SimpleMatcher(pattern.toLowerCase()) {
 
-        @Override
-        public int hashCode() {
-            return pattern.hashCode();
-        }
-
-        @Override
-        public String toString() {
-            return pattern;
+                @Override
+                public boolean test(String candidate) {
+                    return super.test(candidate.toLowerCase());
+                }
+            };
         }
     }
 
-    // MatcherCombiner is a combination of a set of matchers
-    // matches if any of the set do
-    // Empty MultiMatcher always returns false
-    private static final class MatcherCombiner extends WildcardMatcher {
+    /**
+     * A matcher for the very common case "string*". Uses String.startsWith() internally.
+     */
+    static final class PrefixMatcher extends AbstractSimpleWildcardMatcher {
+        private final String prefix;
+        private final boolean caseSensitive;
 
-        private final Collection<WildcardMatcher> wildcardMatchers;
+        PrefixMatcher(String pattern, boolean caseSensitive) {
+            super(pattern);
+            assert pattern.endsWith("*");
+            this.prefix = pattern.substring(0, pattern.length() - 1);
+            this.caseSensitive = caseSensitive;
+        }
+
+        @Override
+        public boolean test(String s) {
+            if (this.caseSensitive) {
+                return s.startsWith(prefix);
+            } else {
+                return StringUtils.startsWithIgnoreCase(s, this.prefix);
+            }
+        }
+
+        @Override
+        public WildcardMatcher ignoreCase() {
+            return new PrefixMatcher(this.pattern, false);
+        }
+    }
+
+    /**
+     * A matcher for the case "*string*". Uses String.contains() internally.
+     */
+    static final class ContainsMatcher extends AbstractSimpleWildcardMatcher {
+        private final String string;
+        private final boolean caseSensitive;
+
+        ContainsMatcher(String pattern, boolean caseSensitive) {
+            super(pattern);
+            assert pattern.endsWith("*") && pattern.startsWith("*");
+            this.string = pattern.substring(1, pattern.length() - 1);
+            this.caseSensitive = caseSensitive;
+        }
+
+        @Override
+        public boolean test(String s) {
+            if (this.caseSensitive) {
+                return s.contains(string);
+            } else {
+                return StringUtils.containsIgnoreCase(s, this.string);
+            }
+        }
+
+        @Override
+        public WildcardMatcher ignoreCase() {
+            return new ContainsMatcher(this.pattern, false);
+        }
+    }
+
+    /**
+     * MatcherCombiner is a combination of a set of matchers.
+     * This class matches if at least one of the contained matchers matches.
+     */
+    static final class MatcherCombiner extends WildcardMatcher {
+
+        private final WildcardMatcher[] wildcardMatchers;
         private final int hashCode;
+        private final String asString;
 
         MatcherCombiner(Collection<WildcardMatcher> wildcardMatchers) {
             Preconditions.checkArgument(wildcardMatchers.size() > 1);
-            this.wildcardMatchers = wildcardMatchers;
-            hashCode = wildcardMatchers.hashCode();
+            this.wildcardMatchers = wildcardMatchers.toArray(new WildcardMatcher[0]);
+            this.hashCode = wildcardMatchers.hashCode();
+            this.asString = wildcardMatchers.toString();
         }
 
         @Override
         public boolean test(String candidate) {
-            return wildcardMatchers.stream().anyMatch(m -> m.test(candidate));
+            for (int i = 0; i < this.wildcardMatchers.length; i++) {
+                if (this.wildcardMatchers[i].test(candidate)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         @Override
-        public Optional<WildcardMatcher> findFirst(final String candidate) {
-            return wildcardMatchers.stream().filter(m -> m.test(candidate)).findFirst();
+        public WildcardMatcher ignoreCase() {
+            return new MatcherCombiner(Stream.of(this.wildcardMatchers).map(WildcardMatcher::ignoreCase).toList());
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            MatcherCombiner that = (MatcherCombiner) o;
-            return wildcardMatchers.equals(that.wildcardMatchers);
+            if (o instanceof MatcherCombiner matcherCombiner) {
+                return Arrays.equals(this.wildcardMatchers, matcherCombiner.wildcardMatchers);
+            } else {
+                return false;
+            }
         }
 
         @Override
@@ -550,7 +560,35 @@ public abstract class WildcardMatcher implements Predicate<String> {
 
         @Override
         public String toString() {
-            return wildcardMatchers.toString();
+            return asString;
+        }
+    }
+
+    static abstract class AbstractSimpleWildcardMatcher extends WildcardMatcher {
+        protected final String pattern;
+
+        AbstractSimpleWildcardMatcher(String pattern) {
+            this.pattern = pattern;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o instanceof AbstractSimpleWildcardMatcher simpleMatcher) {
+                return simpleMatcher.pattern.equals(this.pattern);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return this.pattern.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return this.pattern;
         }
     }
 }

--- a/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
+++ b/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
@@ -58,10 +58,8 @@ public final class DefaultInterClusterRequestEvaluator implements InterClusterRe
 
     public DefaultInterClusterRequestEvaluator(final Settings settings) {
         this.certOid = settings.get(ConfigConstants.SECURITY_CERT_OID, "1.2.3.4.5.5");
-        this.staticNodesDnFromEsYml = WildcardMatcher.from(
-            settings.getAsList(ConfigConstants.SECURITY_NODES_DN, Collections.emptyList()),
-            false
-        );
+        this.staticNodesDnFromEsYml = WildcardMatcher.from(settings.getAsList(ConfigConstants.SECURITY_NODES_DN, Collections.emptyList()))
+            .ignoreCase();
         this.dynamicNodesDnConfigEnabled = settings.getAsBoolean(ConfigConstants.SECURITY_NODES_DN_DYNAMIC_CONFIG_ENABLED, false);
         this.dynamicNodesDn = Collections.emptyMap();
     }

--- a/src/test/java/org/opensearch/security/UtilTests.java
+++ b/src/test/java/org/opensearch/security/UtilTests.java
@@ -49,7 +49,7 @@ public class UtilTests {
     }
 
     static private WildcardMatcher iwc(String pattern) {
-        return WildcardMatcher.from(pattern, false);
+        return WildcardMatcher.from(pattern).ignoreCase();
     }
 
     static private final PasswordHasher passwordHasher = PasswordHasherFactory.createPasswordHasher(


### PR DESCRIPTION
### Description
Backport from #5470 

While researching https://github.com/opensearch-project/security/issues/5464 we found that the string matching algorithm used by WildcardMatcher does significantly more comparisons than necessary for simple cases.

This PR does not change the matching algorithm, but it introduces special cases for the most common patterns: "prefix*" and "*contains*". In a simple micro benchmark, we found that these optimizations can reduce the runtime required for matching large amounts of strings by 30% (see comments for micro benchmark code).

Additionally, this PR removes unused methods from WildcardMatcher and improves test coverage.

[Describe what this change achieves]
* Category Enhancement
* Why these changes are required? For clusters with many indices and roles, runtime of wildcard matching gets very significant.
* What is the old behavior before changes and new behavior after changes? No behavioral changes.

### Testing
New unit tests in `WilldcardMatcherTests`

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
