### PR TITLE
Fix build-health CI check by increasing heap size for gradle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
         with:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
-      - run: ./gradlew clean buildHealth
+      - run: ./gradlew clean buildHealth -Dorg.gradle.jvmargs="-Xms1g -Xmx4g -XX:+UseG1GC -XX:MaxMetaspaceSize=512m"
 
       - uses: actions/upload-artifact@v5
         if: always()


### PR DESCRIPTION
### Description

This PR fixes build-health CI check by increasing heap size for gradle

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
