### PR TITLE
add suggest api to ad read access role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Makes resource settings dynamic ([#5677](https://github.com/opensearch-project/security/pull/5677))
 - [Resource Sharing] Allow multiple sharable resource types in single resource index ([#5713](https://github.com/opensearch-project/security/pull/5713))
 - Adding Alerting V2 roles to roles.yml ([#5747](https://github.com/opensearch-project/security/pull/5747))
+- add suggest api to ad read access role ([#5754](https://github.com/opensearch-project/security/pull/5754))
 
 ### Bug Fixes
 - Create a WildcardMatcher.NONE when creating a WildcardMatcher with an empty string ([#5694](https://github.com/opensearch-project/security/pull/5694))

--- a/config/roles.yml
+++ b/config/roles.yml
@@ -72,6 +72,7 @@ anomaly_read_access:
   cluster_permissions:
     - 'cluster:admin/opendistro/ad/detector/info'
     - 'cluster:admin/opendistro/ad/detector/search'
+    - 'cluster:admin/opendistro/ad/detector/suggest'
     - 'cluster:admin/opendistro/ad/detector/validate'
     - 'cluster:admin/opendistro/ad/detectors/get'
     - 'cluster:admin/opendistro/ad/result/search'


### PR DESCRIPTION
### Description
[Describe what this change achieves]
* add suggest api to ad read access role

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
no.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
no.

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] New Roles/Permissions have a corresponding security dashboards plugin PR
- [X] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
