### PR TITLE
Allow any plugin system request when `plugins.security.system_indices.enabled` is set to `false`

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexDisabledTests.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexDisabledTests.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,13 +56,6 @@ public class SystemIndexDisabledTests {
         )
         .build();
 
-    @Before
-    public void setup() {
-        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
-            client.delete(".system-index1");
-        }
-    }
-
     @Test
     public void testPluginShouldBeAbleToIndexIntoAnySystemIndexWhenProtectionIsDisabled() {
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
@@ -79,10 +71,12 @@ public class SystemIndexDisabledTests {
                 response.getBody(),
                 not(
                     containsString(
-                        "no permissions for [] and User [name=plugin:org.opensearch.security.systemindex.sampleplugin.SystemIndexPlugin1"
+                        "no permissions for [indices:data/write/bulk[s], indices:data/write/index] and User [name=plugin:org.opensearch.security.systemindex.sampleplugin.SystemIndexPlugin1"
                     )
                 )
             );
+
+            assertThat(response.getBody(), not(containsString("\"errors\":true")));
         }
     }
 }

--- a/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/SystemIndexAccessEvaluator.java
@@ -305,34 +305,41 @@ public class SystemIndexAccessEvaluator {
         }
 
         // the following section should only be run for index actions
-        if (this.isSystemIndexEnabled && user.isPluginUser() && !isClusterPerm(action)) {
-            Set<String> matchingPluginIndices = SystemIndexRegistry.matchesPluginSystemIndexPattern(
-                user.getName().replace("plugin:", ""),
-                requestedResolved.getAllIndices()
-            );
-            if (requestedResolved.getAllIndices().equals(matchingPluginIndices)) {
-                // plugin is authorized to perform any actions on its own registered system indices
+        if (user.isPluginUser()) {
+            if (this.isSystemIndexEnabled && !isClusterPerm(action)) {
+                Set<String> matchingPluginIndices = SystemIndexRegistry.matchesPluginSystemIndexPattern(
+                    user.getName().replace("plugin:", ""),
+                    requestedResolved.getAllIndices()
+                );
+                if (requestedResolved.getAllIndices().equals(matchingPluginIndices)) {
+                    // plugin is authorized to perform any actions on its own registered system indices
+                    presponse.allowed = true;
+                    presponse.markComplete();
+                    return;
+                } else {
+                    Set<String> matchingSystemIndices = SystemIndexRegistry.matchesSystemIndexPattern(requestedResolved.getAllIndices());
+                    matchingSystemIndices.removeAll(matchingPluginIndices);
+                    // See if request matches other system indices not belong to the plugin
+                    if (!matchingSystemIndices.isEmpty()) {
+                        if (log.isInfoEnabled()) {
+                            log.info(
+                                "Plugin {} can only perform {} on it's own registered System Indices. System indices from request that match plugin's registered system indices: {}",
+                                user.getName(),
+                                action,
+                                matchingPluginIndices
+                            );
+                        }
+                        presponse.allowed = false;
+                        presponse.getMissingPrivileges();
+                        presponse.markComplete();
+                        return;
+                    }
+                }
+            } else {
+                // no system index protection and request originating from plugin, allow
                 presponse.allowed = true;
                 presponse.markComplete();
                 return;
-            } else {
-                Set<String> matchingSystemIndices = SystemIndexRegistry.matchesSystemIndexPattern(requestedResolved.getAllIndices());
-                matchingSystemIndices.removeAll(matchingPluginIndices);
-                // See if request matches other system indices not belong to the plugin
-                if (!matchingSystemIndices.isEmpty()) {
-                    if (log.isInfoEnabled()) {
-                        log.info(
-                            "Plugin {} can only perform {} on it's own registered System Indices. System indices from request that match plugin's registered system indices: {}",
-                            user.getName(),
-                            action,
-                            matchingPluginIndices
-                        );
-                    }
-                    presponse.allowed = false;
-                    presponse.getMissingPrivileges();
-                    presponse.markComplete();
-                    return;
-                }
             }
         }
 


### PR DESCRIPTION
### Description

An error was seen in Geospatial plugin after adopting the new convention for system index access which enforces strong ownership over system indices where plugins can access their own system indices by default, but need to declare additional permissions explicitly.

There is a bug when `plugins.security.system_indices.enabled` is set to `false` where index requests are failing because the SystemIndexAccessEvaluator is being skipped. This PR reverts to previous behavior which allows any action originating from a plugin when `plugins.security.system_indices.enabled` is set to `false`.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

Resolves https://github.com/opensearch-project/geospatial/issues/792

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
