### PR TITLE
Add tenancy access info to serialized user in threadcontext

### DIFF
--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -284,15 +284,15 @@ public class PrivilegesEvaluator {
         return configModel != null && dcm != null && actionPrivileges.get() != null;
     }
 
-    private void setUserInfoInThreadContext(User user, Set<String> mappedRoles, PrivilegesEvaluationContext context) {
+    private void setUserInfoInThreadContext(PrivilegesEvaluationContext context) {
         if (threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT) == null) {
             StringJoiner joiner = new StringJoiner("|");
             // Escape any pipe characters in the values before joining
-            joiner.add(escapePipe(user.getName()));
-            joiner.add(escapePipe(String.join(",", user.getRoles())));
-            joiner.add(escapePipe(String.join(",", mappedRoles)));
+            joiner.add(escapePipe(context.getUser().getName()));
+            joiner.add(escapePipe(String.join(",", context.getUser().getRoles())));
+            joiner.add(escapePipe(String.join(",", context.getMappedRoles())));
 
-            String requestedTenant = user.getRequestedTenant();
+            String requestedTenant = context.getUser().getRequestedTenant();
             joiner.add(requestedTenant);
             String tenantAccessToCheck = getTenancyAccess(requestedTenant, this.tenantPrivileges.get().tenantMap(context));
             joiner.add(tenantAccessToCheck);
@@ -407,7 +407,7 @@ public class PrivilegesEvaluator {
             context.setMappedRoles(mappedRoles);
         }
 
-        setUserInfoInThreadContext(user, mappedRoles, context);
+        setUserInfoInThreadContext(context);
 
         final boolean isDebugEnabled = log.isDebugEnabled();
         if (isDebugEnabled) {


### PR DESCRIPTION
### Description

This PR adds information about the user's level of access to the requested tenant when serializing the user into the threadcontext. There can be 1 of 3 levels of access. 1) No Access - user has no access to the requested tenant, 2) Read Only - User has read only access to the requested tenant and 3) Write access - user can save saved objects to the requested tenant

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
