### PR TITLE
[Backport 2.19] Use RestRequestFilter.getFilteredRequest to declare sensitive API params (#5710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Bug Fixes
 - Create a WildcardMatcher.NONE when creating a WildcardMatcher with an empty string ([#5694](https://github.com/opensearch-project/security/pull/5694))
+- Use RestRequestFilter.getFilteredRequest to declare sensitive API params ([#5710](https://github.com/opensearch-project/security/pull/5710))
 
 ### Maintenance
 - Bump `com.nimbusds:nimbus-jose-jwt:9.48` from 9.48 to 10.0.2 ([#5480](https://github.com/opensearch-project/security/pull/5480))

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.security.filter;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -47,6 +48,7 @@ import org.opensearch.rest.NamedRoute;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.rest.RestRequestFilter;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
 import org.opensearch.security.auth.BackendRegistry;
@@ -155,7 +157,11 @@ public class SecurityRestFilter {
                 }
             });
 
+            RestRequest filteredRequest = maybeFilterRestRequest(request);
+
             final SecurityRequestChannel requestChannel = SecurityRequestFactory.from(request, channel);
+            // for audit logging
+            final SecurityRequestChannel filteredRequestChannel = SecurityRequestFactory.from(filteredRequest, channel);
 
             // Authenticate request
             if (!NettyAttribute.popFrom(request, Netty4HttpRequestHeaderVerifier.IS_AUTHENTICATED).orElse(false)) {
@@ -172,12 +178,12 @@ public class SecurityRestFilter {
             String intiatingUser = threadContext.getTransient(OPENDISTRO_SECURITY_INITIATING_USER);
             if (userIsSuperAdmin(user, adminDNs)) {
                 // Super admins are always authorized
-                auditLog.logSucceededLogin(user.getName(), true, intiatingUser, requestChannel);
+                auditLog.logSucceededLogin(user.getName(), true, intiatingUser, filteredRequestChannel);
                 delegate.handleRequest(request, channel, client);
                 return;
             }
             if (user != null) {
-                auditLog.logSucceededLogin(user.getName(), false, intiatingUser, requestChannel);
+                auditLog.logSucceededLogin(user.getName(), false, intiatingUser, filteredRequestChannel);
             }
             final Optional<SecurityResponse> deniedResponse = whitelistingSettings.checkRequestIsAllowed(requestChannel)
                 .or(() -> allowlistingSettings.checkRequestIsAllowed(requestChannel));
@@ -187,14 +193,22 @@ public class SecurityRestFilter {
                 return;
             }
 
-            authorizeRequest(delegate, requestChannel, user);
-            if (requestChannel.getQueuedResponse().isPresent()) {
-                channel.sendResponse(requestChannel.getQueuedResponse().get().asRestResponse());
+            authorizeRequest(delegate, filteredRequestChannel, user);
+            if (filteredRequestChannel.getQueuedResponse().isPresent()) {
+                channel.sendResponse(filteredRequestChannel.getQueuedResponse().get().asRestResponse());
                 return;
             }
 
             // Caller was authorized, forward the request to the handler
             delegate.handleRequest(request, channel, client);
+        }
+
+        RestRequest maybeFilterRestRequest(RestRequest request) throws IOException {
+            // Skip PATCH because filtering only supports JSON object bodies, not arrays.
+            if (delegate instanceof RestRequestFilter && (request.method() != RestRequest.Method.PATCH)) {
+                return ((RestRequestFilter) delegate).getFilteredRequest(request);
+            }
+            return request;
         }
     }
 


### PR DESCRIPTION
(cherry picked from commit acadb8cf259011493144e6a5c5f9f251fde35ba0)

### Description

Backport #5710 to 2.19

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
