### PR TITLE
Fixed TLS endpoint identification by SAN

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/TlsHostnameVerificationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/TlsHostnameVerificationTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+package org.opensearch.security;
+
+import java.util.Map;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.security.ssl.util.SSLConfigConstants;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.certificate.TestCertificates;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.log.LogsRule;
+
+@RunWith(com.carrotsearch.randomizedtesting.RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class TlsHostnameVerificationTests {
+
+    @Rule
+    public LogsRule logsRule = new LogsRule("org.opensearch.transport.netty4.ssl.SecureNetty4Transport");
+
+    public LocalCluster.Builder clusterBuilder = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(ConfigConstants.SECURITY_SSL_ONLY, true, SSLConfigConstants.SECURITY_SSL_TRANSPORT_ENFORCE_HOSTNAME_VERIFICATION, true)
+        )
+        .sslOnly(true);
+
+    @Test
+    public void clusterShouldStart_nodesSanIpsAreValid() {
+        // Note: We cannot use hostnames in this environment. However, IP addresses also work as valid SANs which are also
+        // subject to hostname verification. Thus, we use here certificates with IP SANs
+        TestCertificates testCertificates = new TestCertificates(ClusterManager.THREE_CLUSTER_MANAGERS.getNodes(), "127.0.0.1");
+        try (LocalCluster cluster = clusterBuilder.testCertificates(testCertificates).build()) {
+            cluster.before();
+        } catch (Exception e) {
+            Assert.fail("Cluster should start, no exception expected but got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void clusterShouldNotStart_nodesSanIpsAreInvalid() {
+        TestCertificates testCertificates = new TestCertificates(ClusterManager.THREE_CLUSTER_MANAGERS.getNodes(), "127.0.0.2");
+        try (LocalCluster cluster = clusterBuilder.testCertificates(testCertificates).build()) {
+            cluster.before();
+            Assert.fail("Cluster should not start, an exception expected");
+        } catch (Exception e) {
+            logsRule.assertThatContain("No subject alternative names matching IP address 127.0.0.1 found");
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/certificate/TestCertificates.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/certificate/TestCertificates.java
@@ -79,9 +79,15 @@ public class TestCertificates {
     }
 
     public TestCertificates(final int numberOfNodes) {
+        this(numberOfNodes, "127.0.0.1");
+    }
+
+    public TestCertificates(final int numberOfNodes, String nodeSanIp) {
         this.caCertificate = createCaCertificate();
         this.numberOfNodes = numberOfNodes;
-        this.nodeCertificates = IntStream.range(0, this.numberOfNodes).mapToObj(this::createNodeCertificate).collect(Collectors.toList());
+        this.nodeCertificates = IntStream.range(0, this.numberOfNodes)
+            .mapToObj(node -> this.createNodeCertificate(node, nodeSanIp))
+            .collect(Collectors.toList());
         this.ldapCertificate = createLdapCertificate();
         this.adminCertificate = createAdminCertificate(ADMIN_DN);
         log.info("Test certificates successfully generated");
@@ -142,12 +148,12 @@ public class TestCertificates {
         }
     }
 
-    private CertificateData createNodeCertificate(Integer node) {
+    private CertificateData createNodeCertificate(Integer node, String nodeSanIp) {
         final var subject = String.format(NODE_SUBJECT_PATTERN, node);
         String domain = String.format("node-%d.example.com", node);
         CertificateMetadata metadata = CertificateMetadata.basicMetadata(subject, CERTIFICATE_VALIDITY_DAYS)
             .withKeyUsage(false, DIGITAL_SIGNATURE, NON_REPUDIATION, KEY_ENCIPHERMENT, CLIENT_AUTH, SERVER_AUTH)
-            .withSubjectAlternativeName("1.2.3.4.5.5", List.of(domain, "localhost"), "127.0.0.1");
+            .withSubjectAlternativeName("1.2.3.4.5.5", List.of(domain, "localhost"), nodeSanIp);
         return CertificatesIssuerFactory.rsaBaseCertificateIssuer().issueSignedCertificate(metadata, caCertificate);
     }
 

--- a/src/integrationTest/resources/log4j2-test.properties
+++ b/src/integrationTest/resources/log4j2-test.properties
@@ -47,3 +47,12 @@ logger.backendreg.appenderRef.capturing.ref = logCapturingAppender
 logger.ldap.name=org.opensearch.security.auth.ldap.backend
 logger.ldap.level=TRACE
 logger.ldap.appenderRef.capturing.ref = logCapturingAppender
+
+# Logger required by test org.opensearch.security.TlsHostnameVerificationTests
+logger.securenetty4transport.name = org.opensearch.transport.netty4.ssl.SecureNetty4Transport
+logger.securenetty4transport.level = error
+logger.securenetty4transport.appenderRef.capturing.ref = logCapturingAppender
+
+
+logger.p.name=org.opensearch.security.privileges
+logger.p.level=DEBUG

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -128,7 +128,7 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
 
             @Override
             public Optional<SSLEngine> buildSecureClientTransportEngine(Settings settings, String hostname, int port) throws SSLException {
-                return sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT).map(c -> c.createSSLEngine(hostname, port));
+                return sslSettingsManager.sslContextHandler(CertType.TRANSPORT_CLIENT).map(c -> c.createClientSSLEngine(hostname, port));
             }
         });
     }

--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,8 +58,17 @@ public class SslContextHandler {
         return sslContext.newEngine(NettyAllocator.getAllocator());
     }
 
-    public SSLEngine createSSLEngine(final String hostname, final int port) {
-        return sslContext.newEngine(NettyAllocator.getAllocator(), hostname, port);
+    /**
+     * Creates a SSL engine for usage as a client. In this case, we can optionally perform hostname verification.
+     */
+    public SSLEngine createClientSSLEngine(final String hostname, final int port) {
+        SSLEngine sslEngine = sslContext.newEngine(NettyAllocator.getAllocator(), hostname, port);
+        if (hostname != null) {
+            SSLParameters sslParams = new SSLParameters();
+            sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+            sslEngine.setSSLParameters(sslParams);
+        }
+        return sslEngine;
     }
 
     public SslConfiguration sslConfiguration() {


### PR DESCRIPTION
### Description

This fixes TLS endpoint identification

* Category: Bugfix
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Testing

- Integration test

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
