### PR TITLE
Fixed NPE in LDAP recursive role search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Updates DlsFlsValveImpl condition to return true if request is internal and not a protected resource request ([#5721](https://github.com/opensearch-project/security/pull/5721))
 - [Performance] Call AdminDns.isAdmin once per request ([#5752](https://github.com/opensearch-project/security/pull/5752))
 - Update operations on `.kibana` system index now work correctly with Dashboards multi tenancy enabled. ([#5778](https://github.com/opensearch-project/security/pull/5778))
+- Fixes an issue where recursive LDAP role search would fail with a NullPointerException ([#5861](https://github.com/opensearch-project/security/pull/5861))
 
 ### Refactoring
 - [Resource Sharing] Make migrate api require default access level to be supplied and updates documentations + tests ([#5717](https://github.com/opensearch-project/security/pull/5717))

--- a/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -902,6 +902,10 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                         continue;
                     }
 
+                    if (connection == null) {
+                        connection = getConnection(settings, configPath);
+                    }
+
                     final Set<LdapName> nestedRoles = resolveNestedRoles(
                         roleLdapName,
                         connection,


### PR DESCRIPTION
### Description

Fixes a NPE occuring in specific conditions in LDAP role search. 

* Category: Bugfix
* Why these changes are required? it does not work
* What is the old behavior before changes and new behavior after changes? well, it works now

### Issues Resolved

Fixes #5832

### Testing

- New unit test

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
