### PR TITLE
Allow changes to CHANGELOG.md in automatic-merges workflow

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -29,4 +29,5 @@ jobs:
             opensearch-trigger-bot[bot]
           allowed-files: |
             build.gradle
+            CHANGELOG.md
             .github/workflows/*.yml


### PR DESCRIPTION
### Description

Allow changes to CHANGELOG.md in automatic-merges workflow

Resolves issue seen in http://github.com/opensearch-project/security/actions/runs/17307368792/job/49133587579

> Run peternied/discerning-merger@v3
Some files were not allowed 'CHANGELOG.md'. Skipping...

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
