### PR TITLE
[Backport 2.19] Create a WildcardMatcher.NONE when creating a WildcardMatcher with an empty string (#5694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased 2.19.x]
 
+### Bug Fixes
+- Create a WildcardMatcher.NONE when creating a WildcardMatcher with an empty string ([#5694](https://github.com/opensearch-project/security/pull/5694))
+
 ### Maintenance
 - Bump `com.nimbusds:nimbus-jose-jwt:9.48` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))
 - Bump `checkstyle` from 10.3.3 to 10.26.1 ([#5480](https://github.com/opensearch-project/security/pull/5480))

--- a/src/main/java/org/opensearch/security/support/WildcardMatcher.java
+++ b/src/main/java/org/opensearch/security/support/WildcardMatcher.java
@@ -132,7 +132,7 @@ public abstract class WildcardMatcher implements Predicate<String> {
     };
 
     public static WildcardMatcher from(String pattern) {
-        if (pattern == null) {
+        if (pattern == null || pattern.isBlank()) {
             return NONE;
         } else if (pattern.equals("*")) {
             return ANY;

--- a/src/test/java/org/opensearch/security/UtilTests.java
+++ b/src/test/java/org/opensearch/security/UtilTests.java
@@ -81,6 +81,9 @@ public class UtilTests {
         assertTrue(wc("abc").test("abc"));
         assertFalse(wc("ABC").test("abc"));
         assertFalse(wc(null).test("abc"));
+        assertFalse(wc("").test("abc"));
+        // Creating a WildcardMatcher with blank should create a matcher that matches nothing
+        assertFalse(wc("").test(""));
         assertTrue(WildcardMatcher.from(null, "abc").test("abc"));
     }
 


### PR DESCRIPTION
(cherry picked from commit 67af4cc208ad9b05a9b4393bf7475741cdddb47e)

### Description

Backport #5694 to 2.19.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
