### PR TITLE
Update query param name to check if a user has access to call an API

### DIFF
--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -99,6 +99,7 @@ import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.isActionTraceEnabled;
 import static org.opensearch.security.OpenSearchSecurityPlugin.traceAction;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_PERFORM_PERMISSION_CHECK_PARAM;
 
 public class SecurityFilter implements ActionFilter {
 
@@ -116,7 +117,6 @@ public class SecurityFilter implements ActionFilter {
     private final WildcardMatcher immutableIndicesMatcher;
     private final RolesInjector rolesInjector;
     private final UserInjector userInjector;
-    public static final String HAS_PERMISSION_CHECK_PARAM = "has_permission_check";
 
     public SecurityFilter(
         final Settings settings,
@@ -517,8 +517,8 @@ public class SecurityFilter implements ActionFilter {
         PrivilegesEvaluatorResponse pres,
         String action
     ) {
-        String isSimulation = threadContext.getHeader(HAS_PERMISSION_CHECK_PARAM);
-        if (Boolean.parseBoolean(isSimulation)) {
+        String performPermissionCheck = threadContext.getHeader(SECURITY_PERFORM_PERMISSION_CHECK_PARAM);
+        if (Boolean.parseBoolean(performPermissionCheck)) {
 
             @SuppressWarnings("unchecked")
             Response response = (Response) new PermissionCheckResponse(pres.isAllowed(), pres.getMissingPrivileges());

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -75,6 +75,7 @@ import org.greenrobot.eventbus.Subscribe;
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.support.ConfigConstants.OPENDISTRO_SECURITY_INITIATING_USER;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_PERFORM_PERMISSION_CHECK_PARAM;
 
 public class SecurityRestFilter {
 
@@ -92,7 +93,6 @@ public class SecurityRestFilter {
 
     public static final String HEALTH_SUFFIX = "health";
     public static final String WHO_AM_I_SUFFIX = "whoami";
-    private static final String HAS_PERMISSION_CHECK_PARAM = "has_permission_check";
 
     public static final String REGEX_PATH_PREFIX = "/(" + LEGACY_OPENDISTRO_PREFIX + "|" + PLUGINS_PREFIX + ")/" + "(.*)";
     public static final Pattern PATTERN_PATH_PREFIX = Pattern.compile(REGEX_PATH_PREFIX);
@@ -168,9 +168,9 @@ public class SecurityRestFilter {
                 return;
             }
 
-            boolean hasPermissionCheck = request.paramAsBoolean(HAS_PERMISSION_CHECK_PARAM, false);
-            if (hasPermissionCheck) {
-                threadContext.putHeader(HAS_PERMISSION_CHECK_PARAM, Boolean.TRUE.toString());
+            boolean performPermissionCheck = request.paramAsBoolean(SECURITY_PERFORM_PERMISSION_CHECK_PARAM, false);
+            if (performPermissionCheck) {
+                threadContext.putHeader(SECURITY_PERFORM_PERMISSION_CHECK_PARAM, Boolean.TRUE.toString());
             }
             // Authorize Request
             final User user = threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
@@ -178,7 +178,7 @@ public class SecurityRestFilter {
             if (userIsSuperAdmin(user, adminDNs)) {
                 // Super admins are always authorized
                 auditLog.logSucceededLogin(user.getName(), true, intiatingUser, requestChannel);
-                if (hasPermissionCheck) {
+                if (performPermissionCheck) {
                     log.debug("Permission check skipped: Super admin has full access");
                     handleSuperAdminPermissionCheck(channel);
                     return;

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -159,7 +159,7 @@ public class ConfigConstants {
     public static final String SECURITY_AUTHCZ_IMPERSONATION_DN = SECURITY_SETTINGS_PREFIX + "authcz.impersonation_dn";
     public static final String SECURITY_AUTHCZ_REST_IMPERSONATION_USERS = SECURITY_SETTINGS_PREFIX + "authcz.rest_impersonation_user";
 
-    public static final String SECURITY_HAS_PERMISSION_CHECK_PARAM = "has_permission_check";
+    public static final String SECURITY_PERFORM_PERMISSION_CHECK_PARAM = "perform_permission_check";
 
     public static final String BCRYPT = "bcrypt";
     public static final String PBKDF2 = "pbkdf2";

--- a/src/test/java/org/opensearch/security/filter/SecurityRestFilterTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityRestFilterTests.java
@@ -304,34 +304,8 @@ public class SecurityRestFilterTests extends AbstractRestApiUnitTest {
     }
 
     /**
-     * Tests that when has_permission_check param is absent;
-     * the normal request flow is executed.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testWithoutHasPermissionCheckParam() throws Exception {
-        setup();
-
-        rh.keystore = "restapi/kirk-keystore.jks";
-        rh.sendAdminCertificate = true;
-        response = rh.executePutRequest(
-            "_plugins/_security/api/allowlist",
-            "{\"enabled\": true, \"requests\": {\"/_cluster/health\": [\"GET\"]}}",
-            nonAdminCredsHeader
-        );
-
-        // No has_permission_check param behaves like normal flow (no simulation fields)
-        rh.sendAdminCertificate = false;
-        assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertFalse(response.getBody().contains("\"accessAllowed\""));
-        assertFalse(response.getBody().contains("\"missingPrivileges\""));
-
-    }
-
-    /**
-     * Tests that the has_permission_check param works correctly.
-     * When has_permission_check=true is added to a request, returns
+     * Tests that the perform_permission_check param works correctly.
+     * When perform_permission_check=true is added to a request, returns
      * whether the request would be allowed or Denied, without actually executing the request.
      *
      * @throws Exception
@@ -342,7 +316,7 @@ public class SecurityRestFilterTests extends AbstractRestApiUnitTest {
 
         rh.keystore = "restapi/kirk-keystore.jks";
         rh.sendAdminCertificate = true;
-        response = rh.executeGetRequest("_cluster/health?has_permission_check=true", nonAdminCredsHeader);
+        response = rh.executeGetRequest("_cluster/health?perform_permission_check=true", nonAdminCredsHeader);
         rh.sendAdminCertificate = false;
         // user has permissions to GET /_cluster/health response accessAllowed:true
         assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
@@ -352,10 +326,10 @@ public class SecurityRestFilterTests extends AbstractRestApiUnitTest {
         rh.sendAdminCertificate = true;
         response = rh.executePutRequest(
             "_plugins/_security/api/allowlist",
-            "{\"enabled\": true, \"requests\": {\"/_search?has_permission_check=false\": [\"GET\"]}}",
+            "{\"enabled\": true, \"requests\": {\"/_search?perform_permission_check=false\": [\"GET\"]}}",
             nonAdminCredsHeader
         );
-        // has_permission_check=false (normal execution flow) no simulation fields in response
+        // perform_permission_check=false (normal execution flow) no simulation fields in response
         rh.sendAdminCertificate = false;
         assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertFalse(response.getBody().contains("\"accessAllowed\":"));
@@ -378,7 +352,7 @@ public class SecurityRestFilterTests extends AbstractRestApiUnitTest {
         rh.sendAdminCertificate = false;
 
         // test_user has no permissions to GET /_cluster/health response accessAllowed:false
-        response = rh.executeGetRequest("_cluster/health?has_permission_check=true", testUserHeader);
+        response = rh.executeGetRequest("_cluster/health?perform_permission_check=true", testUserHeader);
         assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_OK));
         assertTrue(response.getBody().contains("\"accessAllowed\":false"));
         assertTrue(response.getBody().contains("\"missingPrivileges\":[\"cluster:monitor/health\"]"));


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation) 
Refactoring
* Why these changes are required?
In this [PR](https://github.com/opensearch-project/security/pull/5496) we added support to check if a user has access using query param `has_permission_check`. Changing to `perform_permission_check` (sounds more appropriate) 
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
UT

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
