### PR TITLE
Makes resource settings dynamic

### DIFF
--- a/spi/src/main/java/org/opensearch/security/spi/resources/client/ResourceSharingClient.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/client/ResourceSharingClient.java
@@ -54,4 +54,11 @@ public interface ResourceSharingClient {
      * @param listener The listener to be notified with the set of accessible resources.
      */
     void getAccessibleResourceIds(String resourceIndex, ActionListener<Set<String>> listener);
+
+    /**
+     * Returns a flag to indicate whether resource-sharing is enabled for resource-type
+     * @param resourceType the type for which resource-sharing status is to be checked
+     * @return true if enabled, false otherwise
+     */
+    boolean isFeatureEnabledForType(String resourceType);
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessControlClient.java
@@ -29,14 +29,16 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
 
     private final ResourceAccessHandler resourceAccessHandler;
     private final Set<String> resourceIndices;
+    private final ResourcePluginInfo resourcePluginInfo;
 
     /**
      * Constructs a new ResourceAccessControlClient.
      *
      */
-    public ResourceAccessControlClient(ResourceAccessHandler resourceAccessHandler, Set<String> resourceIndices) {
+    public ResourceAccessControlClient(ResourceAccessHandler resourceAccessHandler, ResourcePluginInfo resourcePluginInfo) {
         this.resourceAccessHandler = resourceAccessHandler;
-        this.resourceIndices = resourceIndices;
+        this.resourceIndices = resourcePluginInfo.getResourceIndices();
+        this.resourcePluginInfo = resourcePluginInfo;
     }
 
     /**
@@ -97,5 +99,15 @@ public final class ResourceAccessControlClient implements ResourceSharingClient 
     @Override
     public void getAccessibleResourceIds(String resourceIndex, ActionListener<Set<String>> listener) {
         resourceAccessHandler.getOwnAndSharedResourceIdsForCurrentUser(resourceIndex, listener);
+    }
+
+    /**
+     * Returns a flag to indicate whether resource-sharing is enabled for resource-type
+     * @param resourceType the type for which resource-sharing status is to be checked
+     * @return true if enabled, false otherwise
+     */
+    @Override
+    public boolean isFeatureEnabledForType(String resourceType) {
+        return resourcePluginInfo.indexByType(resourceType) != null;
     }
 }

--- a/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceIndexListener.java
@@ -9,6 +9,7 @@
 package org.opensearch.security.resources;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.logging.log4j.LogManager;
@@ -19,6 +20,7 @@ import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.engine.Engine;
 import org.opensearch.index.shard.IndexingOperationListener;
 import org.opensearch.security.auth.UserSubjectImpl;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.spi.resources.sharing.CreatedBy;
 import org.opensearch.security.spi.resources.sharing.ResourceSharing;
 import org.opensearch.security.support.ConfigConstants;
@@ -37,10 +39,24 @@ public class ResourceIndexListener implements IndexingOperationListener {
     private final ResourceSharingIndexHandler resourceSharingIndexHandler;
 
     private final ThreadPool threadPool;
+    private final ResourcePluginInfo resourcePluginInfo;
 
-    public ResourceIndexListener(ThreadPool threadPool, Client client, ResourcePluginInfo resourcePluginInfo) {
+    private final OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting;
+
+    private final OpensearchDynamicSetting<List<String>> protectedResourceTypesSetting;
+
+    public ResourceIndexListener(
+        ThreadPool threadPool,
+        Client client,
+        ResourcePluginInfo resourcePluginInfo,
+        OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting,
+        OpensearchDynamicSetting<List<String>> resourceSharingProtectedResourceTypesSetting
+    ) {
         this.threadPool = threadPool;
         this.resourceSharingIndexHandler = new ResourceSharingIndexHandler(client, threadPool, resourcePluginInfo);
+        this.resourcePluginInfo = resourcePluginInfo;
+        this.resourceSharingEnabledSetting = resourceSharingEnabledSetting;
+        this.protectedResourceTypesSetting = resourceSharingProtectedResourceTypesSetting;
     }
 
     /**
@@ -48,7 +64,19 @@ public class ResourceIndexListener implements IndexingOperationListener {
      */
     @Override
     public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {
+
+        if (!resourceSharingEnabledSetting.getDynamicSettingValue()) {
+            // feature is disabled
+            return;
+        }
         String resourceIndex = shardId.getIndexName();
+
+        List<String> protectedResourceTypes = protectedResourceTypesSetting.getDynamicSettingValue();
+        if (!protectedResourceTypes.contains(resourcePluginInfo.typeByIndex(resourceIndex))) {
+            // type is marked as not protected
+            return;
+        }
+
         log.debug("postIndex called on {}", resourceIndex);
 
         String resourceId = index.id();
@@ -104,7 +132,18 @@ public class ResourceIndexListener implements IndexingOperationListener {
      */
     @Override
     public void postDelete(ShardId shardId, Engine.Delete delete, Engine.DeleteResult result) {
+        if (!resourceSharingEnabledSetting.getDynamicSettingValue()) {
+            // feature is disabled
+            return;
+        }
         String resourceIndex = shardId.getIndexName();
+
+        List<String> protectedResourceTypes = protectedResourceTypesSetting.getDynamicSettingValue();
+        if (!protectedResourceTypes.contains(resourcePluginInfo.typeByIndex(resourceIndex))) {
+            // type is marked as not protected
+            return;
+        }
+
         log.debug("postDelete called on {}", resourceIndex);
 
         String resourceId = delete.id();

--- a/src/main/java/org/opensearch/security/resources/settings/ResourceSharingFeatureFlagSetting.java
+++ b/src/main/java/org/opensearch/security/resources/settings/ResourceSharingFeatureFlagSetting.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.resources.settings;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.resources.ResourcePluginInfo;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.spi.resources.client.ResourceSharingClient;
+import org.opensearch.security.support.ConfigConstants;
+
+public class ResourceSharingFeatureFlagSetting extends OpensearchDynamicSetting<Boolean> {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private static final String SETTING = ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED;
+
+    private final ResourcePluginInfo resourcePluginInfo;
+
+    public ResourceSharingFeatureFlagSetting(final Settings settings, final ResourcePluginInfo resourcePluginInfo) {
+        super(getSetting(), getSettingInitialValue(settings));
+        this.resourcePluginInfo = resourcePluginInfo;
+    }
+
+    private static Setting<Boolean> getSetting() {
+        return Setting.boolSetting(
+            SETTING,
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+    }
+
+    private static Boolean getSettingInitialValue(final Settings settings) {
+        return settings.getAsBoolean(SETTING, ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED_DEFAULT);
+    }
+
+    @Override
+    public void registerClusterSettingsChangeListener(final ClusterSettings clusterSettings) {
+        clusterSettings.addSettingsUpdateConsumer(getSetting(), isEnabled -> {
+            logger.info(getClusterChangeMessage(isEnabled));
+            setDynamicSettingValue(isEnabled);
+            if (isEnabled) {
+                ResourceSharingClient resourceSharingClient = resourcePluginInfo.getResourceAccessControlClient();
+                resourcePluginInfo.getResourceSharingExtensions().forEach(resourceSharingExtension -> {
+                    resourceSharingExtension.assignResourceSharingClient(resourceSharingClient); // associate the client
+                });
+            } else {
+                resourcePluginInfo.getResourceSharingExtensions().forEach(resourceSharingExtension -> {
+                    resourceSharingExtension.assignResourceSharingClient(null); // dissociate the client
+                });
+            }
+        });
+    }
+
+    @Override
+    protected String getClusterChangeMessage(final Boolean isEnabled) {
+        return String.format(
+            "Detected change in settings, cluster setting for resource-sharing feature flag is %s",
+            isEnabled ? "enabled" : "disabled"
+        );
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/settings/ResourceSharingProtectedResourcesSetting.java
+++ b/src/main/java/org/opensearch/security/resources/settings/ResourceSharingProtectedResourcesSetting.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ */
+
+package org.opensearch.security.resources.settings;
+
+import java.util.List;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.resources.ResourcePluginInfo;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.support.ConfigConstants;
+
+public class ResourceSharingProtectedResourcesSetting extends OpensearchDynamicSetting<List<String>> {
+
+    private final Logger logger = LogManager.getLogger(getClass());
+
+    private static final String SETTING = ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES;
+
+    private final ResourcePluginInfo resourcePluginInfo;
+
+    public ResourceSharingProtectedResourcesSetting(final Settings settings, ResourcePluginInfo resourcePluginInfo) {
+        super(getSetting(), getSettingInitialValue(settings));
+        this.resourcePluginInfo = resourcePluginInfo;
+    }
+
+    private static Setting<List<String>> getSetting() {
+        return Setting.listSetting(
+            SETTING,
+            ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES_DEFAULT,
+            Function.identity(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+        );
+    }
+
+    private static List<String> getSettingInitialValue(final Settings settings) {
+        return settings.getAsList(SETTING, ConfigConstants.OPENSEARCH_RESOURCE_SHARING_PROTECTED_TYPES_DEFAULT);
+    }
+
+    @Override
+    public void registerClusterSettingsChangeListener(final ClusterSettings clusterSettings) {
+        clusterSettings.addSettingsUpdateConsumer(getSetting(), dynamicSettingNewValue -> {
+            logger.info(getClusterChangeMessage(dynamicSettingNewValue));
+            setDynamicSettingValue(dynamicSettingNewValue);
+            this.resourcePluginInfo.updateProtectedTypes(dynamicSettingNewValue);
+        });
+    }
+
+    @Override
+    protected String getClusterChangeMessage(final List<String> dynamicSettingNewValue) {
+        return String.format("Detected change in settings, new resource-sharing protected resource-types are %s", dynamicSettingNewValue);
+    }
+}

--- a/src/main/java/org/opensearch/security/resources/settings/package-info.java
+++ b/src/main/java/org/opensearch/security/resources/settings/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains settings related to resource-sharing feature
+ */
+package org.opensearch.security.resources.settings;

--- a/src/main/java/org/opensearch/security/setting/OpensearchDynamicSetting.java
+++ b/src/main/java/org/opensearch/security/setting/OpensearchDynamicSetting.java
@@ -45,7 +45,7 @@ public abstract class OpensearchDynamicSetting<T> {
         return String.format("Detected change in settings, updated cluster setting value is %s", dynamicSettingNewValue);
     }
 
-    private void setDynamicSettingValue(final T dynamicSettingValue) {
+    protected void setDynamicSettingValue(final T dynamicSettingValue) {
         this.dynamicSettingValue = dynamicSettingValue;
     }
 

--- a/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/ResourceAccessEvaluatorTest.java
@@ -20,6 +20,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.security.auth.UserSubjectImpl;
 import org.opensearch.security.resources.ResourceAccessHandler;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.support.ConfigConstants;
 
 import org.mockito.ArgumentCaptor;
@@ -53,7 +54,12 @@ public class ResourceAccessEvaluatorTest {
     public void setup() {
         Settings settings = Settings.builder().put(ConfigConstants.OPENSEARCH_RESOURCE_SHARING_ENABLED, true).build();
         threadContext = new ThreadContext(Settings.EMPTY);
-        evaluator = new ResourceAccessEvaluator(Collections.singleton(IDX), settings, resourceAccessHandler);
+        evaluator = new ResourceAccessEvaluator(
+            Collections.singleton(IDX),
+            resourceAccessHandler,
+            mock(OpensearchDynamicSetting.class),
+            mock(OpensearchDynamicSetting.class)
+        );
     }
 
     private void stubAuthenticatedUser() {


### PR DESCRIPTION
### Description
Makes resource sharing settings dynamic. Also adds capability for plugin to chose codepath based on protected resource-types
* Category : Enhancement
* Why these changes are required?
* To allow settings to be update-able by customers through cluster-settings API


### Issues Resolved
TBD


### Testing
Manual + Automated Testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
