### PR TITLE
Integration of security with stream transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Optimized performance for construction of internal action privileges data structure  ([#5470](https://github.com/opensearch-project/security/pull/5470))
 * Restricting query optimization via star tree index for users with queries on indices with DLS/FLS/FieldMasked restrictions ([#5492](https://github.com/opensearch-project/security/pull/5492))
 * Handle subject in nested claim for JWT auth backends ([#5467](https://github.com/opensearch-project/security/pull/5467))
+* Integration with stream transport ([#5530](https://github.com/opensearch-project/security/pull/5530))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/transport/SecuritySSLRequestHandler.java
@@ -52,7 +52,7 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
     private final SslExceptionHandler errorHandler;
     private final SSLConfig SSLConfig;
 
-    private static final Set<String> DEFAULT_CHANNEL_TYPES = Set.of("direct", "transport");
+    private static final Set<String> DEFAULT_CHANNEL_TYPES = Set.of("direct", "transport", "stream-transport");
 
     public SecuritySSLRequestHandler(
         String action,
@@ -98,6 +98,10 @@ public class SecuritySSLRequestHandler<T extends TransportRequest> implements Tr
             final Exception exception = ExceptionUtils.createBadHeaderException();
             channel.sendResponse(exception);
             throw exception;
+        }
+        if ("stream-transport".equals(channel.getChannelType())) {
+            messageReceivedDecorate(request, actualHandler, channel, task);
+            return;
         }
 
         if (!"transport".equals(channel.getChannelType())) { // netty4

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -162,10 +162,9 @@ public class SecurityInterceptor {
         );
 
         final boolean isDebugEnabled = log.isDebugEnabled();
-
-        final boolean isSameNodeRequest = localNode != null
-            && localNode.equals(connection.getNode())
-            && (options.type() == null || !options.type().equals(TransportRequestOptions.Type.STREAM));
+        final boolean isStreamChannel = options != null && TransportRequestOptions.Type.STREAM.equals(options.type());
+        // skip the same node optimization for stream transport which doesn't use DirectChannel and thus ser/de is needed
+        final boolean isSameNodeRequest = localNode != null && localNode.equals(connection.getNode()) && !isStreamChannel;
 
         try (ThreadContext.StoredContext stashedContext = getThreadContext().stashContext()) {
             final TransportResponseHandler<T> restoringHandler = new RestoringTransportResponseHandler<T>(handler, stashedContext);

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -73,6 +73,7 @@ import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
 import org.opensearch.transport.TransportRequestOptions;
 import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.stream.StreamTransportResponse;
 
 public class SecurityInterceptor {
 
@@ -162,7 +163,9 @@ public class SecurityInterceptor {
 
         final boolean isDebugEnabled = log.isDebugEnabled();
 
-        final boolean isSameNodeRequest = localNode != null && localNode.equals(connection.getNode());
+        final boolean isSameNodeRequest = localNode != null
+            && localNode.equals(connection.getNode())
+            && (options.type() == null || !options.type().equals(TransportRequestOptions.Type.STREAM));
 
         try (ThreadContext.StoredContext stashedContext = getThreadContext().stashContext()) {
             final TransportResponseHandler<T> restoringHandler = new RestoringTransportResponseHandler<T>(handler, stashedContext);
@@ -372,6 +375,13 @@ public class SecurityInterceptor {
         @Override
         public T read(StreamInput in) throws IOException {
             return innerHandler.read(in);
+        }
+
+        @Override
+        public void handleStreamResponse(StreamTransportResponse<T> response) {
+            // we do not have to process headers like OPENDISTRO_SECURITY_DLS_QUERY_HEADER which is done in handleResponse(),
+            // as it is only necessary for cross-cluster search if the remote cluster is on OpenSearch 2.19.x or earlier.
+            innerHandler.handleStreamResponse(response);
         }
 
         @Override

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -29,6 +29,7 @@ package org.opensearch.security.transport;
 // CS-SUPPRESS-SINGLE: RegexpSingleline Extensions manager used to allow/disallow TLS connections to extensions
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -73,6 +74,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
     private final InterClusterRequestEvaluator requestEvalProvider;
     private final ClusterService cs;
     private final UserFactory userFactory;
+    private static final Set<String> knownChannelTypes = Set.of("direct", "transport", "stream-transport");
 
     SecurityRequestHandler(
         String action,
@@ -130,7 +132,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
             String channelType = transportChannel.getChannelType();
 
-            if (!channelType.equals("direct") && !channelType.equals("transport") && !channelType.equals("stream-transport")) {
+            if (!knownChannelTypes.contains(channelType)) {
                 TransportChannel innerChannel = getInnerChannel(transportChannel);
                 channelType = innerChannel.getChannelType();
             }

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -130,7 +130,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
             String channelType = transportChannel.getChannelType();
 
-            if (!channelType.equals("direct") && !channelType.equals("transport")) {
+            if (!channelType.equals("direct") && !channelType.equals("transport") && !channelType.equals("stream-transport")) {
                 TransportChannel innerChannel = getInnerChannel(transportChannel);
                 channelType = innerChannel.getChannelType();
             }
@@ -237,6 +237,11 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             }
 
             if (channelType.equals("direct")) {
+                super.messageReceivedDecorate(request, handler, transportChannel, task);
+                return;
+            }
+
+            if (channelType.equals("stream-transport")) {
                 super.messageReceivedDecorate(request, handler, transportChannel, task);
                 return;
             }

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -182,6 +182,7 @@ public class SecurityInterceptorTests {
 
         request = mock(TransportRequest.class);
         options = mock(TransportRequestOptions.class);
+        when(options.type()).thenReturn(TransportRequestOptions.Type.REG);
 
         localAddress = null;
         remoteAddress = null;
@@ -439,4 +440,13 @@ public class SecurityInterceptorTests {
         // this is a local request
         completableRequestDecorate(sender, connection1, action, request, options, handler, localNode);
     }
+
+    @Test
+    public void testStreamRequestType() {
+        TransportRequestOptions streamOptions = mock(TransportRequestOptions.class);
+        when(streamOptions.type()).thenReturn(TransportRequestOptions.Type.STREAM);
+
+        completableRequestDecorate(jdkSerializedSender, connection1, action, request, streamOptions, handler, localNode);
+    }
+
 }


### PR DESCRIPTION
### Description
With introduction of stream transport in OpenSearch (https://github.com/opensearch-project/OpenSearch/pull/18722), there could be multiple responses for a transport request, thus security plugin need to ensure the headers are injected for each response. Currently, stream transport is only available for node-node communication. 

The new flight based stream transport doesn't use DirectChannel for local node, thus this PR also addresses bypassing optimization done for local node. 

### Issues Resolved

### Testing

- Manually tested using scripts here -  https://gist.github.com/rishabhmaurya/f714a87ac775a70b0632c5e9e9ea15f4 
- Unit tests
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
