### PR TITLE
Fixed index resolution for rollover requests

### DIFF
--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -786,9 +786,11 @@ public class IndexResolverReplacer {
                 return false;
             }
             ((Replaceable) request).indices(newIndices);
-        } else if (request instanceof RolloverRequest) {
-            provider.provide(((RolloverRequest) request).indices(), request, false);
-            return false;
+        } else if (request instanceof RolloverRequest rolloverRequest) {
+            provider.provide(rolloverRequest.indices(), request, false);
+            if (rolloverRequest.getNewIndexName() != null) { // only when target index is explicitly provided
+                provider.provide(new String[] { rolloverRequest.getNewIndexName() }, request, false);
+            }
         } else if (request instanceof BulkShardRequest) {
             provider.provide(((ReplicationRequest) request).indices(), request, false);
             // replace not supported?


### PR DESCRIPTION
### Description

Fixes the interpretation of the target index param in rollover requests.

* Category: Bug fix
* Why these changes are required? The target index param was incorrectly considered.
* What is the old behavior before changes and new behavior after changes? No changes

### Testing

- Updated integration test

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
