### PR TITLE
[Resource Sharing] Adds API to provide dashboards support for resource access management 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Enhancements
 
 - [Resource Sharing] Keep track of tenant for sharable resources by persisting user requested tenant with sharing info ([#5588](https://github.com/opensearch-project/security/pull/5588))
+- [Resource Sharing] Adds API to provide dashboards support for resource access management ([#5597](https://github.com/opensearch-project/security/pull/5597))
 
 ### Bug Fixes
 

--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -108,6 +108,7 @@ opensearchplugin {
 
       # ...
     ```
+
 #### **Example resource-action-groups yml**
 ```yml
 resource_types:

--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -93,19 +93,23 @@ opensearchplugin {
     resource_types:
       <resource-type-1>:
           <action-group-1>:
-          - <action1>
-          - <action2>
+              allowed_actions:
+                  - <action1>
+                  - <action2>
           <action-group-2>:
-          - <action1>
-          - <action2>
+              allowed_actions:
+                  - <action1>
+                  - <action2>
 
       <resource-type-2>:
           <action-group-1>:
-          - <action1>
-          - <action2>
+              allowed_actions:
+                  - <action1>
+                  - <action2>
           <action-group-2>:
-          - <action1>
-          - <action2>
+              allowed_actions:
+                  - <action1>
+                  - <action2>
 
       # ...
     ```

--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -113,7 +113,7 @@ opensearchplugin {
 
       # ...
     ```
-NOTE: The resource-type supplied here must match the ones supplied in each of the resource-providers declared in the ResourceSharingExtension implementation.
+**NOTE**: The resource-type supplied here must match the ones supplied in each of the resource-providers declared in the ResourceSharingExtension implementation.
 
 #### **Example resource-action-groups yml**
 ```yml
@@ -568,7 +568,7 @@ Creates or replaces sharing settings for a resource.
 ```json
 {
   "resource_id": "resource-123",
-  "resource_type": "my-resource-index",
+  "resource_type": "my-type",
   "share_with": {
     "read_only": {
       "users": ["alice"],
@@ -613,7 +613,7 @@ Updates sharing settings by **adding** or **removing** recipients at any access 
 ```json
 {
   "resource_id": "resource-123",
-  "resource_type": "my-resource-index",
+  "resource_type": "my-type",
   "add": {
     "read_only": {
       "users": ["charlie"]
@@ -658,7 +658,7 @@ Updates sharing settings by **adding** or **removing** recipients at any access 
 - `"revoke"` – Removes recipients
 
 
-### 3. `GET /_plugins/_security/api/resource/share?resource_id=<id>&resource_type=<index>`
+### 3. `GET /_plugins/_security/api/resource/share?resource_id=<id>&resource_type=<type>`
 
 **Description:**
 Retrieves the current sharing configuration for a given resource.
@@ -666,7 +666,7 @@ Retrieves the current sharing configuration for a given resource.
 **Example Request:**
 
 ```
-GET /_plugins/_security/api/resource/share?resource_id=resource-123&resource_type=my-resource-index
+GET /_plugins/_security/api/resource/share?resource_id=resource-123&resource_type=my-type
 ```
 
 **Response:**
@@ -705,8 +705,7 @@ GET /_plugins/_security/api/resource/types
 {
   "types": [
     {
-      "type": "org.opensearch.sample.SampleResource",
-      "index": ".sample_resource",
+      "type": "sample-resource",
       "action_groups": ["sample_read_only", "sample_read_write", "sample_full_access"]
     }
   ]
@@ -714,7 +713,7 @@ GET /_plugins/_security/api/resource/types
 ```
 NOTE: `action_groups` are fetched from `resource-action-groups.yml` supplied by resource plugin.
 
-### 5. `GET /_plugins/_security/api/resource/list?resource_type=<resource-index-name>`
+### 5. `GET /_plugins/_security/api/resource/list?resource_type=<type>`
 
 **Description:**
 Retrieves sharing information for all records accessible to requesting user for the given resource_index.
@@ -722,7 +721,7 @@ Retrieves sharing information for all records accessible to requesting user for 
 **Example Request:**
 as user `darshit`
 ```
-GET /_plugins/_security/api/resource/list?resource_type=.sample_resource
+GET /_plugins/_security/api/resource/list?resource_type=sample-resource
 ```
 
 **Response:**

--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -373,14 +373,14 @@ By default, all `shareableResources` are private — visible only to their **own
 
 ### **Example: Publicly Shared Resource**
 
-To make a resource accessible to everyone, share it with all entities using the wildcard `*`:
+To make a resource accessible to everyone, share it with `users` entity using the wildcard `*`:
 
 ```json
 {
   "share_with": {
     "default": {
-      "backend_roles": ["*"],
-      "roles": ["*"],
+      "backend_roles": ["some_backend_role"],
+      "roles": ["some_role"],
       "users": ["*"]
     }
   }

--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -44,6 +44,7 @@ This feature introduces **one primary component** for plugin developers:
 ### **Plugin Implementation Requirements:**
 
 - **Resource indices must be declared as system indices** to prevent unauthorized direct access.
+  NOTE: If system-index protection is disabled, requests will be evaluated as normal index requests.
 - **Declare a `compileOnly` dependency** on `opensearch-security-spi` package and opensearch-security plugin zip:
 ```build.gradle
 configurations {
@@ -90,7 +91,7 @@ opensearchplugin {
   - This file must be structured in a following way:
     ```yml
     resource_types:
-      <fully-qualified-resource-class-name-1>:
+      <resource-type-1>:
           <action-group-1>:
           - <action1>
           - <action2>
@@ -98,7 +99,7 @@ opensearchplugin {
           - <action1>
           - <action2>
 
-      <fully-qualified-resource-class-name-2>:
+      <resource-type-2>:
           <action-group-1>:
           - <action1>
           - <action2>
@@ -108,22 +109,20 @@ opensearchplugin {
 
       # ...
     ```
+NOTE: The resource-type supplied here must match the ones supplied in each of the resource-providers declared in the ResourceSharingExtension implementation.
 
 #### **Example resource-action-groups yml**
 ```yml
 resource_types:
-  org.opensearch.sample.SampleResource:
+  sample-resource:
       sample_read_only:
         - "cluster:admin/sample-resource-plugin/get"
-        - "indices:data/read*"
 
       sample_read_write:
         - "cluster:admin/sample-resource-plugin/*"
-        - "indices:*"
 
       sample_full_access:
         - "cluster:admin/sample-resource-plugin/*"
-        - "indices:*"
         - "cluster:admin/security/resource/share"
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -572,7 +572,6 @@ allprojects {
         }
         integrationTestImplementation 'org.slf4j:slf4j-api:2.0.12'
         integrationTestImplementation 'com.selectivem.collections:special-collections-complete:1.4.0'
-        integrationTestImplementation "org.opensearch.plugin:lang-painless:${opensearch_version}"
     }
 }
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
@@ -29,6 +29,7 @@ import org.opensearch.test.framework.matcher.RestMatchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_CREATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
@@ -36,7 +37,6 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_REVOKE_EN
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
@@ -111,13 +111,13 @@ public class SecurityDisabledTests {
 
             response = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
-                shareWithPayload(USER_ADMIN.getName(), sampleReadOnlyResourceAG)
+                shareWithPayload(USER_ADMIN.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             assertNotImplementedResponse(response, "Cannot share resource");
 
             response = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
-                revokeAccessPayload(USER_ADMIN.getName(), sampleReadOnlyResourceAG)
+                revokeAccessPayload(USER_ADMIN.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             assertNotImplementedResponse(response, "Cannot revoke access to resource");
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/SecurityDisabledTests.java
@@ -37,7 +37,7 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_REVOKE_EN
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
@@ -113,13 +113,13 @@ public class SecurityDisabledTests {
 
             response = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
-                shareWithPayload(USER_ADMIN.getName(), sampleReadOnlyAG.name())
+                shareWithPayload(USER_ADMIN.getName(), sampleReadOnlyResourceAG)
             );
             assertNotImplementedResponse(response, "Cannot share resource");
 
             response = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
-                revokeAccessPayload(USER_ADMIN.getName(), sampleReadOnlyAG.name())
+                revokeAccessPayload(USER_ADMIN.getName(), sampleReadOnlyResourceAG)
             );
             assertNotImplementedResponse(response, "Cannot revoke access to resource");
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -85,8 +85,10 @@ public final class TestUtils {
     public static final String SAMPLE_RESOURCE_SHARE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/share";
     public static final String SAMPLE_RESOURCE_REVOKE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/revoke";
 
-    static final String RESOURCE_SHARING_MIGRATION_ENDPOINT = "_plugins/_security/api/resources/migrate";
-    static final String SECURITY_SHARE_ENDPOINT = "_plugins/_security/api/resource/share";
+    public static final String RESOURCE_SHARING_MIGRATION_ENDPOINT = "_plugins/_security/api/resources/migrate";
+    public static final String SECURITY_SHARE_ENDPOINT = "_plugins/_security/api/resource/share";
+    public static final String SECURITY_TYPES_ENDPOINT = "_plugins/_security/api/resource/types";
+    public static final String SECURITY_LIST_ENDPOINT = "_plugins/_security/api/resource/list";
 
     public static LocalCluster newCluster(boolean featureEnabled, boolean systemIndexEnabled) {
         return new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS_COORDINATOR)
@@ -154,7 +156,7 @@ public final class TestUtils {
 
     }
 
-    static String migrationPayload_valid() {
+    public static String migrationPayload_valid() {
         return """
             {
             "source_index": "%s",
@@ -164,7 +166,7 @@ public final class TestUtils {
             """.formatted(RESOURCE_INDEX_NAME, "user/name", "user/backend_roles");
     }
 
-    static String migrationPayload_valid_withSpecifiedAccessLevel() {
+    public static String migrationPayload_valid_withSpecifiedAccessLevel() {
         return """
             {
             "source_index": "%s",
@@ -175,7 +177,7 @@ public final class TestUtils {
             """.formatted(RESOURCE_INDEX_NAME, "user/name", "user/backend_roles", "read_only");
     }
 
-    static String migrationPayload_missingSourceIndex() {
+    public static String migrationPayload_missingSourceIndex() {
         return """
             {
             "username_path": "%s",
@@ -184,7 +186,7 @@ public final class TestUtils {
             """.formatted("user/name", "user/backend_roles");
     }
 
-    static String migrationPayload_missingUserName() {
+    public static String migrationPayload_missingUserName() {
         return """
             {
             "source_index": "%s",
@@ -193,7 +195,7 @@ public final class TestUtils {
             """.formatted(RESOURCE_INDEX_NAME, "user/backend_roles");
     }
 
-    static String migrationPayload_missingBackendRoles() {
+    public static String migrationPayload_missingBackendRoles() {
         return """
             {
             "source_index": "%s",
@@ -202,7 +204,7 @@ public final class TestUtils {
             """.formatted(RESOURCE_INDEX_NAME, "user/name");
     }
 
-    static String putSharingInfoPayload(String resourceId, String resourceIndex, String accessLevel, String user) {
+    public static String putSharingInfoPayload(String resourceId, String resourceIndex, String accessLevel, String user) {
         return """
             {
               "resource_id": "%s",

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -202,7 +202,7 @@ public final class TestUtils {
             """.formatted(RESOURCE_INDEX_NAME, "user/name");
     }
 
-    public static String putSharingInfoPayload(String resourceId, String resourceIndex, String accessLevel, String user) {
+    public static String putSharingInfoPayload(String resourceId, String resourceType, String accessLevel, String user) {
         return """
             {
               "resource_id": "%s",
@@ -213,7 +213,7 @@ public final class TestUtils {
                 }
               }
             }
-            """.formatted(resourceId, resourceIndex, accessLevel, user);
+            """.formatted(resourceId, resourceType, accessLevel, user);
     }
 
     public static class PatchSharingInfoPayloadBuilder {

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -72,9 +72,9 @@ public final class TestUtils {
     // No Permission
     public final static TestSecurityConfig.User NO_ACCESS_USER = new TestSecurityConfig.User("resource_sharing_test_user_no_perms");
 
-    public static final String sampleReadOnlyResourceAG = "sample_read_only";
-    public static final String sampleReadWriteResourceAG = "sample_read_write";
-    public static final String sampleFullAccessResourceAG = "sample_full_access";
+    public static final String SAMPLE_READ_ONLY_RESOURCE_AG = "sample_read_only";
+    public static final String SAMPLE_READ_WRITE_RESOURCE_AG = "sample_read_write";
+    public static final String SAMPLE_FULL_ACCESS_RESOURCE_AG = "sample_full_access";
 
     public static final String SAMPLE_RESOURCE_CREATE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/create";
     public static final String SAMPLE_RESOURCE_GET_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/get";

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -72,19 +72,9 @@ public final class TestUtils {
     // No Permission
     public final static TestSecurityConfig.User NO_ACCESS_USER = new TestSecurityConfig.User("resource_sharing_test_user_no_perms");
 
-    public static final TestSecurityConfig.ActionGroup sampleReadOnlyAG = new TestSecurityConfig.ActionGroup(
-        "sample_plugin_index_read_access",
-        TestSecurityConfig.ActionGroup.Type.INDEX,
-        "indices:data/read*",
-        "cluster:admin/sample-resource-plugin/get"
-    );
-    public static final TestSecurityConfig.ActionGroup sampleAllAG = new TestSecurityConfig.ActionGroup(
-        "sample_plugin_index_all_access",
-        TestSecurityConfig.ActionGroup.Type.INDEX,
-        "indices:*",
-        "cluster:admin/sample-resource-plugin/*",
-        "cluster:admin/security/resource/share"
-    );
+    public static final String sampleReadOnlyResourceAG = "sample_read_only";
+    public static final String sampleReadWriteResourceAG = "sample_read_write";
+    public static final String sampleFullAccessResourceAG = "sample_full_access";
 
     public static final String SAMPLE_RESOURCE_CREATE_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/create";
     public static final String SAMPLE_RESOURCE_GET_ENDPOINT = SAMPLE_RESOURCE_PLUGIN_PREFIX + "/get";
@@ -116,7 +106,6 @@ public final class TestUtils {
             .anonymousAuth(true)
             .authc(AUTHC_HTTPBASIC_INTERNAL)
             .users(USER_ADMIN, FULL_ACCESS_USER, LIMITED_ACCESS_USER, NO_ACCESS_USER)
-            .actionGroups(sampleReadOnlyAG, sampleAllAG)
             .nodeSettings(
                 Map.of(OPENSEARCH_RESOURCE_SHARING_ENABLED, featureEnabled, SECURITY_SYSTEM_INDICES_ENABLED_KEY, systemIndexEnabled)
             )

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -218,7 +218,7 @@ public final class TestUtils {
 
     public static class PatchSharingInfoPayloadBuilder {
         private String resourceId;
-        private String resourceIndex;
+        private String resourceType;
         private final Map<String, Recipients> share = new HashMap<>();
         private final Map<String, Recipients> revoke = new HashMap<>();
 
@@ -227,8 +227,8 @@ public final class TestUtils {
             return this;
         }
 
-        public PatchSharingInfoPayloadBuilder resourceIndex(String resourceIndex) {
-            this.resourceIndex = resourceIndex;
+        public PatchSharingInfoPayloadBuilder resourceType(String resourceType) {
+            this.resourceType = resourceType;
             return this;
         }
 
@@ -282,7 +282,7 @@ public final class TestUtils {
                     %s
                   }
                 }
-                """.formatted(resourceId, resourceIndex, allShares, allRevokes);
+                """.formatted(resourceId, resourceType, allShares, allRevokes);
         }
     }
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
@@ -40,8 +40,8 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -117,8 +117,8 @@ public class ApiAccessTests {
 
             // feature is disabled, and thus request is treated as normal request.
             // Since user doesn't have permission to the share and revoke endpoints they will receive 403s
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // search returns 403 since user doesn't have access to invoke search
             api.assertApiGetSearchForbidden(NO_ACCESS_USER);
@@ -161,10 +161,10 @@ public class ApiAccessTests {
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleReadOnlyAG.name(),
+                sampleReadOnlyResourceAG,
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource
             api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
@@ -206,8 +206,8 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource, 2 total results
             api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
@@ -245,14 +245,14 @@ public class ApiAccessTests {
                 // can't share or revoke, as handlers don't exist
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
+                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
+                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
@@ -339,8 +339,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // search returns 403 since user doesn't have access to invoke search
             api.assertApiGetSearchForbidden(NO_ACCESS_USER);
@@ -385,10 +385,10 @@ public class ApiAccessTests {
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleReadOnlyAG.name(),
+                sampleReadOnlyResourceAG,
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource
             api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
@@ -432,8 +432,8 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource, 2 total results
             api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
@@ -470,13 +470,13 @@ public class ApiAccessTests {
                 // can't share or revoke, as handlers don't exist
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + id,
-                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
+                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + id,
-                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleAllAG.name())
+                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/disabled/ApiAccessTests.java
@@ -31,6 +31,8 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_CREATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
@@ -40,8 +42,6 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -117,8 +117,8 @@ public class ApiAccessTests {
 
             // feature is disabled, and thus request is treated as normal request.
             // Since user doesn't have permission to the share and revoke endpoints they will receive 403s
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // search returns 403 since user doesn't have access to invoke search
             api.assertApiGetSearchForbidden(NO_ACCESS_USER);
@@ -161,10 +161,10 @@ public class ApiAccessTests {
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleReadOnlyResourceAG,
+                SAMPLE_READ_ONLY_RESOURCE_AG,
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource
             api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
@@ -206,8 +206,8 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource, 2 total results
             api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
@@ -245,14 +245,14 @@ public class ApiAccessTests {
                 // can't share or revoke, as handlers don't exist
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    shareWithPayload(FULL_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    revokeAccessPayload(FULL_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
@@ -339,8 +339,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // search returns 403 since user doesn't have access to invoke search
             api.assertApiGetSearchForbidden(NO_ACCESS_USER);
@@ -385,10 +385,10 @@ public class ApiAccessTests {
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleReadOnlyResourceAG,
+                SAMPLE_READ_ONLY_RESOURCE_AG,
                 HttpStatus.SC_NOT_IMPLEMENTED
             );
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource
             api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
@@ -432,8 +432,8 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // feature is disabled, no handler's exist
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_NOT_IMPLEMENTED);
 
             // should be able to search for admin's resource, 2 total results
             api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sampleUpdateAdmin");
@@ -470,13 +470,13 @@ public class ApiAccessTests {
                 // can't share or revoke, as handlers don't exist
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + id,
-                    shareWithPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    shareWithPayload(FULL_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + id,
-                    revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    revokeAccessPayload(FULL_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
                 resp.assertStatusCode(HttpStatus.SC_NOT_IMPLEMENTED);
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
@@ -31,6 +31,8 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_CREATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
@@ -40,8 +42,6 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -113,8 +113,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // cannot share admin's resource with itself
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // cannot see admin's resource when searching
             api.assertApiGetSearch(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
@@ -152,14 +152,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should not be able to search for admin's resource, can only see self-resource
@@ -199,15 +199,15 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiShare(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
             api.assertApiPostSearch(searchByNamePayload("sampleUpdateUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
 
             // should not be able to search for admin's resource, 1 total result
@@ -240,14 +240,14 @@ public class ApiAccessTests {
                 // can share and revoke admin's resource
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    shareWithPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    revokeAccessPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
@@ -328,8 +328,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // cannot share admin's resource with itself
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // should not be able to search for any resource
             api.assertApiGetSearch(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
@@ -369,14 +369,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for own resource
@@ -416,14 +416,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiShare(userResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for its own resource
@@ -457,14 +457,14 @@ public class ApiAccessTests {
                 // can share and revoke admin's resource
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    shareWithPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                    revokeAccessPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
@@ -40,8 +40,8 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -113,8 +113,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // cannot share admin's resource with itself
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // cannot see admin's resource when searching
             api.assertApiGetSearch(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
@@ -152,14 +152,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should not be able to search for admin's resource, can only see self-resource
@@ -199,15 +199,15 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiShare(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
             api.assertApiPostSearch(searchByNamePayload("sampleUpdateUser"), LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, FULL_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
 
             // should not be able to search for admin's resource, 1 total result
@@ -240,14 +240,14 @@ public class ApiAccessTests {
                 // can share and revoke admin's resource
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                    shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
@@ -328,8 +328,8 @@ public class ApiAccessTests {
             api.assertApiGet(adminResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // cannot share admin's resource with itself
-            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, NO_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // should not be able to search for any resource
             api.assertApiGetSearch(NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, 0, "");
@@ -369,14 +369,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiShare(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, LIMITED_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for own resource
@@ -416,14 +416,14 @@ public class ApiAccessTests {
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
-            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
-            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_FORBIDDEN);
+            api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertApiRevoke(adminResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_FORBIDDEN);
 
             // can share or revoke own resource
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertApiShare(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiShare(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sampleUpdateUser");
-            api.assertApiRevoke(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+            api.assertApiRevoke(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
             api.assertApiGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
 
             // should be able to search only for its own resource
@@ -457,14 +457,14 @@ public class ApiAccessTests {
                 // can share and revoke admin's resource
                 resp = client.postJson(
                     SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId,
-                    shareWithPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                    shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);
 
                 resp = client.postJson(
                     SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId,
-                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                    revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
                 );
 
                 resp.assertStatusCode(HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
@@ -14,6 +14,7 @@ import org.apache.http.HttpStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -168,6 +169,7 @@ public class DirectIndexAccessTests {
      */
     @RunWith(RandomizedRunner.class)
     @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+    @Ignore // Direct index access should be checked as normal index access request
     public static class SystemIndexDisabled {
 
         @ClassRule

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
@@ -30,11 +30,11 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SEARCH_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.directSharePayload;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -76,8 +76,8 @@ public class DirectIndexAccessTests {
         private void assertResourceSharingIndexAccess(String id, TestSecurityConfig.User user) {
             // cannot interact with resource sharing index
             api.assertDirectViewSharingRecord(id, user, HttpStatus.SC_FORBIDDEN);
-            api.assertDirectShare(id, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertDirectRevoke(id, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectShare(id, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectRevoke(id, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
             api.assertDirectDeleteResourceSharingRecord(id, user, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -130,8 +130,8 @@ public class DirectIndexAccessTests {
 
             // cannot interact with resource sharing index
             api.assertDirectViewSharingRecord(id, FULL_ACCESS_USER, HttpStatus.SC_NOT_FOUND);
-            api.assertDirectShare(id, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertDirectRevoke(id, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectShare(id, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectRevoke(id, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
             api.assertDirectDeleteResourceSharingRecord(id, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -152,7 +152,7 @@ public class DirectIndexAccessTests {
                 client.get(RESOURCE_SHARING_INDEX + "/_doc/" + id).assertStatusCode(HttpStatus.SC_OK);
                 client.postJson(
                     RESOURCE_SHARING_INDEX + "/_doc/" + id,
-                    directSharePayload(id, USER_ADMIN.getName(), NO_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                    directSharePayload(id, USER_ADMIN.getName(), NO_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
                 ).assertStatusCode(HttpStatus.SC_OK);
                 client.delete(RESOURCE_SHARING_INDEX + "/_doc/" + id).assertStatusCode(HttpStatus.SC_OK);
 
@@ -209,8 +209,8 @@ public class DirectIndexAccessTests {
 
             // cannot interact with resource sharing index
             api.assertDirectViewSharingRecord(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
-            api.assertDirectShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-            api.assertDirectRevoke(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectShare(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectRevoke(adminResId, NO_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
             api.assertDirectDeleteResourceSharingRecord(adminResId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
         }
 
@@ -227,7 +227,7 @@ public class DirectIndexAccessTests {
             // cannot read admin's resource directly since system index protection is enabled
             api.assertDirectGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             // once admin share's record, user can then query it directly
-            api.assertDirectShare(adminResId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertDirectShare(adminResId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.awaitSharingEntry(LIMITED_ACCESS_USER.getName());
             api.assertDirectGet(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
 
@@ -246,14 +246,14 @@ public class DirectIndexAccessTests {
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleFullAccessResourceAG,
+                SAMPLE_FULL_ACCESS_RESOURCE_AG,
                 HttpStatus.SC_FORBIDDEN
             );
             api.assertDirectRevoke(
                 adminResId,
                 LIMITED_ACCESS_USER,
                 LIMITED_ACCESS_USER,
-                sampleFullAccessResourceAG,
+                SAMPLE_FULL_ACCESS_RESOURCE_AG,
                 HttpStatus.SC_FORBIDDEN
             );
             api.assertDirectDeleteResourceSharingRecord(adminResId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
@@ -274,13 +274,13 @@ public class DirectIndexAccessTests {
             // cannot read admin's resource directly since resource is not shared with them
             api.assertDirectGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
             // once admin share's record, user can then query it directly
-            api.assertDirectShare(adminResId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertDirectShare(adminResId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.awaitSharingEntry(FULL_ACCESS_USER.getName());
             api.assertDirectGet(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
 
             // admin cannot read user's resource until after they share it with admin
             api.assertDirectGet(userResId, USER_ADMIN, HttpStatus.SC_FORBIDDEN, "");
-            api.assertDirectShare(userResId, FULL_ACCESS_USER, USER_ADMIN, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+            api.assertDirectShare(userResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertDirectGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
             // can only access own resource since
@@ -298,8 +298,8 @@ public class DirectIndexAccessTests {
 
             // can view, share, revoke and delete resource sharing record(s) directly
             api.assertDirectViewSharingRecord(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertDirectShare(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
-            api.assertDirectRevoke(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+            api.assertDirectShare(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
+            api.assertDirectRevoke(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertDirectDeleteResourceSharingRecord(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
         }
 
@@ -321,7 +321,7 @@ public class DirectIndexAccessTests {
                 client.get(RESOURCE_SHARING_INDEX + "/_doc/" + adminResId).assertStatusCode(HttpStatus.SC_OK);
                 client.postJson(
                     RESOURCE_SHARING_INDEX + "/_doc/" + adminResId,
-                    directSharePayload(adminResId, USER_ADMIN.getName(), NO_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                    directSharePayload(adminResId, USER_ADMIN.getName(), NO_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
                 ).assertStatusCode(HttpStatus.SC_OK);
                 client.delete(RESOURCE_SHARING_INDEX + "/_doc/" + adminResId).assertStatusCode(HttpStatus.SC_OK);
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
@@ -38,8 +38,8 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -104,7 +104,7 @@ public class DryRunAccessTests {
         }
 
         // share resource at readonly level with no_access_user
-        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
 
         try (TestRestClient client = cluster.getRestClient(NO_ACCESS_USER)) {
             // recheck read access
@@ -123,7 +123,7 @@ public class DryRunAccessTests {
             // cannot share resource
             resp = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyAG.name())
+                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(false));
@@ -132,7 +132,7 @@ public class DryRunAccessTests {
             // cannot revoke resource access
             resp = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyAG.name())
+                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(false));
@@ -146,7 +146,7 @@ public class DryRunAccessTests {
         }
 
         // share resource at full-access level with no_access_user
-        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
 
         // user will now also be able to update, share, revoke and delete resource
         try (TestRestClient client = cluster.getRestClient(NO_ACCESS_USER)) {
@@ -166,7 +166,7 @@ public class DryRunAccessTests {
             // can share resource
             resp = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyAG.name())
+                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(true));
@@ -175,7 +175,7 @@ public class DryRunAccessTests {
             // can revoke resource access
             resp = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyAG.name())
+                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(true));

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DryRunAccessTests.java
@@ -30,6 +30,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_CREATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
@@ -38,8 +40,6 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -104,7 +104,7 @@ public class DryRunAccessTests {
         }
 
         // share resource at readonly level with no_access_user
-        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
 
         try (TestRestClient client = cluster.getRestClient(NO_ACCESS_USER)) {
             // recheck read access
@@ -123,7 +123,7 @@ public class DryRunAccessTests {
             // cannot share resource
             resp = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                shareWithPayload(FULL_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(false));
@@ -132,7 +132,7 @@ public class DryRunAccessTests {
             // cannot revoke resource access
             resp = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                revokeAccessPayload(FULL_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(false));
@@ -146,7 +146,7 @@ public class DryRunAccessTests {
         }
 
         // share resource at full-access level with no_access_user
-        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(adminResId, USER_ADMIN, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
 
         // user will now also be able to update, share, revoke and delete resource
         try (TestRestClient client = cluster.getRestClient(NO_ACCESS_USER)) {
@@ -166,7 +166,7 @@ public class DryRunAccessTests {
             // can share resource
             resp = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                shareWithPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                shareWithPayload(FULL_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(true));
@@ -175,7 +175,7 @@ public class DryRunAccessTests {
             // can revoke resource access
             resp = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + adminResId + "?perform_permission_check=true",
-                revokeAccessPayload(FULL_ACCESS_USER.getName(), sampleReadOnlyResourceAG)
+                revokeAccessPayload(FULL_ACCESS_USER.getName(), SAMPLE_READ_ONLY_RESOURCE_AG)
             );
             resp.assertStatusCode(HttpStatus.SC_OK);
             assertThat(resp.bodyAsMap().get("accessAllowed"), equalTo(true));

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ResourceSharingMultiTenancyTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ResourceSharingMultiTenancyTests.java
@@ -23,8 +23,9 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -56,7 +57,7 @@ public class ResourceSharingMultiTenancyTests {
     public void testCreateResourceWithMultiTenancyEnabled() {
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             TestRestClient.HttpResponse sharingInfoResponse = client.get(
-                "_plugins/_security/api/resource/share?resource_id=" + resourceId + "&resource_type=" + RESOURCE_INDEX_NAME
+                SECURITY_SHARE_ENDPOINT + "?resource_id=" + resourceId + "&resource_type=" + RESOURCE_TYPE
             );
             assertThat(sharingInfoResponse.getBody(), containsString("\"created_by\":{\"user\":\"admin\",\"tenant\":\"customtenant\"}"));
         }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/AdminCertificateAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/AdminCertificateAccessTests.java
@@ -30,7 +30,7 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -68,14 +68,14 @@ public class AdminCertificateAccessTests {
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
             HttpResponse response = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
-                shareWithPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
             );
 
             response.assertStatusCode(HttpStatus.SC_OK);
 
             response = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
-                revokeAccessPayload(NO_ACCESS_USER.getName(), sampleAllAG.name())
+                revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
             );
 
             response.assertStatusCode(HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/AdminCertificateAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/AdminCertificateAccessTests.java
@@ -23,6 +23,7 @@ import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_DELETE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_GET_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_REVOKE_ENDPOINT;
@@ -30,7 +31,6 @@ import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_SHARE_END
 import static org.opensearch.sample.resource.TestUtils.SAMPLE_RESOURCE_UPDATE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.revokeAccessPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
 import static org.opensearch.sample.resource.TestUtils.shareWithPayload;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -68,14 +68,14 @@ public class AdminCertificateAccessTests {
         try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
             HttpResponse response = client.postJson(
                 SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId,
-                shareWithPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                shareWithPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
             );
 
             response.assertStatusCode(HttpStatus.SC_OK);
 
             response = client.postJson(
                 SAMPLE_RESOURCE_REVOKE_ENDPOINT + "/" + resourceId,
-                revokeAccessPayload(NO_ACCESS_USER.getName(), sampleFullAccessResourceAG)
+                revokeAccessPayload(NO_ACCESS_USER.getName(), SAMPLE_FULL_ACCESS_RESOURCE_AG)
             );
 
             response.assertStatusCode(HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
@@ -24,8 +24,8 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class FullAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertRUDAccess(TestSecurityConfig.User user) {
@@ -72,13 +72,13 @@ public class FullAccessTests {
     // while resource is shared, they can access it and share it someone else
     private void assertSharingAccess(TestSecurityConfig.User user, TestSecurityConfig.User target) {
         api.assertApiGet(resourceId, target, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiShare(resourceId, user, target, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, user, target, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(target.getName());
 
         api.assertApiGet(resourceId, target, HttpStatus.SC_OK, "sample");
-        api.assertApiShare(resourceId, target, new TestSecurityConfig.User("test"), sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, target, new TestSecurityConfig.User("test"), SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
 
-        api.assertApiRevoke(resourceId, user, target, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, user, target, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiGet(resourceId, target, HttpStatus.SC_FORBIDDEN, "");
     }
@@ -87,7 +87,7 @@ public class FullAccessTests {
     public void fullAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName()); // wait until sharing info is populated
 
         // can share admin's resource with others since full access was granted
@@ -100,7 +100,7 @@ public class FullAccessTests {
     public void limitedAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName()); // wait until sharing info is populated
 
         assertSharingAccess(LIMITED_ACCESS_USER, FULL_ACCESS_USER);
@@ -112,7 +112,7 @@ public class FullAccessTests {
     public void noAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(NO_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(NO_ACCESS_USER.getName());
 
         assertSharingAccess(NO_ACCESS_USER, LIMITED_ACCESS_USER);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/FullAccessTests.java
@@ -25,7 +25,7 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class FullAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertRUDAccess(TestSecurityConfig.User user) {
@@ -72,13 +72,13 @@ public class FullAccessTests {
     // while resource is shared, they can access it and share it someone else
     private void assertSharingAccess(TestSecurityConfig.User user, TestSecurityConfig.User target) {
         api.assertApiGet(resourceId, target, HttpStatus.SC_FORBIDDEN, "");
-        api.assertApiShare(resourceId, user, target, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, user, target, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(target.getName());
 
         api.assertApiGet(resourceId, target, HttpStatus.SC_OK, "sample");
-        api.assertApiShare(resourceId, target, new TestSecurityConfig.User("test"), sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, target, new TestSecurityConfig.User("test"), sampleFullAccessResourceAG, HttpStatus.SC_OK);
 
-        api.assertApiRevoke(resourceId, user, target, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, user, target, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiGet(resourceId, target, HttpStatus.SC_FORBIDDEN, "");
     }
@@ -87,7 +87,7 @@ public class FullAccessTests {
     public void fullAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName()); // wait until sharing info is populated
 
         // can share admin's resource with others since full access was granted
@@ -100,7 +100,7 @@ public class FullAccessTests {
     public void limitedAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName()); // wait until sharing info is populated
 
         assertSharingAccess(LIMITED_ACCESS_USER, FULL_ACCESS_USER);
@@ -112,7 +112,7 @@ public class FullAccessTests {
     public void noAccessUser_canCRUD() {
         assertNoAccessBeforeSharing(NO_ACCESS_USER);
         // share at sampleAllAG level
-        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(NO_ACCESS_USER.getName());
 
         assertSharingAccess(NO_ACCESS_USER, LIMITED_ACCESS_USER);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
@@ -24,8 +24,8 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class MixedAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly(TestSecurityConfig.User user) {
@@ -67,15 +67,15 @@ public class MixedAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertFullAccess(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_OK);
-        api.assertApiRevoke(resourceId, user, USER_ADMIN, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, user, USER_ADMIN, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiDelete(resourceId, user, HttpStatus.SC_OK);
     }
@@ -85,8 +85,8 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited-perms user
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName());
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName());
 
@@ -94,7 +94,7 @@ public class MixedAccessTests {
         assertReadOnly(FULL_ACCESS_USER);
 
         // 3. limited access user shares with full-access user at sampleAllAG
-        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName());
 
         // 4. full-access user now has full-access to admin's resource
@@ -107,9 +107,9 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
 
         // 1. share with both users at read-only level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
-        api.awaitSharingEntry(sampleReadOnlyAG.name());
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.awaitSharingEntry(sampleReadOnlyResourceAG);
 
         // 2. assert both now have read-only access
         assertReadOnly(LIMITED_ACCESS_USER);
@@ -120,15 +120,15 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
 
         // 1. share with user at read-only level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName());
 
         // 2. assert user now has read-only access
         assertReadOnly(LIMITED_ACCESS_USER);
 
         // 3. share with user at full-access level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
-        api.awaitSharingEntry(sampleAllAG.name());
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.awaitSharingEntry(sampleFullAccessResourceAG);
 
         // 4. assert user now has full access
         assertFullAccess(LIMITED_ACCESS_USER);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/MixedAccessTests.java
@@ -23,9 +23,9 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class MixedAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly(TestSecurityConfig.User user) {
@@ -67,15 +67,15 @@ public class MixedAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertFullAccess(TestSecurityConfig.User user) {
         api.assertApiGet(resourceId, user, HttpStatus.SC_OK, "sample");
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_OK);
-        api.assertApiRevoke(resourceId, user, USER_ADMIN, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, user, USER_ADMIN, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiDelete(resourceId, user, HttpStatus.SC_OK);
     }
@@ -85,8 +85,8 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited-perms user
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName());
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName());
 
@@ -94,7 +94,7 @@ public class MixedAccessTests {
         assertReadOnly(FULL_ACCESS_USER);
 
         // 3. limited access user shares with full-access user at sampleAllAG
-        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName());
 
         // 4. full-access user now has full-access to admin's resource
@@ -107,9 +107,9 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
 
         // 1. share with both users at read-only level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
-        api.awaitSharingEntry(sampleReadOnlyResourceAG);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
+        api.awaitSharingEntry(SAMPLE_READ_ONLY_RESOURCE_AG);
 
         // 2. assert both now have read-only access
         assertReadOnly(LIMITED_ACCESS_USER);
@@ -120,15 +120,15 @@ public class MixedAccessTests {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
 
         // 1. share with user at read-only level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName());
 
         // 2. assert user now has read-only access
         assertReadOnly(LIMITED_ACCESS_USER);
 
         // 3. share with user at full-access level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
-        api.awaitSharingEntry(sampleFullAccessResourceAG);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
+        api.awaitSharingEntry(SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
         // 4. assert user now has full access
         assertFullAccess(LIMITED_ACCESS_USER);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
@@ -23,9 +23,9 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class PubliclySharedDocTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly() {
@@ -67,15 +67,27 @@ public class PubliclySharedDocTests {
         api.assertApiUpdate(resourceId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, FULL_ACCESS_USER, TestUtils.FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(
+            resourceId,
+            FULL_ACCESS_USER,
+            TestUtils.FULL_ACCESS_USER,
+            SAMPLE_FULL_ACCESS_RESOURCE_AG,
+            HttpStatus.SC_FORBIDDEN
+        );
+        api.assertApiRevoke(resourceId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertFullAccess() {
         api.assertApiGet(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
         api.assertApiUpdate(resourceId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, TestUtils.LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
-        api.assertApiRevoke(resourceId, LIMITED_ACCESS_USER, USER_ADMIN, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(
+            resourceId,
+            LIMITED_ACCESS_USER,
+            TestUtils.LIMITED_ACCESS_USER,
+            SAMPLE_FULL_ACCESS_RESOURCE_AG,
+            HttpStatus.SC_OK
+        );
+        api.assertApiRevoke(resourceId, LIMITED_ACCESS_USER, USER_ADMIN, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiDelete(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK);
     }
@@ -84,7 +96,7 @@ public class PubliclySharedDocTests {
     public void readOnly() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited perms user
-        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry("*");
 
         // 2. check read-only access for full-access user
@@ -95,7 +107,7 @@ public class PubliclySharedDocTests {
     public void fullAccess() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited perms user
-        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry("*");
 
         // 2. check read-only access for full-access user

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/PubliclySharedDocTests.java
@@ -24,8 +24,8 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -58,8 +58,8 @@ public class PubliclySharedDocTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly() {
@@ -67,15 +67,15 @@ public class PubliclySharedDocTests {
         api.assertApiUpdate(resourceId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, FULL_ACCESS_USER, TestUtils.FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, FULL_ACCESS_USER, TestUtils.FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, FULL_ACCESS_USER, FULL_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertFullAccess() {
         api.assertApiGet(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
         api.assertApiUpdate(resourceId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
-        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, TestUtils.LIMITED_ACCESS_USER, sampleAllAG.name(), HttpStatus.SC_OK);
-        api.assertApiRevoke(resourceId, LIMITED_ACCESS_USER, USER_ADMIN, sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, LIMITED_ACCESS_USER, TestUtils.LIMITED_ACCESS_USER, sampleFullAccessResourceAG, HttpStatus.SC_OK);
+        api.assertApiRevoke(resourceId, LIMITED_ACCESS_USER, USER_ADMIN, sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry();
         api.assertApiDelete(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK);
     }
@@ -84,7 +84,7 @@ public class PubliclySharedDocTests {
     public void readOnly() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited perms user
-        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleReadOnlyResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry("*");
 
         // 2. check read-only access for full-access user
@@ -95,7 +95,7 @@ public class PubliclySharedDocTests {
     public void fullAccess() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // 1. share at read-only for full-access user and at full-access for limited perms user
-        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleAllAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, new TestSecurityConfig.User("*"), sampleFullAccessResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry("*");
 
         // 2. check read-only access for full-access user

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
@@ -26,9 +26,9 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -64,8 +64,8 @@ public class ReadOnlyAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly(TestSecurityConfig.User user) {
@@ -73,15 +73,15 @@ public class ReadOnlyAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
     }
 
     @Test
     public void fullAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(FULL_ACCESS_USER);
     }
@@ -90,7 +90,7 @@ public class ReadOnlyAccessTests {
     public void limitedAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(LIMITED_ACCESS_USER);
     }
@@ -99,7 +99,7 @@ public class ReadOnlyAccessTests {
     public void noAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(NO_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
         api.awaitSharingEntry(NO_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(NO_ACCESS_USER);
     }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/multi_share/ReadOnlyAccessTests.java
@@ -27,8 +27,8 @@ import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
-import static org.opensearch.sample.resource.TestUtils.sampleAllAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyAG;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -64,8 +64,8 @@ public class ReadOnlyAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     private void assertReadOnly(TestSecurityConfig.User user) {
@@ -73,15 +73,15 @@ public class ReadOnlyAccessTests {
         api.assertApiUpdate(resourceId, user, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
         api.assertApiDelete(resourceId, user, HttpStatus.SC_FORBIDDEN);
 
-        api.assertApiShare(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
-        api.assertApiRevoke(resourceId, user, user, sampleAllAG.name(), HttpStatus.SC_FORBIDDEN);
+        api.assertApiShare(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
+        api.assertApiRevoke(resourceId, user, user, sampleFullAccessResourceAG, HttpStatus.SC_FORBIDDEN);
     }
 
     @Test
     public void fullAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(FULL_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, FULL_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(FULL_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(FULL_ACCESS_USER);
     }
@@ -90,7 +90,7 @@ public class ReadOnlyAccessTests {
     public void limitedAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(LIMITED_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, LIMITED_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(LIMITED_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(LIMITED_ACCESS_USER);
     }
@@ -99,7 +99,7 @@ public class ReadOnlyAccessTests {
     public void noAccessUser_canRead_cannotUpdateDeleteShareRevoke() {
         assertNoAccessBeforeSharing(NO_ACCESS_USER);
         // share at sampleReadOnly level
-        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyAG.name(), HttpStatus.SC_OK);
+        api.assertApiShare(resourceId, USER_ADMIN, NO_ACCESS_USER, sampleReadOnlyResourceAG, HttpStatus.SC_OK);
         api.awaitSharingEntry(NO_ACCESS_USER.getName()); // wait until sharing info is populated
         assertReadOnly(NO_ACCESS_USER);
     }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
@@ -1,0 +1,177 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.securityapis;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.sample.resource.TestUtils;
+import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.spi.resources.sharing.Recipients;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SECURITY_LIST_ENDPOINT;
+import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
+import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
+import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * This test file tests the list API that lists current user's accessible resources
+ * Sharing behaviour is tested in ShareApiTests, this class simply tests that the shared resources are visible after sharing through list api
+ */
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class AccessibleResourcesApiTests {
+    @ClassRule
+    public static LocalCluster cluster = newCluster(true, true);
+
+    private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+    private String adminResId;
+
+    @Before
+    public void setup() {
+        adminResId = api.createSampleResourceAs(USER_ADMIN);
+        api.awaitSharingEntry();
+    }
+
+    @After
+    public void clearIndices() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            client.delete(RESOURCE_INDEX_NAME);
+            client.delete(RESOURCE_SHARING_INDEX);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertListApiWithUser(TestSecurityConfig.User user) {
+        // Sharing behaviour is tested in ShareApiTests, this class simply tests that the shared resources are visible after sharing through
+        // list api
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> types = (List<Object>) response.bodyAsMap().get("resources");
+            assertThat(types.size(), equalTo(0));
+        }
+        // share at read-only, can_share should say false
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse response = client.putJson(
+                SECURITY_SHARE_ENDPOINT,
+                putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyResourceAG, user.getName())
+            );
+            response.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(response.getBody(), containsString(user.getName()));
+        }
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
+            assertThat(resources.size(), equalTo(1));
+            Map<String, Object> resource = (Map<String, Object>) resources.getFirst();
+            assertThat(resource.get("resource_id"), equalTo(adminResId));
+            assertThat(resource.get("created_by"), equalTo(Map.of("user", USER_ADMIN.getName())));
+            assertThat(
+                resource.get("share_with"),
+                equalTo(Map.of(sampleReadOnlyResourceAG, Map.of(Recipient.USERS.getName(), List.of(user.getName()))))
+            );
+            assertThat(resource.get("can_share"), equalTo(Boolean.FALSE));
+        }
+
+        // share at read-only, can_share should say false
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            Map<Recipient, Set<String>> recs = new HashMap<>();
+            Set<String> users = new HashSet<>();
+            users.add(user.getName());
+            recs.put(Recipient.USERS, users);
+            Recipients recipients = new Recipients(recs);
+
+            TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
+            patchSharingInfoPayloadBuilder.resourceId(adminResId)
+                .resourceIndex(RESOURCE_INDEX_NAME)
+                .share(recipients, sampleFullAccessResourceAG);
+
+            TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
+            response.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(response.getBody(), containsString(user.getName()));
+        }
+        try (TestRestClient client = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
+            assertThat(resources.size(), equalTo(1));
+            Map<String, Object> resource = (Map<String, Object>) resources.getFirst();
+            assertThat(resource.get("resource_id"), equalTo(adminResId));
+            assertThat(resource.get("created_by"), equalTo(Map.of("user", USER_ADMIN.getName())));
+            Map<String, Object> shareWith = Map.of(
+                sampleReadOnlyResourceAG,
+                Map.of(Recipient.USERS.getName(), List.of(user.getName())),
+                sampleFullAccessResourceAG,
+                Map.of(Recipient.USERS.getName(), List.of(user.getName()))
+            );
+            assertThat(resource.get("share_with"), equalTo(shareWith));
+            assertThat(resource.get("can_share"), equalTo(Boolean.TRUE));
+        }
+    }
+
+    @Test
+    public void testListAccessibleResources_noAccessUser() {
+        // no-access-user should be able to see resource once shared.
+        assertListApiWithUser(NO_ACCESS_USER);
+    }
+
+    @Test
+    public void testListAccessibleResources_limitedAccessUser() {
+        // no-access-user should be able to see resource once shared.
+        assertListApiWithUser(LIMITED_ACCESS_USER);
+    }
+
+    @Test
+    public void testListAccessibleResources_fullAccessUser() {
+        // no-access-user should be able to see resource once shared.
+        assertListApiWithUser(FULL_ACCESS_USER);
+    }
+
+    @Test
+    public void testListAccessibleResources_resourceOwner() {
+        // owner should be able to see their own resource through list api
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
+            assertThat(resources.size(), equalTo(1));
+            Map<String, Object> resource = (Map<String, Object>) resources.getFirst();
+            assertThat(resource.get("resource_id"), equalTo(adminResId));
+            assertThat(resource.get("created_by"), equalTo(Map.of("user", USER_ADMIN.getName())));
+            assertThat(resource.get("can_share"), equalTo(Boolean.TRUE));
+        }
+    }
+}

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
@@ -36,12 +36,12 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SECURITY_LIST_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -86,7 +86,7 @@ public class AccessibleResourcesApiTests {
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             TestRestClient.HttpResponse response = client.putJson(
                 SECURITY_SHARE_ENDPOINT,
-                putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyResourceAG, user.getName())
+                putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, user.getName())
             );
             response.assertStatusCode(HttpStatus.SC_OK);
             assertThat(response.getBody(), containsString(user.getName()));
@@ -101,12 +101,12 @@ public class AccessibleResourcesApiTests {
             assertThat(resource.get("created_by"), equalTo(Map.of("user", USER_ADMIN.getName())));
             assertThat(
                 resource.get("share_with"),
-                equalTo(Map.of(sampleReadOnlyResourceAG, Map.of(Recipient.USERS.getName(), List.of(user.getName()))))
+                equalTo(Map.of(SAMPLE_READ_ONLY_RESOURCE_AG, Map.of(Recipient.USERS.getName(), List.of(user.getName()))))
             );
             assertThat(resource.get("can_share"), equalTo(Boolean.FALSE));
         }
 
-        // share at read-only, can_share should say false
+        // share at full-access, can_share should say true
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             Map<Recipient, Set<String>> recs = new HashMap<>();
             Set<String> users = new HashSet<>();
@@ -117,7 +117,7 @@ public class AccessibleResourcesApiTests {
             TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
             patchSharingInfoPayloadBuilder.resourceId(adminResId)
                 .resourceIndex(RESOURCE_INDEX_NAME)
-                .share(recipients, sampleFullAccessResourceAG);
+                .share(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
             TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
             response.assertStatusCode(HttpStatus.SC_OK);
@@ -132,9 +132,9 @@ public class AccessibleResourcesApiTests {
             assertThat(resource.get("resource_id"), equalTo(adminResId));
             assertThat(resource.get("created_by"), equalTo(Map.of("user", USER_ADMIN.getName())));
             Map<String, Object> shareWith = Map.of(
-                sampleReadOnlyResourceAG,
+                SAMPLE_READ_ONLY_RESOURCE_AG,
                 Map.of(Recipient.USERS.getName(), List.of(user.getName())),
-                sampleFullAccessResourceAG,
+                SAMPLE_FULL_ACCESS_RESOURCE_AG,
                 Map.of(Recipient.USERS.getName(), List.of(user.getName()))
             );
             assertThat(resource.get("share_with"), equalTo(shareWith));

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
@@ -73,6 +73,17 @@ public class AccessibleResourcesApiTests {
         }
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testListAccessibleResources_gibberishParams() {
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + "some-type");
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> types = (List<Object>) response.bodyAsMap().get("resources");
+            assertThat(types.size(), equalTo(0));
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private void assertListApiWithUser(TestSecurityConfig.User user) {
         // Sharing behaviour is tested in ShareApiTests, this class simply tests that the shared resources are visible after sharing through

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/AccessibleResourcesApiTests.java
@@ -43,6 +43,7 @@ import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -77,7 +78,7 @@ public class AccessibleResourcesApiTests {
         // Sharing behaviour is tested in ShareApiTests, this class simply tests that the shared resources are visible after sharing through
         // list api
         try (TestRestClient client = cluster.getRestClient(user)) {
-            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_TYPE);
             response.assertStatusCode(HttpStatus.SC_OK);
             List<Object> types = (List<Object>) response.bodyAsMap().get("resources");
             assertThat(types.size(), equalTo(0));
@@ -86,13 +87,13 @@ public class AccessibleResourcesApiTests {
         try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
             TestRestClient.HttpResponse response = client.putJson(
                 SECURITY_SHARE_ENDPOINT,
-                putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, user.getName())
+                putSharingInfoPayload(adminResId, RESOURCE_TYPE, SAMPLE_READ_ONLY_RESOURCE_AG, user.getName())
             );
             response.assertStatusCode(HttpStatus.SC_OK);
             assertThat(response.getBody(), containsString(user.getName()));
         }
         try (TestRestClient client = cluster.getRestClient(user)) {
-            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_TYPE);
             response.assertStatusCode(HttpStatus.SC_OK);
             List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
             assertThat(resources.size(), equalTo(1));
@@ -116,7 +117,7 @@ public class AccessibleResourcesApiTests {
 
             TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
             patchSharingInfoPayloadBuilder.resourceId(adminResId)
-                .resourceIndex(RESOURCE_INDEX_NAME)
+                .resourceType(RESOURCE_TYPE)
                 .share(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
             TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
@@ -124,7 +125,7 @@ public class AccessibleResourcesApiTests {
             assertThat(response.getBody(), containsString(user.getName()));
         }
         try (TestRestClient client = cluster.getRestClient(user)) {
-            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+            TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_TYPE);
             response.assertStatusCode(HttpStatus.SC_OK);
             List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
             assertThat(resources.size(), equalTo(1));
@@ -162,7 +163,7 @@ public class AccessibleResourcesApiTests {
 
     @SuppressWarnings("unchecked")
     private void assertListApiWithOwnerAndSuperAdmin(TestRestClient client) {
-        TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_INDEX_NAME);
+        TestRestClient.HttpResponse response = client.get(SECURITY_LIST_ENDPOINT + "?resource_type=" + RESOURCE_TYPE);
         response.assertStatusCode(HttpStatus.SC_OK);
         List<Object> resources = (List<Object>) response.bodyAsMap().get("resources");
         assertThat(resources.size(), equalTo(1));

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
@@ -9,7 +9,7 @@
  * GitHub history for details.
  */
 
-package org.opensearch.sample.resource;
+package org.opensearch.sample.resource.securityapis;
 
 import java.util.List;
 import java.util.Map;

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
@@ -37,11 +37,11 @@ import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
 import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_FULL_ACCESS_RESOURCE_AG;
+import static org.opensearch.sample.resource.TestUtils.SAMPLE_READ_ONLY_RESOURCE_AG;
 import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
-import static org.opensearch.sample.resource.TestUtils.sampleFullAccessResourceAG;
-import static org.opensearch.sample.resource.TestUtils.sampleReadOnlyResourceAG;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
@@ -89,7 +89,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyResourceAG, NO_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
@@ -98,7 +98,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleFullAccessResourceAG, LIMITED_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_FULL_ACCESS_RESOURCE_AG, LIMITED_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(LIMITED_ACCESS_USER.getName()));
@@ -109,7 +109,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleReadOnlyResourceAG, NO_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(NO_ACCESS_USER.getName()));
@@ -130,7 +130,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, sampleFullAccessResourceAG, FULL_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_FULL_ACCESS_RESOURCE_AG, FULL_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(FULL_ACCESS_USER.getName()));
@@ -157,7 +157,7 @@ public class ShareApiTests {
             TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
             patchSharingInfoPayloadBuilder.resourceId(adminResId)
                 .resourceIndex(RESOURCE_INDEX_NAME)
-                .share(recipients, sampleFullAccessResourceAG);
+                .share(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
             // full-access user cannot share with itself since user doesn't have permission to share
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
@@ -183,13 +183,13 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
                 // add limited user
                 users.add(LIMITED_ACCESS_USER.getName());
-                patchSharingInfoPayloadBuilder.share(recipients, sampleFullAccessResourceAG);
+                patchSharingInfoPayloadBuilder.share(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
                 // remove self
                 Set<String> revokedUsers = new HashSet<>();
                 revokedUsers.add(FULL_ACCESS_USER.getName());
                 recs.put(Recipient.USERS, revokedUsers);
                 recipients = new Recipients(recs);
-                patchSharingInfoPayloadBuilder.revoke(recipients, sampleFullAccessResourceAG);
+                patchSharingInfoPayloadBuilder.revoke(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
                 TestRestClient.HttpResponse response = client.patch(SECURITY_SHARE_ENDPOINT, patchSharingInfoPayloadBuilder.build());
                 response.assertStatusCode(HttpStatus.SC_OK);

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
@@ -43,6 +43,7 @@ import static org.opensearch.sample.resource.TestUtils.SECURITY_SHARE_ENDPOINT;
 import static org.opensearch.sample.resource.TestUtils.newCluster;
 import static org.opensearch.sample.resource.TestUtils.putSharingInfoPayload;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
 
 /**
@@ -89,7 +90,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_TYPE, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
@@ -98,7 +99,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_FULL_ACCESS_RESOURCE_AG, LIMITED_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_TYPE, SAMPLE_FULL_ACCESS_RESOURCE_AG, LIMITED_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(LIMITED_ACCESS_USER.getName()));
@@ -109,7 +110,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(LIMITED_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_TYPE, SAMPLE_READ_ONLY_RESOURCE_AG, NO_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(NO_ACCESS_USER.getName()));
@@ -121,7 +122,7 @@ public class ShareApiTests {
             // non-permission user cannot list shared resources,
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.get(
-                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_INDEX_NAME
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_TYPE
                 );
                 response.assertStatusCode(HttpStatus.SC_FORBIDDEN);
             }
@@ -130,7 +131,7 @@ public class ShareApiTests {
             try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
                 TestRestClient.HttpResponse response = client.putJson(
                     SECURITY_SHARE_ENDPOINT,
-                    putSharingInfoPayload(adminResId, RESOURCE_INDEX_NAME, SAMPLE_FULL_ACCESS_RESOURCE_AG, FULL_ACCESS_USER.getName())
+                    putSharingInfoPayload(adminResId, RESOURCE_TYPE, SAMPLE_FULL_ACCESS_RESOURCE_AG, FULL_ACCESS_USER.getName())
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.getBody(), containsString(FULL_ACCESS_USER.getName()));
@@ -139,7 +140,7 @@ public class ShareApiTests {
             // non-permission user can now list shared_with resources by calling share API
             try (TestRestClient client = cluster.getRestClient(FULL_ACCESS_USER)) {
                 TestRestClient.HttpResponse response = client.get(
-                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_INDEX_NAME
+                    SECURITY_SHARE_ENDPOINT + "?resource_id=" + adminResId + "&resource_type=" + RESOURCE_TYPE
                 );
                 response.assertStatusCode(HttpStatus.SC_OK);
                 assertThat(response.bodyAsJsonNode().get("sharing_info").get("resource_id").asText(), equalTo(adminResId));
@@ -156,7 +157,7 @@ public class ShareApiTests {
 
             TestUtils.PatchSharingInfoPayloadBuilder patchSharingInfoPayloadBuilder = new TestUtils.PatchSharingInfoPayloadBuilder();
             patchSharingInfoPayloadBuilder.resourceId(adminResId)
-                .resourceIndex(RESOURCE_INDEX_NAME)
+                .resourceType(RESOURCE_TYPE)
                 .share(recipients, SAMPLE_FULL_ACCESS_RESOURCE_AG);
 
             // full-access user cannot share with itself since user doesn't have permission to share

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareApiTests.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.sample.resource;
+package org.opensearch.sample.resource.securityapis;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
+import org.opensearch.sample.resource.TestUtils;
 import org.opensearch.security.spi.resources.sharing.Recipient;
 import org.opensearch.security.spi.resources.sharing.Recipients;
 import org.opensearch.test.framework.cluster.LocalCluster;

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
@@ -57,7 +57,6 @@ public class ShareableResourceTypesInfoApiTests {
             assertThat(types.size(), equalTo(1));
             Map<String, Object> responseBody = (Map<String, Object>) types.getFirst();
             assertThat(responseBody.get("type"), equalTo("sample-resource"));
-            assertThat(responseBody.get("index"), equalTo(".sample_resource"));
             assertThat(responseBody.get("action_groups"), equalTo(List.of("sample_read_only", "sample_read_write", "sample_full_access")));
         }
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
@@ -56,7 +56,7 @@ public class ShareableResourceTypesInfoApiTests {
             List<Object> types = (List<Object>) response.bodyAsMap().get("types");
             assertThat(types.size(), equalTo(1));
             Map<String, Object> responseBody = (Map<String, Object>) types.getFirst();
-            assertThat(responseBody.get("type"), equalTo("org.opensearch.sample.SampleResource"));
+            assertThat(responseBody.get("type"), equalTo("sample-resource"));
             assertThat(responseBody.get("index"), equalTo(".sample_resource"));
             assertThat(responseBody.get("action_groups"), equalTo(List.of("sample_read_only", "sample_read_write", "sample_full_access")));
         }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/ShareableResourceTypesInfoApiTests.java
@@ -34,7 +34,7 @@ import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
  */
 @RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
-public class TypesApiTests {
+public class ShareableResourceTypesInfoApiTests {
     @ClassRule
     public static LocalCluster cluster = newCluster(true, true);
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/TypesApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/TypesApiTests.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.securityapis;
+
+import java.util.List;
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.SECURITY_TYPES_ENDPOINT;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+
+/**
+ * This test file tests the types API that lists available resource types
+ */
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TypesApiTests {
+    @ClassRule
+    public static LocalCluster cluster = newCluster(true, true);
+
+    @After
+    public void clearIndices() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            client.delete(RESOURCE_INDEX_NAME);
+            client.delete(RESOURCE_SHARING_INDEX);
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testTypesApi_mustListSampleResourceAsAType() {
+        // no-access-user should be able to call types api that lists available resource types
+        try (TestRestClient client = cluster.getRestClient(NO_ACCESS_USER)) {
+            TestRestClient.HttpResponse response = client.get(SECURITY_TYPES_ENDPOINT);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            List<Object> types = (List<Object>) response.bodyAsMap().get("types");
+            assertThat(types.size(), equalTo(1));
+            Map<String, Object> responseBody = (Map<String, Object>) types.getFirst();
+            assertThat(responseBody.get("type"), equalTo("org.opensearch.sample.SampleResource"));
+            assertThat(responseBody.get("index"), equalTo(".sample_resource"));
+            assertThat(responseBody.get("action_groups"), equalTo(List.of("sample_read_only", "sample_read_write", "sample_full_access")));
+        }
+
+    }
+}

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResource.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResource.java
@@ -27,6 +27,7 @@ import org.opensearch.core.xcontent.XContentParser;
 
 import static org.opensearch.core.xcontent.ConstructingObjectParser.constructorArg;
 import static org.opensearch.core.xcontent.ConstructingObjectParser.optionalConstructorArg;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Sample resource declared by this plugin.
@@ -50,23 +51,19 @@ public class SampleResource implements NamedWriteable, ToXContentObject {
         this.user = new User(in);
     }
 
-    private static final ConstructingObjectParser<SampleResource, Void> PARSER = new ConstructingObjectParser<>(
-        "sample_resource",
-        true,
-        a -> {
-            SampleResource s;
-            try {
-                s = new SampleResource();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            s.setName((String) a[0]);
-            s.setDescription((String) a[1]);
-            s.setAttributes((Map<String, String>) a[2]);
-            s.setUser((User) a[3]);
-            return s;
+    private static final ConstructingObjectParser<SampleResource, Void> PARSER = new ConstructingObjectParser<>(RESOURCE_TYPE, true, a -> {
+        SampleResource s;
+        try {
+            s = new SampleResource();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-    );
+        s.setName((String) a[0]);
+        s.setDescription((String) a[1]);
+        s.setAttributes((Map<String, String>) a[2]);
+        s.setUser((User) a[3]);
+        return s;
+    });
 
     static {
         PARSER.declareString(constructorArg(), new ParseField("name"));
@@ -117,6 +114,6 @@ public class SampleResource implements NamedWriteable, ToXContentObject {
 
     @Override
     public String getWriteableName() {
-        return "sample_resource";
+        return RESOURCE_TYPE;
     }
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
@@ -19,6 +19,7 @@ import org.opensearch.security.spi.resources.ResourceSharingExtension;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Responsible for parsing the XContent into a SampleResource object.
@@ -27,7 +28,7 @@ public class SampleResourceExtension implements ResourceSharingExtension {
 
     @Override
     public Set<ResourceProvider> getResourceProviders() {
-        return Set.of(new ResourceProvider("sample-resource", RESOURCE_INDEX_NAME));
+        return Set.of(new ResourceProvider(RESOURCE_TYPE, RESOURCE_INDEX_NAME));
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/SampleResourceExtension.java
@@ -27,7 +27,7 @@ public class SampleResourceExtension implements ResourceSharingExtension {
 
     @Override
     public Set<ResourceProvider> getResourceProviders() {
-        return Set.of(new ResourceProvider(SampleResource.class.getCanonicalName(), RESOURCE_INDEX_NAME));
+        return Set.of(new ResourceProvider("sample-resource", RESOURCE_INDEX_NAME));
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/CreateResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/CreateResourceTransportAction.java
@@ -9,6 +9,9 @@
 package org.opensearch.sample.resource.actions.transport;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,6 +22,7 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.commons.ConfigConstants;
 import org.opensearch.commons.authuser.User;
 import org.opensearch.core.action.ActionListener;
@@ -32,7 +36,6 @@ import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
-import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
 /**
@@ -68,21 +71,75 @@ public class CreateResourceTransportAction extends HandledTransportAction<Create
         SampleResource sample = request.getResource();
         if (request.shouldStoreUser()) sample.setUser(user);
 
-        try (XContentBuilder builder = jsonBuilder()) {
-            IndexRequest ir = nodeClient.prepareIndex(RESOURCE_INDEX_NAME)
-                .setWaitForActiveShards(1)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                .setSource(sample.toXContent(builder, ToXContent.EMPTY_PARAMS))
-                .request();
-
-            log.debug("Index Request: {}", ir.toString());
-
-            nodeClient.index(ir, ActionListener.wrap(idxResponse -> {
-                log.debug("Created resource: {}", idxResponse.getId());
-                listener.onResponse(new CreateResourceResponse("Created resource: " + idxResponse.getId()));
-            }, listener::onFailure));
+        // 1. Read mapping JSON from the config file
+        final String mappingJson;
+        try {
+            URL url = CreateResourceTransportAction.class.getClassLoader().getResource("mappings.json");
+            if (url == null) {
+                listener.onFailure(new IllegalStateException("mappings.json not found on classpath"));
+                return;
+            }
+            try (InputStream is = url.openStream()) {
+                mappingJson = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            }
         } catch (IOException e) {
-            listener.onFailure(new RuntimeException(e));
+            listener.onFailure(new RuntimeException("Failed to read mappings.json from classpath", e));
+            return;
         }
+
+        // 2. Ensure index exists with mapping, then index the doc
+        ensureIndexWithMapping(nodeClient, mappingJson, ActionListener.wrap(v -> {
+            try (XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder()) {
+                IndexRequest ir = nodeClient.prepareIndex(RESOURCE_INDEX_NAME)
+                    .setWaitForActiveShards(1)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                    .setSource(sample.toXContent(builder, ToXContent.EMPTY_PARAMS))
+                    .request();
+
+                log.debug("Index Request: {}", ir);
+
+                nodeClient.index(ir, ActionListener.wrap(idxResponse -> {
+                    log.debug("Created resource: {}", idxResponse.getId());
+                    listener.onResponse(new CreateResourceResponse("Created resource: " + idxResponse.getId()));
+                }, listener::onFailure));
+            } catch (IOException e) {
+                listener.onFailure(new RuntimeException(e));
+            }
+        }, listener::onFailure));
     }
+
+    /**
+     * Ensures the index exists with the provided mapping.
+     * - If the index does not exist: creates it with the mapping.
+     * - If the index exists: updates (puts) the mapping.
+     */
+    private void ensureIndexWithMapping(Client client, String mappingJson, ActionListener<Void> listener) {
+        String indexName = RESOURCE_INDEX_NAME;
+        client.admin().indices().prepareExists(indexName).execute(ActionListener.wrap(existsResp -> {
+            if (!existsResp.isExists()) {
+                // Create index with mapping
+                client.admin().indices().prepareCreate(indexName).setMapping(mappingJson).execute(ActionListener.wrap(createResp -> {
+                    if (!createResp.isAcknowledged()) {
+                        listener.onFailure(new IllegalStateException("CreateIndex not acknowledged for " + indexName));
+                        return;
+                    }
+                    listener.onResponse(null);
+                }, listener::onFailure));
+            } else {
+                // Update mapping on existing index
+                client.admin()
+                    .indices()
+                    .preparePutMapping(indexName)
+                    .setSource(mappingJson, XContentType.JSON)
+                    .execute(ActionListener.wrap(ack -> {
+                        if (!ack.isAcknowledged()) {
+                            listener.onFailure(new IllegalStateException("PutMapping not acknowledged for " + indexName));
+                            return;
+                        }
+                        listener.onResponse(null);
+                    }, listener::onFailure));
+            }
+        }, listener::onFailure));
+    }
+
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/Constants.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/utils/Constants.java
@@ -13,6 +13,7 @@ package org.opensearch.sample.utils;
  */
 public class Constants {
     public static final String RESOURCE_INDEX_NAME = ".sample_resource";
+    public static final String RESOURCE_TYPE = "sample-resource";
 
     public static final String SAMPLE_RESOURCE_PLUGIN_PREFIX = "_plugins/sample_plugin";
     public static final String SAMPLE_RESOURCE_PLUGIN_API_PREFIX = "/" + SAMPLE_RESOURCE_PLUGIN_PREFIX;

--- a/sample-resource-plugin/src/main/resources/mappings.json
+++ b/sample-resource-plugin/src/main/resources/mappings.json
@@ -1,0 +1,11 @@
+{
+  "dynamic": true,
+  "_meta": {
+    "schema_version": 1
+  },
+  "properties": {
+    "all_shared_principals": {
+      "type": "keyword"
+    }
+  }
+}

--- a/sample-resource-plugin/src/main/resources/resource-action-groups.yml
+++ b/sample-resource-plugin/src/main/resources/resource-action-groups.yml
@@ -1,0 +1,27 @@
+#sample_read_only:
+#  - "cluster:admin/sample-resource-plugin/get"
+#  - "indices:data/read*"
+#
+#sample_read_write:
+#  - "cluster:admin/sample-resource-plugin/*"
+#  - "indices:*"
+#
+#sample_full_access:
+#  - "cluster:admin/sample-resource-plugin/*"
+#  - "indices:*"
+#  - "cluster:admin/security/resource/share"
+
+resource_types:
+  org.opensearch.sample.SampleResource:
+      sample_read_only:
+        - "cluster:admin/sample-resource-plugin/get"
+        - "indices:data/read*"
+
+      sample_read_write:
+        - "cluster:admin/sample-resource-plugin/*"
+        - "indices:*"
+
+      sample_full_access:
+        - "cluster:admin/sample-resource-plugin/*"
+        - "indices:*"
+        - "cluster:admin/security/resource/share"

--- a/sample-resource-plugin/src/main/resources/resource-action-groups.yml
+++ b/sample-resource-plugin/src/main/resources/resource-action-groups.yml
@@ -1,11 +1,14 @@
 resource_types:
   sample-resource:
       sample_read_only:
-        - "cluster:admin/sample-resource-plugin/get"
+        allowed_actions:
+          - "cluster:admin/sample-resource-plugin/get"
 
       sample_read_write:
-        - "cluster:admin/sample-resource-plugin/*"
+        allowed_actions:
+          - "cluster:admin/sample-resource-plugin/*"
 
       sample_full_access:
-        - "cluster:admin/sample-resource-plugin/*"
-        - "cluster:admin/security/resource/share"
+        allowed_actions:
+          - "cluster:admin/sample-resource-plugin/*"
+          - "cluster:admin/security/resource/share"

--- a/sample-resource-plugin/src/main/resources/resource-action-groups.yml
+++ b/sample-resource-plugin/src/main/resources/resource-action-groups.yml
@@ -1,14 +1,11 @@
 resource_types:
-  org.opensearch.sample.SampleResource:
+  sample-resource:
       sample_read_only:
         - "cluster:admin/sample-resource-plugin/get"
-        - "indices:data/read*"
 
       sample_read_write:
         - "cluster:admin/sample-resource-plugin/*"
-        - "indices:*"
 
       sample_full_access:
         - "cluster:admin/sample-resource-plugin/*"
-        - "indices:*"
         - "cluster:admin/security/resource/share"

--- a/sample-resource-plugin/src/main/resources/resource-action-groups.yml
+++ b/sample-resource-plugin/src/main/resources/resource-action-groups.yml
@@ -1,16 +1,3 @@
-#sample_read_only:
-#  - "cluster:admin/sample-resource-plugin/get"
-#  - "indices:data/read*"
-#
-#sample_read_write:
-#  - "cluster:admin/sample-resource-plugin/*"
-#  - "indices:*"
-#
-#sample_full_access:
-#  - "cluster:admin/sample-resource-plugin/*"
-#  - "indices:*"
-#  - "cluster:admin/security/resource/share"
-
 resource_types:
   org.opensearch.sample.SampleResource:
       sample_read_only:

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -148,7 +148,7 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
                 return orig;
             });
         }
-        return new ShareWith(updated).prune();
+        return new ShareWith(updated);
     }
 
     /**
@@ -164,10 +164,10 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
             Recipients revokeRecipients = entry.getValue();
             updated.computeIfPresent(level, (lvl, orig) -> {
                 orig.revoke(revokeRecipients);
-                return pruneRecipients(orig); // removes any null levels
+                return orig;
             });
         }
-        return new ShareWith(updated).prune();
+        return new ShareWith(updated);
     }
 
     /** Return a normalized ShareWith with no empty buckets and no empty action-groups. */

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -9,6 +9,7 @@
 package org.opensearch.security.spi.resources.sharing;
 
 import java.io.IOException;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -82,16 +83,15 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject();
-
-        for (String accessLevel : sharingInfo.keySet()) {
-            builder.field(accessLevel);
-            Recipients recipients = sharingInfo.get(accessLevel);
-            recipients.toXContent(builder, params);
+    public XContentBuilder toXContent(XContentBuilder b, Params params) throws IOException {
+        b.startObject();
+        for (Map.Entry<String, Recipients> e : this.sharingInfo.entrySet()) {
+            Recipients norm = pruneRecipients(e.getValue());
+            if (norm == null) continue; // skip empty level
+            b.field(e.getKey());
+            norm.toXContent(b, params); // TODO ensure this skips empty arrays too
         }
-
-        return builder.endObject();
+        return b.endObject();
     }
 
     public static ShareWith fromXContent(XContentParser parser) throws IOException {
@@ -148,7 +148,7 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
                 return orig;
             });
         }
-        return new ShareWith(updated);
+        return new ShareWith(updated).prune();
     }
 
     /**
@@ -164,9 +164,39 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
             Recipients revokeRecipients = entry.getValue();
             updated.computeIfPresent(level, (lvl, orig) -> {
                 orig.revoke(revokeRecipients);
-                return orig;
+                return pruneRecipients(orig); // removes any null levels
             });
         }
-        return new ShareWith(updated);
+        return new ShareWith(updated).prune();
     }
+
+    /** Return a normalized ShareWith with no empty buckets and no empty action-groups. */
+    public ShareWith prune() {
+        Map<String, Recipients> cleaned = new HashMap<>();
+        for (Map.Entry<String, Recipients> e : this.sharingInfo.entrySet()) {
+            Recipients prunedRecipients = pruneRecipients(e.getValue());
+            if (prunedRecipients != null) {
+                cleaned.put(e.getKey(), prunedRecipients);
+            }
+        }
+        return new ShareWith(cleaned);
+    }
+
+    private static Recipients pruneRecipients(Recipients r) {
+        if (r == null) return null;
+        Map<Recipient, Set<String>> src = r.getRecipients();
+        if (src == null || src.isEmpty()) return null;
+
+        Map<Recipient, Set<String>> cleaned = new EnumMap<>(Recipient.class);
+        for (Map.Entry<Recipient, Set<String>> e : src.entrySet()) {
+            Set<String> vals = e.getValue();
+            if (vals == null) continue;
+            Set<String> filtered = vals.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+            if (!filtered.isEmpty()) cleaned.put(e.getKey(), filtered);
+        }
+        return cleaned.isEmpty() ? null : new Recipients(cleaned); // use your builder/ctor
+    }
+
 }

--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ShareWith.java
@@ -11,8 +11,10 @@ package org.opensearch.security.spi.resources.sharing;
 import java.io.IOException;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.opensearch.core.common.io.stream.NamedWriteable;
 import org.opensearch.core.common.io.stream.StreamInput;
@@ -193,10 +195,10 @@ public class ShareWith implements ToXContentFragment, NamedWriteable {
             if (vals == null) continue;
             Set<String> filtered = vals.stream()
                 .filter(s -> s != null && !s.isBlank())
-                .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
+                .collect(Collectors.toCollection(LinkedHashSet::new));
             if (!filtered.isEmpty()) cleaned.put(e.getKey(), filtered);
         }
-        return cleaned.isEmpty() ? null : new Recipients(cleaned); // use your builder/ctor
+        return cleaned.isEmpty() ? null : new Recipients(cleaned);
     }
 
 }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -709,9 +709,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
                     OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
                 )) {
-                    handlers.add(new ShareRestAction());
+                    handlers.add(new ShareRestAction(resourcePluginInfo));
                     handlers.add(new ResourceTypesRestAction(resourcePluginInfo));
-                    handlers.add(new AccessibleResourcesRestAction(resourceAccessHandler));
+                    handlers.add(new AccessibleResourcesRestAction(resourceAccessHandler, resourcePluginInfo));
                 }
 
             }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -779,7 +779,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
             )) {
                 // Listening on POST and DELETE operations in resource indices
-                ResourceIndexListener resourceIndexListener = new ResourceIndexListener(threadPool, localClient);
+                ResourceIndexListener resourceIndexListener = new ResourceIndexListener(threadPool, localClient, resourcePluginInfo);
                 // CS-SUPPRESS-SINGLE: RegexpSingleline get Resource Sharing Extensions
                 Set<String> resourceIndices = resourcePluginInfo.getResourceIndices();
                 // CS-ENFORCE-SINGLE
@@ -1182,7 +1182,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         final CompatConfig compatConfig = new CompatConfig(environment, transportPassiveAuthSetting);
 
-        rsIndexHandler = new ResourceSharingIndexHandler(localClient, threadPool);
+        rsIndexHandler = new ResourceSharingIndexHandler(localClient, threadPool, resourcePluginInfo);
         evaluator = new PrivilegesEvaluator(
             clusterService,
             clusterService::state,
@@ -1231,12 +1231,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             // CS-ENFORCE-SINGLE
         }
 
-        resourceAccessEvaluator = new ResourceAccessEvaluator(
-            resourcePluginInfo.getResourceIndices(),
-            settings,
-            resourceAccessHandler,
-            resourcePluginInfo
-        );
+        resourceAccessEvaluator = new ResourceAccessEvaluator(resourcePluginInfo.getResourceIndices(), settings, resourceAccessHandler);
 
         sf = new SecurityFilter(
             settings,

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -181,6 +181,8 @@ import org.opensearch.security.resources.ResourceAccessHandler;
 import org.opensearch.security.resources.ResourceIndexListener;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.resources.ResourceSharingIndexHandler;
+import org.opensearch.security.resources.api.list.AccessibleResourcesRestAction;
+import org.opensearch.security.resources.api.list.ResourceTypesRestAction;
 import org.opensearch.security.resources.api.share.ShareAction;
 import org.opensearch.security.resources.api.share.ShareRestAction;
 import org.opensearch.security.resources.api.share.ShareTransportAction;
@@ -294,6 +296,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     private volatile PasswordHasher passwordHasher;
     private volatile DlsFlsBaseContext dlsFlsBaseContext;
     private ResourceSharingIndexHandler rsIndexHandler;
+    private ResourceAccessHandler resourceAccessHandler;
     private final ResourcePluginInfo resourcePluginInfo = new ResourcePluginInfo();
     // CS-SUPPRESS-SINGLE: RegexpSingleline get Extensions Settings
     private final Set<ResourceSharingExtension> resourceSharingExtensions = new HashSet<>();
@@ -697,6 +700,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
                 )) {
                     handlers.add(new ShareRestAction());
+                    handlers.add(new ResourceTypesRestAction(resourcePluginInfo));
+                    handlers.add(new AccessibleResourcesRestAction(resourceAccessHandler));
                 }
 
             }
@@ -1200,7 +1205,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             cr.subscribeOnChange(configMap -> { ((DlsFlsValveImpl) dlsFlsValve).updateConfiguration(cr.getConfiguration(CType.ROLES)); });
         }
 
-        ResourceAccessHandler resourceAccessHandler = new ResourceAccessHandler(threadPool, rsIndexHandler, adminDns, evaluator);
+        resourceAccessHandler = new ResourceAccessHandler(threadPool, rsIndexHandler, adminDns, evaluator);
         if (settings.getAsBoolean(
             ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
             ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -90,7 +90,6 @@ import org.opensearch.security.privileges.PrivilegesEvaluator;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.ResourceAccessEvaluator;
 import org.opensearch.security.resolver.IndexResolverReplacer;
-import org.opensearch.security.resources.ResourceAccessHandler;
 import org.opensearch.security.support.Base64Helper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.HeaderHelper;
@@ -133,8 +132,7 @@ public class SecurityFilter implements ActionFilter {
         final CompatConfig compatConfig,
         final IndexResolverReplacer indexResolverReplacer,
         final XFFResolver xffResolver,
-        Set<String> resourceIndices,
-        ResourceAccessHandler resourceAccessHandler
+        ResourceAccessEvaluator resourceAccessEvaluator
     ) {
         this.evalp = evalp;
         this.adminDns = adminDns;
@@ -150,7 +148,7 @@ public class SecurityFilter implements ActionFilter {
         );
         this.rolesInjector = new RolesInjector(auditLog);
         this.userInjector = new UserInjector(settings, threadPool, auditLog, xffResolver);
-        this.resourceAccessEvaluator = new ResourceAccessEvaluator(resourceIndices, settings, resourceAccessHandler);
+        this.resourceAccessEvaluator = resourceAccessEvaluator;
         log.info("{} indices are made immutable.", immutableIndicesMatcher);
     }
 

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -10,6 +10,8 @@
 
 package org.opensearch.security.privileges;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -21,6 +23,9 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
 import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.resources.ResourcePluginInfo;
+import org.opensearch.security.spi.resources.sharing.Recipient;
+import org.opensearch.security.spi.resources.sharing.ResourceSharing;
 import org.opensearch.security.support.ConfigConstants;
 
 /**
@@ -39,14 +44,23 @@ import org.opensearch.security.support.ConfigConstants;
 public class ResourceAccessEvaluator {
     private static final Logger log = LogManager.getLogger(ResourceAccessEvaluator.class);
 
+    public static final String SHARE_PERMISSION = "cluster:admin/security/resource/share";
+
     private final Set<String> resourceIndices;
     private final Settings settings;
     private final ResourceAccessHandler resourceAccessHandler;
+    private final ResourcePluginInfo resourcePluginInfo;
 
-    public ResourceAccessEvaluator(Set<String> resourceIndices, Settings settings, ResourceAccessHandler resourceAccessHandler) {
+    public ResourceAccessEvaluator(
+        Set<String> resourceIndices,
+        Settings settings,
+        ResourceAccessHandler resourceAccessHandler,
+        ResourcePluginInfo resourcePluginInfo
+    ) {
         this.resourceIndices = resourceIndices;
         this.settings = settings;
         this.resourceAccessHandler = resourceAccessHandler;
+        this.resourcePluginInfo = resourcePluginInfo;
     }
 
     /**
@@ -109,6 +123,54 @@ public class ResourceAccessEvaluator {
             return false;
         }
         return true;
+    }
+
+    /** Resolve access-level for THIS resource type and check required action. */
+    public boolean groupAllows(String resourceType, String accessLevel, String requiredAction) {
+        if (resourceType == null || accessLevel == null || requiredAction == null) return false;
+        return resourcePluginInfo.flattenedForType(resourceType).resolve(Set.of(accessLevel)).contains(requiredAction);
+    }
+
+    /**
+     * Checks whether current user has sharing permission
+     * @param resource
+     * @param resourceType
+     * @param ctx
+     * @param isAdmin
+     * @return
+     */
+    public boolean canUserShare(ResourceSharing resource, String resourceType, PrivilegesEvaluationContext ctx, boolean isAdmin) {
+        if (resource == null) return false;
+
+        if (isAdmin || resource.isCreatedBy(ctx.getUser().getName())) return true;
+
+        var sw = resource.getShareWith();
+        if (sw == null || sw.getSharingInfo().isEmpty()) return false;
+
+        Set<String> users = Set.of(ctx.getUser().getName());
+        Set<String> roles = new HashSet<>(ctx.getUser().getSecurityRoles());
+        Set<String> backend = new HashSet<>(ctx.getUser().getRoles());
+
+        for (String level : sw.getSharingInfo().keySet()) {
+            if (!groupAllows(resourceType, level, SHARE_PERMISSION)) continue;
+
+            var recips = sw.atAccessLevel(level);
+            if (recips == null) continue;
+
+            var u = recips.getRecipients().getOrDefault(Recipient.USERS, Set.of());
+            var r = recips.getRecipients().getOrDefault(Recipient.ROLES, Set.of());
+            var b = recips.getRecipients().getOrDefault(Recipient.BACKEND_ROLES, Set.of());
+
+            boolean matches = u.contains("*")
+                || r.contains("*")
+                || b.contains("*")
+                || !Collections.disjoint(u, users)
+                || !Collections.disjoint(r, roles)
+                || !Collections.disjoint(b, backend);
+
+            if (matches) return true;
+        }
+        return false;
     }
 
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
@@ -38,6 +38,7 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
      *
      * @param resourceId    The ID of the resource to verify.
      * @param resourceIndex The index in which the resource resides.
+     * @param action        The action to be evaluated against
      * @param listener      Callback that receives {@code true} if access is granted, {@code false} otherwise.
      */
     @Override

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -204,7 +204,7 @@ public class ResourceAccessHandler {
         Set<String> userBackendRoles = new HashSet<>(user.getRoles());
 
         // At present, plugins and tokens are not supported for access to resources
-        if (!(effectiveContext.getActionPrivileges() instanceof RoleBasedActionPrivileges roleBasedActionPrivileges)) {
+        if (!(effectiveContext.getActionPrivileges() instanceof RoleBasedActionPrivileges)) {
             LOGGER.debug(
                 "Plugin/Token access to resources is currently not supported. {} is not authorized to access resource {}.",
                 user.getName(),

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -152,7 +152,7 @@ public class ResourceAccessHandler {
         }
 
         if (adminDNs.isAdmin(user)) {
-            loadAllResourceSharingRecords(resourceIndex, user, true, ActionListener.wrap(listener::onResponse, listener::onFailure));
+            loadAllResourceSharingRecords(resourceIndex, ActionListener.wrap(listener::onResponse, listener::onFailure));
             return;
         }
 
@@ -444,12 +444,7 @@ public class ResourceAccessHandler {
         this.resourceSharingIndexHandler.fetchAllResourceIds(resourceIndex, listener);
     }
 
-    private void loadAllResourceSharingRecords(
-        String resourceIndex,
-        User user,
-        boolean isAdmin,
-        ActionListener<Set<SharingRecord>> listener
-    ) {
-        this.resourceSharingIndexHandler.fetchAllResourceSharingRecords(resourceIndex, user, isAdmin, listener);
+    private void loadAllResourceSharingRecords(String resourceIndex, ActionListener<Set<SharingRecord>> listener) {
+        this.resourceSharingIndexHandler.fetchAllResourceSharingRecords(resourceIndex, listener);
     }
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -141,7 +141,7 @@ public class ResourceAccessHandler {
      * @param resourceIndex The resource index to check for accessible resources.
      * @param listener      The listener to be notified with the set of resource sharing records.
      */
-    public void getResourceSharingInfoForCurrentUser(@NonNull String resourceIndex, ActionListener<Set<ResourceSharing>> listener) {
+    public void getResourceSharingInfoForCurrentUser(@NonNull String resourceIndex, ActionListener<Set<SharingRecord>> listener) {
         UserSubjectImpl userSub = (UserSubjectImpl) threadContext.getPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER);
         User user = userSub == null ? null : userSub.getUser();
 
@@ -152,7 +152,7 @@ public class ResourceAccessHandler {
         }
 
         if (adminDNs.isAdmin(user)) {
-            loadAllResourceSharingRecords(resourceIndex, ActionListener.wrap(listener::onResponse, listener::onFailure));
+            loadAllResourceSharingRecords(resourceIndex, user, true, ActionListener.wrap(listener::onResponse, listener::onFailure));
             return;
         }
 
@@ -160,7 +160,7 @@ public class ResourceAccessHandler {
         BoolQueryBuilder query = getAccessibleResourcesBoolQuery(user.getName(), flatPrincipals);
 
         // 3) Fetch all accessible resource sharing records
-        resourceSharingIndexHandler.fetchAccessibleResourceSharingRecords(resourceIndex, flatPrincipals, query, listener);
+        resourceSharingIndexHandler.fetchAccessibleResourceSharingRecords(resourceIndex, user, flatPrincipals, query, listener);
     }
 
     /**
@@ -444,7 +444,12 @@ public class ResourceAccessHandler {
         this.resourceSharingIndexHandler.fetchAllResourceIds(resourceIndex, listener);
     }
 
-    private void loadAllResourceSharingRecords(String resourceIndex, ActionListener<Set<ResourceSharing>> listener) {
-        this.resourceSharingIndexHandler.fetchAllResourceSharingRecords(resourceIndex, listener);
+    private void loadAllResourceSharingRecords(
+        String resourceIndex,
+        User user,
+        boolean isAdmin,
+        ActionListener<Set<SharingRecord>> listener
+    ) {
+        this.resourceSharingIndexHandler.fetchAllResourceSharingRecords(resourceIndex, user, isAdmin, listener);
     }
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessHandler.java
@@ -432,20 +432,12 @@ public class ResourceAccessHandler {
         users.add(user.getName());
         users.add("*"); // for matching against publicly shared resource
 
-        // for roles:
-        Set<String> roles = new HashSet<>(user.getSecurityRoles());
-        roles.add("*"); // for matching against publicly shared resource
-
-        // for backend_roles:
-        Set<String> backendRoles = new HashSet<>(user.getRoles());
-        backendRoles.add("*"); // for matching against publicly shared resource
-
         // return flattened principals to build the bool query
         return Stream.concat(
             // users
             users.stream().map(u -> "user:" + u),
             // then roles and backend_roles
-            Stream.concat(roles.stream().map(r -> "role:" + r), backendRoles.stream().map(b -> "backend:" + b))
+            Stream.concat(user.getSecurityRoles().stream().map(r -> "role:" + r), user.getRoles().stream().map(b -> "backend:" + b))
         ).collect(Collectors.toSet());
     }
 

--- a/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
@@ -39,7 +39,7 @@ public class ResourceActionGroupsHelper {
      *
      * Sample yml file:
      *   resource_types:
-     *   org.opensearch.sample.SampleResource:
+     *   sample_resource:
      *       sample_read_only:
      *         - "cluster:admin/sample-resource-plugin/get"
      *         - "indices:data/read*"
@@ -70,11 +70,11 @@ public class ResourceActionGroupsHelper {
 
                 // For each type this extension provides, read its OWN map directly as groups (no wrapper)
                 for (var rp : ext.getResourceProviders()) {
-                    String typeFqn = rp.resourceType();
+                    String resType = rp.resourceType();
 
-                    Object typeCfgNode = byType.get(typeFqn);
+                    Object typeCfgNode = byType.get(resType);
                     if (!(typeCfgNode instanceof Map<?, ?> typeMapRaw)) {
-                        log.info("No per-type block for {} in {}", typeFqn, ext.getClass().getName());
+                        log.info("No per-type block for {} in {}", resType, ext.getClass().getName());
                         continue; // no fallback
                     }
 
@@ -99,10 +99,10 @@ public class ResourceActionGroupsHelper {
                     FlattenedActionGroups flattened = new FlattenedActionGroups(cfg);
 
                     // Publish to ResourcePluginInfo → used by UI and authZ
-                    resourcePluginInfo.registerActionGroupNames(typeFqn, cfg.getCEntries().keySet());
-                    resourcePluginInfo.registerFlattened(typeFqn, flattened);
+                    resourcePluginInfo.registerActionGroupNames(resType, cfg.getCEntries().keySet());
+                    resourcePluginInfo.registerFlattened(resType, flattened);
 
-                    log.info("Registered {} action-groups for {}", cfg.getCEntries().size(), typeFqn);
+                    log.info("Registered {} action-groups for {}", cfg.getCEntries().size(), resType);
                 }
 
             } catch (Exception e) {

--- a/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
@@ -26,6 +26,7 @@ import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 
 import org.yaml.snakeyaml.Yaml;
 
+// CS-SUPPRESS-SINGLE: RegexpSingleline get Resource Sharing Extensions
 /**
  * Helper class to load `resource-action-groups.yml` file for all resource sharing extensions.
  */
@@ -155,3 +156,4 @@ public class ResourceActionGroupsHelper {
         return new Yaml().dump(normalized);
     }
 }
+// CS-ENFORCE-SINGLE

--- a/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceActionGroupsHelper.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.security.securityconf.FlattenedActionGroups;
+import org.opensearch.security.securityconf.impl.CType;
+import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
+
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Helper class to load `resource-action-groups.yml` file for all resource sharing extensions.
+ */
+public class ResourceActionGroupsHelper {
+    public static final Logger log = LogManager.getLogger(ResourceActionGroupsHelper.class);
+
+    /**
+     * Loads action-groups config from the {@code resource-action-groups.yml} file from each resource sharing extension
+     * @param resourcePluginInfo will store the loaded action-groups config
+     *
+     * Sample yml file:
+     *   resource_types:
+     *   org.opensearch.sample.SampleResource:
+     *       sample_read_only:
+     *         - "cluster:admin/sample-resource-plugin/get"
+     *         - "indices:data/read*"
+     */
+    public static void loadActionGroupsConfig(ResourcePluginInfo resourcePluginInfo) {
+        var exts = resourcePluginInfo.getResourceSharingExtensions();
+        for (var ext : exts) {
+            URL url = ext.getClass().getClassLoader().getResource("resource-action-groups.yml");
+            if (url == null) {
+                log.info("resource-action-groups.yml not found for {}", ext.getClass().getName());
+                continue;
+            }
+
+            try (var in = url.openStream()) {
+                String yaml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+
+                Map<String, Object> root = new Yaml().load(yaml);
+                if (root == null) {
+                    log.info("Empty resource-action-groups.yml for {}", ext.getClass().getName());
+                    continue;
+                }
+
+                Object rtNode = root.get("resource_types");
+                if (!(rtNode instanceof Map<?, ?> byType)) {
+                    log.warn("'resource_types' missing or invalid in {}", ext.getClass().getName());
+                    continue;
+                }
+
+                // For each type this extension provides, read its OWN map directly as groups (no wrapper)
+                for (var rp : ext.getResourceProviders()) {
+                    String typeFqn = rp.resourceType();
+
+                    Object typeCfgNode = byType.get(typeFqn);
+                    if (!(typeCfgNode instanceof Map<?, ?> typeMapRaw)) {
+                        log.info("No per-type block for {} in {}", typeFqn, ext.getClass().getName());
+                        continue; // no fallback
+                    }
+
+                    // buildActionGroupsYaml() accepts only lists-of-strings; anything else becomes allowed_actions: []
+                    String perTypeAgYaml = buildActionGroupsYaml(typeMapRaw);
+
+                    // Parse + flatten for THIS type
+                    SecurityDynamicConfiguration<ActionGroupsV7> cfg = SecurityDynamicConfiguration.fromYaml(
+                        perTypeAgYaml,
+                        CType.ACTIONGROUPS
+                    );
+
+                    // prune groups that ended up empty after normalization
+                    cfg.getCEntries()
+                        .entrySet()
+                        .removeIf(
+                            e -> e.getValue() == null
+                                || e.getValue().getAllowed_actions() == null
+                                || e.getValue().getAllowed_actions().isEmpty()
+                        );
+
+                    FlattenedActionGroups flattened = new FlattenedActionGroups(cfg);
+
+                    // Publish to ResourcePluginInfo → used by UI and authZ
+                    resourcePluginInfo.registerActionGroupNames(typeFqn, cfg.getCEntries().keySet());
+                    resourcePluginInfo.registerFlattened(typeFqn, flattened);
+
+                    log.info("Registered {} action-groups for {}", cfg.getCEntries().size(), typeFqn);
+                }
+
+            } catch (Exception e) {
+                log.warn("Failed loading/parsing resource-action-groups.yml for {}: {}", ext.getClass().getName(), e.toString());
+            }
+        }
+    }
+
+    /**
+     * Build a minimal action-groups YAML from a per-type "action_groups" map.
+     * Input shape:
+     * { actionGroupName -> [ ... ] }
+     * Output YAML:
+     *   actionGroupName:
+     *     allowed_actions:
+     *       - "..."
+     */
+    private static String buildActionGroupsYaml(Map<?, ?> groupsRaw) {
+        Map<String, Object> normalized = new LinkedHashMap<>();
+
+        if (groupsRaw != null) {
+            for (Map.Entry<?, ?> e : groupsRaw.entrySet()) {
+                String group = String.valueOf(e.getKey());
+                Object v = e.getValue();
+
+                // default to empty list
+                List<String> actions = List.of();
+
+                // Accept ONLY shape A: group: [ "action:a", "action:b", ... ]
+                if (v instanceof Collection<?> coll) {
+                    List<String> tmp = new ArrayList<>(coll.size());
+                    boolean allStrings = true;
+                    for (Object item : coll) {
+                        if (!(item instanceof String s)) {
+                            allStrings = false;
+                            break;
+                        }
+                        tmp.add(s);
+                    }
+                    if (allStrings) {
+                        actions = tmp;
+                    }
+                }
+
+                Map<String, Object> groupObj = new LinkedHashMap<>();
+                groupObj.put("allowed_actions", actions);
+                normalized.put(group, groupObj);
+            }
+        }
+
+        return new Yaml().dump(normalized);
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
@@ -38,9 +38,9 @@ public class ResourceIndexListener implements IndexingOperationListener {
 
     private final ThreadPool threadPool;
 
-    public ResourceIndexListener(ThreadPool threadPool, Client client) {
+    public ResourceIndexListener(ThreadPool threadPool, Client client, ResourcePluginInfo resourcePluginInfo) {
         this.threadPool = threadPool;
-        this.resourceSharingIndexHandler = new ResourceSharingIndexHandler(client, threadPool);
+        this.resourceSharingIndexHandler = new ResourceSharingIndexHandler(client, threadPool, resourcePluginInfo);
     }
 
     /**

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -51,8 +51,9 @@ public class ResourcePluginInfo {
         resourceSharingExtensions.clear();
         resourceSharingExtensions.addAll(extensions);
 
-        // also cache type→index mapping
+        // also cache type->index and index->type mapping
         typeToIndex.clear();
+        indexToType.clear();
         for (var ext : extensions) {
             for (var rp : ext.getResourceProviders()) {
                 typeToIndex.put(rp.resourceType(), rp.resourceIndexName());

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -82,13 +82,12 @@ public class ResourcePluginInfo {
 
     /** Register/merge action-group names for a given resource type. */
 
-    public record ResourceDashboardInfo(String resourceType, String resourceIndexName, Set<String> actionGroups // names only (for UI)
+    public record ResourceDashboardInfo(String resourceType, Set<String> actionGroups // names only (for UI)
     ) implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder b, Params p) throws IOException {
             b.startObject();
             b.field("type", resourceType);
-            b.field("index", resourceIndexName);
             b.field("action_groups", actionGroups == null ? Collections.emptyList() : actionGroups);
             return b.endObject();
         }
@@ -113,13 +112,16 @@ public class ResourcePluginInfo {
         return indexToType.get(index);
     }
 
+    public String indexByType(String type) {
+        return typeToIndex.get(type);
+    }
+
     public Set<ResourceDashboardInfo> getResourceTypes() {
         return typeToIndex.entrySet()
             .stream()
             .map(
                 e -> new ResourceDashboardInfo(
                     e.getKey(),
-                    e.getValue(),
                     Collections.unmodifiableSet(typeToGroupNames.getOrDefault(e.getKey(), new LinkedHashSet<>()))
                 )
             )

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -69,11 +69,6 @@ public class ResourcePluginInfo {
 
     public record ResourceDashboardInfo(String resourceType, String resourceIndexName, Set<String> actionGroups // names only (for UI)
     ) implements ToXContentObject {
-        // public ResourceDashboardInfo {
-        // Objects.requireNonNull(resourceType, "resourceType");
-        // Objects.requireNonNull(resourceIndexName, "resourceIndexName");
-        // Objects.requireNonNull(actionGroups, "actionGroups");
-        // }
         @Override
         public XContentBuilder toXContent(XContentBuilder b, Params p) throws IOException {
             b.startObject();

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -10,6 +10,8 @@ package org.opensearch.security.resources;
 
 // CS-SUPPRESS-SINGLE: RegexpSingleline get Resource Sharing Extensions
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -40,6 +42,22 @@ public class ResourcePluginInfo {
         return resourceSharingExtensions.stream()
             .flatMap(ext -> ext.getResourceProviders().stream().map(ResourceProvider::resourceIndexName))
             .collect(Collectors.toSet());
+    }
+
+    public record ResourceTypeAndIndex(String resourceType, String resourceIndexName) {
+        public ResourceTypeAndIndex {
+            Objects.requireNonNull(resourceType, "resourceType");
+            Objects.requireNonNull(resourceIndexName, "resourceIndexName");
+        }
+    }
+
+    /** Returns unique (resourceType, resourceIndexName) pairs. */
+    public Set<ResourceTypeAndIndex> getResourceTypes() {
+        Set<ResourceTypeAndIndex> pairs = resourceSharingExtensions.stream()
+            .flatMap(ext -> ext.getResourceProviders().stream())
+            .map(rp -> new ResourceTypeAndIndex(rp.resourceType(), rp.resourceIndexName()))
+            .collect(Collectors.toCollection(LinkedHashSet::new)); // deterministic order
+        return ImmutableSet.copyOf(pairs);
     }
 }
 // CS-ENFORCE-SINGLE

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -58,6 +58,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.index.query.AbstractQueryBuilder;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -382,6 +383,11 @@ public class ResourceSharingIndexHandler {
                 LOGGER.debug("Found {} accessible resources in {}", resourceIds.size(), resourceIndex);
                 listener.onResponse(resourceIds);
             }, exception -> {
+                if (exception instanceof IndexNotFoundException) {
+                    LOGGER.debug("Index {} not found, returning empty set", resourceIndex, exception);
+                    listener.onResponse(Collections.emptySet());
+                    return;
+                }
                 LOGGER.error("Search failed for resourceIndex={}, entities={}", resourceIndex, entities, exception);
                 listener.onFailure(exception);
             }));

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -685,8 +685,6 @@ public class ResourceSharingIndexHandler {
 
             ResourceSharing updatedSharingInfo = new ResourceSharing(resourceId, resourceSharing.getCreatedBy(), cleaned);
 
-            LOGGER.info("updted {}", updatedSharingInfo);
-
             try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
                 // update the record
                 IndexRequest ir = client.prepareIndex(resourceSharingIndex)

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -692,7 +692,13 @@ public class ResourceSharingIndexHandler {
                 updatedShareWith = updatedShareWith.revoke(revoke);
             }
 
-            ShareWith cleaned = updatedShareWith == null ? null : updatedShareWith.prune();
+            ShareWith cleaned = null;
+            if (updatedShareWith != null) {
+                ShareWith pruned = updatedShareWith.prune();
+                if (!pruned.isPrivate()) {
+                    cleaned = pruned; // store only if something non-empty remains
+                }
+            }
 
             ResourceSharing updatedSharingInfo = new ResourceSharing(resourceId, resourceSharing.getCreatedBy(), cleaned);
 

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -256,12 +256,7 @@ public class ResourceSharingIndexHandler {
         }
     }
 
-    public void fetchAllResourceSharingRecords(
-        String resourceIndex,
-        User user,
-        boolean isAdmin,
-        ActionListener<Set<SharingRecord>> listener
-    ) {
+    public void fetchAllResourceSharingRecords(String resourceIndex, ActionListener<Set<SharingRecord>> listener) {
         String resourceSharingIndex = getSharingIndex(resourceIndex);
         LOGGER.debug("Fetching all documents asynchronously from {}", resourceSharingIndex);
         Scroll scroll = new Scroll(TimeValue.timeValueMinutes(1L));

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -681,7 +681,11 @@ public class ResourceSharingIndexHandler {
                 updatedShareWith = updatedShareWith.revoke(revoke);
             }
 
-            ResourceSharing updatedSharingInfo = new ResourceSharing(resourceId, resourceSharing.getCreatedBy(), updatedShareWith);
+            ShareWith cleaned = updatedShareWith == null ? null : updatedShareWith.prune();
+
+            ResourceSharing updatedSharingInfo = new ResourceSharing(resourceId, resourceSharing.getCreatedBy(), cleaned);
+
+            LOGGER.info("updted {}", updatedSharingInfo);
 
             try (ThreadContext.StoredContext ctx = this.threadPool.getThreadContext().stashContext()) {
                 // update the record

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -375,12 +375,12 @@ public class ResourceSharingIndexHandler {
 
             // We match any doc whose "principals" contains at least one of the entities
             // e.g., "user:alice", "role:admin", "backend:ops"
-            BoolQueryBuilder boolQuery = QueryBuilders.boolQuery()
-                .filter(QueryBuilders.termsQuery("all_shared_principals.keyword", entities));
+            BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("all_shared_principals", entities));
+            LOGGER.debug("Fetching accessible resource ids query {}", boolQuery);
 
             executeIdCollectingSearchRequest(scroll, searchRequest, boolQuery, ActionListener.wrap(resourceIds -> {
                 ctx.restore();
-                LOGGER.debug("Found {} accessible resources in {}", resourceIds.size(), resourceIndex);
+                LOGGER.debug("Found {} accessible resources in {} for entities {}", resourceIds.size(), resourceIndex, entities);
                 listener.onResponse(resourceIds);
             }, exception -> {
                 if (exception instanceof IndexNotFoundException) {

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -1010,11 +1010,8 @@ public class ResourceSharingIndexHandler {
         // Phase 1: resolve resource IDs from the RESOURCE index
         fetchAccessibleResourceIds(resourceIndex, flatPrincipals, ActionListener.wrap(ids -> {
             if (ids == null || ids.isEmpty()) {
-                try {
-                    listener.onResponse(Collections.emptySet());
-                } finally {
-                    stored.restore();
-                }
+                stored.restore();
+                listener.onResponse(Collections.emptySet());
                 return;
             }
 
@@ -1031,11 +1028,9 @@ public class ResourceSharingIndexHandler {
             submitNextRef.set(() -> {
                 int start = cursor.getAndAdd(BATCH); // offset
                 if (start >= idList.size()) {
-                    try {
-                        listener.onResponse(out);
-                    } finally {
-                        stored.restore();
-                    }
+                    stored.restore();
+                    listener.onResponse(out);
+
                     return;
                 }
                 int end = Math.min(start + BATCH, idList.size());
@@ -1083,11 +1078,8 @@ public class ResourceSharingIndexHandler {
             submitNextRef.get().run();
 
         }, e -> {
-            try {
-                listener.onFailure(e);
-            } finally {
-                stored.restore();
-            }
+            stored.restore();
+            listener.onFailure(e);
         }));
     }
 

--- a/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceSharingIndexHandler.java
@@ -376,7 +376,6 @@ public class ResourceSharingIndexHandler {
             // We match any doc whose "principals" contains at least one of the entities
             // e.g., "user:alice", "role:admin", "backend:ops"
             BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termsQuery("all_shared_principals", entities));
-            LOGGER.debug("Fetching accessible resource ids query {}", boolQuery);
 
             executeIdCollectingSearchRequest(scroll, searchRequest, boolQuery, ActionListener.wrap(resourceIds -> {
                 ctx.restore();

--- a/src/main/java/org/opensearch/security/resources/SharingRecord.java
+++ b/src/main/java/org/opensearch/security/resources/SharingRecord.java
@@ -9,71 +9,27 @@
 package org.opensearch.security.resources;
 
 import java.io.IOException;
-import java.util.Objects;
 
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
-import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.security.spi.resources.sharing.CreatedBy;
-import org.opensearch.security.spi.resources.sharing.ShareWith;
+import org.opensearch.security.spi.resources.sharing.ResourceSharing;
 
-public class SharingRecord implements ToXContentObject {
-    private String resourceId;
-    private CreatedBy createdBy;
-    private ShareWith shareWith;
-    private boolean canShare;
-
-    public SharingRecord(String resourceId, CreatedBy createdBy, ShareWith shareWith) {
-        this.resourceId = resourceId;
-        this.createdBy = createdBy;
-        this.shareWith = shareWith;
-        this.canShare = false;
-    }
-
-    public void setCanShare(boolean canShare) {
-        this.canShare = canShare;
-    }
+public record SharingRecord(ResourceSharing resourceSharing, boolean canShare) implements ToXContentObject {
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field("resourceId", resourceId);
-        builder.field("createdBy", createdBy);
-        builder.field("shareWith", shareWith);
-        builder.field("canShare", canShare);
+        builder.field("resource_id", resourceSharing.getResourceId());
+
+        builder.field("created_by");
+        resourceSharing.getCreatedBy().toXContent(builder, params);
+
+        if (resourceSharing.getShareWith() != null) {
+            builder.field("share_with");
+            resourceSharing.getShareWith().toXContent(builder, params);
+        }
+        builder.field("can_share", canShare);
         builder.endObject();
         return builder;
-    }
-
-    public static SharingRecord fromXContent(XContentParser parser) throws IOException {
-        String resourceId = null;
-        CreatedBy createdBy = null;
-        ShareWith shareWith = null;
-
-        String currentFieldName = null;
-        XContentParser.Token token;
-
-        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
-            if (token == XContentParser.Token.FIELD_NAME) {
-                currentFieldName = parser.currentName();
-            } else {
-                switch (Objects.requireNonNull(currentFieldName)) {
-                    case "resource_id":
-                        resourceId = parser.text();
-                        break;
-                    case "created_by":
-                        createdBy = CreatedBy.fromXContent(parser);
-                        break;
-                    case "share_with":
-                        shareWith = ShareWith.fromXContent(parser);
-                        break;
-                    default:
-                        parser.skipChildren();
-                        break;
-                }
-            }
-        }
-
-        return new SharingRecord(resourceId, createdBy, shareWith);
     }
 }

--- a/src/main/java/org/opensearch/security/resources/SharingRecord.java
+++ b/src/main/java/org/opensearch/security/resources/SharingRecord.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.security.spi.resources.sharing.CreatedBy;
+import org.opensearch.security.spi.resources.sharing.ShareWith;
+
+public class SharingRecord implements ToXContentObject {
+    private String resourceId;
+    private CreatedBy createdBy;
+    private ShareWith shareWith;
+    private boolean canShare;
+
+    public SharingRecord(String resourceId, CreatedBy createdBy, ShareWith shareWith) {
+        this.resourceId = resourceId;
+        this.createdBy = createdBy;
+        this.shareWith = shareWith;
+        this.canShare = false;
+    }
+
+    public void setCanShare(boolean canShare) {
+        this.canShare = canShare;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("resourceId", resourceId);
+        builder.field("createdBy", createdBy);
+        builder.field("shareWith", shareWith);
+        builder.field("canShare", canShare);
+        builder.endObject();
+        return builder;
+    }
+
+    public static SharingRecord fromXContent(XContentParser parser) throws IOException {
+        String resourceId = null;
+        CreatedBy createdBy = null;
+        ShareWith shareWith = null;
+
+        String currentFieldName = null;
+        XContentParser.Token token;
+
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else {
+                switch (Objects.requireNonNull(currentFieldName)) {
+                    case "resource_id":
+                        resourceId = parser.text();
+                        break;
+                    case "created_by":
+                        createdBy = CreatedBy.fromXContent(parser);
+                        break;
+                    case "share_with":
+                        shareWith = ShareWith.fromXContent(parser);
+                        break;
+                    default:
+                        parser.skipChildren();
+                        break;
+                }
+            }
+        }
+
+        return new SharingRecord(resourceId, createdBy, shareWith);
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/SharingRecord.java
+++ b/src/main/java/org/opensearch/security/resources/SharingRecord.java
@@ -14,6 +14,11 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.security.spi.resources.sharing.ResourceSharing;
 
+/**
+ * Record class that is used as response to dashboards api {@code `/resource/list`} request
+ * @param resourceSharing the sharing record document to be returned
+ * @param canShare to indicate whether user can share this further
+ */
 public record SharingRecord(ResourceSharing resourceSharing, boolean canShare) implements ToXContentObject {
 
     @Override

--- a/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
@@ -26,6 +26,7 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.resources.SharingRecord;
 import org.opensearch.transport.client.node.NodeClient;
 
@@ -41,10 +42,12 @@ public class AccessibleResourcesRestAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(AccessibleResourcesRestAction.class);
 
     private final ResourceAccessHandler resourceAccessHandler;
+    private final ResourcePluginInfo resourcePluginInfo;
 
-    public AccessibleResourcesRestAction(final ResourceAccessHandler resourceAccessHandler) {
+    public AccessibleResourcesRestAction(final ResourceAccessHandler resourceAccessHandler, ResourcePluginInfo resourcePluginInfo) {
         super();
         this.resourceAccessHandler = resourceAccessHandler;
+        this.resourcePluginInfo = resourcePluginInfo;
     }
 
     @Override
@@ -59,7 +62,9 @@ public class AccessibleResourcesRestAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
-        final String resourceIndex = Objects.requireNonNull(request.param("resource_type"), "resource_type is required");
+        final String resourceType = Objects.requireNonNull(request.param("resource_type"), "resource_type is required");
+
+        final String resourceIndex = resourcePluginInfo.indexByType(resourceType);
 
         return channel -> resourceAccessHandler.getResourceSharingInfoForCurrentUser(resourceIndex, ActionListener.wrap(rows -> {
 

--- a/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
@@ -63,8 +63,6 @@ public class AccessibleResourcesRestAction extends BaseRestHandler {
 
         return channel -> resourceAccessHandler.getResourceSharingInfoForCurrentUser(resourceIndex, ActionListener.wrap(rows -> {
 
-            // TODO evaluate which user can share and which cannot
-
             try (XContentBuilder b = channel.newBuilder()) {
                 b.startObject();
                 b.startArray("resources");

--- a/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
@@ -26,7 +26,7 @@ import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.resources.ResourceAccessHandler;
-import org.opensearch.security.spi.resources.sharing.ResourceSharing;
+import org.opensearch.security.resources.SharingRecord;
 import org.opensearch.transport.client.node.NodeClient;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
@@ -68,7 +68,7 @@ public class AccessibleResourcesRestAction extends BaseRestHandler {
             try (XContentBuilder b = channel.newBuilder()) {
                 b.startObject();
                 b.startArray("resources");
-                for (ResourceSharing row : rows) {
+                for (SharingRecord row : rows) {
                     row.toXContent(b, ToXContent.EMPTY_PARAMS);
                 }
                 b.endArray();

--- a/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/list/AccessibleResourcesRestAction.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.list;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.spi.resources.sharing.ResourceSharing;
+import org.opensearch.transport.client.node.NodeClient;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.security.dlic.rest.api.Responses.response;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_RESOURCE_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
+/**
+ * This class implements the list REST API to list accessible resources in a given resource type.
+ */
+public class AccessibleResourcesRestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(AccessibleResourcesRestAction.class);
+
+    private final ResourceAccessHandler resourceAccessHandler;
+
+    public AccessibleResourcesRestAction(final ResourceAccessHandler resourceAccessHandler) {
+        super();
+        this.resourceAccessHandler = resourceAccessHandler;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return addRoutesPrefix(ImmutableList.of(new Route(GET, "/list")), PLUGIN_API_RESOURCE_ROUTE_PREFIX);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getName();
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        final String resourceIndex = Objects.requireNonNull(request.param("resource_type"), "resource_type is required");
+
+        return channel -> resourceAccessHandler.getResourceSharingInfoForCurrentUser(resourceIndex, ActionListener.wrap(rows -> {
+
+            // TODO evaluate which user can share and which cannot
+
+            try (XContentBuilder b = channel.newBuilder()) {
+                b.startObject();
+                b.startArray("resources");
+                for (ResourceSharing row : rows) {
+                    row.toXContent(b, ToXContent.EMPTY_PARAMS);
+                }
+                b.endArray();
+                b.endObject();
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, b));
+            } catch (IOException ioe) {
+                handleError(channel, ioe);
+            }
+        }, e -> handleError(channel, e)));
+    }
+
+    private void handleError(RestChannel channel, Exception e) {
+        LOGGER.error("Error while processing request", e);
+        final String message = e.getMessage();
+        if (e instanceof OpenSearchStatusException ex) {
+            response(channel, ex.status(), message);
+        } else {
+            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/resources/api/list/ResourceTypesRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/list/ResourceTypesRestAction.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.list;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.OpenSearchStatusException;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.security.resources.ResourcePluginInfo;
+import org.opensearch.transport.client.node.NodeClient;
+
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.security.dlic.rest.api.Responses.response;
+import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_RESOURCE_ROUTE_PREFIX;
+import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
+
+/**
+ * This class implements the list REST API to list registered resource types.
+ */
+public class ResourceTypesRestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(ResourceTypesRestAction.class);
+
+    private final Set<ResourcePluginInfo.ResourceTypeAndIndex> resourceTypes;
+
+    public ResourceTypesRestAction(final ResourcePluginInfo resourcePluginInfo) {
+        super();
+        this.resourceTypes = resourcePluginInfo.getResourceTypes();
+    }
+
+    @Override
+    public List<Route> routes() {
+        return addRoutesPrefix(ImmutableList.of(new Route(GET, "/types")), PLUGIN_API_RESOURCE_ROUTE_PREFIX);
+    }
+
+    @Override
+    public String getName() {
+        return getClass().getName();
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        return channel -> {
+            try (XContentBuilder builder = channel.newBuilder()) { // NOSONAR
+                builder.startObject();
+                builder.startArray("types");
+                for (var p : resourceTypes) {
+                    builder.startObject();
+                    builder.field("type", p.resourceType());
+                    builder.field("index", p.resourceIndexName());
+                    builder.endObject();
+                }
+                builder.endArray();
+                builder.endObject();
+
+                channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+            } catch (Exception e) {
+                // handleError() writes the error response itself; don't send another response after this.
+                handleError(channel, e);
+            }
+        };
+    }
+
+    private void handleError(RestChannel channel, Exception e) {
+        LOGGER.error("Error while processing request", e);
+        final String message = e.getMessage();
+        if (e instanceof OpenSearchStatusException ex) {
+            response(channel, ex.status(), message);
+        } else {
+            channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, message));
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -19,6 +19,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import joptsimple.internal.Strings;
@@ -173,7 +174,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
             return new ShareRequest(this);
         }
 
-        public void parseContent(XContentParser xContentParser) throws IOException {
+        public void parseContent(XContentParser xContentParser, ResourcePluginInfo resourcePluginInfo) throws IOException {
             try (XContentParser parser = xContentParser) {
                 XContentParser.Token token; // START_OBJECT
                 while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
@@ -185,7 +186,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
                                 this.resourceId(parser.text());
                                 break;
                             case "resource_type":
-                                this.resourceIndex(parser.text());
+                                this.resourceIndex(resourcePluginInfo.indexByType(parser.text()));
                                 break;
                             case "share_with":
                                 this.shareWith(ShareWith.fromXContent(parser));

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -82,6 +82,8 @@ public class DashboardsInfoAction extends BaseRestHandler {
     private final PrivilegesEvaluator evaluator;
     private final ThreadContext threadContext;
 
+    private final boolean isResourceSharingFeatureEnabled;
+
     public static final String DEFAULT_PASSWORD_MESSAGE = "Password should be at least 8 characters long and contain at least one "
         + "uppercase letter, one lowercase letter, one digit, and one special character.";
 
@@ -94,6 +96,10 @@ public class DashboardsInfoAction extends BaseRestHandler {
         final ThreadPool threadPool
     ) {
         super();
+        isResourceSharingFeatureEnabled = settings.getAsBoolean(
+                ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
+                ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
+        );
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;
     }
@@ -139,6 +145,7 @@ public class DashboardsInfoAction extends BaseRestHandler {
                         "password_validation_regex",
                         client.settings().get(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX, DEFAULT_PASSWORD_REGEX)
                     );
+                    builder.field("resource_sharing_enabled", isResourceSharingFeatureEnabled);
                     builder.endObject();
 
                     response = new BytesRestResponse(RestStatus.OK, builder);

--- a/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
+++ b/src/main/java/org/opensearch/security/rest/DashboardsInfoAction.java
@@ -97,8 +97,8 @@ public class DashboardsInfoAction extends BaseRestHandler {
     ) {
         super();
         isResourceSharingFeatureEnabled = settings.getAsBoolean(
-                ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
-                ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
         );
         this.threadContext = threadPool.getThreadContext();
         this.evaluator = evaluator;

--- a/src/test/java/org/opensearch/security/filter/SecurityFilterTests.java
+++ b/src/test/java/org/opensearch/security/filter/SecurityFilterTests.java
@@ -13,7 +13,6 @@ package org.opensearch.security.filter;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
@@ -32,8 +31,8 @@ import org.opensearch.security.configuration.CompatConfig;
 import org.opensearch.security.configuration.DlsFlsRequestValve;
 import org.opensearch.security.http.XFFResolver;
 import org.opensearch.security.privileges.PrivilegesEvaluator;
+import org.opensearch.security.privileges.ResourceAccessEvaluator;
 import org.opensearch.security.resolver.IndexResolverReplacer;
-import org.opensearch.security.resources.ResourceAccessHandler;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.threadpool.ThreadPool;
@@ -91,8 +90,7 @@ public class SecurityFilterTests {
             mock(CompatConfig.class),
             mock(IndexResolverReplacer.class),
             mock(XFFResolver.class),
-            Set.of(),
-            mock(ResourceAccessHandler.class)
+            mock(ResourceAccessEvaluator.class)
         );
         assertThat(expected, equalTo(filter.getImmutableIndicesMatcher()));
     }
@@ -117,8 +115,7 @@ public class SecurityFilterTests {
             mock(CompatConfig.class),
             mock(IndexResolverReplacer.class),
             mock(XFFResolver.class),
-            Set.of(),
-            mock(ResourceAccessHandler.class)
+            mock(ResourceAccessEvaluator.class)
         );
 
         // Act

--- a/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
@@ -20,6 +20,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.security.auth.UserSubjectImpl;
 import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -45,6 +46,9 @@ public class ResourceAccessEvaluatorTest {
     private ResourceAccessHandler resourceAccessHandler;
 
     @Mock
+    private ResourcePluginInfo resourcePluginInfo;
+
+    @Mock
     private PrivilegesEvaluationContext context;
 
     private ThreadContext threadContext;
@@ -56,7 +60,7 @@ public class ResourceAccessEvaluatorTest {
     public void setup() {
         Settings settings = Settings.builder().put(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, true).build();
         threadContext = new ThreadContext(Settings.EMPTY);
-        evaluator = new ResourceAccessEvaluator(Collections.singleton(IDX), settings, resourceAccessHandler);
+        evaluator = new ResourceAccessEvaluator(Collections.singleton(IDX), settings, resourceAccessHandler, resourcePluginInfo);
     }
 
     private void stubAuthenticatedUser() {

--- a/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
@@ -20,9 +20,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.security.auth.UserSubjectImpl;
 import org.opensearch.security.resources.ResourceAccessHandler;
-import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.support.ConfigConstants;
-import org.opensearch.threadpool.ThreadPool;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -39,14 +37,9 @@ import static org.mockito.Mockito.verify;
 @RunWith(MockitoJUnitRunner.class)
 @SuppressWarnings("unchecked") // action listener mock
 public class ResourceAccessEvaluatorTest {
-    @Mock
-    private ThreadPool threadPool;
 
     @Mock
     private ResourceAccessHandler resourceAccessHandler;
-
-    @Mock
-    private ResourcePluginInfo resourcePluginInfo;
 
     @Mock
     private PrivilegesEvaluationContext context;
@@ -60,7 +53,7 @@ public class ResourceAccessEvaluatorTest {
     public void setup() {
         Settings settings = Settings.builder().put(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, true).build();
         threadContext = new ThreadContext(Settings.EMPTY);
-        evaluator = new ResourceAccessEvaluator(Collections.singleton(IDX), settings, resourceAccessHandler, resourcePluginInfo);
+        evaluator = new ResourceAccessEvaluator(Collections.singleton(IDX), settings, resourceAccessHandler);
     }
 
     private void stubAuthenticatedUser() {

--- a/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
+++ b/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
@@ -245,7 +245,7 @@ public class ResourceAccessHandlerTest {
         ActionListener<Set<String>> listener = mock(ActionListener.class);
 
         doAnswer(inv -> {
-            ActionListener<Set<String>> l = inv.getArgument(3);
+            ActionListener<Set<String>> l = inv.getArgument(2);
             l.onResponse(Set.of("res1"));
             return null;
         }).when(sharingIndexHandler).fetchAccessibleResourceIds(any(), any(), any());

--- a/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
+++ b/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
@@ -62,6 +62,9 @@ public class ResourceAccessHandlerTest {
     @Mock
     private RoleBasedActionPrivileges roleBasedPrivileges;
 
+    @Mock
+    private ResourcePluginInfo resourcePluginInfo;
+
     private ThreadContext threadContext;
     private ResourceAccessHandler handler;
 
@@ -73,7 +76,7 @@ public class ResourceAccessHandlerTest {
     public void setup() {
         threadContext = new ThreadContext(Settings.EMPTY);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
-        handler = new ResourceAccessHandler(threadPool, sharingIndexHandler, adminDNs, privilegesEvaluator);
+        handler = new ResourceAccessHandler(threadPool, sharingIndexHandler, adminDNs, privilegesEvaluator, resourcePluginInfo);
     }
 
     private void injectUser(User user) {

--- a/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
+++ b/src/test/java/org/opensearch/security/resources/ResourceAccessHandlerTest.java
@@ -248,7 +248,7 @@ public class ResourceAccessHandlerTest {
             ActionListener<Set<String>> l = inv.getArgument(3);
             l.onResponse(Set.of("res1"));
             return null;
-        }).when(sharingIndexHandler).fetchAccessibleResourceIds(any(), any(), any(), any());
+        }).when(sharingIndexHandler).fetchAccessibleResourceIds(any(), any(), any());
 
         handler.getOwnAndSharedResourceIdsForCurrentUser(INDEX, listener);
         verify(listener).onResponse(Set.of("res1"));


### PR DESCRIPTION
### Description
Adds support for dashboard page to manage resource access. Enables plugins to supply static per-resource action-groups through yml config.

* Category : Enhancement


### Issues Resolved
- resolves #5607
- resolves #5608 

### Testing
Automated + manual

- Apis added:

### 1. `GET /_plugins/_security/api/resource/types`

**Description:**
Retrieves the current sharing configuration for a given resource.

**Example Request:**

```
GET /_plugins/_security/api/resource/types
```

**Response:**

```json
{
  "types": [
    {
      "type": "org.opensearch.sample.SampleResource",
      "index": ".sample_resource",
      "action_groups": ["sample_read_only", "sample_read_write", "sample_full_access"]
    }
  ]
}
```
NOTE: `action_groups` are fetched from `resource-action-groups.yml` supplied by resource plugin.

### 2. `GET /_plugins/_security/api/resource/list?resource_type=<resource-index-name>`

**Description:**
Retrieves sharing information for all records accessible to requesting user for the given resource_index.

**Example Request:**
as user `darshit`
```
GET /_plugins/_security/api/resource/list?resource_type=.sample_resource
```

**Response:**

```json
{
  "resources": [
    {
      "resource_id": "1",
      "created_by":  {
        "user": "darshit",
        "tenant": "some-tenant"
      },
      "share_with": {
        "sample_read_only": {
          "users": ["craig"]
        }
      },
      "can_share": true
    }
  ]
}
```

NOTE:
- `share_with` may not be present if resource has not been shared yet
- if same request is made as user `craig`, `can_share` value for resource_id `1` will be `false` since `craig` does not have share permission.




### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
~- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR~
~- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
