### PR TITLE
Adding PPL Alerting role permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Moved configuration reloading to dedicated thread to improve node stability  ([#5479](https://github.com/opensearch-project/security/pull/5479))
 - Makes resource settings dynamic ([#5677](https://github.com/opensearch-project/security/pull/5677))
 - [Resource Sharing] Allow multiple sharable resource types in single resource index ([#5713](https://github.com/opensearch-project/security/pull/5713))
+- Adding Alerting V2 roles to roles.yml ([#5747](https://github.com/opensearch-project/security/pull/5747))
 
 ### Bug Fixes
 - Create a WildcardMatcher.NONE when creating a WildcardMatcher with an empty string ([#5694](https://github.com/opensearch-project/security/pull/5694))

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -35,6 +35,9 @@ alerting_read_access:
     - 'cluster:admin/opensearch/alerting/comments/search'
     - 'cluster:admin/opensearch/alerting/findings/get'
     - 'cluster:admin/opensearch/alerting/remote/indexes/get'
+    - 'cluster:admin/opensearch/alerting/v2/alerts/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/get'
+    - 'cluster:admin/opensearch/alerting/v2/monitor/search'
     - 'cluster:admin/opensearch/alerting/workflow/get'
     - 'cluster:admin/opensearch/alerting/workflow_alerts/get'
 


### PR DESCRIPTION
### Description
Adding PPL Alerting actions to `alerting_full_access` role, and adding PPL Alerting's alert indices as system indices.

### Issues Resolved
https://github.com/opensearch-project/alerting/issues/1880

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Alerting plugin contains integration tests on cluster with Security plugin installed to test role access: https://github.com/toepkerd/alerting/blob/ppl-main/alerting/src/test/kotlin/org/opensearch/alerting/resthandler/SecureMonitorV2RestApiIT.kt

### Check List
- [Y] New functionality includes testing
- [N] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [N/A] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [Y] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
