### PR TITLE
Adds a list setting to explicitly specify resources to be protected

### DIFF
--- a/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
+++ b/RESOURCE_SHARING_AND_ACCESS_CONTROL.md
@@ -506,7 +506,9 @@ Since no entities are listed, the resource is accessible **only by its creator a
 
 ## Part 2: Cluster-admin and User guide
 
-## **1. Feature Flag**
+## **1. Setup**
+
+### **Feature Flag**
 This feature is controlled by the following flag:
 
 - **Feature flag:** `plugins.security.experimental.resource_sharing.enabled`
@@ -515,6 +517,17 @@ This feature is controlled by the following flag:
   ```yaml
   plugins.security.experimental.resource_sharing.enabled: true
   ```
+### **List protected types**
+
+The list of protected types are controlled through following opensearch setting
+
+- **Setting:** `plugins.security.experimental.resource_sharing.protected_types`
+- **Default value:** `[]`
+- **How to specify a type?** Add entries of existing types in the list:
+  ```yaml
+  plugins.security.experimental.resource_sharing.protected_types: [sample-resource]
+  ```
+NOTE: These types will be available on documentation website.
 
 ## **2. User Setup**
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/TestUtils.java
@@ -39,9 +39,11 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 import static org.opensearch.sample.utils.Constants.SAMPLE_RESOURCE_PLUGIN_PREFIX;
 import static org.opensearch.security.resources.ResourceSharingIndexHandler.getSharingIndex;
 import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_SYSTEM_INDICES_ENABLED_KEY;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
@@ -90,6 +92,10 @@ public final class TestUtils {
     public static final String SECURITY_LIST_ENDPOINT = "_plugins/_security/api/resource/list";
 
     public static LocalCluster newCluster(boolean featureEnabled, boolean systemIndexEnabled) {
+        return newCluster(featureEnabled, systemIndexEnabled, List.of(RESOURCE_TYPE));
+    }
+
+    public static LocalCluster newCluster(boolean featureEnabled, boolean systemIndexEnabled, List<String> protectedResourceTypes) {
         return new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS_COORDINATOR)
             .plugin(
                 new PluginInfo(
@@ -108,7 +114,14 @@ public final class TestUtils {
             .authc(AUTHC_HTTPBASIC_INTERNAL)
             .users(USER_ADMIN, FULL_ACCESS_USER, LIMITED_ACCESS_USER, NO_ACCESS_USER)
             .nodeSettings(
-                Map.of(OPENSEARCH_RESOURCE_SHARING_ENABLED, featureEnabled, SECURITY_SYSTEM_INDICES_ENABLED_KEY, systemIndexEnabled)
+                Map.of(
+                    OPENSEARCH_RESOURCE_SHARING_ENABLED,
+                    featureEnabled,
+                    SECURITY_SYSTEM_INDICES_ENABLED_KEY,
+                    systemIndexEnabled,
+                    OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES,
+                    protectedResourceTypes
+                )
             )
             .build();
     }

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/DirectIndexAccessTests.java
@@ -284,15 +284,11 @@ public class DirectIndexAccessTests {
             api.assertDirectShare(userResId, FULL_ACCESS_USER, USER_ADMIN, SAMPLE_READ_ONLY_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertDirectGet(userResId, USER_ADMIN, HttpStatus.SC_OK, "sample");
 
-            // can only access own resource since
             api.assertDirectGetSearch(FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
             api.assertDirectPostSearch(searchAllPayload(), FULL_ACCESS_USER, HttpStatus.SC_OK, 2, "sample");
             api.assertDirectPostSearch(searchByNamePayload("sample"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sample");
             api.assertDirectPostSearch(searchByNamePayload("sampleUser"), FULL_ACCESS_USER, HttpStatus.SC_OK, 1, "sampleUser");
 
-            // cannot update or delete resource
-            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
-            api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
             // can update and delete own resource
             api.assertDirectUpdate(userResId, FULL_ACCESS_USER, "sampleUpdateUser", HttpStatus.SC_OK);
             api.assertDirectDelete(userResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
@@ -302,6 +298,10 @@ public class DirectIndexAccessTests {
             api.assertDirectShare(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertDirectRevoke(adminResId, FULL_ACCESS_USER, NO_ACCESS_USER, SAMPLE_FULL_ACCESS_RESOURCE_AG, HttpStatus.SC_OK);
             api.assertDirectDeleteResourceSharingRecord(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
+
+            // can update or delete admin resource, since system index protection is disabled and user has direct index access.
+            api.assertDirectUpdate(adminResId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+            api.assertDirectDelete(adminResId, FULL_ACCESS_USER, HttpStatus.SC_OK);
         }
 
         @Test

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ExcludedResourceTypeTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/feature/enabled/ExcludedResourceTypeTests.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.sample.resource.feature.enabled;
+
+import java.util.List;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.apache.http.HttpStatus;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.sample.resource.TestUtils;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.opensearch.sample.resource.TestUtils.FULL_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.LIMITED_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.NO_ACCESS_USER;
+import static org.opensearch.sample.resource.TestUtils.RESOURCE_SHARING_INDEX;
+import static org.opensearch.sample.resource.TestUtils.newCluster;
+import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
+
+/**
+ * Test resource access when sample-resource is not marked as protected resource, even-though resource sharing protection is enabled.
+ */
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class ExcludedResourceTypeTests {
+
+    // do not include sample resource as protected resource, should behave as if feature was disable for that resource
+    @ClassRule
+    public static LocalCluster cluster = newCluster(true, true, List.of());
+
+    private final TestUtils.ApiHelper api = new TestUtils.ApiHelper(cluster);
+    private String resourceId;
+
+    @Before
+    public void setup() {
+        resourceId = api.createSampleResourceAs(USER_ADMIN);
+    }
+
+    @After
+    public void cleanup() {
+        api.wipeOutResourceEntries();
+    }
+
+    @Test
+    public void testSampleResourceSharingIndexDoesNotExist() {
+        try (TestRestClient client = cluster.getRestClient(cluster.getAdminCertificate())) {
+            TestRestClient.HttpResponse response = client.get("_cat/indices?expand_wildcards=all");
+            response.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(response.getBody(), not(containsString(RESOURCE_SHARING_INDEX)));
+        }
+    }
+
+    @Test
+    public void fullAccessUser_canCRUD() {
+        api.assertApiGet(resourceId, FULL_ACCESS_USER, HttpStatus.SC_OK, "sample");
+        api.assertApiUpdate(resourceId, FULL_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_OK);
+        api.assertApiDelete(resourceId, FULL_ACCESS_USER, HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void limitedAccessUser_canCRUD() {
+        api.assertApiGet(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_OK, "sample");
+        api.assertApiUpdate(resourceId, LIMITED_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+        api.assertApiDelete(resourceId, LIMITED_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+    }
+
+    @Test
+    public void noAccessUser_canCRUD() {
+        api.assertApiGet(resourceId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN, "");
+        api.assertApiUpdate(resourceId, NO_ACCESS_USER, "sampleUpdateAdmin", HttpStatus.SC_FORBIDDEN);
+        api.assertApiDelete(resourceId, NO_ACCESS_USER, HttpStatus.SC_FORBIDDEN);
+    }
+}

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
@@ -46,8 +46,10 @@ import static org.opensearch.sample.resource.TestUtils.migrationPayload_missingU
 import static org.opensearch.sample.resource.TestUtils.migrationPayload_valid;
 import static org.opensearch.sample.resource.TestUtils.migrationPayload_valid_withSpecifiedAccessLevel;
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 import static org.opensearch.security.resources.ResourceSharingIndexHandler.getSharingIndex;
 import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_SYSTEM_INDICES_ENABLED_KEY;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 
@@ -79,7 +81,16 @@ public class MigrateApiTests {
         .anonymousAuth(false)
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .users(MIGRATION_USER)
-        .nodeSettings(Map.of(SECURITY_SYSTEM_INDICES_ENABLED_KEY, true, OPENSEARCH_RESOURCE_SHARING_ENABLED, true))
+        .nodeSettings(
+            Map.of(
+                SECURITY_SYSTEM_INDICES_ENABLED_KEY,
+                true,
+                OPENSEARCH_RESOURCE_SHARING_ENABLED,
+                true,
+                OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES,
+                List.of(RESOURCE_TYPE)
+            )
+        )
         .build();
 
     @After

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/CreateResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/CreateResourceRequest.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.sample.SampleResource;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for CreateSampleResource transport action
@@ -57,6 +58,11 @@ public class CreateResourceRequest extends ActionRequest implements DocRequest {
 
     public boolean shouldStoreUser() {
         return this.shouldStoreUser;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/UpdateResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/create/UpdateResourceRequest.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.sample.SampleResource;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for UpdateResource transport action
@@ -57,6 +58,11 @@ public class UpdateResourceRequest extends ActionRequest implements DocRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/delete/DeleteResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/delete/DeleteResourceRequest.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for DeleteSampleResource transport action
@@ -48,6 +49,11 @@ public class DeleteResourceRequest extends ActionRequest implements DocRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/get/GetResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/get/GetResourceRequest.java
@@ -17,6 +17,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for GetSampleResource transport action
@@ -48,6 +49,11 @@ public class GetResourceRequest extends ActionRequest implements DocRequest {
 
     public String getResourceId() {
         return this.resourceId;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/revoke/RevokeResourceAccessRequest.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for revoking access to a sample resource
@@ -54,6 +55,11 @@ public class RevokeResourceAccessRequest extends ActionRequest implements DocReq
 
     public ShareWith getEntitiesToRevoke() {
         return revokeAccess;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
+++ b/sample-resource-plugin/src/main/java/org/opensearch/sample/resource/actions/rest/share/ShareResourceRequest.java
@@ -18,6 +18,7 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.security.spi.resources.sharing.ShareWith;
 
 import static org.opensearch.sample.utils.Constants.RESOURCE_INDEX_NAME;
+import static org.opensearch.sample.utils.Constants.RESOURCE_TYPE;
 
 /**
  * Request object for sharing sample resource transport action
@@ -55,6 +56,11 @@ public class ShareResourceRequest extends ActionRequest implements DocRequest {
 
     public ShareWith getShareWith() {
         return shareWithRecipients;
+    }
+
+    @Override
+    public String type() {
+        return RESOURCE_TYPE;
     }
 
     @Override

--- a/spi/README.md
+++ b/spi/README.md
@@ -176,6 +176,11 @@ public class ShareResourceRequest extends ActionRequest implements DocRequest {
     }
 
     @Override
+    public String type() {
+        return RESOURCE_TYPE;
+    }
+
+    @Override
     public String index() {
         return RESOURCE_INDEX_NAME;
     }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2236,6 +2236,18 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 )
             );
 
+            // resource marked here will be protected, other resources will not be proected with resource sharing model
+            // Defaults to all current resources as protected
+            settings.add(
+                Setting.listSetting(
+                    ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES,
+                    ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES_DEFAULT,
+                    Function.identity(),
+                    Property.NodeScope,
+                    Property.Filtered
+                )
+            );
+
             settings.add(UserFactory.Caching.MAX_SIZE);
             settings.add(UserFactory.Caching.EXPIRE_AFTER_ACCESS);
 
@@ -2456,7 +2468,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         // discover & register extensions and their types
         Set<ResourceSharingExtension> exts = new HashSet<>(loader.loadExtensions(ResourceSharingExtension.class));
-        resourcePluginInfo.setResourceSharingExtensions(exts);
+        resourcePluginInfo.setResourceSharingExtensions(
+            exts,
+            settings.getAsList(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES)
+        );
 
         // load action-groups in memory
         ResourceActionGroupsHelper.loadActionGroupsConfig(resourcePluginInfo);

--- a/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
+++ b/src/main/java/org/opensearch/security/privileges/ResourceAccessEvaluator.java
@@ -10,6 +10,7 @@
 
 package org.opensearch.security.privileges;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
@@ -98,6 +99,10 @@ public class ResourceAccessEvaluator {
             ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED,
             ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT
         );
+        List<String> protectedTypes = settings.getAsList(
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES,
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES_DEFAULT
+        );
         if (!isResourceSharingFeatureEnabled) return false;
         if (!(request instanceof DocRequest docRequest)) return false;
         if (request instanceof GetRequest) return false;
@@ -110,7 +115,9 @@ public class ResourceAccessEvaluator {
             log.debug("Request index {} is not a protected resource index", docRequest.index());
             return false;
         }
-        return true;
+
+        // if a resource is not included in protected resource list, we do not perform resource-level authorization
+        return protectedTypes.contains(docRequest.type());
     }
 
 }

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -48,7 +49,7 @@ public class ResourcePluginInfo {
     // AuthZ: resolved (flattened) groups per type
     private final Map<String, FlattenedActionGroups> typeToFlattened = new HashMap<>();
 
-    public void setResourceSharingExtensions(Set<ResourceSharingExtension> extensions) {
+    public void setResourceSharingExtensions(Set<ResourceSharingExtension> extensions, List<String> protectedTypes) {
         resourceSharingExtensions.clear();
         typeToIndex.clear();
         indexToType.clear();
@@ -56,6 +57,10 @@ public class ResourcePluginInfo {
         Set<String> resourceTypes = new HashSet<>();
         for (ResourceSharingExtension extension : extensions) {
             for (var rp : extension.getResourceProviders()) {
+                // exclude resource types not mentioned in the explicit list. defaults to no resource marked as protected resources
+                if (protectedTypes.isEmpty() || !protectedTypes.contains(rp.resourceType())) {
+                    return;
+                }
                 if (!resourceTypes.contains(rp.resourceType())) {
                     // add name seen so far to the resource-types set
                     resourceTypes.add(rp.resourceType());
@@ -117,14 +122,9 @@ public class ResourcePluginInfo {
     }
 
     public Set<ResourceDashboardInfo> getResourceTypes() {
-        return typeToIndex.entrySet()
+        return typeToIndex.keySet()
             .stream()
-            .map(
-                e -> new ResourceDashboardInfo(
-                    e.getKey(),
-                    Collections.unmodifiableSet(typeToGroupNames.getOrDefault(e.getKey(), new LinkedHashSet<>()))
-                )
-            )
+            .map(s -> new ResourceDashboardInfo(s, Collections.unmodifiableSet(typeToGroupNames.getOrDefault(s, new LinkedHashSet<>()))))
             .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -41,6 +41,8 @@ public class ShareRequest extends ActionRequest implements DocRequest {
     @JsonProperty("revoke")
     private final ShareWith revoke;
 
+    private final String resourceType;
+
     private final RestRequest.Method method;
 
     /**
@@ -53,6 +55,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         this.add = builder.add;
         this.revoke = builder.revoke;
         this.method = builder.method;
+        this.resourceType = builder.resourceType;
     }
 
     public ShareRequest(StreamInput in) throws IOException {
@@ -60,6 +63,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         this.method = in.readEnum(RestRequest.Method.class);
         this.resourceId = in.readString();
         this.resourceIndex = in.readString();
+        this.resourceType = in.readString();
         this.shareWith = in.readOptionalWriteable(ShareWith::new);
         this.add = in.readOptionalWriteable(ShareWith::new);
         this.revoke = in.readOptionalWriteable(ShareWith::new);
@@ -70,6 +74,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         out.writeEnum(method);
         out.writeString(resourceId);
         out.writeString(resourceIndex);
+        out.writeString(resourceType);
         out.writeOptionalWriteable(shareWith);
         out.writeOptionalWriteable(add);
         out.writeOptionalWriteable(revoke);
@@ -115,6 +120,11 @@ public class ShareRequest extends ActionRequest implements DocRequest {
         return method;
     }
 
+    @Override
+    public String type() {
+        return resourceType;
+    }
+
     /**
      * Get the index that this request operates on
      *
@@ -141,6 +151,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
     public static class Builder {
         private String resourceId;
         private String resourceIndex;
+        private String resourceType;
         private ShareWith shareWith;
         private ShareWith add;
         private ShareWith revoke;
@@ -152,6 +163,10 @@ public class ShareRequest extends ActionRequest implements DocRequest {
 
         public void resourceIndex(String resourceIndex) {
             this.resourceIndex = resourceIndex;
+        }
+
+        public void resourceType(String resourceType) {
+            this.resourceType = resourceType;
         }
 
         public void shareWith(ShareWith shareWith) {
@@ -186,6 +201,7 @@ public class ShareRequest extends ActionRequest implements DocRequest {
                                 this.resourceId(parser.text());
                                 break;
                             case "resource_type":
+                                this.resourceType(parser.text());
                                 this.resourceIndex(resourcePluginInfo.indexByType(parser.text()));
                                 break;
                             case "share_with":

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRestAction.java
@@ -73,6 +73,7 @@ public class ShareRestAction extends BaseRestHandler {
 
         if (resourceIndex != null) {
             builder.resourceIndex(resourceIndex);
+            builder.resourceType(resourceType);
         }
         if (resourceId != null) {
             builder.resourceId(resourceId);

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -426,6 +426,13 @@ public class ConfigConstants {
     public static final String OPENSEARCH_RESOURCE_SHARING_ENABLED = "plugins.security.experimental.resource_sharing.enabled";
     public static final boolean OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT = false;
 
+    // Protected resource types
+    // Resource sharing will only apply to these types
+    public static final String OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES =
+        "plugins.security.experimental.resource_sharing.protected_types";
+    public static final List<String> OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES_DEFAULT = List.of(); // defaults to no registered types as
+                                                                                                      // protected
+
     public static Set<String> getSettingAsSet(
         final Settings settings,
         final String key,


### PR DESCRIPTION
### Description
Adds an opensearch setting that allow cluster-admins to specify which resources must be marked as protected.
```yml
plugins.security.experimental.resource_sharing.protected_types: []
```

* Category : Enhancement
* Why these changes are required?
* To allow individual control over which resources should be access-protected
* What is the old behavior before changes and new behavior after changes?
* Without this change, by default, all resources onboarded to this feature will receive protection, meaning cluster-admins cannot opt out of resource-protection for specific types. With this change, such specification will be allowed.

### Issues Resolved
TBD


### Testing
Automated + manual

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
