### PR TITLE
[Bug Fix] Makes initial share map mutable to allow multiple shares

### DIFF
--- a/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/sharing/ResourceSharing.java
@@ -11,6 +11,7 @@ package org.opensearch.security.spi.resources.sharing;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,9 @@ public class ResourceSharing implements ToXContentFragment, NamedWriteable {
 
     public void share(String accessLevel, Recipients target) {
         if (shareWith == null) {
-            shareWith = new ShareWith(Map.of(accessLevel, target));
+            Map<String, Recipients> recs = new HashMap<>();
+            recs.put(accessLevel, target);
+            shareWith = new ShareWith(recs);
             return;
         }
         Recipients sharedWith = shareWith.atAccessLevel(accessLevel);


### PR DESCRIPTION
### Description
While testing the UI, I discovered that initial share didn't allow sharing with multiple access roles at once. Upon debugging, the root cause was found to be usage of Map.of() in ResourceSharing.share() making it immutable.
This PR makes it mutable.

### Testing
Manual + automated testing

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
