### PR TITLE
Inject user custom attributes

### DIFF
--- a/src/main/java/org/opensearch/security/auth/RolesInjector.java
+++ b/src/main/java/org/opensearch/security/auth/RolesInjector.java
@@ -72,8 +72,8 @@ final public class RolesInjector {
         }
         Set<String> roles = ImmutableSet.copyOf(strs[1].split(","));
 
-
-        Map<String, String> customAttributes = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_CUSTOM_ATTRIBUTES);
+        Map<String, String> customAttributes = threadPool.getThreadContext()
+            .getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_CUSTOM_ATTRIBUTES);
 
         User user = new User(strs[0]).withSecurityRoles(roles).withAttributes(customAttributes);
 

--- a/src/main/java/org/opensearch/security/auth/RolesInjector.java
+++ b/src/main/java/org/opensearch/security/auth/RolesInjector.java
@@ -15,6 +15,7 @@
 
 package org.opensearch.security.auth;
 
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
@@ -70,7 +71,11 @@ final public class RolesInjector {
             return null;
         }
         Set<String> roles = ImmutableSet.copyOf(strs[1].split(","));
-        User user = new User(strs[0]).withSecurityRoles(roles);
+
+
+        Map<String, String> customAttributes = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_USER_CUSTOM_ATTRIBUTES);
+
+        User user = new User(strs[0]).withSecurityRoles(roles).withAttributes(customAttributes);
 
         addUser(user, threadPool);
         return roles;

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -307,7 +307,7 @@ public class PrivilegesEvaluator {
             log.debug(joiner);
 
             if (this.isUserAttributeSerializationEnabled()) {
-                joiner.add(Base64Helper.serializeObject((Serializable) context.getUser().getCustomAttributesMap()));
+                joiner.add(Base64Helper.serializeObject(new HashMap<>(context.getUser().getCustomAttributesMap())));
             }
 
             threadContext.putTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT, joiner.toString());

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluator.java
@@ -26,7 +26,6 @@
 
 package org.opensearch.security.privileges;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -131,6 +131,7 @@ public class ConfigConstants {
 
     public static final String OPENDISTRO_SECURITY_INJECTED_USER = "injected_user";
     public static final String OPENDISTRO_SECURITY_INJECTED_USER_HEADER = "injected_user_header";
+    public static final String OPENDISTRO_SECURITY_INJECTED_USER_CUSTOM_ATTRIBUTES = "injected_user_custom_attributes";
 
     public static final String OPENDISTRO_SECURITY_XFF_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "xff_done";
 


### PR DESCRIPTION
### Description

These changes are a follow-up to #5491. They are part of ongoing work to address #5491. These changes specifically inject user custom attributes to the security plugin context so that DLS/FLS replacement on queries will work properly.

These changes work in concert with these changes in other plugins:

https://github.com/opensearch-project/common-utils/pull/827
https://github.com/opensearch-project/alerting/pull/1917

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
  * Enhancement/bug fix
* Why these changes are required?
  * To ensure that user custom attributes are available in the security plugin so that DLS/FLS queries will work properly. See #5491 
* What is the old behavior before changes and new behavior after changes?
  * User custom attributes are now available on the user object in the security plugin

### Issues Resolved

Addresses #5491

### Testing

I have been doing manual testing in Docker by compiling the jar files and mounting the jar files into the containers.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
