### PR TITLE
[Backport 3.5] Make gRPC JWT header keys case insensitive (#5929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Enhancements
 - Introduce new dynamic setting (plugins.security.dls.write_blocked) to block all writes when restrictions apply ([#5828](https://github.com/opensearch-project/security/pull/5828))
-
+- Fix JWT case-sensitive header parsing over gRPC transport ([#5929](https://github.com/opensearch-project/security/issues/5929))
 - Support nested JWT claims in role DLS queries ([#5687](https://github.com/opensearch-project/security/issues/5687))
 - Support creation of client SSL engine with a given SNI ([#5894](https://github.com/opensearch-project/security/pull/5894))
 - Enable audit logging of document contents for DELETE operations ([#5914](https://github.com/opensearch-project/security/pull/5914))

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcAnonymousAuthTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcAnonymousAuthTest.java
@@ -112,7 +112,7 @@ public class GrpcAnonymousAuthTest {
                 doBulk(channelWithAuth, "test-invalid-auth", 2);
                 fail("Expected authentication failure - invalid auth header");
             } catch (StatusRuntimeException e) {
-                assertEquals(Status.Code.INVALID_ARGUMENT, e.getStatus().getCode());
+                assertEquals(Status.Code.UNAUTHENTICATED, e.getStatus().getCode());
             }
         } finally {
             channel.shutdown();

--- a/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDefaultAuthHeaderTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDefaultAuthHeaderTest.java
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.grpc;
+
+import java.security.KeyPair;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.Version;
+import org.opensearch.plugins.PluginInfo;
+import org.opensearch.security.OpenSearchSecurityPlugin;
+import org.opensearch.test.framework.JwtConfigBuilder;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.grpc.GrpcPlugin;
+
+import io.grpc.Channel;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_ROLE;
+import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
+import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
+import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
+import static org.opensearch.security.grpc.GrpcHelpers.doBulk;
+import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
+import static org.opensearch.security.grpc.GrpcHelpers.secureChannel;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class JWTGrpcDefaultAuthHeaderTest {
+
+    public static final List<String> CLAIM_USERNAME = List.of("preferred-username");
+    public static final List<String> CLAIM_ROLES = List.of("backend-user-roles");
+    private static final KeyPair KEY_PAIR = Keys.keyPairFor(SignatureAlgorithm.RS256);
+    private static final String PUBLIC_KEY = new String(Base64.getEncoder().encode(KEY_PAIR.getPublic().getEncoded()), US_ASCII);
+
+    private String createValidJwtToken(String username, String... roles) {
+        Date now = new Date();
+        return Jwts.builder()
+            .claim(CLAIM_USERNAME.get(0), username)
+            .claim(CLAIM_ROLES.get(0), String.join(",", roles))
+            .setIssuer("test-issuer")
+            .setSubject(username)
+            .setIssuedAt(now)
+            .setExpiration(new Date(now.getTime() + 3600 * 1000))
+            .signWith(KEY_PAIR.getPrivate(), SignatureAlgorithm.RS256)
+            .compact();
+    }
+
+    // JWT auth domain with default Authorization header
+    public static final TestSecurityConfig.AuthcDomain JWT_AUTH_DOMAIN = new TestSecurityConfig.AuthcDomain("jwt", 1, true)
+        .jwtHttpAuthenticator(new JwtConfigBuilder().signingKey(List.of(PUBLIC_KEY)).subjectKey(CLAIM_USERNAME).rolesKey(CLAIM_ROLES))
+        .backend("noop");
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .certificates(TEST_CERTIFICATES)
+        .nodeSettings(SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
+        .plugin(
+            new PluginInfo(
+                GrpcPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "21",
+                GrpcPlugin.class.getName(),
+                null,
+                Collections.emptyList(),
+                false
+            )
+        )
+        .plugin(
+            new PluginInfo(
+                OpenSearchSecurityPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "21",
+                OpenSearchSecurityPlugin.class.getName(),
+                null,
+                List.of("org.opensearch.transport.grpc.GrpcPlugin"),
+                false
+            )
+        )
+        .users(GRPC_INDEX_USER)
+        .roles(GRPC_INDEX_ROLE)
+        .rolesMapping(new TestSecurityConfig.RoleMapping(GRPC_INDEX_ROLE.getName()).backendRoles("grpc_index_role"))
+        .authc(JWT_AUTH_DOMAIN)
+        .build();
+
+    @Test
+    public void testAuthorizationHeaderCaseInsensitive() throws Exception {
+        String jwtToken = createValidJwtToken("grpc_user", "grpc_index_role");
+        ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
+
+        try {
+            ClientInterceptor authInterceptor = createHeaderInterceptor(Map.of("authorization", "Bearer " + jwtToken));
+            Channel channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            var bulkResp = doBulk(channelWithAuth, "test-grpc-index-lower", 2);
+            assertNotNull(bulkResp);
+            assertFalse(bulkResp.getErrors());
+            assertEquals(2, bulkResp.getItemsCount());
+
+            authInterceptor = createHeaderInterceptor(Map.of("Authorization", "Bearer " + jwtToken));
+            channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            bulkResp = doBulk(channelWithAuth, "test-grpc-index-standard", 2);
+            assertNotNull(bulkResp);
+            assertFalse(bulkResp.getErrors());
+            assertEquals(2, bulkResp.getItemsCount());
+
+            authInterceptor = createHeaderInterceptor(Map.of("AutHoRiZaTION", "Bearer " + jwtToken));
+            channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            bulkResp = doBulk(channelWithAuth, "test-grpc-index-mixed", 2);
+            assertNotNull(bulkResp);
+            assertFalse(bulkResp.getErrors());
+            assertEquals(2, bulkResp.getItemsCount());
+        } finally {
+            channel.shutdown();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/auth/BackendRegistry.java
+++ b/src/main/java/org/opensearch/security/auth/BackendRegistry.java
@@ -1,9 +1,16 @@
 /*
- * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2015-2018 _floragunn_ GmbH
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * The OpenSearch Contributors require contributions made to
- * this file be licensed under the Apache-2.0 license or a
- * compatible open source license.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /*
@@ -262,7 +269,7 @@ public class BackendRegistry {
          */
         ThreadContext threadContext = this.threadPool.getThreadContext();
         final String sslPrincipal = (String) threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_PRINCIPAL);
-        if (!gRPC && adminDns.isAdminDN(sslPrincipal)) {
+        if (adminDns.isAdminDN(sslPrincipal)) {
             // PKI authenticated REST call
             User superuser = new User(sslPrincipal);
             UserSubject subject = new UserSubjectImpl(threadPool, superuser);

--- a/src/main/java/org/opensearch/security/filter/GrpcRequestChannel.java
+++ b/src/main/java/org/opensearch/security/filter/GrpcRequestChannel.java
@@ -14,11 +14,11 @@ package org.opensearch.security.filter;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.net.ssl.SSLEngine;
 
 import org.opensearch.rest.RestRequest.Method;
@@ -44,8 +44,12 @@ public class GrpcRequestChannel implements SecurityRequestChannel {
         this.headers = extractHeaders(metadata);
     }
 
+    /**
+     * @param metadata gRPC metadata object.
+     * @return case-insensitive header map - excluding binary headers.
+     */
     private Map<String, List<String>> extractHeaders(Metadata metadata) {
-        Map<String, List<String>> headerMap = new HashMap<>();
+        Map<String, List<String>> headerMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (String key : metadata.keys()) {
             if (!key.endsWith("-bin")) { // Skip binary headers
                 String value = metadata.get(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER));

--- a/src/test/java/org/opensearch/security/filter/GrpcRequestChannelTest.java
+++ b/src/test/java/org/opensearch/security/filter/GrpcRequestChannelTest.java
@@ -84,6 +84,34 @@ public class GrpcRequestChannelTest {
     }
 
     @Test
+    public void testHeaderExtractionCaseInsensitive() {
+        ServerCall<Object, Object> serverCall = createMockServerCall("org.opensearch.protobufs.services.DocumentService/Bulk");
+
+        Metadata metadata = new Metadata();
+        Metadata.Key<String> authKey = Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key<String> contentKey = Metadata.Key.of("content-type", Metadata.ASCII_STRING_MARSHALLER);
+        Metadata.Key<String> customKey = Metadata.Key.of("x-custom-header", Metadata.ASCII_STRING_MARSHALLER);
+        metadata.put(authKey, "Bearer mytoken123");
+        metadata.put(contentKey, "application/json");
+        metadata.put(customKey, "custom-value");
+
+        GrpcRequestChannel channel = new GrpcRequestChannel(serverCall, metadata);
+
+        assertEquals("Bearer mytoken123", channel.header("authorization"));
+        assertEquals("Bearer mytoken123", channel.header("Authorization"));
+        assertEquals("Bearer mytoken123", channel.header("AUTHORIZATION"));
+        assertEquals("Bearer mytoken123", channel.header("AuThOrIzAtIoN"));
+
+        assertEquals("application/json", channel.header("content-type"));
+        assertEquals("application/json", channel.header("Content-Type"));
+        assertEquals("application/json", channel.header("CONTENT-TYPE"));
+
+        assertEquals("custom-value", channel.header("x-custom-header"));
+        assertEquals("custom-value", channel.header("X-Custom-Header"));
+        assertEquals("custom-value", channel.header("X-CUSTOM-HEADER"));
+    }
+
+    @Test
     public void testPathAndUri() {
         ServerCall<Object, Object> serverCall = createMockServerCall("org.opensearch.protobufs.services.DocumentService/Bulk");
 


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/security/commit/e842cd2a21bac45f3e6adb1c2967ee0c504ead11 from https://github.com/opensearch-project/security/pull/5929.

### Issues Resolved
N/A

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
