### PR TITLE
Remove reflective call to getInnerChannel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Modularized PrivilegesEvaluator ([#5791](https://github.com/opensearch-project/security/pull/5791))
 - [Resource Sharing] Adds post support for update sharing info API ([#5799](https://github.com/opensearch-project/security/pull/5799))
 - Cleaned up use of PrivilegesEvaluatorResponse ([#5804](https://github.com/opensearch-project/security/pull/5804))
+- Remove reflective call to getInnerChannel ([#5816](https://github.com/opensearch-project/security/pull/5816))
 
 ### Maintenance
 - Bump `org.junit.jupiter:junit-jupiter` from 5.13.4 to 5.14.1 ([#5678](https://github.com/opensearch-project/security/pull/5678), [#5764](https://github.com/opensearch-project/security/pull/5764))

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -28,7 +28,6 @@ package org.opensearch.security.transport;
 
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -72,7 +71,6 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
     private final InterClusterRequestEvaluator requestEvalProvider;
     private final ClusterService cs;
     private final UserFactory userFactory;
-    private static final Set<String> knownChannelTypes = Set.of("direct", "transport", "stream-transport");
 
     SecurityRequestHandler(
         String action,
@@ -129,11 +127,6 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             }
 
             String channelType = transportChannel.getChannelType();
-
-            if (!knownChannelTypes.contains(channelType)) {
-                TransportChannel innerChannel = getInnerChannel(transportChannel);
-                channelType = innerChannel.getChannelType();
-            }
 
             getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_CHANNEL_TYPE, channelType);
             getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ACTION_NAME, task.getAction());


### PR DESCRIPTION
### Description

getInnerChannel was a weird pattern introduced to tightly couple the security plugin and performance-analyzer. PA removed the method in https://github.com/opensearch-project/performance-analyzer/pull/845 in favor of delegating to the wrapped handler instead of providing a custom value for getChannelType.

The reflective code is no longer necessary in the security repo.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Related to https://github.com/opensearch-project/performance-analyzer/issues/840

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
