### PR TITLE
Bump `org.lz4:lz4-java` from 1.8.0 to 1.10.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade springframework to 7.0.1 and zookeeper to 3.9.4 ([#5829](https://github.com/opensearch-project/security/pull/5829))
 - Bump `org.opensearch:common-utils` from 3.2.0.0-SNAPSHOT to 3.3.2.0 ([#5830](https://github.com/opensearch-project/security/pull/5830))
 - Bump `commons-cli:commons-cli` from 1.10.0 to 1.11.0 ([#5840](https://github.com/opensearch-project/security/pull/5840))
-- Use new group name for lz4-java and upgrade to 1.10.1 ([#5845](https://github.com/opensearch-project/security/pull/5845))
+- Bump `org.lz4:lz4-java` from 1.8.0 to 1.8.1 ([#5845](https://github.com/opensearch-project/security/pull/5845))
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Upgrade springframework to 7.0.1 and zookeeper to 3.9.4 ([#5829](https://github.com/opensearch-project/security/pull/5829))
 - Bump `org.opensearch:common-utils` from 3.2.0.0-SNAPSHOT to 3.3.2.0 ([#5830](https://github.com/opensearch-project/security/pull/5830))
 - Bump `commons-cli:commons-cli` from 1.10.0 to 1.11.0 ([#5840](https://github.com/opensearch-project/security/pull/5840))
+- Use new group name for lz4-java and upgrade to 1.10.1 ([#5845](https://github.com/opensearch-project/security/pull/5845))
 
 ### Documentation
 

--- a/build.gradle
+++ b/build.gradle
@@ -733,7 +733,7 @@ dependencies {
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:3.1'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'at.yawk.lz4:lz4-java:1.10.1'
+    runtimeOnly 'org.lz4:lz4-java:1.8.1'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.8'

--- a/build.gradle
+++ b/build.gradle
@@ -522,6 +522,8 @@ configurations {
 
             // For org.opensearch.plugin:transport-grpc
             force "com.google.guava:failureaccess:1.0.3"
+
+            exclude group: "org.lz4", module: "lz4-java"
         }
     }
 }
@@ -733,7 +735,7 @@ dependencies {
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:3.1'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'org.lz4:lz4-java:1.8.1'
+    runtimeOnly 'at.yawk.lz4:lz4-java:1.8.1'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.8'

--- a/build.gradle
+++ b/build.gradle
@@ -733,7 +733,7 @@ dependencies {
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:3.1'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'org.lz4:lz4-java:1.8.0'
+    runtimeOnly 'at.yawk.lz4:lz4-java:1.10.1'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.8'

--- a/build.gradle
+++ b/build.gradle
@@ -735,7 +735,7 @@ dependencies {
     runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     runtimeOnly 'com.google.j2objc:j2objc-annotations:3.1'
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'at.yawk.lz4:lz4-java:1.8.1'
+    runtimeOnly 'at.yawk.lz4:lz4-java:1.10.1'
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
     runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.8'


### PR DESCRIPTION
### Description

Bump `org.lz4:lz4-java` from 1.8.0 to 1.10.1 

Note: This dependency has moved see https://mvnrepository.com/artifact/org.lz4/lz4-java. I have tried to use the new coordinates, but it is incompatible with our current version of kafka-clients.

Resolves CVE flagged in Docker scan here: https://github.com/opensearch-project/opensearch-build/issues/5764#issuecomment-3628338494

- CVE-2025-12183
- CVE-2025-66566

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintanence

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
