### PR TITLE
Restricting star tree index for users with DLS/FLS/FieldMasking restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Introduced setting `plugins.security.privileges_evaluation.precomputed_privileges.enabled` ([#5465](https://github.com/opensearch-project/security/pull/5465))
 * Optimized wildcard matching runtime performance ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
+* Restricting query optimization via star tree index for users with queries on indices with DLS/FLS/FieldMasked restrictions ([#5492](https://github.com/opensearch-project/security/pull/5492))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -75,7 +75,6 @@ import org.opensearch.security.privileges.dlsfls.DlsFlsLegacyHeaders;
 import org.opensearch.security.privileges.dlsfls.DlsFlsProcessedConfig;
 import org.opensearch.security.privileges.dlsfls.DlsRestriction;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
-import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
 import org.opensearch.security.privileges.dlsfls.IndexToRuleMap;
 import org.opensearch.security.resolver.IndexResolverReplacer;
 import org.opensearch.security.securityconf.DynamicConfigFactory;
@@ -409,9 +408,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
             // Restrict access for star tree index if there are any DLS/FLS/field masking restrictions
             if (searchContext.getQueryShardContext().getStarTreeQueryContext() != null) {
-                FieldPrivileges.FlsRule fls = config.getFieldPrivileges().getRestriction(privilegesEvaluationContext, index);
-                FieldMasking.FieldMaskingRule rule = config.getFieldMasking().getRestriction(privilegesEvaluationContext, index);
-                if (!dlsRestriction.isUnrestricted() || !fls.isUnrestricted() || !rule.isUnrestricted()) {
+                boolean flsUnrestricted = config.getFieldPrivileges().isUnrestricted(privilegesEvaluationContext, index);
+                boolean fieldMaskingUnrestricted = config.getFieldMasking().isUnrestricted(privilegesEvaluationContext, index);
+                if (!dlsRestriction.isUnrestricted() || !flsUnrestricted || !fieldMaskingUnrestricted) {
                     searchContext.getQueryShardContext().setStarTreeQueryContext(null);
                 }
             }

--- a/src/test/java/org/opensearch/security/dlic/dlsfls/StarTreeDlsFlsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/dlsfls/StarTreeDlsFlsTest.java
@@ -1,0 +1,433 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.dlic.dlsfls;
+
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.forcemerge.ForceMergeRequest;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.security.test.DynamicSecurityConfig;
+import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Integration tests for star tree functionality with DLS/FLS restrictions.
+ * Tests that star tree queries are disabled when DLS/FLS is applied.
+ */
+public class StarTreeDlsFlsTest extends AbstractDlsFlsTest {
+
+    private static final String STARTREE_INDEX_NAME = "startree_sales";
+    private static final String REGULAR_INDEX_NAME = "regular_sales";
+
+    protected void setupStarTreeTest() throws Exception {
+        final Settings settings = Settings.EMPTY;
+        final DynamicSecurityConfig dynamicSecurityConfig = new DynamicSecurityConfig().setSecurityRoles("roles_startree.yml")
+            .setSecurityRolesMapping("roles_mapping_startree.yml")
+            .setSecurityInternalUsers("internal_users_startree.yml");
+
+        setup(settings, dynamicSecurityConfig);
+    }
+
+    @Override
+    protected void populateData(Client tc) {
+        // Create star tree index with composite mapping
+        try {
+            tc.admin()
+                .indices()
+                .create(
+                    new CreateIndexRequest(STARTREE_INDEX_NAME).settings(
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                            .put("index.composite_index", true)
+                            .put("index.append_only.enabled", true)
+                            .put("index.search.star_tree_index.enabled", true)
+                            .build()
+                    )
+                        .mapping(
+                            XContentFactory.jsonBuilder()
+                                .startObject()
+                                .startObject("composite")
+                                .startObject("sales_star_tree")
+                                .field("type", "star_tree")
+                                .startObject("config")
+                                .startArray("ordered_dimensions")
+                                .startObject()
+                                .field("name", "department")
+                                .endObject()
+                                .startObject()
+                                .field("name", "region")
+                                .endObject()
+                                .endArray()
+                                .startArray("metrics")
+                                .startObject()
+                                .field("name", "sales_amount")
+                                .field("stats", new String[] { "sum", "value_count" })
+                                .endObject()
+                                .endArray()
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .startObject("properties")
+                                .startObject("department")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("region")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("sales_amount")
+                                .field("type", "double")
+                                .endObject()
+                                .startObject("employee_id")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("sensitive_data")
+                                .field("type", "text")
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .toString()
+                        )
+                )
+                .actionGet();
+
+            // Create regular index for comparison
+            tc.admin()
+                .indices()
+                .create(
+                    new CreateIndexRequest(REGULAR_INDEX_NAME).settings(
+                        Settings.builder()
+                            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                            .build()
+                    )
+                        .mapping(
+                            XContentFactory.jsonBuilder()
+                                .startObject()
+                                .startObject("properties")
+                                .startObject("department")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("region")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("sales_amount")
+                                .field("type", "double")
+                                .endObject()
+                                .startObject("employee_id")
+                                .field("type", "keyword")
+                                .endObject()
+                                .startObject("sensitive_data")
+                                .field("type", "text")
+                                .endObject()
+                                .endObject()
+                                .endObject()
+                                .toString()
+                        )
+                )
+                .actionGet();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create indices", e);
+        }
+
+        // Populate star tree index with test data
+        tc.index(
+            new IndexRequest(STARTREE_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"engineering\", \"region\": \"us-west\", \"sales_amount\": 1000.0, \"employee_id\": \"emp1\", \"sensitive_data\": \"confidential info 1\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(STARTREE_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"engineering\", \"region\": \"us-east\", \"sales_amount\": 1500.0, \"employee_id\": \"emp2\", \"sensitive_data\": \"confidential info 2\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(STARTREE_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"sales\", \"region\": \"us-west\", \"sales_amount\": 2000.0, \"employee_id\": \"emp3\", \"sensitive_data\": \"confidential info 3\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(STARTREE_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"sales\", \"region\": \"us-east\", \"sales_amount\": 2500.0, \"employee_id\": \"emp4\", \"sensitive_data\": \"confidential info 4\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        // Populate regular index with same data
+        tc.index(
+            new IndexRequest(REGULAR_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"engineering\", \"region\": \"us-west\", \"sales_amount\": 1000.0, \"employee_id\": \"emp1\", \"sensitive_data\": \"confidential info 1\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(REGULAR_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"engineering\", \"region\": \"us-east\", \"sales_amount\": 1500.0, \"employee_id\": \"emp2\", \"sensitive_data\": \"confidential info 2\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(REGULAR_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"sales\", \"region\": \"us-west\", \"sales_amount\": 2000.0, \"employee_id\": \"emp3\", \"sensitive_data\": \"confidential info 3\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        tc.index(
+            new IndexRequest(REGULAR_INDEX_NAME).setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+                .source(
+                    "{\"department\": \"sales\", \"region\": \"us-east\", \"sales_amount\": 2500.0, \"employee_id\": \"emp4\", \"sensitive_data\": \"confidential info 4\"}",
+                    XContentType.JSON
+                )
+        ).actionGet();
+
+        // Force merge to create star tree segments
+        tc.admin().indices().forceMerge(new ForceMergeRequest(STARTREE_INDEX_NAME).maxNumSegments(1)).actionGet();
+        tc.admin().indices().forceMerge(new ForceMergeRequest(REGULAR_INDEX_NAME).maxNumSegments(1)).actionGet();
+
+        try {
+            Thread.sleep(2000); // Allow time for indexing and merging
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Test
+    public void testStarTreeWithoutDlsFls() throws Exception {
+        setupStarTreeTest();
+
+        // Test aggregation query that should use star tree (no DLS/FLS restrictions)
+        String aggregationQuery = "{"
+            + "\"size\": 0,"
+            + "\"aggs\": {"
+            + "  \"departments\": {"
+            + "    \"terms\": {"
+            + "      \"field\": \"department\""
+            + "    },"
+            + "    \"aggs\": {"
+            + "      \"total_sales\": {"
+            + "        \"sum\": {"
+            + "          \"field\": \"sales_amount\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}"
+            + "}";
+
+        // Execute query as admin (no restrictions)
+        HttpResponse response = rh.executePostRequest(
+            "/" + STARTREE_INDEX_NAME + "/_search?pretty",
+            aggregationQuery,
+            encodeBasicHeader("startree_admin", "password")
+        );
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+
+        /**
+         * "aggregations" : {
+         *     "departments" : {
+         *       "doc_count_error_upper_bound" : 0,
+         *       "sum_other_doc_count" : 0,
+         *       "buckets" : [
+         *         {
+         *           "key" : "engineering",
+         *           "doc_count" : 2,
+         *           "total_sales" : {
+         *             "value" : 2500.0
+         *           }
+         *         },
+         *         {
+         *           "key" : "sales",
+         *           "doc_count" : 2,
+         *           "total_sales" : {
+         *             "value" : 4500.0
+         *           }
+         *         }
+         *       ]
+         *     }
+         *   }
+         */
+        Assert.assertTrue(
+            "Should contain correct sales total",
+            response.getBody().contains("2500.0") && response.getBody().contains("4500.0")
+        );
+
+        // Check star tree stats - should show star tree queries were used
+        HttpResponse statsResponse = rh.executeGetRequest(
+            "/" + STARTREE_INDEX_NAME + "/_stats/search?pretty",
+            encodeBasicHeader("startree_admin", "password")
+        );
+        assertThat(statsResponse.getStatusCode(), is(HttpStatus.SC_OK));
+
+        Assert.assertTrue(
+            "Star tree query total should be 1 since there are no restrictions",
+            statsResponse.getBody().contains("\"startree_query_total\" : 1")
+        );
+
+        Assert.assertTrue(
+            "Regular query total should be > 0",
+            statsResponse.getBody().contains("\"query_total\" : 1")
+                || statsResponse.getBody().matches(".*\"query_total\"\\s*:\\s*[1-9]\\d*.*")
+        );
+
+    }
+
+    @Test
+    public void testStarTreeWithDlsRestriction() throws Exception {
+        setupStarTreeTest();
+
+        String aggregationQuery = "{"
+            + "\"size\": 0,"
+            + "\"aggs\": {"
+            + "  \"departments\": {"
+            + "    \"terms\": {"
+            + "      \"field\": \"department\""
+            + "    },"
+            + "    \"aggs\": {"
+            + "      \"total_sales\": {"
+            + "        \"sum\": {"
+            + "          \"field\": \"sales_amount\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}"
+            + "}";
+
+        HttpResponse response = rh.executePostRequest(
+            "/" + STARTREE_INDEX_NAME + "/_search?pretty",
+            aggregationQuery,
+            encodeBasicHeader("startree_dls_user", "password")
+        );
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        HttpResponse statsResponse = rh.executeGetRequest(
+            "/" + STARTREE_INDEX_NAME + "/_stats/search?pretty",
+            encodeBasicHeader("startree_admin", "password")
+        );
+        assertThat(statsResponse.getStatusCode(), is(HttpStatus.SC_OK));
+        String statsBody = statsResponse.getBody();
+        // Assert that star tree queries are 0 (disabled due to FLS)
+        Assert.assertTrue("Star tree query total should be 0 when FLS is applied", statsBody.contains("\"startree_query_total\" : 0"));
+
+        Assert.assertTrue(
+            "Regular query total should be > 0",
+            statsBody.contains("\"query_total\" : 1") || statsBody.matches(".*\"query_total\"\\s*:\\s*[1-9]\\d*.*")
+        );
+    }
+
+    @Test
+    public void testStarTreeWithFlsRestriction() throws Exception {
+        setupStarTreeTest();
+
+        // Test aggregation query with FLS restriction
+        String aggregationQuery = "{"
+            + "\"size\": 0,"
+            + "\"aggs\": {"
+            + "  \"departments\": {"
+            + "    \"terms\": {"
+            + "      \"field\": \"department\""
+            + "    },"
+            + "    \"aggs\": {"
+            + "      \"total_sales\": {"
+            + "        \"sum\": {"
+            + "          \"field\": \"sales_amount\""
+            + "        }"
+            + "      }"
+            + "    }"
+            + "  }"
+            + "}"
+            + "}";
+
+        HttpResponse response = rh.executePostRequest(
+            "/" + STARTREE_INDEX_NAME + "/_search?pretty",
+            aggregationQuery,
+            encodeBasicHeader("startree_fls_user", "password")
+        );
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+        HttpResponse statsResponse = rh.executeGetRequest(
+            "/" + STARTREE_INDEX_NAME + "/_stats/search?pretty",
+            encodeBasicHeader("startree_admin", "password")
+        );
+        assertThat(statsResponse.getStatusCode(), is(HttpStatus.SC_OK));
+
+        String statsBody = statsResponse.getBody();
+        // Assert that star tree queries are 0 (disabled due to FLS)
+        Assert.assertTrue("Star tree query total should be 0 when FLS is applied", statsBody.contains("\"startree_query_total\" : 0"));
+
+        Assert.assertTrue(
+            "Regular query total should be > 0",
+            statsBody.contains("\"query_total\" : 1") || statsBody.matches(".*\"query_total\"\\s*:\\s*[1-9]\\d*.*")
+        );
+    }
+
+    @Test
+    public void testStarTreeWithFieldMasking() throws Exception {
+        setupStarTreeTest();
+
+        // Test query with field masking
+        String searchQuery = "{"
+            + "\"query\": {"
+            + "  \"match_all\": {}"
+            + "},"
+            + "\"_source\": [\"department\", \"sales_amount\", \"sensitive_data\"]"
+            + "}";
+
+        // Execute query as user with field masking
+        HttpResponse response = rh.executePostRequest(
+            "/" + STARTREE_INDEX_NAME + "/_search?pretty",
+            searchQuery,
+            encodeBasicHeader("startree_masked_user", "password")
+        );
+        assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+
+        // Check star tree stats - should show NO star tree queries were used due to field masking
+        HttpResponse statsResponse = rh.executeGetRequest(
+            "/" + STARTREE_INDEX_NAME + "/_stats/search?pretty",
+            encodeBasicHeader("startree_admin", "password")
+        );
+        assertThat(statsResponse.getStatusCode(), is(HttpStatus.SC_OK));
+
+        String statsBody = statsResponse.getBody();
+        // Assert that star tree queries are 0 (disabled due to FLS)
+        Assert.assertTrue("Star tree query total should be 0 when FLS is applied", statsBody.contains("\"startree_query_total\" : 0"));
+
+        Assert.assertTrue(
+            "Regular query total should be > 0",
+            statsBody.contains("\"query_total\" : 1") || statsBody.matches(".*\"query_total\"\\s*:\\s*[1-9]\\d*.*")
+        );
+
+    }
+}

--- a/src/test/resources/dlsfls/internal_users_startree.yml
+++ b/src/test/resources/dlsfls/internal_users_startree.yml
@@ -1,0 +1,28 @@
+---
+_meta:
+  type: "internalusers"
+  config_version: 2
+
+startree_dls_user:
+  hash: "$2y$12$SP9z.rBgEHTlueKkiqSK/OxqB2PLJN/eRoNJ8WOPoHWIpirvbFAAy" # "password"
+  reserved: false
+  backend_roles: []
+  description: "User with DLS restrictions for star tree testing"
+
+startree_fls_user:
+  hash: "$2y$12$SP9z.rBgEHTlueKkiqSK/OxqB2PLJN/eRoNJ8WOPoHWIpirvbFAAy" # "password"
+  reserved: false
+  backend_roles: []
+  description: "User with FLS restrictions for star tree testing"
+
+startree_masked_user:
+  hash: "$2y$12$SP9z.rBgEHTlueKkiqSK/OxqB2PLJN/eRoNJ8WOPoHWIpirvbFAAy" # "password"
+  reserved: false
+  backend_roles: []
+  description: "User with field masking for star tree testing"
+
+startree_admin:
+  hash: "$2y$12$SP9z.rBgEHTlueKkiqSK/OxqB2PLJN/eRoNJ8WOPoHWIpirvbFAAy" # "password"
+  reserved: false
+  backend_roles: []
+  description: "Admin user for star tree testing"

--- a/src/test/resources/dlsfls/roles_mapping_startree.yml
+++ b/src/test/resources/dlsfls/roles_mapping_startree.yml
@@ -1,0 +1,32 @@
+---
+_meta:
+  type: "rolesmapping"
+  config_version: 2
+
+startree_dls_role:
+  reserved: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "startree_dls_user"
+
+startree_fls_role:
+  reserved: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "startree_fls_user"
+
+startree_masked_role:
+  reserved: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "startree_masked_user"
+
+startree_admin_role:
+  reserved: false
+  backend_roles: []
+  hosts: []
+  users:
+    - "startree_admin"

--- a/src/test/resources/dlsfls/roles_startree.yml
+++ b/src/test/resources/dlsfls/roles_startree.yml
@@ -1,0 +1,63 @@
+---
+_meta:
+  type: "roles"
+  config_version: 2
+
+# Role with DLS restriction - only allows access to engineering department
+startree_dls_role:
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "startree_sales"
+        - "regular_sales"
+      dls: '{"term": {"department": "engineering"}}'
+      allowed_actions:
+        - "indices:data/read/search*"
+        - "indices:data/read/get*"
+        - "indices:admin/mappings/get*"
+        - "indices:monitor/stats*"
+
+# Role with FLS restriction - hides sensitive_data field
+startree_fls_role:
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "startree_sales"
+        - "regular_sales"
+      fls:
+        - "department"
+        - "region"
+        - "sales_amount"
+        - "employee_id"
+        # Note: sensitive_data is excluded
+      allowed_actions:
+        - "indices:data/read/search*"
+        - "indices:data/read/get*"
+        - "indices:admin/mappings/get*"
+        - "indices:monitor/stats*"
+
+# Role with field masking - masks sensitive_data field
+startree_masked_role:
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - "startree_sales"
+        - "regular_sales"
+      masked_fields:
+        - "sensitive_data"
+      allowed_actions:
+        - "indices:data/read/search*"
+        - "indices:data/read/get*"
+        - "indices:admin/mappings/get*"
+        - "indices:monitor/stats*"
+
+# Admin role for stats access
+startree_admin_role:
+  cluster_permissions:
+    - "cluster:monitor/stats*"
+    - "cluster:admin/indices/stats*"
+  index_permissions:
+    - index_patterns:
+        - "*"
+      allowed_actions:
+        - "*"

--- a/src/test/resources/dlsfls/roles_startree.yml
+++ b/src/test/resources/dlsfls/roles_startree.yml
@@ -12,9 +12,9 @@ startree_dls_role:
         - "regular_sales"
       dls: '{"term": {"department": "engineering"}}'
       allowed_actions:
-        - "indices:data/read/search*"
-        - "indices:data/read/get*"
         - "indices:admin/mappings/get*"
+        - "indices:data/read/get*"
+        - "indices:data/read/search*"
         - "indices:monitor/stats*"
 
 # Role with FLS restriction - hides sensitive_data field
@@ -31,9 +31,9 @@ startree_fls_role:
         - "employee_id"
         # Note: sensitive_data is excluded
       allowed_actions:
-        - "indices:data/read/search*"
-        - "indices:data/read/get*"
         - "indices:admin/mappings/get*"
+        - "indices:data/read/get*"
+        - "indices:data/read/search*"
         - "indices:monitor/stats*"
 
 # Role with field masking - masks sensitive_data field
@@ -46,16 +46,16 @@ startree_masked_role:
       masked_fields:
         - "sensitive_data"
       allowed_actions:
-        - "indices:data/read/search*"
-        - "indices:data/read/get*"
         - "indices:admin/mappings/get*"
+        - "indices:data/read/get*"
+        - "indices:data/read/search*"
         - "indices:monitor/stats*"
 
 # Admin role for stats access
 startree_admin_role:
   cluster_permissions:
-    - "cluster:monitor/stats*"
     - "cluster:admin/indices/stats*"
+    - "cluster:monitor/stats*"
   index_permissions:
     - index_patterns:
         - "*"


### PR DESCRIPTION
### Description
Restricts usage of star tree index when DLS/FLS/FieldMasking restrictions are applied for user for a particular index.

As part of this PR , we set the `StarTreeQueryContext` to null when DLS/FLS/FieldMasking restrictions are present, so that the query falls back to the default aggregations behavior. We'll just skip using star tree for optimizations.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
