### PR TITLE
[Backport 2.19] Fix plugin install GH workflow for Windows

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -41,11 +41,22 @@ jobs:
 
       - name: Run Opensearch with A Single Plugin
         uses: derek-ho/start-opensearch@v6
+        if: ${{ runner.os != 'Windows' }}
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ steps.random-password.outputs.generated_name }}
+          jdk-version: 17
+
+      - name: Run Opensearch with A Single Plugin
+        uses: derek-ho/start-opensearch@v7
+        if: ${{ runner.os == 'Windows' }}
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugins: "file:///$((Get-Location).Path -replace '\\\\','/')/${{ env.PLUGIN_NAME }}.zip"
+          security-enabled: true
+          admin-password: ${{ steps.generate-password.outputs.password }}
           jdk-version: 17
 
       - name: Run sanity tests

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -56,7 +56,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:///$((Get-Location).Path -replace '\\\\','/')/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
-          admin-password: ${{ steps.generate-password.outputs.password }}
+          admin-password: ${{ steps.random-password.outputs.password }}
           jdk-version: 17
 
       - name: Run sanity tests

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -56,7 +56,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:///$((Get-Location).Path -replace '\\\\','/')/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
-          admin-password: ${{ steps.random-password.outputs.password }}
+          admin-password: ${{ steps.random-password.outputs.generated_name }}
           jdk-version: 17
 
       - name: Run sanity tests


### PR DESCRIPTION
### Description

Backport the windows plugin_install fix from https://github.com/opensearch-project/security/pull/5579 to 2.19

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
