### PR TITLE
Remove `commons-io` and `commons-lang3` maven metadata from being shaded in opensaml jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `actions/download-artifact` from 4 to 5 ([#5550](https://github.com/opensearch-project/security/pull/5550))
 - Bump `commons-cli:commons-cli` from 1.9.0 to 1.10.0 ([#5533](https://github.com/opensearch-project/security/pull/5533))
 - Bump `checkstyle` to 11.0.0 and `spotbugs` to 6.2.4 ([#5555](https://github.com/opensearch-project/security/pull/5555))
+- Removes `commons-io` maven metadata from shaded opensaml jar to fix CVE-2024-47554 ([#5558](https://github.com/opensearch-project/security/pull/5558))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bump `actions/download-artifact` from 4 to 5 ([#5550](https://github.com/opensearch-project/security/pull/5550))
 - Bump `commons-cli:commons-cli` from 1.9.0 to 1.10.0 ([#5533](https://github.com/opensearch-project/security/pull/5533))
 - Bump `checkstyle` to 11.0.0 and `spotbugs` to 6.2.4 ([#5555](https://github.com/opensearch-project/security/pull/5555))
-- Removes `commons-io` maven metadata from shaded opensaml jar to fix CVE-2024-47554 ([#5558](https://github.com/opensearch-project/security/pull/5558))
+- Removes `commons-io` and `commons-lang3` maven metadata from shaded opensaml jar to fix CVE-2024-47554 ([#5558](https://github.com/opensearch-project/security/pull/5558))
 
 ### Documentation
 

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -70,6 +70,7 @@ tasks.shadowJar {
     exclude 'org/slf4j/**'
     exclude 'javax/**'
     exclude 'META-INF/maven/commons-io/commons-io/**'
+    exclude 'META-INF/maven/org.apache.commons/commons-lang3/**'
     exclude 'META-INF/versions/**/org/bouncycastle/**'
     exclude 'META-INF/services/org.opensaml.security.crypto.ec.NamedCurve'
 }

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -69,6 +69,7 @@ tasks.shadowJar {
     exclude 'org/publicsuffix/**'
     exclude 'org/slf4j/**'
     exclude 'javax/**'
+    exclude 'META-INF/maven/commons-io/commons-io/**'
     exclude 'META-INF/versions/**/org/bouncycastle/**'
     exclude 'META-INF/services/org.opensaml.security.crypto.ec.NamedCurve'
 }


### PR DESCRIPTION
Unblocks 3.0 build by addressing CVE-2024-47554

https://github.com/opensearch-project/opensearch-build/issues/5595#issuecomment-3177822911



### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
