### PR TITLE
[Resource Sharing] Keep track of tenant for sharable resources by persisting user requested tenant with sharing info

### DIFF
--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hc.core5.http.Header;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 
@@ -325,10 +326,10 @@ public final class TestUtils {
         }
 
         // Helper to create a sample resource and return its ID
-        public String createSampleResourceAs(TestSecurityConfig.User user) {
+        public String createSampleResourceAs(TestSecurityConfig.User user, Header... headers) {
             try (TestRestClient client = cluster.getRestClient(user)) {
                 String sample = "{\"name\":\"sample\"}";
-                TestRestClient.HttpResponse resp = client.putJson(SAMPLE_RESOURCE_CREATE_ENDPOINT, sample);
+                TestRestClient.HttpResponse resp = client.putJson(SAMPLE_RESOURCE_CREATE_ENDPOINT, sample, headers);
                 resp.assertStatusCode(HttpStatus.SC_OK);
                 return resp.getTextFromJsonBody("/message").split(":")[1].trim();
             }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ResourceSharingMultiTenancyTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ResourceSharingMultiTenancyTests.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.feature.enabled;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.sample.resource.TestUtils;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * Test resource access when shared with full-access (sampleAllAG action-group).
+ * All tests are against USER_ADMIN's resource created during setup.
+ */
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class ResourceSharingMultiTenancyTests {
+
+    @ClassRule
+    public static LocalCluster cluster = newCluster(true, true);
+
+    private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+    private String resourceId;
+
+    @Before
+    public void setup() {
+        resourceId = api.createSampleResourceAs(USER_ADMIN, new BasicHeader("securitytenant", "customtenant"));
+        api.awaitSharingEntry(); // wait until sharing entry is created
+    }
+
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
+    @Test
+    public void testCreateResourceWithMultiTenancyEnabled() {
+        try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
+            TestRestClient.HttpResponse sharingInfoResponse = client.get(
+                "_plugins/_security/api/resource/share?resource_id=" + resourceId + "&resource_type=" + RESOURCE_INDEX_NAME
+            );
+            assertThat(sharingInfoResponse.getBody(), containsString("\"created_by\":{\"user\":\"admin\",\"tenant\":\"customtenant\"}"));
+        }
+    }
+}

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/CreatedBy.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/CreatedBy.java
@@ -25,22 +25,41 @@ import org.opensearch.core.xcontent.XContentParser;
 public class CreatedBy implements ToXContentFragment, NamedWriteable {
 
     private final String username;
+    private final String tenant; // capture tenant if multi-tenancy is enabled
 
     public CreatedBy(String username) {
         this.username = username;
+        this.tenant = null;
+    }
+
+    public CreatedBy(String username, String tenant) {
+        this.username = username;
+        this.tenant = tenant;
     }
 
     public CreatedBy(StreamInput in) throws IOException {
         this.username = in.readString();
+        this.tenant = in.readOptionalString();
     }
 
     public String getUsername() {
         return username;
     }
 
+    public String getTenant() {
+        return tenant;
+    }
+
     @Override
     public String toString() {
-        return "CreatedBy {user='" + this.username + '\'' + '}';
+        if (tenant != null) {
+            return """
+                CreatedBy {user='%s', tenant='%s'}
+                """.formatted(username, tenant).trim();
+        }
+        return """
+            CreatedBy {user='%s'}
+            """.formatted(username).trim();
     }
 
     @Override
@@ -51,24 +70,34 @@ public class CreatedBy implements ToXContentFragment, NamedWriteable {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(username);
+        out.writeOptionalString(tenant);
     }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        if (tenant != null) {
+            return builder.startObject().field("user", username).field("tenant", tenant).endObject();
+        }
         return builder.startObject().field("user", username).endObject();
     }
 
     public static CreatedBy fromXContent(XContentParser parser) throws IOException {
         String username = null;
+        String tenant = null;
         XContentParser.Token token;
 
         while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
             if (token == XContentParser.Token.FIELD_NAME) {
-                if (!"user".equals(parser.currentName())) {
-                    throw new IllegalArgumentException("created_by must only contain a single field with user");
+                String fieldName = parser.currentName();
+                if ("user".equals(fieldName)) {
+                    parser.nextToken();
+                    username = parser.text();
+                } else if ("tenant".equals(fieldName)) {
+                    parser.nextToken();
+                    tenant = parser.text();
+                } else {
+                    throw new IllegalArgumentException("created_by contains unknown field: " + fieldName);
                 }
-            } else if (token == XContentParser.Token.VALUE_STRING) {
-                username = parser.text();
             }
         }
 
@@ -76,6 +105,6 @@ public class CreatedBy implements ToXContentFragment, NamedWriteable {
             throw new IllegalArgumentException("created_by cannot be empty");
         }
 
-        return new CreatedBy(username);
+        return new CreatedBy(username, tenant);
     }
 }

--- a/spi/src/test/java/org/opensearch/security/spi/resources/CreatedByTests.java
+++ b/spi/src/test/java/org/opensearch/security/spi/resources/CreatedByTests.java
@@ -46,6 +46,16 @@ public class CreatedByTests {
     }
 
     @Test
+    public void testCreatedByConstructorWithValidUserAndTenant() {
+        String expectedUser = "testUser";
+        String expectedTenant = "customTenant";
+        CreatedBy createdBy = new CreatedBy(expectedUser, expectedTenant);
+
+        MatcherAssert.assertThat(expectedUser, is(equalTo(createdBy.getUsername())));
+        MatcherAssert.assertThat(expectedTenant, is(equalTo(createdBy.getTenant())));
+    }
+
+    @Test
     public void testCreatedByFromStreamInput() throws IOException {
         String expectedUser = "testUser";
 

--- a/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
@@ -73,7 +73,14 @@ public class ResourceIndexListener implements IndexingOperationListener {
                     resourceIndex
                 );
             }, e -> { log.debug(e.getMessage()); });
-            this.resourceSharingIndexHandler.indexResourceSharing(resourceId, resourceIndex, new CreatedBy(user.getName()), null, listener);
+            // User.getRequestedTenant() is null if multi-tenancy is disabled
+            this.resourceSharingIndexHandler.indexResourceSharing(
+                resourceId,
+                resourceIndex,
+                new CreatedBy(user.getName(), user.getRequestedTenant()),
+                null,
+                listener
+            );
 
         } catch (IOException e) {
             log.debug("Failed to create a resource sharing entry for resource: {}", resourceId, e);


### PR DESCRIPTION
### Description

This PR keeps track of the tenant associated with a sharable resource when multi-tenancy is enabled and adds integration tests with multi-tenancy enabled to the sample resource plugin.

If multi-tenancy is disabled (i.e. `user.getRequestedTenant() == null`) then it would not keep track of tenant.

```
{
    "sharing_info":
    {
        "resource_id": "0syx4pgBAqFBFKRNT2SD",
        "created_by":
        {
            "user": "admin",
            "tenant": "customtenant"
        },
        "share_with":
        {
            "sample_plugin_index_all_access":
            {
                "users":
                [
                    "resource_sharing_test_user_all_access"
                ]
            }
        }
    }
}
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Enhancement

### Issues Resolved

Related to: https://github.com/opensearch-project/security/issues/4500

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
