### PR TITLE
[Resource Sharing] Keep track of list of`all_shared_principals` for which sharable resource is visible for searching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 
-- Added new option skip_users to client cert authenticator  (clientcert_auth_domain.http_authenticator.config.skip_users in config.yml)([#4378](https://github.com/opensearch-project/security/pull/5525))
-- [Resource Sharing] Fixes accessible resource ids search by marking created_by.user field as keyword search instead of text ([#5574](https://github.com/opensearch-project/security/pull/5574))
-- [Resource Sharing] Reverts @Inject pattern usage for ResourceSharingExtension to client accessor pattern. ([#5576](https://github.com/opensearch-project/security/pull/5576))
 * Added new option skip_users to client cert authenticator  (clientcert_auth_domain.http_authenticator.config.skip_users in config.yml)([#4378](https://github.com/opensearch-project/security/pull/5525))
 * [Resource Sharing] Fixes accessible resource ids search by marking created_by.user field as keyword search instead of text ([#5574](https://github.com/opensearch-project/security/pull/5574))
 * [Resource Sharing] Reverts @Inject pattern usage for ResourceSharingExtension to client accessor pattern. ([#5576](https://github.com/opensearch-project/security/pull/5576))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 
+- [Resource Sharing] Keep track of list of principals for which sharable resource is visible for searching ([#5596](https://github.com/opensearch-project/security/pull/5596))
+
 ### Bug Fixes
 
-* Added new option skip_users to client cert authenticator  (clientcert_auth_domain.http_authenticator.config.skip_users in config.yml)([#4378](https://github.com/opensearch-project/security/pull/5525))
-* [Resource Sharing] Fixes accessible resource ids search by marking created_by.user field as keyword search instead of text ([#5574](https://github.com/opensearch-project/security/pull/5574))
-* [Resource Sharing] Reverts @Inject pattern usage for ResourceSharingExtension to client accessor pattern. ([#5576](https://github.com/opensearch-project/security/pull/5576))
+- Added new option skip_users to client cert authenticator  (clientcert_auth_domain.http_authenticator.config.skip_users in config.yml)([#4378](https://github.com/opensearch-project/security/pull/5525))
+- [Resource Sharing] Fixes accessible resource ids search by marking created_by.user field as keyword search instead of text ([#5574](https://github.com/opensearch-project/security/pull/5574))
+- [Resource Sharing] Reverts @Inject pattern usage for ResourceSharingExtension to client accessor pattern. ([#5576](https://github.com/opensearch-project/security/pull/5576))
 
 ### Refactoring
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/MigrateApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/MigrateApiTests.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.opensearch.Version;
-import org.opensearch.painless.PainlessModulePlugin;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.sample.SampleResourcePlugin;
 import org.opensearch.security.OpenSearchSecurityPlugin;
@@ -64,7 +63,6 @@ public class MigrateApiTests {
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.DEFAULT)
-        .plugin(PainlessModulePlugin.class)
         .plugin(
             new PluginInfo(
                 SampleResourcePlugin.class.getName(),

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.opensearch.Version;
-import org.opensearch.painless.PainlessModulePlugin;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.sample.SampleResourcePlugin;
 import org.opensearch.security.OpenSearchSecurityPlugin;
@@ -65,7 +64,6 @@ public class SecurityDisabledTests {
                 false
             )
         )
-        .plugin(PainlessModulePlugin.class)
         .loadConfigurationIntoIndex(false)
         .nodeSettings(Map.of("plugins.security.disabled", true, "plugins.security.ssl.http.enabled", false))
         .build();

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -22,7 +22,6 @@ import org.opensearch.Version;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.painless.PainlessModulePlugin;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.sample.SampleResourcePlugin;
 import org.opensearch.security.OpenSearchSecurityPlugin;
@@ -112,7 +111,6 @@ public final class TestUtils {
                     false
                 )
             )
-            .plugin(PainlessModulePlugin.class)
             .anonymousAuth(true)
             .authc(AUTHC_HTTPBASIC_INTERNAL)
             .users(USER_ADMIN, FULL_ACCESS_USER, LIMITED_ACCESS_USER, NO_ACCESS_USER)

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/secure/SecurePluginTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/secure/SecurePluginTests.java
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith;
 
 import org.opensearch.Version;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.painless.PainlessModulePlugin;
 import org.opensearch.plugins.PluginInfo;
 import org.opensearch.sample.SampleResourcePlugin;
 import org.opensearch.security.OpenSearchSecurityPlugin;
@@ -47,7 +46,6 @@ public class SecurePluginTests {
         .anonymousAuth(false)
         .authc(AUTHC_DOMAIN)
         .users(USER_ADMIN)
-        .plugin(PainlessModulePlugin.class)
         .plugin(
             new PluginInfo(
                 SampleResourcePlugin.class.getName(),

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -70,6 +70,7 @@ public class SearchResourceTransportAction extends HandledTransportAction<Search
     private void searchFilteredIds(SearchRequest request, ActionListener<SearchResponse> listener) {
         SearchSourceBuilder src = request.source() != null ? request.source() : new SearchSourceBuilder();
         ActionListener<Set<String>> idsListener = ActionListener.wrap(resourceIds -> {
+            System.out.println("resourceIds to filter: " + resourceIds);
             mergeAccessibleFilter(src, resourceIds);
             request.source(src);
             nodeClient.search(request, listener);

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -70,7 +70,6 @@ public class SearchResourceTransportAction extends HandledTransportAction<Search
     private void searchFilteredIds(SearchRequest request, ActionListener<SearchResponse> listener) {
         SearchSourceBuilder src = request.source() != null ? request.source() : new SearchSourceBuilder();
         ActionListener<Set<String>> idsListener = ActionListener.wrap(resourceIds -> {
-            System.out.println("resourceIds to filter: " + resourceIds);
             mergeAccessibleFilter(src, resourceIds);
             request.source(src);
             nodeClient.search(request, listener);

--- a/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
@@ -9,7 +9,6 @@
 package org.opensearch.security.resources;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
@@ -72,14 +71,6 @@ public class ResourceIndexListener implements IndexingOperationListener {
                     entry,
                     resourceId,
                     resourceIndex
-                );
-                this.resourceSharingIndexHandler.updateResourceVisibility(
-                    resourceId,
-                    resourceIndex,
-                    List.of("user:" + user.getName()),
-                    ActionListener.wrap((updateResponse) -> {
-                        log.debug("postUpdate: Successfully updated visibility for resource {} within index {}", resourceId, resourceIndex);
-                    }, (e) -> { log.debug(e.getMessage()); })
                 );
             }, e -> { log.debug(e.getMessage()); });
             this.resourceSharingIndexHandler.indexResourceSharing(resourceId, resourceIndex, new CreatedBy(user.getName()), null, listener);

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -534,7 +534,18 @@ public class ResourceSharingIndexHandler {
                         resourceId,
                         resourceIndex
                     );
-                    listener.onResponse(sharingInfo);
+                    updateResourceVisibility(
+                        resourceId,
+                        resourceIndex,
+                        sharingInfo.getAllPrincipals(),
+                        ActionListener.wrap((updateResponse) -> {
+                            LOGGER.debug("Successfully updated visibility for resource {} within index {}", resourceId, resourceIndex);
+                            listener.onResponse(sharingInfo);
+                        }, (e) -> {
+                            LOGGER.error("Failed to update principals field in [{}] for resource [{}]", resourceIndex, resourceId, e);
+                            listener.onResponse(sharingInfo);
+                        })
+                    );
                 }, (failResponse) -> {
                     LOGGER.error(failResponse.getMessage());
                     listener.onFailure(failResponse);

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -634,7 +634,18 @@ public class ResourceSharingIndexHandler {
                 ActionListener<IndexResponse> irListener = ActionListener.wrap(idxResponse -> {
                     ctx.restore();
                     LOGGER.info("Successfully revoked access of {} to resource {} in index {}.", revokeAccess, resourceId, resourceIndex);
-                    listener.onResponse(sharingInfo);
+                    updateResourceVisibility(
+                        resourceId,
+                        resourceIndex,
+                        sharingInfo.getAllPrincipals(),
+                        ActionListener.wrap((updateResponse) -> {
+                            LOGGER.debug("Successfully updated visibility for resource {} within index {}", resourceId, resourceIndex);
+                            listener.onResponse(sharingInfo);
+                        }, (e) -> {
+                            LOGGER.error("Failed to update principals field in [{}] for resource [{}]", resourceIndex, resourceId, e);
+                            listener.onResponse(sharingInfo);
+                        })
+                    );
                 }, (failResponse) -> {
                     LOGGER.error(failResponse.getMessage());
                     listener.onFailure(failResponse);

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -160,7 +160,7 @@ public class ResourceSharingIndexHandler {
         try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
             UpdateRequest ur = client.prepareUpdate(resourceIndex, resourceId)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .setDoc(Map.of("principals", principals))
+                .setDoc(Map.of("all_shared_principals", principals))
                 .setId(resourceId)
                 .request();
 
@@ -345,7 +345,8 @@ public class ResourceSharingIndexHandler {
 
             // We match any doc whose "principals" contains at least one of the entities
             // e.g., "user:alice", "role:admin", "backend:ops"
-            BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("principals.keyword", entities));
+            BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
+                .filter(QueryBuilders.termsQuery("all_shared_principals.keyword", entities));
 
             executeIdCollectingSearchRequest(scroll, searchRequest, boolQuery, ActionListener.wrap(resourceIds -> {
                 ctx.restore();


### PR DESCRIPTION
### Description

This change updates the `fetchAccessibleResourceIds` method in `ResourceSharingIndexHandler` to search the **resource index** directly instead of the `*-sharing` index.

* **Category**: Enhancement
* **Why these changes are required?**
  Previously, we only searched the resource sharing index (`*-sharing`) and derived principals from `share_with`. This required scripts and runtime fields to flatten recipients, adding overhead. This PR also keeps track of `principals` in each resource document, we can query this field directly to determine visibility. Principals are of the form: `user:{username}`, `role:{rolename}`, `backend:{backend_role_name}`. `user:*` will be used as the convention for making a resource publicly visible.

  Keeping track of `principals` in the resource document improves:

  * **Visibility**: resource docs reflect who can access them without needing to cross-reference the sharing index.
  * **Searchability**: access checks can run efficiently using `termsQuery("principals", entities)`.
  * **Performance**: avoids costly runtime scripts and reduces indirection across indices.
* **Old behavior**: Queries ran against the `*-sharing` index, required derived runtime fields, and fetched `resource_id` from `_source`.
* **New behavior**: Queries run directly on the resource index, filtering by the `principals` field, and collect `_id`s as resource identifiers.

*Note*: There will be a follow-up change to this PR to change `fetchAccessibleResourceIds` to a behind-the-scenes DLS clause which would not require the resource plugin to make 2 queries to get the list of visible IDs followed by the request they intend to make. The security plugin would inject a clause behind-the-scenes to limit the result set to a resource plugin based on the authenticated user.

### Issues Resolved

Related to: https://github.com/opensearch-project/security/issues/4500

### Testing

* Added/updated unit tests for `fetchAccessibleResourceIds` to validate queries against `principals`.
* Verified integration tests where resources are created, shared, and revoked—ensuring `principals` updates are honored in queries.
* Manual testing with multiple users, roles, and backend roles to confirm correct visibility enforcement.

### Check List

* [x] New functionality includes testing
* [x] New functionality has been documented
* [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
* [ ] API changes companion pull request [[created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
* [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [[here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).