### PR TITLE
[Bug Fix] Handles resource updates which otherwise may wipe out all_shared_principals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - [Resource Sharing] Always treat GET _doc request as indices request even when performed on sharable resource index ([#5631](https://github.com/opensearch-project/security/pull/5631))
 - Fix JWT log spam when JWT authenticator is configured with an empty list for roles_key ([#5640](https://github.com/opensearch-project/security/pull/5640))
 - Updates resource visibility when handling PATCH api to update sharing record ([#5654](https://github.com/opensearch-project/security/pull/5654))
+- Handles resource updates which otherwise may wipe out all_shared_principals ([#5658](https://github.com/opensearch-project/security/pull/5658))
 
 ### Refactoring
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ApiAccessTests.java
@@ -150,6 +150,9 @@ public class ApiAccessTests {
             // can update own resource
             api.assertApiUpdate(userResId, LIMITED_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertApiGet(userResId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
+            // resource should be visible even after update
+
+            api.assertApiGetSearch(LIMITED_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
             api.assertApiShare(adminResId, LIMITED_ACCESS_USER, LIMITED_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);
@@ -197,6 +200,8 @@ public class ApiAccessTests {
             // can update own resource
             api.assertApiUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertApiGet(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sampleUpdateUser");
+            // resource should be visible even after update
+            api.assertApiGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUpdateUser");
 
             // cannot share or revoke admin's resource
             api.assertApiShare(adminResId, FULL_ACCESS_USER, FULL_ACCESS_USER, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_FORBIDDEN);

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/transport/SearchResourceTransportAction.java
@@ -39,7 +39,5 @@ public class SearchResourceTransportAction extends HandledTransportAction<Search
     @Override
     protected void doExecute(Task task, SearchRequest request, ActionListener<SearchResponse> listener) {
         pluginClient.search(request, listener);
-
     }
-
 }


### PR DESCRIPTION
### Description
AD saw test failure during CI run which was result of `all_shared_principals` field being removed from the document on update request. This PR fixes it by prevent such scenarios and explicitly updating `all_shared_principals` on index-requests masked as updates.
https://github.com/opensearch-project/anomaly-detection/pull/1546

* Category: Bug fix
* Why these changes are required?
Search Request after updates would fail.


### Testing
Manual + Automated

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
