### PR TITLE
bug fix: security attributes attribute matching logic

### DIFF
--- a/src/main/java/org/opensearch/security/auth/PrincipalAttribute.java
+++ b/src/main/java/org/opensearch/security/auth/PrincipalAttribute.java
@@ -130,11 +130,11 @@ public enum PrincipalAttribute implements Attribute {
         Map<String, Float> scoreMap = new HashMap<>();
 
         for (String value : attributeExtractor.extract()) {
-            Set<String> matches = attributeValueStore.getExactMatch(value);
+            List<MatchLabel<String>> matches = attributeValueStore.getExactMatch(value);
             String subField = parsePrincipalValue(value)[0];
             assert WEIGHTED_SUBFIELDS.containsKey(subField);
-            for (String label : matches) {
-                scoreMap.merge(label, WEIGHTED_SUBFIELDS.get(subField), Float::sum);
+            for (MatchLabel<String> entry : matches) {
+                scoreMap.merge(entry.getFeatureValue(), entry.getMatchScore() * WEIGHTED_SUBFIELDS.get(subField), Float::sum);
             }
         }
 


### PR DESCRIPTION
### Description
This change updates the handling of principal attribute matches to correctly use the match score returned by getExactMatch() instead of assigning a fixed score.

Previously, we treated all principal attribute matches as having a score of 1.0, regardless of whether they were exact matches or empty cases.

More details here: https://github.com/opensearch-project/OpenSearch/pull/19599 
Impact
### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
