### PR TITLE
fix authToken

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -338,6 +338,8 @@ public class InternalUsersApiAction extends AbstractApiAction {
                             .put("opendistro_security_roles", DataType.ARRAY)
                             .put("hash", DataType.STRING)
                             .put("password", DataType.STRING)
+                            .put("service", DataType.BOOLEAN)
+                            .put("enabled", DataType.BOOLEAN)
                             .build();
                     }
                 });

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/InternalUserV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/InternalUserV7.java
@@ -127,11 +127,11 @@ public class InternalUserV7 implements Hideable, Hashed, StaticDefinable {
         this.attributes = attributes;
     }
 
-    public boolean enabled() {
+    public boolean isEnabled() {
         return this.enabled;
     }
 
-    public boolean service() {
+    public boolean isService() {
         return this.service;
     }
 


### PR DESCRIPTION
### Description
fixes Service Account tokens API https://docs.opensearch.org/latest/security/access-control/authentication-tokens/
### Why these changes are required?
- Wrong index name (INTERNALUSERS instead of .opendistro_security)
- Config cache not refreshed after index write
- enabled/service fields at wrong level

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
manual testing
#### Step 1: Create a Service Account
```bash
curl -X PUT "https://localhost:9200/_plugins/_security/api/internalusers/my-service-account?pretty=true" \
    -H "Content-Type: application/json" \
    -u 'admin:'$OPENSEARCH_INITIAL_ADMIN_PASSWORD -k \
    -d '{
      "service": true,
      "enabled": true,
      "backend_roles": ["service_admin"],
      "description": "My service account"
    }'
#{
#  "status" : "CREATED",
#  "message" : "'my-service-account' created."
#}
```

#### Step 2: Create dedicated service role
```bash
curl -X PUT "https://localhost:9200/_plugins/_security/api/rolesmapping/all_access?pretty=true" \
-H "Content-Type: application/json" \
-u 'admin:'$OPENSEARCH_INITIAL_ADMIN_PASSWORD -k \
-d '{
    "backend_roles": ["service_admin", "admin"]
}'
```

#### (optional) Get all internal users
```bash
curl -X GET "https://localhost:9200/_plugins/_security/api/internalusers?pretty=true" \
    -H "Content-Type: application/json" \
    -u 'admin:'$OPENSEARCH_INITIAL_ADMIN_PASSWORD \
    -k
```

#### Step 3: Generate or Regenerate Auth Token
```bash
curl -X POST "https://localhost:9200/_plugins/_security/api/internalusers/my-service-account/authtoken?pretty=true" \
    -u 'admin:'$OPENSEARCH_INITIAL_ADMIN_PASSWORD \
    -k
# {
#     "status": "OK",
#     "message": "'my-service-account' authtoken generated Basic auth token with user=my-service-account, password=6lR92QmzVesku"
# }
```

#### Step 4: Use the Token
```bash
curl -X GET "https://localhost:9200/_cluster/health?pretty=true" \
    -H "Authorization: Basic $(echo -n 'my-service-account:6lR92QmzVesku' | base64)" \
    -k
```



### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
