### PR TITLE
Bump gradle to 8.14.3 and move gRPC transport out of experimental

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=845952a9d6afa783db70bb3b0effaae45ae5542ca2bb7929619e8af49cb634cf
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionSha256Sum=ed1a8d686605fd7c23bdf62c7fc7add1c5b23b2bbc3721e661934ef4a4911d7c
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
@@ -17,7 +17,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.opensearch.plugin.transport.grpc.GrpcPlugin;
 import org.opensearch.protobufs.BulkResponse;
 import org.opensearch.protobufs.SearchResponse;
 import org.opensearch.test.framework.cluster.ClusterManager;
@@ -40,7 +39,6 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthNoneTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
-        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthNoneTests.java
@@ -21,6 +21,7 @@ import org.opensearch.protobufs.BulkResponse;
 import org.opensearch.protobufs.SearchResponse;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
@@ -39,6 +40,7 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthNoneTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
@@ -18,10 +18,10 @@ import org.junit.runner.RunWith;
 
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
 import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_OPT;

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
@@ -16,7 +16,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.opensearch.plugin.transport.grpc.GrpcPlugin;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
@@ -36,7 +35,6 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthOptionalTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
-        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthOptionalTests.java
@@ -21,6 +21,7 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
+import org.opensearch.transport.grpc.GrpcPlugin;
 
 import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
 import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_OPT;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthOptionalTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
@@ -18,10 +18,10 @@ import org.junit.runner.RunWith;
 
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
 import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_REQUIRE;

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
@@ -21,6 +21,7 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 
 import io.grpc.ManagedChannel;
 import io.grpc.StatusRuntimeException;
+import org.opensearch.transport.grpc.GrpcPlugin;
 
 import static org.opensearch.security.grpc.GrpcClientAuthNoneTests.assertBulkAndSearchTestIndex;
 import static org.opensearch.security.grpc.GrpcHelpers.CLIENT_AUTH_REQUIRE;
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthRequireTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcClientAuthRequireTests.java
@@ -16,7 +16,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.opensearch.plugin.transport.grpc.GrpcPlugin;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 
@@ -36,7 +35,6 @@ import static org.junit.Assert.assertThrows;
 public class GrpcClientAuthRequireTests {
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
-        .plugin(GrpcPlugin.class)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_GRPC_TRANSPORT_SETTINGS)
         .loadConfigurationIntoIndex(false)

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -16,7 +16,7 @@ import java.util.Map;
 
 import org.opensearch.common.transport.PortsRange;
 import org.opensearch.core.common.transport.TransportAddress;
-import org.opensearch.plugin.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
+import org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.BulkRequestBody;
 import org.opensearch.protobufs.BulkResponse;

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -16,7 +16,6 @@ import java.util.Map;
 
 import org.opensearch.common.transport.PortsRange;
 import org.opensearch.core.common.transport.TransportAddress;
-import org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.BulkRequestBody;
 import org.opensearch.protobufs.BulkResponse;
@@ -32,6 +31,7 @@ import org.opensearch.protobufs.services.SearchServiceGrpc;
 import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
+import org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
 
 import io.grpc.ChannelCredentials;
 import io.grpc.Grpc;

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -48,17 +48,17 @@ public class GrpcHelpers {
     protected static final TestCertificates UN_TRUSTED_TEST_CERTIFICATES = new TestCertificates();
 
     protected static final Map<String, Object> CLIENT_AUTH_NONE = Map.of(
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "NONE"
     );
 
     protected static final Map<String, Object> CLIENT_AUTH_OPT = Map.of(
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "OPTIONAL"
     );
 
     protected static final Map<String, Object> CLIENT_AUTH_REQUIRE = Map.of(
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode",
+        "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "REQUIRE"
     );
 
@@ -68,16 +68,16 @@ public class GrpcHelpers {
         "plugins.security.ssl_only",
         true,
         "aux.transport.types",
-        "experimental-secure-transport-grpc",
-        "aux.transport.experimental-secure-transport-grpc.port",
+        "secure-transport-grpc",
+        "aux.transport.secure-transport-grpc.port",
         PORTS_RANGE.getPortRangeString(),
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled",
+        "plugins.security.ssl.aux.secure-transport-grpc.enabled",
         true,
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemkey_filepath",
+        "plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath",
         TEST_CERTIFICATES.getNodeKey(0, null).getAbsolutePath(),
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemcert_filepath",
+        "plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath",
         TEST_CERTIFICATES.getNodeCertificate(0).getAbsolutePath(),
-        "plugins.security.ssl.aux.experimental-secure-transport-grpc.pemtrustedcas_filepath",
+        "plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath",
         TEST_CERTIFICATES.getRootCertificate().getAbsolutePath()
     );
 


### PR DESCRIPTION
### Description
Pending core change: https://github.com/opensearch-project/OpenSearch/pull/18915
gRPC transport is moving out of experimental in core. Settings in ITs need to reflect this change.

### Issues Resolved
N/A

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Unit/Integration tests

Testing plugin install step locally with the following:
```
export SNAP_VERSION=3.2.0
export PLAT=darwin
export REPOS_DIR=<security and OS repos path>

export OS_REPO=${REPOS_DIR}OpenSearch
export SEC_REPO=${REPOS_DIR}security
export SEC_TAR=${SEC_REPO}/build/distributions/opensearch-security-${SNAP_VERSION}.0-SNAPSHOT.zip
export OS_INSTALL=${OS_REPO}/distribution/archives/${PLAT}-tar/build/install/opensearch-${SNAP_VERSION}-SNAPSHOT

cd ${OS_REPO} && ./gradlew :distribution:archives:${PLAT}-tar:assemble 
cd ${SEC_REPO} && ./gradlew :assemble

${OS_INSTALL}/bin/opensearch-plugin install file://${SEC_TAR}

# Create demo certs - Respond yes yes no - Keep cluster mode disabled
export OPENSEARCH_INITIAL_ADMIN_PASSWORD=PrTestPass369char! && \
chmod +x "${OS_INSTALL}/plugins/opensearch-security/tools/install_demo_configuration.sh" && \
"${OS_INSTALL}/plugins/opensearch-security/tools/install_demo_configuration.sh"

${OS_INSTALL}/bin/opensearch
```

Seeing single process start with no issue:
```
[2025-08-05T13:18:03,641][INFO ][o.o.c.r.a.AllocationService] [6cb1339d7f79] Cluster health status changed from [YELLOW] to [GREEN] (reason: [shards started [[security-auditlog-2025.08.05][0]]]).
```

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
