### PR TITLE
Add SPIFFEPrincipalExtractor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [Resource Sharing] Adds migrate API to move resource-sharing info to security plugin ([#5389](https://github.com/opensearch-project/security/pull/5389))
 * Introduces support for the Argon2 Password Hashing Algorithm ([#5441] (https://github.com/opensearch-project/security/pull/5441))
 * Introduced permission validation support using query parameter without executing the request ([#5496](https://github.com/opensearch-project/security/pull/5496))
+* Introduced SPIFFE X.509 SVID support via SPIFFEPrincipalExtractor ([#5521](https://github.com/opensearch-project/security/pull/5521))
 
 ### Enhancements
 

--- a/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractor.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.ssl.transport;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class SPIFFEPrincipalExtractor implements PrincipalExtractor {
+    /**
+     * PrincipalExtractor implementation that extracts a SPIFFE URI from an X.509 certificate's SAN.
+     * Returns "CN=spiffe://..." if found, otherwise null.
+     * Used for SPIFFE X.509 SVID-based authentication in OpenSearch clusters.
+     */
+
+    protected final Logger log = LogManager.getLogger(this.getClass());
+
+    @Override
+    @SuppressWarnings("removal")
+    public String extractPrincipal(final X509Certificate x509Certificate, final Type type) {
+        if (x509Certificate == null) {
+            return null;
+        }
+
+        final Collection<List<?>> altNames = AccessController.doPrivileged(new PrivilegedAction<Collection<List<?>>>() {
+            @Override
+            public Collection<List<?>> run() {
+                try {
+                    return x509Certificate.getSubjectAlternativeNames();
+                } catch (CertificateParsingException e) {
+                    log.error("Unable to parse X509 altNames", e);
+                    return null;
+                }
+            }
+        });
+
+        if (altNames == null) {
+            return null;
+        }
+
+        for (List<?> sanItem : altNames) {
+            if (sanItem == null || sanItem.size() < 2) {
+                continue;
+            }
+            Integer altNameType = (Integer) sanItem.get(0);
+            Object altNameValue = sanItem.get(1);
+            if (altNameType != null && altNameType == 6 && altNameValue instanceof String) {
+                String uriValue = (String) altNameValue;
+                if (uriValue.startsWith("spiffe://")) {
+                    if (log.isTraceEnabled()) {
+                        log.trace("principal: CN={}", uriValue);
+                    }
+                    return String.format("CN=%s", uriValue);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/transport/SPIFFEPrincipalExtractorTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.ssl.transport;
+
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SPIFFEPrincipalExtractorTest {
+
+    @Test
+    public void testExtractSpiffePrincipal() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(Arrays.asList(0, "otherName"));
+        sanList.add(Arrays.asList(1, "rfc822Name"));
+        sanList.add(Arrays.asList(2, "DNSName"));
+        sanList.add(Arrays.asList(3, "x400Address"));
+        sanList.add(Arrays.asList(4, "directoryName"));
+        sanList.add(Arrays.asList(5, "ediPartyName"));
+        sanList.add(Arrays.asList(6, "spiffe://example.org/test")); // uniformResourceIdentifier
+        sanList.add(Arrays.asList(7, "IPAddress"));
+        sanList.add(Arrays.asList(8, "registeredID"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertEquals("CN=spiffe://example.org/test", principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_noSpiffeUri() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(Arrays.asList(6, "not-spiffe://example.org/test"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_nullCertificate() {
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        assertNull(extractor.extractPrincipal(null, PrincipalExtractor.Type.TRANSPORT));
+    }
+
+    @Test
+    public void testExtractPrincipal_nullSAN() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenReturn(null);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_certificateParsingException() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenThrow(new CertificateParsingException("bad"));
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_sanItemNullAndTooShort() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(null); // hits sanItem == null
+        sanList.add(Arrays.asList(6)); // size < 2
+
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+
+    @Test
+    public void testExtractPrincipal_altNameTypeNotIntegerOrValueNotString() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        // altNameType is null
+        sanList.add(Arrays.asList(null, "spiffe://example.org/test"));
+        // altNameValue not a string
+        sanList.add(Arrays.asList(6, 12345));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        SPIFFEPrincipalExtractor extractor = new SPIFFEPrincipalExtractor();
+        String principal = extractor.extractPrincipal(cert, PrincipalExtractor.Type.TRANSPORT);
+
+        assertNull(principal);
+    }
+}


### PR DESCRIPTION
### Description
* Category: Feature

* Why these changes are required?

As an OpenSearch cluster operator, I want to be able to use existing [SPIFFE](https://spiffe.io/) X509-SVID (https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md) identities for node and admin authentication, so that I do not have to setup dedicated workload PKI infrastructure for OpenSearch.

* What is the old behavior before changes and new behavior after changes?

Default behavior is unchanged, this adds an additional implementation of the `PrincipalExtractor` class that may be utilized via the existing `plugins.security.ssl.transport.principal_extractor_class` configuration parameter.

### Testing
Unit tests in `org.opensearch.security.ssl.transport.SPIFFEPrincipalExtractorTest`
Manually tested in a running cluster over the past few months for node transport.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
