### PR TITLE
[Resource Sharing] Adds `/search` API to sample plugins

### DIFF
--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -367,10 +367,19 @@ public final class TestUtils {
             assertGetSearch(SAMPLE_RESOURCE_SEARCH_ENDPOINT, user, HttpStatus.SC_FORBIDDEN, 0, null);
         }
 
+        public void assertDirectGetSearchForbidden(TestSecurityConfig.User user) {
+            assertGetSearch(RESOURCE_INDEX_NAME + "/_search", user, HttpStatus.SC_FORBIDDEN, 0, null);
+        }
+
         public void assertApiGetSearch(TestSecurityConfig.User user, int status, int expectedHits, String expectedResourceName) {
             assertGetSearch(SAMPLE_RESOURCE_SEARCH_ENDPOINT, user, status, expectedHits, expectedResourceName);
         }
 
+        public void assertDirectGetSearch(TestSecurityConfig.User user, int status, int expectedHits, String expectedResourceName) {
+            assertGetSearch(RESOURCE_INDEX_NAME + "/_search", user, status, expectedHits, expectedResourceName);
+        }
+
+        @SuppressWarnings("unchecked")
         private void assertGetSearch(
             String endpoint,
             TestSecurityConfig.User user,
@@ -382,7 +391,8 @@ public final class TestUtils {
                 TestRestClient.HttpResponse response = client.get(endpoint);
                 response.assertStatusCode(status);
                 if (status == HttpStatus.SC_OK) {
-                    // assertThat(response.bodyAsMap().get("hits").size(), is(expectedHits))
+                    Map<String, Object> hits = (Map<String, Object>) response.bodyAsMap().get("hits");
+                    assertThat(((List<String>) hits.get("hits")).size(), is(equalTo(expectedHits)));
                     assertThat(response.getBody(), containsString(expectedResourceName));
                 }
             }
@@ -416,6 +426,10 @@ public final class TestUtils {
             assertPostSearch(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchPayload, user, HttpStatus.SC_FORBIDDEN, 0, null);
         }
 
+        public void assertDirectPostSearchForbidden(String searchPayload, TestSecurityConfig.User user) {
+            assertPostSearch(RESOURCE_INDEX_NAME + "/_search", searchPayload, user, HttpStatus.SC_FORBIDDEN, 0, null);
+        }
+
         public void assertApiPostSearch(
             String searchPayload,
             TestSecurityConfig.User user,
@@ -424,6 +438,16 @@ public final class TestUtils {
             String expectedResourceName
         ) {
             assertPostSearch(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchPayload, user, status, expectedHits, expectedResourceName);
+        }
+
+        public void assertDirectPostSearch(
+            String searchPayload,
+            TestSecurityConfig.User user,
+            int status,
+            int expectedHits,
+            String expectedResourceName
+        ) {
+            assertPostSearch(RESOURCE_INDEX_NAME + "/_search", searchPayload, user, status, expectedHits, expectedResourceName);
         }
 
         @SuppressWarnings("unchecked")
@@ -472,7 +496,7 @@ public final class TestUtils {
         }
 
         public void assertDirectUpdate(String resourceId, TestSecurityConfig.User user, String newName, int status) {
-            assertUpdate(RESOURCE_INDEX_NAME + "/_doc/" + resourceId, newName, user, status);
+            assertUpdate(RESOURCE_INDEX_NAME + "/_doc/" + resourceId + "?refresh=true", newName, user, status);
         }
 
         private void assertUpdate(String endpoint, String newName, TestSecurityConfig.User user, int status) {

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
@@ -391,7 +391,7 @@ public class ApiAccessTests {
             api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource
-            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
             api.assertApiPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
             api.assertApiPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
             api.assertApiPostSearch(searchByNamePayload("sampleUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUser");

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.disabled;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -24,6 +25,8 @@ import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.sample.resource.TestUtils.ApiHelper.searchAllPayload;
+import static org.opensearch.sample.resource.TestUtils.ApiHelper.searchByNamePayload;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
@@ -32,6 +35,7 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_CREATE_EN
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_REVOKE_ENDPOINT;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SEARCH_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
@@ -68,6 +72,11 @@ public class ApiAccessTests {
             adminResId = api.createSampleResourceAs(USER_ADMIN);
         }
 
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
+        }
+
         @Test
         public void testPluginInstalledCorrectly() {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
@@ -99,14 +108,22 @@ public class ApiAccessTests {
 
             // cannot get admin's resource
             api.assertApiGet(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
+            // get non-existent resource returns 403
+            api.assertApiGet("randomId", NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
+
             // cannot update admin's resource
-            api.assertApiUpdate(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(adminResId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // feature is disabled, and thus request is treated as normal request.
             // Since user doesn't have permission to the share and revoke endpoints they will receive 403s
             api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
             api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+
+            // search returns 403 since user doesn't have access to invoke search
+            api.assertApiGetSearchForbidden(NO_ACCESS_USER);
+            api.assertApiPostSearchForbidden(searchAllPayload(), NO_ACCESS_USER);
+            api.assertApiPostSearchForbidden(searchByNamePayload("sample"), NO_ACCESS_USER);
 
             // cannot delete admin's resource
             api.assertApiDelete(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
@@ -130,11 +147,14 @@ public class ApiAccessTests {
             // can see admin's resource
             api.assertApiGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
             api.assertApiGetAll(LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
+            // get non-existent resource returns 404
+            api.assertApiGet("randomId", LIMITED_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
+
             // cannot update admin's resource since user doesn't have update permission
-            api.assertApiUpdate(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(adminResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
             // cannot update own resource since user doesn't have update permission
-            api.assertApiUpdate(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(userResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
 
             // feature is disabled, no handler's exist
             api.assertApiShare(
@@ -145,6 +165,12 @@ public class ApiAccessTests {
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
             api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+
+            // should be able to search for admin's resource
+            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
+            api.assertApiPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
+            api.assertApiPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertApiPostSearch(searchByNamePayload("sampleUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUser");
 
             // cannot delete own resource since user doesn't have delete permission
             api.assertApiDelete(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
@@ -169,17 +195,26 @@ public class ApiAccessTests {
             // can see admin's resource since feature is disabled and user has * permissions
             api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
             api.assertApiGetAll(FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
+            // get non-existent resource returns 404
+            api.assertApiGet("randomId", FULL_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
 
             // can update admin's resource since feature is disabled and user has * permissions
-            api.assertApiUpdate(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
+            api.assertApiUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+            api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateAdmin");
             // can update own resource since feature is disabled and user has * permissions
-            api.assertApiUpdate(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
+            api.assertApiUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
+            api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
             api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
             api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+
+            // should be able to search for admin's resource, 2 total results
+            api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
+            api.assertApiPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
+            api.assertApiPostSearch(searchByNamePayload("sampleUpdateAdmin"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateAdmin");
+            // can search for own resource
+            api.assertApiPostSearch(searchByNamePayload("sampleUpdateUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
 
             // can delete own resource since user has * permissions
             api.assertApiDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
@@ -192,41 +227,51 @@ public class ApiAccessTests {
         public void testApiAccess_adminCertificateUsers() {
             // super-admin can perform any operation
 
-            // can see admin's resource
             try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+                // can see admin's resource
                 HttpResponse resp = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/" + adminResId);
                 resp.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(resp.getBody(), containsString("sample"));
-            }
+                // get non-existent resource returns 404
+                resp = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/randomId");
+                resp.assertStatusCode(HttpStatus.SC_NOT_FOUND);
 
-            // can update admin's resource
-            try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+                // can update admin's resource
                 String updatePayload = "{" + "\"name\": \"sampleUpdated\"" + "}";
-                TestRestClient.HttpResponse resp = client.postJson(SAMPLE_RESOURCE_UPDATE_ENDPOINT + "/" + adminResId, updatePayload);
+                resp = client.postJson(SAMPLE_RESOURCE_UPDATE_ENDPOINT + "/" + adminResId, updatePayload);
                 resp.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(resp.getBody(), containsString("sampleUpdated"));
-            }
 
-            // can't share or revoke, as handlers don't exist
-            try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
-                TestRestClient.HttpResponse response = client.postJson(
+                // can't share or revoke, as handlers don't exist
+                resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
                     shareWithPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
                 );
 
-                response.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
+                resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
-                response = client.postJson(
+                resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
                     revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
                 );
 
-                response.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
-            }
+                resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
-            // can delete admin's resource
-            try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
-                HttpResponse resp = client.delete(SAMPLE_RESOURCE_DELETE_ENDPOINT + "/" + adminResId);
+                // can search resources
+                resp = client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT);
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
+
+                resp = client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchAllPayload());
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
+
+                resp = client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchByNamePayload("sampleUpdated"));
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
+
+                // can delete admin's resource
+                resp = client.delete(SAMPLE_RESOURCE_DELETE_ENDPOINT + "/" + adminResId);
                 resp.assertStatusCode(HttpStatus.SC_OK);
                 resp = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/" + adminResId);
                 resp.assertStatusCode(HttpStatus.SC_NOT_FOUND);
@@ -246,6 +291,11 @@ public class ApiAccessTests {
         public static LocalCluster cluster = newCluster(false, false);
 
         private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
+        }
 
         @Test
         public void testPluginInstalledCorrectly() {
@@ -281,13 +331,21 @@ public class ApiAccessTests {
 
             // cannot get admin's resource
             api.assertApiGet(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
+            // get non-existent resource returns 404
+            api.assertApiGet("randomId", NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
+
             // cannot update admin's resource
-            api.assertApiUpdate(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(adminResId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // feature is disabled, no handler's exist
             api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
             api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+
+            // search returns 403 since user doesn't have access to invoke search
+            api.assertApiGetSearchForbidden(NO_ACCESS_USER);
+            api.assertApiPostSearchForbidden(searchAllPayload(), NO_ACCESS_USER);
+            api.assertApiPostSearchForbidden(searchByNamePayload("sample"), NO_ACCESS_USER);
 
             // cannot delete admin's resource
             api.assertApiDelete(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
@@ -313,11 +371,14 @@ public class ApiAccessTests {
             // can see admin's resource
             api.assertApiGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
             api.assertApiGetAll(LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
+            // get non-existent resource returns 404
+            api.assertApiGet("randomId", LIMITED_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
+
             // cannot update admin's resource
-            api.assertApiUpdate(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(adminResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
             // cannot update own resource
-            api.assertApiUpdate(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertApiUpdate(userResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
 
             // feature is disabled, no handler's exist
             api.assertApiShare(
@@ -328,6 +389,12 @@ public class ApiAccessTests {
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
             api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+
+            // should be able to search for admin's resource
+            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertApiPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
+            api.assertApiPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertApiPostSearch(searchByNamePayload("sampleUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUser");
 
             // cannot delete resource since feature is disabled and user doesn't have delete permission
             api.assertApiDelete(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
@@ -354,17 +421,26 @@ public class ApiAccessTests {
             // can see admin's resource
             api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
             api.assertApiGetAll(FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
+            // get non-existent resource returns 404
+            api.assertApiGet("randomId", LIMITED_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
 
             // can update admin's resource
-            api.assertApiUpdate(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
+            api.assertApiUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+            api.assertApiGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateAdmin");
             // can update a resource
-            api.assertApiUpdate(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
+            api.assertApiUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
+            api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
             api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
             api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+
+            // should be able to search for admin's resource, 2 total results
+            api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
+            api.assertApiPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
+            api.assertApiPostSearch(searchByNamePayload("sampleUpdateAdmin"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateAdmin");
+            // can see own resource
+            api.assertApiPostSearch(searchByNamePayload("sampleUpdateUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
 
             // can delete a resource
             api.assertApiDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
@@ -381,6 +457,9 @@ public class ApiAccessTests {
                 HttpResponse resp = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/" + id);
                 resp.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(resp.getBody(), containsString("sample"));
+                // get non-existent resource returns 404
+                resp = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/randomId");
+                resp.assertStatusCode(HttpStatus.SC_NOT_FOUND);
 
                 // can update all resources
                 String updatePayload = "{" + "\"name\": \"sampleUpdated\"" + "}";
@@ -400,6 +479,19 @@ public class ApiAccessTests {
                     revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
                 );
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
+
+                // can search resources
+                resp = client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT);
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
+
+                resp = client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchAllPayload());
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
+
+                resp = client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchByNamePayload("sampleUpdated"));
+                resp.assertStatusCode(HttpStatus.SC_OK);
+                assertThat(resp.getBody(), containsString("sampleUpdated"));
 
                 // can delete admin's resource
                 resp = client.delete(SAMPLE_RESOURCE_DELETE_ENDPOINT + "/" + id);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/DirectIndexAccessTests.java
@@ -62,7 +62,8 @@ public class DirectIndexAccessTests {
             }
             api.assertDirectGet(id, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             api.assertDirectGetAll(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
-            api.assertDirectUpdate(id, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(id, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+
             api.assertDirectDelete(id, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -81,7 +82,7 @@ public class DirectIndexAccessTests {
             // cannot read admin's resource since system index protection is enabled, will show 404
             api.assertDirectGet(id, LIMITED_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
             // cannot update or delete resource
-            api.assertDirectUpdate(id, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(id, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(id, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -99,7 +100,7 @@ public class DirectIndexAccessTests {
             // cannot read admin's resource directly since SIP is enabled
             api.assertDirectGet(id, FULL_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "sample");
             // cannot update or delete admin resource directly since SIP is enabled
-            api.assertDirectUpdate(id, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(id, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(id, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -145,7 +146,7 @@ public class DirectIndexAccessTests {
                 resp.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
             api.assertDirectGet(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
-            api.assertDirectUpdate(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -163,7 +164,7 @@ public class DirectIndexAccessTests {
             // can read admin's resource
             api.assertDirectGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
             // cannot update or delete resource since user doesn't have update and delete permissions
-            api.assertDirectUpdate(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -183,10 +184,10 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
             api.assertDirectGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUser");
             // can update and delete all resources
-            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertDirectGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
-            api.assertDirectUpdate(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertDirectGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdated");
+            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+            api.assertDirectGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateAdmin");
+            api.assertDirectUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
+            api.assertDirectGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
             api.assertDirectDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/DirectIndexAccessTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.disabled;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -22,9 +23,12 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
+import static org.opensearch.sample.resource.TestUtils.ApiHelper.searchAllPayload;
+import static org.opensearch.sample.resource.TestUtils.ApiHelper.searchByNamePayload;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SEARCH_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
@@ -49,6 +53,11 @@ public class DirectIndexAccessTests {
 
         private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
 
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
+        }
+
         @Test
         public void testRawAccess_noAccessUser() {
             String id = api.createRawResourceAs(cluster.getAdminCertificate());
@@ -63,6 +72,11 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(id, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             api.assertDirectGetAll(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             api.assertDirectUpdate(id, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+
+            // search returns 403 since user doesn't have access to invoke search
+            api.assertDirectGetSearchForbidden(NO_ACCESS_USER);
+            api.assertDirectPostSearchForbidden(searchAllPayload(), NO_ACCESS_USER);
+            api.assertDirectPostSearchForbidden(searchByNamePayload("sample"), NO_ACCESS_USER);
 
             api.assertDirectDelete(id, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
@@ -83,6 +97,13 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(id, LIMITED_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "");
             // cannot update or delete resource
             api.assertDirectUpdate(id, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+
+            // should not be able to search for admin's resource, can not see any resource since system index protection is enabled
+            api.assertDirectGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchByNamePayload("sampleUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+
             api.assertDirectDelete(id, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -101,6 +122,13 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(id, FULL_ACCESS_USER, HttpStatus.SC_NOT_FOUND, "sample");
             // cannot update or delete admin resource directly since SIP is enabled
             api.assertDirectUpdate(id, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+
+            // should not be able to search for any resource since System index protection is enabled
+            api.assertDirectGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchByNamePayload("sample"), FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertDirectPostSearch(searchByNamePayload("sampleUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+
             api.assertDirectDelete(id, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -110,6 +138,11 @@ public class DirectIndexAccessTests {
             String id = api.createRawResourceAs(cluster.getAdminCertificate());
             try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
                 client.get(RESOURCE_INDEX_NAME + "/_doc/" + id).assertStatusCode(HttpStatus.SC_OK);
+                // can search resources
+                client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT).assertStatusCode(HttpStatus.SC_OK);
+                client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchAllPayload()).assertStatusCode(HttpStatus.SC_OK);
+                client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchByNamePayload("sampleUpdated")).assertStatusCode(HttpStatus.SC_OK);
+
                 client.postJson(RESOURCE_INDEX_NAME + "/_doc/" + id, "{\"name\":\"adminDirectUpdated\"}")
                     .assertStatusCode(HttpStatus.SC_OK);
                 client.delete(RESOURCE_INDEX_NAME + "/_doc/" + id).assertStatusCode(HttpStatus.SC_OK);
@@ -135,6 +168,11 @@ public class DirectIndexAccessTests {
             adminResId = api.createSampleResourceAs(USER_ADMIN);
         }
 
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
+        }
+
         @Test
         public void testRawAccess_noAccessUser() {
             // user has no permissions
@@ -147,6 +185,13 @@ public class DirectIndexAccessTests {
             }
             api.assertDirectGet(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             api.assertDirectUpdate(adminResId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+            // should not be able to search for any resource
+            api.assertDirectGetSearch(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
+            api.assertDirectPostSearch(searchAllPayload(), NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
+            api.assertDirectPostSearch(searchByNamePayload("sampleUpdateAdmin"), NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
+            // can see own resource
+            api.assertDirectPostSearch(searchByNamePayload("sampleUser"), NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
+
             api.assertDirectDelete(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -165,6 +210,14 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
             // cannot update or delete resource since user doesn't have update and delete permissions
             api.assertDirectUpdate(adminResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+
+            // should be able to search only for one resource, admin's
+            api.assertDirectGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertDirectPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            api.assertDirectPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
+            // can see own resource
+            api.assertDirectPostSearch(searchByNamePayload("sampleUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+
             api.assertDirectDelete(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -189,6 +242,19 @@ public class DirectIndexAccessTests {
             api.assertDirectUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertDirectGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
+            // should be able to search for all resources
+            api.assertDirectGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateUser");
+            api.assertDirectPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateUser");
+            api.assertDirectPostSearch(searchByNamePayload("sampleUpdateUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
+            // can see own resource
+            api.assertDirectPostSearch(
+                searchByNamePayload("sampleUpdateAdmin"),
+                FULL_ACCESS_USER,
+                HttpStatus.SC_OK,
+                1,
+                "sampleUpdateAdmin"
+            );
+
             api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
             api.assertDirectDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
 
@@ -203,6 +269,11 @@ public class DirectIndexAccessTests {
                 client.get(RESOURCE_INDEX_NAME + "/_doc/" + adminResId).assertStatusCode(HttpStatus.SC_OK);
                 client.postJson(RESOURCE_INDEX_NAME + "/_doc/" + adminResId, "{\"name\":\"adminDirectUpdated\"}")
                     .assertStatusCode(HttpStatus.SC_OK);
+                // can search resources
+                client.get(SAMPLE_RESOURCE_SEARCH_ENDPOINT).assertStatusCode(HttpStatus.SC_OK);
+                client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchAllPayload()).assertStatusCode(HttpStatus.SC_OK);
+                client.postJson(SAMPLE_RESOURCE_SEARCH_ENDPOINT, searchByNamePayload("sampleUpdated")).assertStatusCode(HttpStatus.SC_OK);
+
                 client.delete(RESOURCE_INDEX_NAME + "/_doc/" + adminResId).assertStatusCode(HttpStatus.SC_OK);
             }
         }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
@@ -293,11 +293,6 @@ public class ApiAccessTests {
             api.awaitSharingEntry();
         }
 
-        @After
-        public void cleanup() {
-            api.wipeOutResourceEntries();
-        }
-
         @Test
         public void testPluginInstalledCorrectly() {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
@@ -385,7 +380,7 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for own resource
-            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
             api.assertApiPostSearch(searchAllPayload(), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
             api.assertApiPostSearch(searchByNamePayload("sample"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 0, "");
             // can see own resource
@@ -432,7 +427,7 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for its own resource
-            api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
+            api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
             api.assertApiPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
             api.assertApiPostSearch(searchByNamePayload("sample"), FULL_ACCESS_USER, HttpStatus.SC_OK, 0, "");
             // can see own resource

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.enabled;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -63,7 +64,7 @@ public class DirectIndexAccessTests {
                 resp.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
             api.assertDirectGet(id, user, HttpStatus.SC_FORBIDDEN, "");
-            api.assertDirectUpdate(id, user, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(id, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(id, user, HttpStatus.SC_FORBIDDEN);
 
         }
@@ -80,6 +81,11 @@ public class DirectIndexAccessTests {
         public void setUp() {
             id = api.createRawResourceAs(cluster.getAdminCertificate());
             api.awaitSharingEntry("kirk");
+        }
+
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
         }
 
         @Test
@@ -155,6 +161,11 @@ public class DirectIndexAccessTests {
             api.awaitSharingEntry(); // wait until sharing entry is created
         }
 
+        @After
+        public void cleanup() {
+            api.wipeOutResourceEntries();
+        }
+
         @Test
         public void testRawAccess_noAccessUser() {
             // user has no permission
@@ -166,7 +177,7 @@ public class DirectIndexAccessTests {
                 resp.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
             api.assertDirectGet(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
-            api.assertDirectUpdate(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
 
             // cannot interact with resource sharing index
@@ -194,7 +205,7 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
 
             // cannot update or delete resource
-            api.assertDirectUpdate(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
 
             // cannot access resource sharing index since user doesn't have permissions on that index
@@ -229,10 +240,10 @@ public class DirectIndexAccessTests {
             api.assertDirectGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // cannot update or delete resource
-            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
             api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
             // can update and delete own resource
-            api.assertDirectUpdate(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
+            api.assertDirectUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertDirectDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
 
             // can view, share, revoke and delete resource sharing record(s) directly

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
@@ -13,6 +13,7 @@ import java.util.List;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -60,6 +61,11 @@ public class DryRunAccessTests {
     public void setup() {
         adminResId = api.createSampleResourceAs(USER_ADMIN);
         api.awaitSharingEntry(); // wait until sharing entry is created
+    }
+
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
     }
 
     @Test

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.enabled.multi_share;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -47,9 +48,14 @@ public class FullAccessTests {
         api.awaitSharingEntry(); // wait until sharing entry is created
     }
 
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
     private void assertNoAccessBeforeSharing(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
@@ -58,7 +64,7 @@ public class FullAccessTests {
 
     private void assertRUDAccess(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_OK);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_OK);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_OK);
     }
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.enabled.multi_share;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -47,9 +48,14 @@ public class MixedAccessTests {
         api.awaitSharingEntry(); // wait until sharing entry is created
     }
 
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
     private void assertNoAccessBeforeSharing(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
@@ -58,7 +64,7 @@ public class MixedAccessTests {
 
     private void assertReadOnly(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
@@ -67,7 +73,7 @@ public class MixedAccessTests {
 
     private void assertFullAccess(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_OK);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_OK);
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_OK);
         api.assertApiRevoke(resourceId, user, USER_ADMIN, sampleAllAG.name(), HttpStatus.SC_OK);
         api.awaitSharingEntry();

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
@@ -11,6 +11,7 @@ package org.opensearch.sample.resource.feature.enabled.multi_share;
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import org.apache.http.HttpStatus;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -47,9 +48,14 @@ public class PubliclySharedDocTests {
         api.awaitSharingEntry(); // wait until sharing entry is created
     }
 
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
     private void assertNoAccessBeforeSharing(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
@@ -57,27 +63,21 @@ public class PubliclySharedDocTests {
     }
 
     private void assertReadOnly() {
-        api.assertApiGet(resourceId, TestUtils.FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, TestUtils.FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
-        api.assertApiDelete(resourceId, TestUtils.FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+        api.assertApiGet(resourceId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
+        api.assertApiUpdate(resourceId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+        api.assertApiDelete(resourceId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, TestUtils.FULL_ACCESS_USER, TestUtils.FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(
-            resourceId,
-            TestUtils.FULL_ACCESS_USER,
-            TestUtils.FULL_ACCESS_USER,
-            sampleAllAG.name(),
-            HttpStatus.SC_FORBIDDEN
-        );
+        api.assertApiShare(resourceId, FULL_ACCESS_USER, TestUtils.FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertFullAccess() {
-        api.assertApiGet(resourceId, TestUtils.LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, TestUtils.LIMITED_ACCESS_USER, HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, TestUtils.LIMITED_ACCESS_USER, TestUtils.LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
-        api.assertApiRevoke(resourceId, TestUtils.LIMITED_ACCESS_USER, USER_ADMIN, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiGet(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
+        api.assertApiUpdate(resourceId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, TestUtils.LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, LIMITED_ACCESS_USER, USER_ADMIN, sampleAllAG.name(), HttpStatus.SC_OK);
         api.awaitSharingEntry();
-        api.assertApiDelete(resourceId, TestUtils.LIMITED_ACCESS_USER, HttpStatus.SC_OK);
+        api.assertApiDelete(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK);
     }
 
     @Test

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
@@ -61,7 +61,7 @@ public class ReadOnlyAccessTests {
 
     private void assertNoAccessBeforeSharing(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
@@ -70,7 +70,7 @@ public class ReadOnlyAccessTests {
 
     private void assertReadOnly(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
-        api.assertApiUpdate(resourceId, user, HttpStatus.SC_FORBIDDEN);
+        api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
         api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourcePlugin.java
@@ -45,12 +45,15 @@ import org.opensearch.sample.resource.actions.rest.get.GetResourceAction;
 import org.opensearch.sample.resource.actions.rest.get.GetResourceRestAction;
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessAction;
 import org.opensearch.sample.resource.actions.rest.revoke.RevokeResourceAccessRestAction;
+import org.opensearch.sample.resource.actions.rest.search.SearchResourceAction;
+import org.opensearch.sample.resource.actions.rest.search.SearchResourceRestAction;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceAction;
 import org.opensearch.sample.resource.actions.rest.share.ShareResourceRestAction;
 import org.opensearch.sample.resource.actions.transport.CreateResourceTransportAction;
 import org.opensearch.sample.resource.actions.transport.DeleteResourceTransportAction;
 import org.opensearch.sample.resource.actions.transport.GetResourceTransportAction;
 import org.opensearch.sample.resource.actions.transport.RevokeResourceAccessTransportAction;
+import org.opensearch.sample.resource.actions.transport.SearchResourceTransportAction;
 import org.opensearch.sample.resource.actions.transport.ShareResourceTransportAction;
 import org.opensearch.sample.resource.actions.transport.UpdateResourceTransportAction;
 import org.opensearch.sample.secure.actions.rest.create.SecurePluginAction;
@@ -72,7 +75,7 @@ import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 public class SampleResourcePlugin extends Plugin implements ActionPlugin, SystemIndexPlugin, IdentityAwarePlugin {
     private PluginClient pluginClient;
 
-    public SampleResourcePlugin(final Settings settings) {}
+    public SampleResourcePlugin() {}
 
     @Override
     public Collection<Object> createComponents(
@@ -106,10 +109,12 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
         handlers.add(new CreateResourceRestAction());
         handlers.add(new GetResourceRestAction());
         handlers.add(new DeleteResourceRestAction());
-        handlers.add(new SecurePluginRestAction());
+        handlers.add(new SearchResourceRestAction());
 
         handlers.add(new ShareResourceRestAction());
         handlers.add(new RevokeResourceAccessRestAction());
+
+        handlers.add(new SecurePluginRestAction());
         return handlers;
     }
 
@@ -120,6 +125,7 @@ public class SampleResourcePlugin extends Plugin implements ActionPlugin, System
         actions.add(new ActionHandler<>(GetResourceAction.INSTANCE, GetResourceTransportAction.class));
         actions.add(new ActionHandler<>(UpdateResourceAction.INSTANCE, UpdateResourceTransportAction.class));
         actions.add(new ActionHandler<>(DeleteResourceAction.INSTANCE, DeleteResourceTransportAction.class));
+        actions.add(new ActionHandler<>(SearchResourceAction.INSTANCE, SearchResourceTransportAction.class));
         actions.add(new ActionHandler<>(ShareResourceAction.INSTANCE, ShareResourceTransportAction.class));
         actions.add(new ActionHandler<>(RevokeResourceAccessAction.INSTANCE, RevokeResourceAccessTransportAction.class));
         actions.add(new ActionHandler<>(SecurePluginAction.INSTANCE, SecurePluginTransportAction.class));

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceAction.java
@@ -1,0 +1,26 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.actions.rest.search;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.search.SearchResponse;
+
+/**
+ * Action to search sample resources
+ */
+public class SearchResourceAction extends ActionType<SearchResponse> {
+
+    public static final SearchResourceAction INSTANCE = new SearchResourceAction();
+
+    public static final String NAME = "cluster:admin/sample-resource-plugin/search";
+
+    private SearchResourceAction() {
+        super(NAME, SearchResponse::new);
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceRestAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/search/SearchResourceRestAction.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.actions.rest.search;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.action.RestToXContentListener;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.node.NodeClient;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.SAMPLE_RESOURCE_PLUGIN_API_PREFIX;
+
+/**
+ * Rest action to search sample resource(s)
+ */
+public class SearchResourceRestAction extends BaseRestHandler {
+
+    public SearchResourceRestAction() {}
+
+    @Override
+    public List<Route> routes() {
+        return List.of(
+            new Route(GET, SAMPLE_RESOURCE_PLUGIN_API_PREFIX + "/search"),
+            new Route(POST, SAMPLE_RESOURCE_PLUGIN_API_PREFIX + "/search")
+        );
+    }
+
+    @Override
+    public String getName() {
+        return "search_sample_resource";
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+
+        if (request.hasContentOrSourceParam()) {
+            try (XContentParser parser = request.contentOrSourceParamParser()) {
+                searchSourceBuilder.parseXContent(parser);
+            }
+        } else {
+            // Optional: default query if no body is provided
+            searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+        }
+
+        SearchRequest searchRequest = new SearchRequest().indices(RESOURCE_INDEX_NAME).source(searchSourceBuilder);
+
+        return channel -> client.executeLocally(SearchResourceAction.INSTANCE, searchRequest, new RestToXContentListener<>(channel));
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -82,11 +82,11 @@ public class SearchResourceTransportAction extends HandledTransportAction<Search
     }
 
     private void mergeAccessibleFilter(SearchSourceBuilder src, Set<String> resourceIds) {
-        QueryBuilder accessQB = null;
+        QueryBuilder accessQB;
 
         if (resourceIds == null || resourceIds.isEmpty()) {
             // match nothing
-            src.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
+            accessQB = QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery());
         } else {
             // match only from a provided set of resources
             accessQB = QueryBuilders.idsQuery().addIds(resourceIds.toArray(new String[0]));

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.actions.transport;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.sample.client.ResourceSharingClientAccessor;
+import org.opensearch.sample.resource.actions.rest.search.SearchResourceAction;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.security.spi.resources.client.ResourceSharingClient;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
+/**
+ * Transport action for searching sample resources
+ */
+public class SearchResourceTransportAction extends HandledTransportAction<SearchRequest, SearchResponse> {
+    private static final Logger log = LogManager.getLogger(SearchResourceTransportAction.class);
+
+    private final TransportService transportService;
+    private final Client nodeClient;
+
+    @Inject
+    public SearchResourceTransportAction(TransportService transportService, ActionFilters actionFilters, Client nodeClient) {
+        super(SearchResourceAction.NAME, transportService, actionFilters, SearchRequest::new);
+        this.transportService = transportService;
+        this.nodeClient = nodeClient;
+    }
+
+    @Override
+    protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
+        ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            // if the resource sharing feature is enabled, we only allow search from documents that requested user has access to
+            if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
+                addAccessibleResourcesFilter(request.source());
+            }
+            nodeClient.search(request, listener);
+        } catch (Exception e) {
+            log.error("Failed to search resources", e);
+            listener.onFailure(e);
+        }
+    }
+
+    private void addAccessibleResourcesFilter(SearchSourceBuilder searchSourceBuilder) {
+        ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
+        resourceSharingClient.getAccessibleResourceIds(RESOURCE_INDEX_NAME, ActionListener.wrap(resourceIds -> {
+            if (resourceIds.isEmpty()) {
+                // User has no access → return nothing
+                searchSourceBuilder.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
+            } else {
+                // Restrict search strictly to these ids
+                // check if `.keyword` is correctly used here
+                searchSourceBuilder.query(QueryBuilders.idsQuery().addIds(resourceIds.toArray(new String[0])));
+            }
+        }, failure -> {
+            // do nothing to the source or return empty set?
+            searchSourceBuilder.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
+        }));
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -8,6 +8,8 @@
 
 package org.opensearch.sample.resource.actions.transport;
 
+import java.util.Set;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,6 +20,8 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.sample.client.ResourceSharingClientAccessor;
 import org.opensearch.sample.resource.actions.rest.search.SearchResourceAction;
@@ -49,31 +53,63 @@ public class SearchResourceTransportAction extends HandledTransportAction<Search
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
         try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
-            // if the resource sharing feature is enabled, we only allow search from documents that requested user has access to
-            if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() != null) {
-                addAccessibleResourcesFilter(request.source());
+            if (ResourceSharingClientAccessor.getInstance().getResourceSharingClient() == null) {
+                nodeClient.search(request, listener);
+                return;
             }
-            nodeClient.search(request, listener);
+            // if the resource sharing feature is enabled, we only allow search from documents that requested user has access to
+            searchFilteredIds(request, listener);
         } catch (Exception e) {
             log.error("Failed to search resources", e);
             listener.onFailure(e);
         }
     }
 
-    private void addAccessibleResourcesFilter(SearchSourceBuilder searchSourceBuilder) {
+    private void searchFilteredIds(SearchRequest request, ActionListener<SearchResponse> listener) {
+        SearchSourceBuilder src = request.source() != null ? request.source() : new SearchSourceBuilder();
+        ActionListener<Set<String>> idsListener = ActionListener.wrap(resourceIds -> {
+            mergeAccessibleFilter(src, resourceIds);
+            request.source(src);
+            nodeClient.search(request, listener);
+        }, e -> {
+            mergeAccessibleFilter(src, Set.of());
+            request.source(src);
+            nodeClient.search(request, listener);
+        });
+
         ResourceSharingClient resourceSharingClient = ResourceSharingClientAccessor.getInstance().getResourceSharingClient();
-        resourceSharingClient.getAccessibleResourceIds(RESOURCE_INDEX_NAME, ActionListener.wrap(resourceIds -> {
-            if (resourceIds.isEmpty()) {
-                // User has no access → return nothing
-                searchSourceBuilder.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
-            } else {
-                // Restrict search strictly to these ids
-                // check if `.keyword` is correctly used here
-                searchSourceBuilder.query(QueryBuilders.idsQuery().addIds(resourceIds.toArray(new String[0])));
-            }
-        }, failure -> {
-            // do nothing to the source or return empty set?
-            searchSourceBuilder.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
-        }));
+        resourceSharingClient.getAccessibleResourceIds(RESOURCE_INDEX_NAME, idsListener);
     }
+
+    private void mergeAccessibleFilter(SearchSourceBuilder src, Set<String> resourceIds) {
+        QueryBuilder accessQB = null;
+
+        if (resourceIds == null || resourceIds.isEmpty()) {
+            // match nothing
+            src.query(QueryBuilders.boolQuery().mustNot(QueryBuilders.matchAllQuery()));
+        } else {
+            // match only from a provided set of resources
+            accessQB = QueryBuilders.idsQuery().addIds(resourceIds.toArray(new String[0]));
+        }
+
+        QueryBuilder existing = src.query();
+        if (existing == null) {
+            // No existing query → just the filter
+            src.query(QueryBuilders.boolQuery().filter(accessQB));
+            return;
+        }
+
+        if (existing instanceof BoolQueryBuilder) {
+            // Reuse existing bool: just add a filter clause
+            ((BoolQueryBuilder) existing).filter(accessQB);
+            src.query(existing);
+        } else {
+            // Preserve existing scoring by keeping it in MUST, add our filter
+            BoolQueryBuilder merged = QueryBuilders.boolQuery()
+                .must(existing)      // keep original query semantics/scoring
+                .filter(accessQB);   // filter results
+            src.query(merged);
+        }
+    }
+
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -177,6 +177,7 @@ public class ResourceAccessHandler {
 
         resourceSharingIndexHandler.fetchSharingInfo(resourceIndex, resourceId, ActionListener.wrap(document -> {
             // Document may be null when cluster has enabled resource-sharing protection for that index, but have not migrated any records.
+            // This also means that for non-existing documents, the evaluator will return 403 instead
             if (document == null) {
                 LOGGER.warn("No sharing info found for '{}'. Action {} is not allowed.", resourceId, action);
                 listener.onResponse(false);


### PR DESCRIPTION
### Description
Adds `/search` API to sample plugin and tests its behavior with resource sharing feature.


### Testing
- automated testsing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
