### PR TITLE
fix ConcurrentModificationException for SecurityRoles for 2.x

### DIFF
--- a/src/main/java/org/opensearch/security/user/User.java
+++ b/src/main/java/org/opensearch/security/user/User.java
@@ -282,9 +282,7 @@ public class User implements Serializable, Writeable, CustomAttributesAware {
     }
 
     public final Set<String> getSecurityRoles() {
-        return this.securityRoles == null
-            ? Collections.synchronizedSet(Collections.emptySet())
-            : this.securityRoles;
+        return this.securityRoles == null ? Collections.synchronizedSet(Collections.emptySet()) : this.securityRoles;
     }
 
     /**


### PR DESCRIPTION
### Description
[Describe what this change achieves]

fix ConcurrentModificationException for SecurityRoles for 2.x
[#5859 ](https://github.com/opensearch-project/security/issues/5859)

Change `user.getSecurityRoles()` to `user.getRawSecurityRoles()` to ensure the effectiveness of synchronization.

### Issues Resolved
[List any issues this PR will resolve]
[#5859 ](https://github.com/opensearch-project/security/issues/5859)

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

tested locally as [#5859 ](https://github.com/opensearch-project/security/issues/5859)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
