### PR TITLE
Fix issue serializing user to threadcontext when userRequestedTenant is null

### DIFF
--- a/src/main/java/org/opensearch/security/user/ThreadContextUserInfo.java
+++ b/src/main/java/org/opensearch/security/user/ThreadContextUserInfo.java
@@ -80,7 +80,8 @@ public class ThreadContextUserInfo {
             joiner.add(escapePipe(String.join(",", context.getMappedRoles())));
 
             String requestedTenant = context.getUser().getRequestedTenant();
-            joiner.add(requestedTenant);
+            final String tenant = Strings.isNullOrEmpty(requestedTenant) ? "" : requestedTenant;
+            joiner.add(tenant);
 
             String tenantAccessToCheck = getTenancyAccess(context);
             joiner.add(tenantAccessToCheck);


### PR DESCRIPTION
### Description

This PR does a little cleanup to ensure that userRequestedTenant gets serialized as empty string instead of `null` when userRequestedTenant is null (for instance if multi-tenancy is enabled). I suppose you could argue that we shouldn't serialize tenancy info at all if multi-tenancy is disabled (or serialize user info to the threadcontext at all for that matter...but that's a much larger undertaking). Opening this PR to serialize as empty string instead of null to resolve the linked issue.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Issues Resolved

Fixes https://github.com/opensearch-project/security/issues/5924


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
