### PR TITLE
Added newly introduced core method to TestRestChannel

### DIFF
--- a/src/test/java/org/opensearch/security/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -1000,6 +1000,11 @@ public class HTTPSamlAuthenticatorTest {
         }
 
         @Override
+        public boolean detailedErrorStackTraceEnabled() {
+            return false;
+        }
+
+        @Override
         public void sendResponse(RestResponse response) {
             this.response = response;
 


### PR DESCRIPTION
### Description

The core PR https://github.com/opensearch-project/OpenSearch/pull/19985 added a new method to the `RestChannel` interface which makes test code break here. This adds the new method.

* Category: Test fix
* Why these changes are required? Core change
* What is the old behavior before changes and new behavior after changes? no differences

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
