### PR TITLE
Adding Alerting V2 roles to roles.yml

### DIFF
--- a/config/roles.yml
+++ b/config/roles.yml
@@ -35,11 +35,11 @@ alerting_read_access:
     - 'cluster:admin/opensearch/alerting/comments/search'
     - 'cluster:admin/opensearch/alerting/findings/get'
     - 'cluster:admin/opensearch/alerting/remote/indexes/get'
-    - 'cluster:admin/opensearch/alerting/workflow/get'
-    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
     - 'cluster:admin/opensearch/alerting/v2/alerts/get'
     - 'cluster:admin/opensearch/alerting/v2/monitor/get'
     - 'cluster:admin/opensearch/alerting/v2/monitor/search'
+    - 'cluster:admin/opensearch/alerting/workflow/get'
+    - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
 
 # Allows users to view and acknowledge alerts
 alerting_ack_alerts:


### PR DESCRIPTION
### Description
Adding PPL Alerting actions to `alerting_full_access` role, and adding PPL Alerting's alert indices as system indices.

### Issues Resolved
https://github.com/opensearch-project/alerting/issues/1880

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Alerting plugin contains integration tests on cluster with Security plugin installed to test role access: https://github.com/toepkerd/alerting/blob/ppl-main/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorV2RestApiIT.kt

### Check List
- [Y] New functionality includes testing
- [N] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [Y] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
