### PR TITLE
[Resource Sharing] Also exclude DocWriteRequest from ResourceAccessEvaluator

### DIFF
--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
@@ -291,17 +291,11 @@ public class DirectIndexAccessTests {
             api.assertDirectPostSearch(searchByNamePayload("sampleUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUser");
 
             // cannot update or delete resource
-            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
-            api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+            api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
             // can update and delete own resource
             api.assertDirectUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertDirectDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-
-            // can view, share, revoke and delete resource sharing record(s) directly
-            api.assertDirectViewSharingRecord(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
-            api.assertDirectShare(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
-            api.assertDirectRevoke(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
-            api.assertDirectDeleteResourceSharingRecord(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
         }
 
         @Test

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/DeleteResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/DeleteResourceTransportAction.java
@@ -19,14 +19,13 @@ import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.sample.resource.actions.rest.delete.DeleteResourceAction;
 import org.opensearch.sample.resource.actions.rest.delete.DeleteResourceRequest;
 import org.opensearch.sample.resource.actions.rest.delete.DeleteResourceResponse;
+import org.opensearch.sample.utils.PluginClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
-import org.opensearch.transport.client.node.NodeClient;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
 
@@ -37,13 +36,13 @@ public class DeleteResourceTransportAction extends HandledTransportAction<Delete
     private static final Logger log = LogManager.getLogger(DeleteResourceTransportAction.class);
 
     private final TransportService transportService;
-    private final NodeClient nodeClient;
+    private final PluginClient pluginClient;
 
     @Inject
-    public DeleteResourceTransportAction(TransportService transportService, ActionFilters actionFilters, NodeClient nodeClient) {
+    public DeleteResourceTransportAction(TransportService transportService, ActionFilters actionFilters, PluginClient pluginClient) {
         super(DeleteResourceAction.NAME, transportService, actionFilters, DeleteResourceRequest::new);
         this.transportService = transportService;
-        this.nodeClient = nodeClient;
+        this.pluginClient = pluginClient;
     }
 
     @Override
@@ -64,10 +63,7 @@ public class DeleteResourceTransportAction extends HandledTransportAction<Delete
             listener.onFailure(exception);
         });
 
-        ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
-        try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
-            deleteResource(resourceId, deleteResponseListener);
-        }
+        deleteResource(resourceId, deleteResponseListener);
     }
 
     private void deleteResource(String resourceId, ActionListener<DeleteResponse> listener) {
@@ -75,7 +71,7 @@ public class DeleteResourceTransportAction extends HandledTransportAction<Delete
             WriteRequest.RefreshPolicy.IMMEDIATE
         );
 
-        nodeClient.delete(deleteRequest, listener);
+        pluginClient.delete(deleteRequest, listener);
     }
 
 }

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/UpdateResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/UpdateResourceTransportAction.java
@@ -16,7 +16,6 @@ import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.inject.Inject;
-import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -24,9 +23,9 @@ import org.opensearch.sample.SampleResource;
 import org.opensearch.sample.resource.actions.rest.create.CreateResourceResponse;
 import org.opensearch.sample.resource.actions.rest.create.UpdateResourceAction;
 import org.opensearch.sample.resource.actions.rest.create.UpdateResourceRequest;
+import org.opensearch.sample.utils.PluginClient;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
-import org.opensearch.transport.client.node.NodeClient;
 
 import static org.opensearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
@@ -38,13 +37,13 @@ public class UpdateResourceTransportAction extends HandledTransportAction<Update
     private static final Logger log = LogManager.getLogger(UpdateResourceTransportAction.class);
 
     private final TransportService transportService;
-    private final NodeClient nodeClient;
+    private final PluginClient pluginClient;
 
     @Inject
-    public UpdateResourceTransportAction(TransportService transportService, ActionFilters actionFilters, NodeClient nodeClient) {
+    public UpdateResourceTransportAction(TransportService transportService, ActionFilters actionFilters, PluginClient pluginClient) {
         super(UpdateResourceAction.NAME, transportService, actionFilters, UpdateResourceRequest::new);
         this.transportService = transportService;
-        this.nodeClient = nodeClient;
+        this.pluginClient = pluginClient;
     }
 
     @Override
@@ -58,8 +57,7 @@ public class UpdateResourceTransportAction extends HandledTransportAction<Update
     }
 
     private void updateResource(UpdateResourceRequest request, ActionListener<CreateResourceResponse> listener) {
-        ThreadContext threadContext = this.transportService.getThreadPool().getThreadContext();
-        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+        try {
             String resourceId = request.getResourceId();
             SampleResource sample = request.getResource();
             try (XContentBuilder builder = jsonBuilder()) {
@@ -68,7 +66,7 @@ public class UpdateResourceTransportAction extends HandledTransportAction<Update
 
                 log.debug("Update Request: {}", ur.toString());
 
-                nodeClient.update(ur, ActionListener.wrap(updateResponse -> {
+                pluginClient.update(ur, ActionListener.wrap(updateResponse -> {
                     listener.onResponse(
                         new CreateResourceResponse("Resource " + request.getResource().getName() + " updated successfully.")
                     );

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -101,6 +101,21 @@ public class ResourceAccessEvaluator {
         );
         if (!isResourceSharingFeatureEnabled) return false;
         if (!(request instanceof DocRequest docRequest)) return false;
+        /**
+         * Authorization notes:
+         *
+         * - Treat {@link GetRequest} and all {@link DocWriteRequest} types as standard *index actions*.
+         *   They should NOT be evaluated by {@code ResourceAccessEvaluator}.
+         *
+         * - {@code ResourceAccessEvaluator} is for higher-level transport actions that operate on a
+         *   single shareable resource. Those actions may perform plugin/system-level index operations
+         *   against the system (resource) index that stores resource metadata. Such accesses must be
+         *   evaluated by {@code SystemIndexAccessEvaluator}.
+         *
+         * - {@link DocWriteRequest} is the abstract base for write requests
+         *   ({@link IndexRequest}, {@link UpdateRequest}, {@link DeleteRequest}) and may appear as items
+         *   in a {@code _bulk} request.
+         */
         if (request instanceof GetRequest) return false;
         if (request instanceof DocWriteRequest<?>) return false;
         if (Strings.isNullOrEmpty(docRequest.id())) {

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -17,6 +17,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.DocRequest;
+import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
@@ -101,6 +102,7 @@ public class ResourceAccessEvaluator {
         if (!isResourceSharingFeatureEnabled) return false;
         if (!(request instanceof DocRequest docRequest)) return false;
         if (request instanceof GetRequest) return false;
+        if (request instanceof DocWriteRequest<?>) return false;
         if (Strings.isNullOrEmpty(docRequest.id())) {
             log.debug("Request id is blank or null, request is of type {}", docRequest.getClass().getName());
             return false;


### PR DESCRIPTION
### Description

Similar to https://github.com/opensearch-project/security/pull/5631, this PR will always treat DocWriteRequest (one of IndexRequest, UpdateRequest or DeleteRequest) as an index operation for authorization.

This PR also updates the sample plugin to fully use the `PluginClient` when performing system index access. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
