### PR TITLE
Force dep resolution in libs/opensaml even though classes are excluded from shadow

### DIFF
--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -25,6 +25,15 @@ repositories {
     maven { url "build.shibboleth.net/maven/releases"}
 }
 
+configurations.all {
+    resolutionStrategy {
+        force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+        force "org.bouncycastle:bcpkix-jdk18on:1.82"
+        force "org.bouncycastle:bcprov-jdk18on:1.82"
+        force "org.apache.commons:commons-lang3:${versions.commonslang}"
+    }
+}
+
 task sourcesJar(type: Jar) {
     archiveClassifier.set 'sources'
     from sourceSets.main.allJava


### PR DESCRIPTION
### Description

This PR ensures that the security repo shows as not affected by any known CVEs by forcing dependency resolution in `libs/opensaml`. Forcing dependency resolution in this library will not have any effect because the classes from all of these jars will be excluded from the final shadow jar that this lib produces. This PR is merely to make sure its not flagged during scanning. 

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
