### PR TITLE
Make configuration setting for user attribute serialization dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [SecurityPlugin Health Check] Add AuthZ initialization completion check in health check API [(#5626)](https://github.com/opensearch-project/security/pull/5626)
 - [Resource Sharing] Adds API to provide dashboards support for resource access management ([#5597](https://github.com/opensearch-project/security/pull/5597))
 - Direct JWKS (JSON Web Key Set) support in the JWT authentication backend ([#5578](https://github.com/opensearch-project/security/pull/5578))
-
+- Make configuration setting for user custom attribute serialization dynamic ([#5657](https://github.com/opensearch-project/security/pull/5657))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2288,8 +2288,18 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             return settingsFilter;
         }
         settingsFilter.add("opendistro_security.*");
-        settingsFilter.add("plugins.security.http.*");
-        settingsFilter.add("plugins.security.transport.*");
+        settingsFilter.add("plugins.security.transport_user_cache.*");
+        settingsFilter.add("plugins.security.nodes_dn.*");
+        settingsFilter.add("plugins.security.restapi.*");
+        settingsFilter.add("plugins.security.ssl.*");
+        settingsFilter.add("plugins.security.config_version.*");
+        settingsFilter.add("plugins.security.nodes_dn_dynamic_config_enabled.*");
+        settingsFilter.add("plugins.security.privileges_evaluation.*");
+        settingsFilter.add("plugins.security.authcz.*");
+        settingsFilter.add("plugins.security.password.*");
+        settingsFilter.add("plugins.security.unsupported.*");
+        settingsFilter.add("plugins.security.audit.*");
+        settingsFilter.add("plugins.security.compliance.*");
         return settingsFilter;
     }
 

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2272,7 +2272,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED,
                     ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED_DEFAULT,
                     Property.NodeScope,
-                    Property.Filtered
+                    Property.Filtered,
+                    Property.Dynamic
                 )
             );
         }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2272,7 +2272,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED,
                     ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED_DEFAULT,
                     Property.NodeScope,
-                    Property.Filtered,
                     Property.Dynamic
                 )
             );

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2267,14 +2267,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 )
             );
 
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED,
-                    ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED_DEFAULT,
-                    Property.NodeScope,
-                    Property.Dynamic
-                )
-            );
+            settings.add(SecuritySettings.USER_ATTRIBUTE_SERIALIZATION_ENABLED_SETTING);
         }
 
         return settings;

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2288,7 +2288,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             return settingsFilter;
         }
         settingsFilter.add("opendistro_security.*");
-        settingsFilter.add("plugins.security.*");
+        settingsFilter.add("plugins.security.http.*");
+        settingsFilter.add("plugins.security.transport.*");
         return settingsFilter;
     }
 

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -693,7 +693,8 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
     public List<String> getSettingsFilter() {
         List<String> settingsFilter = new ArrayList<>();
         settingsFilter.add("opendistro_security.*");
-        settingsFilter.add("plugins.security.*");
+        settingsFilter.add("plugins.security.http.*");
+        settingsFilter.add("plugins.security.transport.*");
         return settingsFilter;
     }
 

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -693,8 +693,18 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
     public List<String> getSettingsFilter() {
         List<String> settingsFilter = new ArrayList<>();
         settingsFilter.add("opendistro_security.*");
-        settingsFilter.add("plugins.security.http.*");
-        settingsFilter.add("plugins.security.transport.*");
+        settingsFilter.add("plugins.security.transport_user_cache.*");
+        settingsFilter.add("plugins.security.nodes_dn.*");
+        settingsFilter.add("plugins.security.restapi.*");
+        settingsFilter.add("plugins.security.ssl.*");
+        settingsFilter.add("plugins.security.config_version.*");
+        settingsFilter.add("plugins.security.nodes_dn_dynamic_config_enabled.*");
+        settingsFilter.add("plugins.security.privileges_evaluation.*");
+        settingsFilter.add("plugins.security.authcz.*");
+        settingsFilter.add("plugins.security.password.*");
+        settingsFilter.add("plugins.security.unsupported.*");
+        settingsFilter.add("plugins.security.audit.*");
+        settingsFilter.add("plugins.security.compliance.*");
         return settingsFilter;
     }
 

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -36,4 +36,10 @@ public class SecuritySettings {
         Setting.Property.Dynamic
     ); // Not filtered
 
+    public static final Setting<Boolean> USER_ATTRIBUTE_SERIALIZATION_ENABLED_SETTING = Setting.boolSetting(
+        ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED,
+        ConfigConstants.USER_ATTRIBUTE_SERIALIZATION_ENABLED_DEFAULT,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    ); // Not filtered
 }


### PR DESCRIPTION
### Description

This PR makes the configuration setting for `plugins.security.user_attribute_serialization.enabled`dynamic, so it can be updated via requests to `PUT cluster/_settings`.

* Category - Enhancement
* Why these changes are required? - Makes the configuration of this setting more dynamic, which is especially useful in testing contexts
* What is the old behavior before changes and new behavior after changes? - Before: The setting could only be configured statically in `opensearch.yml`. After: The setting can be dynamically updated with requests to `PUT cluster/_settings`.

### Issues Resolved

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
