### PR TITLE
[2.19] Refactor KafkaSinkTest to use MockProducer and upgrade kafka to 3.9.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,12 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
-        kafka_version  = '3.7.1'
+        kafka_version  = '3.9.1'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'
         guava_version = '33.4.0-jre'
         jaxb_version = '2.3.9'
-        spring_version = '5.3.39'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -695,8 +694,6 @@ dependencies {
     testImplementation "org.apache.kafka:kafka_2.13:${kafka_version}:test"
     testImplementation "org.apache.kafka:kafka-clients:${kafka_version}:test"
     testImplementation 'commons-validator:commons-validator:1.9.0'
-    testImplementation 'org.springframework.kafka:spring-kafka-test:2.9.13'
-    testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
     testImplementation('org.awaitility:awaitility:4.2.2') {
@@ -712,11 +709,6 @@ dependencies {
     }
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
-    // Kafka test execution
-    testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.4'
-    testRuntimeOnly ("org.springframework:spring-core:${spring_version}") {
-        exclude(group:'org.springframework', module: 'spring-jcl' )
-    }
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.16'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.5'
     testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.3') {


### PR DESCRIPTION
### Description

Refactor KafkaSinkTest to use MockProducer and upgrade kafka to 3.9.1.

Addresses whitesource errors. This PR is showing a cleaner scan without anything from kafka flagged: https://github.com/opensearch-project/security/pull/5670/checks?check_run_id=51614975912

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
