### PR TITLE
Replace usages of joptsimple.internal.Strings with org.opensearch.core.common.Strings

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
@@ -28,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.opensearch.core.common.Strings;
 import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.test.framework.AuditCompliance;
 import org.opensearch.test.framework.AuditConfiguration;
@@ -38,8 +39,6 @@ import org.opensearch.test.framework.audit.AuditLogsRule;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
-
-import joptsimple.internal.Strings;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -33,12 +33,12 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.core.common.Strings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.http.jwt.oidc.json.OpenIdProviderConfiguration;
 import org.opensearch.security.util.SettingsBasedSSLConfigurator.SSLConfig;
 
 import com.nimbusds.jose.jwk.JWKSet;
-import joptsimple.internal.Strings;
 
 public class KeySetRetriever implements KeySetProvider {
     private final static Logger log = LogManager.getLogger(KeySetRetriever.class);

--- a/src/main/java/org/opensearch/security/identity/SecurityTokenManager.java
+++ b/src/main/java/org/opensearch/security/identity/SecurityTokenManager.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.identity.Subject;
 import org.opensearch.identity.noop.NoopSubject;
@@ -38,7 +39,6 @@ import org.opensearch.security.user.User;
 import org.opensearch.security.user.UserService;
 import org.opensearch.threadpool.ThreadPool;
 
-import joptsimple.internal.Strings;
 import org.greenrobot.eventbus.Subscribe;
 
 import static org.opensearch.security.util.AuthTokenUtils.isKeyNull;

--- a/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
+++ b/src/main/java/org/opensearch/security/resources/api/share/ShareRequest.java
@@ -15,14 +15,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.DocRequest;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.resources.sharing.ShareWith;
-
-import joptsimple.internal.Strings;
 
 /**
  * This class represents a request to share access to a resource.


### PR DESCRIPTION
### Description

Replace usages of joptsimple.internal.Strings with org.opensearch.core.common.Strings

I plan to raise a PR in core to remove the dependency on jopt-simple entirely and this is forbidden from being used in core.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Refactoring

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
