### PR TITLE
Use FilterLeafReader based DLS for parent/child queries

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.indices.TermsLookup;
+import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.TestSecurityConfig.User;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.RestMatchers.isInternalServerError;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class ParentChildRelationTests {
+    public static final String INDEX_NAME = "dlstest";
+    public static final String TERM_LOOKUP_INDEX_NAME = "term_lookup_index";
+    public static final String TERMS_DOC_ID = "terms_2_2000";
+    public static final String TERM_PATH = "terms_to_search";
+
+    private static final User ADMIN_USER = new User("admin").roles(ALL_ACCESS);
+    private static final User DLS_TEST_USER = new User("dls_test_user").roles(
+        new Role("dls_test_role") //
+            .clusterPermissions("*") //
+            .indexPermissions("read") //
+            .dls(QueryBuilders.termQuery("dls", "2")) //
+            .on(INDEX_NAME)
+    );
+    private static final User DLS_TLQ_TEST_USER = new User("dls_tlq_test_user").roles(
+        new Role("dls_tlq_test_role").clusterPermissions("*") //
+            .indexPermissions("read") //
+            .dls(QueryBuilders.termsLookupQuery("dsl", new TermsLookup(TERM_LOOKUP_INDEX_NAME, TERMS_DOC_ID, TERM_PATH))) //
+            .on(INDEX_NAME)
+    );
+
+    public static final int BASIC_AUTH_DOMAIN_ORDER = 0;
+    public final static AuthcDomain AUTHC_HTTPBASIC_INTERNAL = new AuthcDomain("basic", BASIC_AUTH_DOMAIN_ORDER) //
+        .httpAuthenticatorWithChallenge("basic") //
+        .backend("internal");
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE) //
+        .anonymousAuth(false) //
+        .authc(AUTHC_HTTPBASIC_INTERNAL) //
+        .users(ADMIN_USER, DLS_TEST_USER, DLS_TLQ_TEST_USER) //
+        .build();
+
+    @BeforeClass
+    public static void beforeClass() {
+        Map<String, Object> indexMapping = Map.of(
+            "properties",
+            Map.of(
+                "dls",
+                Map.of("type", "keyword"),
+                "entityStatements",
+                Map.of("type", "join", "relations", Map.of("entity", "statements"))
+            )
+        );
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            // first create an index
+            HttpResponse response = client.put(INDEX_NAME);
+            assertThat(response, isOk());
+            // this will fail if the index does not exist
+            IndexOperationsHelper.createMapping(cluster, INDEX_NAME, indexMapping);
+        }
+        try (Client client = cluster.getInternalNodeClient()) {
+            Map<String, Object> document = Map.of("dls", "1", "entityStatements", "entity");
+            client.prepareIndex(INDEX_NAME).setId("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", "entity");
+            client.prepareIndex(INDEX_NAME).setId("2").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "1", "entityStatements", Map.of("name", "statements", "parent", "1"));
+            client.prepareIndex(INDEX_NAME).setId("3").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", Map.of("name", "statements", "parent", "1"));
+            client.prepareIndex(INDEX_NAME).setId("4").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "2", "entityStatements", Map.of("name", "statements", "parent", "2"));
+            client.prepareIndex(INDEX_NAME).setId("5").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+            document = Map.of("dls", "3", "entityStatements", Map.of("name", "statements", "parent", "2"));
+            client.prepareIndex(INDEX_NAME).setId("6").setRouting("1").setRefreshPolicy(IMMEDIATE).setSource(document).get();
+
+            // create a term lookup index
+            document = Map.of(TERM_PATH, List.of("2", "2000"));
+            client.prepareIndex(TERM_LOOKUP_INDEX_NAME).setId(TERMS_DOC_ID).setRefreshPolicy(IMMEDIATE).setSource(document).get();
+        }
+    }
+
+    @Test
+    public void dlsUserSearchAll() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.get(INDEX_NAME + "/_search?pretty");
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(3));
+            for (JsonNode hit : hits) {
+                String dlsValue = hit.get("_source").get("dls").asText();
+                assertThat(dlsValue, equalTo("2"));
+            }
+        }
+    }
+
+    @Test
+    public void hasParentWithDlsDisallowedParentQuery() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "1"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void hasParentWithDlsAllowedParentQuery() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "2"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(1));
+            String documentId = response.bodyAsJsonNode().get("hits").get("hits").get(0).get("_id").asText();
+            assertThat(documentId, equalTo("5"));
+        }
+    }
+
+    @Test
+    public void hasChildWithDlsDisallowedChild() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_child": {
+                            "type": "statements",
+                            "query": {
+                                "match": {
+                                    "dls": "3"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(0));
+        }
+    }
+
+    @Test
+    public void hasChildWithDlsAllowedChild() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_child": {
+                            "type": "statements",
+                            "query": {
+                                "match": {
+                                    "dls": "2"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isOk());
+            JsonNode hits = response.bodyAsJsonNode().get("hits").get("hits");
+            assertThat(hits.size(), equalTo(1));
+            String documentId = response.bodyAsJsonNode().get("hits").get("hits").get(0).get("_id").asText();
+            assertThat(documentId, equalTo("2"));
+        }
+    }
+
+    @Test
+    public void hasParentWithTlqDls() {
+        try (TestRestClient client = cluster.getRestClient(DLS_TLQ_TEST_USER)) {
+            HttpResponse response = client.postJson(INDEX_NAME + "/_search?pretty", """
+                {
+                    "query": {
+                        "has_parent": {
+                            "parent_type": "entity",
+                            "query": {
+                                "match": {
+                                    "dls": "1"
+                                }
+                            }
+                        }
+                    }
+                }
+                """);
+            assertThat(response, isInternalServerError("/error/reason", "Unable to handle filter level DLS for parent or child queries"));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -902,8 +902,12 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         return threadContext.getTransient("_opendistro_security_issuggest") == Boolean.TRUE;
     }
 
+    private boolean isParentChildQuery() {
+        return threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY) == Boolean.TRUE;
+    }
+
     private boolean applyDlsHere() {
-        if (isSuggest()) {
+        if (isSuggest() || isParentChildQuery()) {
             // we need to apply it here
             return true;
         }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -71,6 +71,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
+    public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";
 

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -55,6 +55,7 @@ import org.opensearch.security.support.Base64Helper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.user.UserFactory;
+import org.opensearch.security.util.ParentChildrenQueryDetector;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
@@ -139,6 +140,11 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                 ShardSearchRequest sr = ((ShardSearchRequest) request);
                 if (sr.source() != null && sr.source().suggest() != null) {
                     getThreadContext().putTransient("_opendistro_security_issuggest", Boolean.TRUE);
+                }
+                if (sr.source() != null && sr.source().query() != null) {
+                    if (ParentChildrenQueryDetector.hasParentOrChildQuery(sr.source().query())) {
+                        getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY, Boolean.TRUE);
+                    }
                 }
             }
 

--- a/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
+++ b/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.util;
+
+import org.apache.lucene.search.BooleanClause;
+
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.join.query.HasChildQueryBuilder;
+import org.opensearch.join.query.HasParentQueryBuilder;
+
+public final class ParentChildrenQueryDetector implements QueryBuilderVisitor {
+
+    private boolean queryPresent = false;
+
+    private ParentChildrenQueryDetector() {
+        // Private constructor to prevent instantiation
+    }
+
+    public static boolean hasParentOrChildQuery(QueryBuilder queryBuilder) {
+        ParentChildrenQueryDetector detector = new ParentChildrenQueryDetector();
+        queryBuilder.visit(detector);
+        return detector.hasParentOrChildQuery();
+    }
+
+    /**
+     * Do not call the method directly. Static method {@link #hasParentOrChildQuery} should be used instead.
+     * @param queryBuilder is a queryBuilder object which is accepeted by the visitor.
+     */
+    @Override
+    public void accept(QueryBuilder queryBuilder) {
+        if (queryBuilder instanceof HasParentQueryBuilder || queryBuilder instanceof HasChildQueryBuilder) {
+            queryPresent = true;
+        }
+    }
+
+    @Override
+    public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+        return this;
+    }
+
+    public boolean hasParentOrChildQuery() {
+        return queryPresent;
+    }
+}

--- a/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
+++ b/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security.util;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.junit.Test;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.join.query.HasChildQueryBuilder;
+import org.opensearch.join.query.HasParentQueryBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class ParentChildrenQueryDetectorTest {
+
+    @Test
+    public void termQueryShouldNotBeParentChildQuery() {
+        TermQueryBuilder query = QueryBuilders.termQuery("field", "value");
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(false));
+    }
+
+    @Test
+    public void topLevelHasParentQueryShouldBeDetected() {
+        HasParentQueryBuilder query = new HasParentQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), false);
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void topLevelHasChildQueryShouldBeDetected() {
+        HasChildQueryBuilder query = new HasChildQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), ScoreMode.None);
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void shouldDetectHasParentQueryInsideBooleanQuery() {
+        BoolQueryBuilder query = QueryBuilders.boolQuery() //
+            .must(new HasParentQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), false)) //
+            .should(QueryBuilders.termQuery("another_field", "another_value"));
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+
+    }
+
+}


### PR DESCRIPTION
### Description

If we detect parent/child queries, we switch the DLS mode to use the FilterLeafReader

* Category: Bug fix
* What is the old behavior before changes and new behavior after changes? none

### Testing

- integration test

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
