### PR TITLE
[Resource Sharing] Restores client accessor pattern to fix compilation issues when security plugin is not installed

### DIFF
--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
@@ -51,7 +51,7 @@ import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 public class SecurityDisabledTests {
 
     @ClassRule
-    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.DEFAULT)
         .plugin(
             new PluginInfo(
                 SampleResourcePlugin.class.getName(),

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
@@ -13,6 +13,7 @@ package org.opensearch.sample;
 
 import java.util.Set;
 
+import org.opensearch.sample.client.ResourceSharingClientAccessor;
 import org.opensearch.security.spi.resources.ResourceProvider;
 import org.opensearch.security.spi.resources.ResourceSharingExtension;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
@@ -23,7 +24,6 @@ import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
  * Responsible for parsing the XContent into a SampleResource object.
  */
 public class SampleResourceExtension implements ResourceSharingExtension {
-    private ResourceSharingClient client;
 
     @Override
     public Set<ResourceProvider> getResourceProviders() {
@@ -32,11 +32,6 @@ public class SampleResourceExtension implements ResourceSharingExtension {
 
     @Override
     public void assignResourceSharingClient(ResourceSharingClient resourceSharingClient) {
-        this.client = resourceSharingClient;
-    }
-
-    @Override
-    public ResourceSharingClient getResourceSharingClient() {
-        return this.client;
+        ResourceSharingClientAccessor.getInstance().setResourceSharingClient(resourceSharingClient);
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/client/ResourceSharingClientAccessor.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/client/ResourceSharingClientAccessor.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.client;
+
+import org.opensearch.security.spi.resources.client.ResourceSharingClient;
+
+/**
+ * Accessor for resource sharing client supplied by the SPI.
+ */
+public class ResourceSharingClientAccessor {
+    private ResourceSharingClient CLIENT;
+
+    private static ResourceSharingClientAccessor resourceSharingClientAccessor;
+
+    private ResourceSharingClientAccessor() {}
+
+    public static ResourceSharingClientAccessor getInstance() {
+        if (resourceSharingClientAccessor == null) {
+            resourceSharingClientAccessor = new ResourceSharingClientAccessor();
+        }
+
+        return resourceSharingClientAccessor;
+    }
+
+    /**
+     * Set the resource sharing client
+     */
+    public void setResourceSharingClient(ResourceSharingClient client) {
+        resourceSharingClientAccessor.CLIENT = client;
+    }
+
+    /**
+     * Get the resource sharing client
+     */
+    public ResourceSharingClient getResourceSharingClient() {
+        return resourceSharingClientAccessor.CLIENT;
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/GetResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/GetResourceTransportAction.java
@@ -32,6 +32,7 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sample.SampleResource;
 import org.opensearch.sample.SampleResourceExtension;
+import org.opensearch.sample.client.ResourceSharingClientAccessor;
 import org.opensearch.sample.resource.actions.rest.get.GetResourceAction;
 import org.opensearch.sample.resource.actions.rest.get.GetResourceRequest;
 import org.opensearch.sample.resource.actions.rest.get.GetResourceResponse;
@@ -51,24 +52,21 @@ public class GetResourceTransportAction extends HandledTransportAction<GetResour
 
     private final TransportService transportService;
     private final NodeClient nodeClient;
-    private final SampleResourceExtension sampleResourceExtension;
 
     @Inject
     public GetResourceTransportAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        NodeClient nodeClient,
-        SampleResourceExtension sampleResourceExtension
+        NodeClient nodeClient
     ) {
         super(GetResourceAction.NAME, transportService, actionFilters, GetResourceRequest::new);
         this.transportService = transportService;
         this.nodeClient = nodeClient;
-        this.sampleResourceExtension = sampleResourceExtension;
     }
 
     @Override
     protected void doExecute(Task task, GetResourceRequest request, ActionListener<GetResourceResponse> listener) {
-        ResourceSharingClient client = sampleResourceExtension.getResourceSharingClient();
+        ResourceSharingClient client = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
         String resourceId = request.getResourceId();
 
         if (Strings.isNullOrEmpty(resourceId)) {

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/RevokeResourceAccessTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/RevokeResourceAccessTransportAction.java
@@ -18,6 +18,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.sample.SampleResourceExtension;
+import org.opensearch.sample.client.ResourceSharingClientAccessor;
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessAction;
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessRequest;
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessResponse;
@@ -39,11 +40,10 @@ public class RevokeResourceAccessTransportAction extends HandledTransportAction<
     @Inject
     public RevokeResourceAccessTransportAction(
         TransportService transportService,
-        ActionFilters actionFilters,
-        SampleResourceExtension sampleResourceExtension
+        ActionFilters actionFilters
     ) {
         super(RevokeResourceAccessAction.NAME, transportService, actionFilters, RevokeResourceAccessRequest::new);
-        this.resourceSharingClient = sampleResourceExtension.getResourceSharingClient();
+        this.resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/ShareResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/ShareResourceTransportAction.java
@@ -18,6 +18,7 @@ import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.sample.SampleResourceExtension;
+import org.opensearch.sample.client.ResourceSharingClientAccessor;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceAction;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceRequest;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceResponse;
@@ -38,11 +39,10 @@ public class ShareResourceTransportAction extends HandledTransportAction<ShareRe
     @Inject
     public ShareResourceTransportAction(
         TransportService transportService,
-        ActionFilters actionFilters,
-        SampleResourceExtension sampleResourceExtension
+        ActionFilters actionFilters
     ) {
         super(ShareResourceAction.NAME, transportService, actionFilters, ShareResourceRequest::new);
-        this.resourceSharingClient = sampleResourceExtension.getResourceSharingClient();
+        this.resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
     }
 
     @Override

--- a/spi/src/main/java/org/opensearch/security/spi/resources/ResourceSharingExtension.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/ResourceSharingExtension.java
@@ -32,11 +32,4 @@ public interface ResourceSharingExtension {
      * @param client the ResourceSharingClient instance
      */
     void assignResourceSharingClient(ResourceSharingClient client);
-
-    /**
-     * Gets the resource sharing client to be used by the plugin
-     * @return the resource sharing client
-     */
-    ResourceSharingClient getResourceSharingClient();
-
 }


### PR DESCRIPTION
### Description
#5408 removed client accessor pattern to allow fetch client by Dependency Injection of the ResourceSharingExtension instance. However, that required that SPI be present on the classpath. That might not be the case in plugins which are not dependent on security.
See this example run from AD plugin PR that fails with ClassNotFoundException:
https://github.com/opensearch-project/anomaly-detection/actions/runs/16732487298/job/47363684918?pr=1533#step:6:635

This was not caught in our e2e test framework because security plugin is always present in the test cluster even if it is disabled.


* Category: Bug fix
* Why these changes are required?
* To unblock compilation of plugins

* What is the old behavior before changes and new behavior after changes?
* Without this change, plugins will not compile when security is not present.

### Testing
automated testing

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
