### PR TITLE
[2.19] Remove https://aws.oss.sonatype.org/content/repositories/snapshots from maven repositories

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -3,7 +3,7 @@ name: Plugin Install
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  OPENSEARCH_VERSION: 2.19.3
+  OPENSEARCH_VERSION: 2.19.4
   PLUGIN_NAME: opensearch-security
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,6 @@ buildscript {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
         maven { url "https://build.shibboleth.net/nexus/content/groups/public" }
         maven { url "https://build.shibboleth.net/nexus/content/repositories/releases" }
@@ -436,7 +435,6 @@ repositories {
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
     maven { url "https://build.shibboleth.net/nexus/content/repositories/releases" }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ import groovy.json.JsonBuilder
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.3-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.4-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
 

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -52,7 +52,6 @@ buildscript {
     repositories {
         mavenLocal()
         maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -65,7 +64,6 @@ buildscript {
 repositories {
     mavenLocal()
     maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-    maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
 }

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -44,7 +44,7 @@ ext {
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "2.19.3-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.19.4-SNAPSHOT")
         opensearch_group = "org.opensearch"
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
         jackson_version = System.getProperty("jackson_version", "2.15.2")
@@ -83,7 +83,7 @@ testingConventions.enabled = false
 validateNebulaPom.enabled = false
 
 String previousVersion = System.getProperty("bwc.version.previous", "2.10.0.0")
-String nextVersion = System.getProperty("bwc.version.next", "2.19.3.0")
+String nextVersion = System.getProperty("bwc.version.next", "2.19.4.0")
 
 String bwcVersion = previousVersion
 String baseName = "securityBwcCluster"


### PR DESCRIPTION
### Description

This PR resolves CI issues seen across PRs related to https://aws.oss.sonatype.org/content/repositories/snapshots being unavailable.

This PR also increments the version to 2.19.4.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
