### PR TITLE
Refactored config REST API tests to avoid unsafe patterns causing memory leaks

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
+++ b/src/integrationTest/java/org/opensearch/security/ConfigurationFiles.java
@@ -11,13 +11,10 @@ package org.opensearch.security;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.Objects;
 
-import org.opensearch.core.common.Strings;
 import org.opensearch.security.securityconf.impl.CType;
 
 public class ConfigurationFiles {
@@ -40,14 +37,6 @@ public class ConfigurationFiles {
             return tempDirectory.toAbsolutePath();
         } catch (IOException ex) {
             throw new RuntimeException("Cannot create directory with security plugin configuration.", ex);
-        }
-    }
-
-    public static void writeToConfig(final CType cType, final Path configFolder, final String content) throws IOException {
-        if (Strings.isNullOrEmpty(content)) return;
-        try (final var out = Files.newOutputStream(cType.configFile(configFolder), StandardOpenOption.APPEND)) {
-            out.write(content.getBytes(StandardCharsets.UTF_8));
-            out.flush();
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractApiIntegrationTest.java
@@ -11,35 +11,21 @@
 
 package org.opensearch.security.api;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpStatus;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.awaitility.Awaitility;
-import org.junit.AfterClass;
-import org.junit.Before;
 
-import org.opensearch.common.CheckedConsumer;
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentFactory;
-import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.ToXContentObject;
-import org.opensearch.security.ConfigurationFiles;
 import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
-import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.TestSecurityConfig;
-import org.opensearch.test.framework.certificate.CertificateData;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
@@ -49,39 +35,24 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.opensearch.security.CrossClusterSearchTests.PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED;
 import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO_PREFIX;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
+import static org.opensearch.security.api.InternalUsersRestApiIntegrationTest.REST_API_ADMIN_INTERNAL_USERS_ONLY;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RELOAD_CERTS_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.RESOURCE_MIGRATE_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
-import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX;
-import static org.opensearch.security.support.ConfigConstants.SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE;
-import static org.opensearch.test.framework.TestSecurityConfig.REST_ADMIN_REST_API_ACCESS;
 
 public abstract class AbstractApiIntegrationTest {
 
-    private static final Logger LOGGER = LogManager.getLogger(TestSecurityConfig.class);
-
-    // Simple random helpers (replacement for randomizedtesting utilities)
     private static final java.util.Random RAND = new java.util.Random();
 
     private static <T> T randomFrom(final java.util.List<T> list) {
         if (list == null || list.isEmpty()) throw new IllegalArgumentException("List must not be empty");
         return list.get(RAND.nextInt(list.size()));
-    }
-
-    private static <T> T randomFrom(final T[] arr) {
-        if (arr == null || arr.length == 0) throw new IllegalArgumentException("Array must not be empty");
-        return arr[RAND.nextInt(arr.length)];
-    }
-
-    private static boolean randomBoolean() {
-        return RAND.nextBoolean();
     }
 
     private static int randomIntBetween(final int min, final int max) {
@@ -98,11 +69,23 @@ public abstract class AbstractApiIntegrationTest {
         return sb.toString();
     }
 
-    public static final String NEW_USER = "new-user";
+    public static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(
+        new TestSecurityConfig.Role("all_access").clusterPermissions("*").indexPermissions("*").on("*")
+    );
+    public static final TestSecurityConfig.User REST_ADMIN_USER = new TestSecurityConfig.User("rest-api-admin").roles(
+        new TestSecurityConfig.Role("role").clusterPermissions(allRestAdminPermissions())
+    );
 
-    public static final String REST_ADMIN_USER = "rest-api-admin";
+    public static final TestSecurityConfig.Role REST_ADMIN_REST_API_ACCESS_ROLE = new TestSecurityConfig.Role(
+        "rest_admin__rest_api_access"
+    );
+    public static final TestSecurityConfig.Role EXAMPLE_ROLE = new TestSecurityConfig.Role("example_role").indexPermissions("crud")
+        .on("example_index");
 
-    public static final String ADMIN_USER_NAME = "admin";
+    /**
+     * A user without any privileges
+     */
+    public static final TestSecurityConfig.User NEW_USER = new TestSecurityConfig.User("new-user");
 
     public static final String DEFAULT_PASSWORD = "secret";
 
@@ -112,119 +95,26 @@ public abstract class AbstractApiIntegrationTest {
         Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, ConfigConstants.BCRYPT).build()
     );
 
-    public static Path configurationFolder;
-
-    protected static TestSecurityConfig testSecurityConfig = new TestSecurityConfig();
-
-    public static LocalCluster localCluster;
-
-    private Class<? extends AbstractApiIntegrationTest> testClass;
-
-    @Before
-    public void startCluster() throws IOException {
-        if (this.getClass().equals(testClass)) {
-            return;
-        }
-        configurationFolder = ConfigurationFiles.createConfigurationDirectory();
-        extendConfiguration();
-        final var clusterManager = randomFrom(List.of(ClusterManager.THREE_CLUSTER_MANAGERS, ClusterManager.SINGLENODE));
-        final var localClusterBuilder = new LocalCluster.Builder().clusterManager(clusterManager)
+    protected static LocalCluster.Builder clusterBuilder() {
+        return new LocalCluster.Builder().clusterManager(ClusterManager.DEFAULT)
             .nodeSettings(getClusterSettings())
-            .defaultConfigurationInitDirectory(configurationFolder.toString())
-            .loadConfigurationIntoIndex(false);
-        localCluster = localClusterBuilder.build();
-        localCluster.before();
-        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
-            Awaitility.await()
-                .alias("Load default configuration")
-                .until(() -> client.securityHealth().getTextFromJsonBody("/status"), equalTo("UP"));
-        }
-        testClass = this.getClass();
+            .authc(TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL)
+            .users(ADMIN_USER, REST_ADMIN_USER, NEW_USER)
+            .roles(EXAMPLE_ROLE, REST_ADMIN_REST_API_ACCESS_ROLE);
     }
 
-    protected Map<String, Object> getClusterSettings() {
+    protected static Map<String, Object> getClusterSettings() {
         Map<String, Object> clusterSettings = new HashMap<>();
-        clusterSettings.put(SECURITY_ALLOW_DEFAULT_INIT_SECURITYINDEX, true);
-        clusterSettings.put(PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED, List.of("user_admin__all_access", REST_ADMIN_REST_API_ACCESS));
-        clusterSettings.put(SECURITY_ALLOW_DEFAULT_INIT_USE_CLUSTER_STATE, randomBoolean());
+        clusterSettings.put(
+            PLUGINS_SECURITY_RESTAPI_ROLES_ENABLED,
+            List.of(
+                "user_admin__all_access",
+                REST_ADMIN_REST_API_ACCESS_ROLE.getName(),
+                "user_rest-api-admin__role",
+                REST_API_ADMIN_INTERNAL_USERS_ONLY
+            )
+        );
         return clusterSettings;
-    }
-
-    private static void extendConfiguration() throws IOException {
-        extendActionGroups(configurationFolder, testSecurityConfig.actionGroups());
-        extendRoles(configurationFolder, testSecurityConfig.roles());
-        extendRolesMapping(configurationFolder, testSecurityConfig.rolesMapping());
-        extendUsers(configurationFolder, testSecurityConfig.getUsers());
-    }
-
-    private static void extendUsers(final Path configFolder, final List<TestSecurityConfig.User> users) throws IOException {
-        if (users == null) return;
-        if (users.isEmpty()) return;
-        LOGGER.info("Adding users to the default configuration: ");
-        try (final var contentBuilder = XContentFactory.yamlBuilder()) {
-            contentBuilder.startObject();
-            for (final var u : users) {
-                LOGGER.info("\t\t - {}", u.getName());
-                contentBuilder.field(u.getName());
-                u.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
-            }
-            contentBuilder.endObject();
-            ConfigurationFiles.writeToConfig(CType.INTERNALUSERS, configFolder, removeDashes(contentBuilder.toString()));
-        }
-    }
-
-    private static void extendActionGroups(final Path configFolder, final List<TestSecurityConfig.ActionGroup> actionGroups)
-        throws IOException {
-        if (actionGroups == null) return;
-        if (actionGroups.isEmpty()) return;
-        LOGGER.info("Adding action groups to the default configuration: ");
-        try (final var contentBuilder = XContentFactory.yamlBuilder()) {
-            contentBuilder.startObject();
-            for (final var ag : actionGroups) {
-                LOGGER.info("\t\t - {}", ag.name());
-                contentBuilder.field(ag.name());
-                ag.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
-            }
-            contentBuilder.endObject();
-            ConfigurationFiles.writeToConfig(CType.ACTIONGROUPS, configFolder, removeDashes(contentBuilder.toString()));
-        }
-    }
-
-    private static void extendRoles(final Path configFolder, final List<TestSecurityConfig.Role> roles) throws IOException {
-        if (roles == null) return;
-        if (roles.isEmpty()) return;
-        LOGGER.info("Adding roles to the default configuration: ");
-        try (final var contentBuilder = XContentFactory.yamlBuilder()) {
-            contentBuilder.startObject();
-            for (final var r : roles) {
-                LOGGER.info("\t\t - {}", r.getName());
-                contentBuilder.field(r.getName());
-                r.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
-            }
-            contentBuilder.endObject();
-            ConfigurationFiles.writeToConfig(CType.ROLES, configFolder, removeDashes(contentBuilder.toString()));
-        }
-    }
-
-    private static void extendRolesMapping(final Path configFolder, final List<TestSecurityConfig.RoleMapping> rolesMapping)
-        throws IOException {
-        if (rolesMapping == null) return;
-        if (rolesMapping.isEmpty()) return;
-        LOGGER.info("Adding roles mapping to the default configuration: ");
-        try (final var contentBuilder = XContentFactory.yamlBuilder()) {
-            contentBuilder.startObject();
-            for (final var rm : rolesMapping) {
-                LOGGER.info("\t\t - {}", rm.name());
-                contentBuilder.field(rm.name());
-                rm.toXContent(contentBuilder, ToXContent.EMPTY_PARAMS);
-            }
-            contentBuilder.endObject();
-            ConfigurationFiles.writeToConfig(CType.ROLESMAPPING, configFolder, removeDashes(contentBuilder.toString()));
-        }
-    }
-
-    private static String removeDashes(final String content) {
-        return content.replace("---", "");
     }
 
     protected static String[] allRestAdminPermissions() {
@@ -262,42 +152,6 @@ public abstract class AbstractApiIntegrationTest {
         return randomFrom(permissions);
     }
 
-    @AfterClass
-    public static void stopCluster() throws IOException {
-        if (localCluster != null) localCluster.close();
-        FileUtils.deleteDirectory(configurationFolder.toFile());
-    }
-
-    protected void withUser(final String user, final CheckedConsumer<TestRestClient, Exception> restClientHandler) throws Exception {
-        withUser(user, DEFAULT_PASSWORD, restClientHandler);
-    }
-
-    protected void withUser(final String user, final String password, final CheckedConsumer<TestRestClient, Exception> restClientHandler)
-        throws Exception {
-        try (TestRestClient client = localCluster.getRestClient(user, password)) {
-            restClientHandler.accept(client);
-        }
-    }
-
-    protected void withUser(
-        final String user,
-        final CertificateData certificateData,
-        final CheckedConsumer<TestRestClient, Exception> restClientHandler
-    ) throws Exception {
-        withUser(user, DEFAULT_PASSWORD, certificateData, restClientHandler);
-    }
-
-    protected void withUser(
-        final String user,
-        final String password,
-        final CertificateData certificateData,
-        final CheckedConsumer<TestRestClient, Exception> restClientHandler
-    ) throws Exception {
-        try (final TestRestClient client = localCluster.getRestClient(user, password, certificateData)) {
-            restClientHandler.accept(client);
-        }
-    }
-
     protected String apiPathPrefix() {
         return randomFrom(List.of(LEGACY_OPENDISTRO_PREFIX, PLUGINS_PREFIX));
     }
@@ -327,31 +181,11 @@ public abstract class AbstractApiIntegrationTest {
         return fullPath.toString();
     }
 
-    void badRequestWithReason(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback, final String expectedMessage)
-        throws Exception {
-        final var response = badRequest(endpointCallback);
-        assertThat(response.getBody(), response.getTextFromJsonBody("/reason"), is(expectedMessage));
-    }
-
-    void badRequestWithMessage(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback, final String expectedMessage)
-        throws Exception {
-        final var response = badRequest(endpointCallback);
-        assertThat(response.getBody(), response.getTextFromJsonBody("/message"), is(expectedMessage));
-    }
-
     public static TestRestClient.HttpResponse badRequest(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback)
         throws Exception {
         final var response = endpointCallback.get();
         assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_BAD_REQUEST));
         assertResponseBody(response.getBody());
-        return response;
-    }
-
-    TestRestClient.HttpResponse created(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback) throws Exception {
-        final var response = endpointCallback.get();
-        assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_CREATED));
-        assertResponseBody(response.getBody());
-        assertThat(response.getBody(), response.getTextFromJsonBody("/status"), equalToIgnoringCase("created"));
         return response;
     }
 
@@ -367,14 +201,6 @@ public abstract class AbstractApiIntegrationTest {
         throws Exception {
         final var response = endpointCallback.get();
         assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
-        assertResponseBody(response.getBody());
-        return response;
-    }
-
-    TestRestClient.HttpResponse methodNotAllowed(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback)
-        throws Exception {
-        final var response = endpointCallback.get();
-        assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_METHOD_NOT_ALLOWED));
         assertResponseBody(response.getBody());
         return response;
     }
@@ -395,34 +221,10 @@ public abstract class AbstractApiIntegrationTest {
         return response;
     }
 
-    void notFound(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback, final String expectedMessage)
-        throws Exception {
-        final var response = notFound(endpointCallback);
-        assertThat(response.getBody(), response.getTextFromJsonBody("/message"), is(expectedMessage));
-    }
-
     public static TestRestClient.HttpResponse ok(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback)
         throws Exception {
         final var response = endpointCallback.get();
         assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertResponseBody(response.getBody());
-        return response;
-    }
-
-    public static TestRestClient.HttpResponse ok(
-        final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback,
-        final String expectedMessage
-    ) throws Exception {
-        final var response = endpointCallback.get();
-        assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_OK));
-        assertResponseBody(response.getBody(), expectedMessage);
-        return response;
-    }
-
-    TestRestClient.HttpResponse unauthorized(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback)
-        throws Exception {
-        final var response = endpointCallback.get();
-        assertThat(response.getBody(), response.getStatusCode(), equalTo(HttpStatus.SC_UNAUTHORIZED));
         assertResponseBody(response.getBody());
         return response;
     }

--- a/src/integrationTest/java/org/opensearch/security/api/AbstractConfigEntityApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractConfigEntityApiIntegrationTest.java
@@ -16,10 +16,10 @@ import java.util.Optional;
 import java.util.StringJoiner;
 
 import org.hamcrest.Matcher;
-import org.junit.Test;
 
 import org.opensearch.common.CheckedSupplier;
 import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import com.nimbusds.jose.util.Pair;
@@ -27,7 +27,6 @@ import com.nimbusds.jose.util.Pair;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.oneOf;
 import static org.opensearch.security.api.PatchPayloadHelper.addOp;
@@ -35,18 +34,16 @@ import static org.opensearch.security.api.PatchPayloadHelper.patch;
 import static org.opensearch.security.api.PatchPayloadHelper.removeOp;
 import static org.opensearch.security.api.PatchPayloadHelper.replaceOp;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotFound;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApiIntegrationTest {
 
-    static {
-        testSecurityConfig.withRestAdminUser(REST_ADMIN_USER, allRestAdminPermissions());
-    }
-
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> clusterSettings = super.getClusterSettings();
-        clusterSettings.put(SECURITY_RESTAPI_ADMIN_ENABLED, true);
-        return clusterSettings;
+    protected static LocalCluster.Builder clusterBuilder() {
+        return AbstractApiIntegrationTest.clusterBuilder().nodeSetting(SECURITY_RESTAPI_ADMIN_ENABLED, true);
     }
 
     interface TestDescriptor {
@@ -99,26 +96,24 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
         return fullPath.toString();
     }
 
-    @Test
-    public void forbiddenForRegularUsers() throws Exception {
-        withUser(NEW_USER, client -> {
-            forbidden(() -> client.putJson(apiPath("some_entity"), EMPTY_BODY));
-            forbidden(() -> client.get(apiPath()));
-            forbidden(() -> client.get(apiPath("some_entity")));
-            forbidden(() -> client.putJson(apiPath("some_entity"), EMPTY_BODY));
-            forbidden(() -> client.patch(apiPath(), EMPTY_BODY));
-            forbidden(() -> client.patch(apiPath("some_entity"), EMPTY_BODY));
-            forbidden(() -> client.delete(apiPath("some_entity")));
-        });
+    public void forbiddenForRegularUsers(LocalCluster localCluster) throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.putJson(apiPath("some_entity"), EMPTY_BODY), isForbidden());
+            assertThat(client.get(apiPath()), isForbidden());
+            assertThat(client.get(apiPath("some_entity")), isForbidden());
+            assertThat(client.putJson(apiPath("some_entity"), EMPTY_BODY), isForbidden());
+            assertThat(client.patch(apiPath(), EMPTY_BODY), isForbidden());
+            assertThat(client.patch(apiPath("some_entity"), EMPTY_BODY), isForbidden());
+            assertThat(client.delete(apiPath("some_entity")), isForbidden());
+        }
     }
 
-    @Test
-    public void availableForAdminUser() throws Exception {
-        final var entitiesNames = predefinedHiddenAndReservedConfigEntities();
+    public void availableForAdminUser(LocalCluster localCluster) throws Exception {
+        final var entitiesNames = predefinedHiddenAndReservedConfigEntities(localCluster);
         final var hiddenEntityName = entitiesNames.getLeft();
         final var reservedEntityName = entitiesNames.getRight();
         // can't see hidden resources
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             verifyNoHiddenEntities(() -> client.get(apiPath()));
             creationOfReadOnlyEntityForbidden(
                 "str1234567",
@@ -131,35 +126,28 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
             verifyUpdateAndDeleteReservedConfigEntityForbidden(reservedEntityName, client);
             verifyCrudOperations(null, null, client);
             verifyBadRequestOperations(client);
-        });
+        }
     }
 
-    Pair<String, String> predefinedHiddenAndReservedConfigEntities() throws Exception {
+    Pair<String, String> predefinedHiddenAndReservedConfigEntities(LocalCluster localCluster) throws Exception {
         final var hiddenEntityName = "str_hidden";
         final var reservedEntityName = "str_reserved";
-        withUser(
-            ADMIN_USER_NAME,
-            localCluster.getAdminCertificate(),
-            client -> created(() -> client.putJson(apiPath(hiddenEntityName), testDescriptor.hiddenEntityPayload()))
-        );
-        withUser(
-            ADMIN_USER_NAME,
-            localCluster.getAdminCertificate(),
-            client -> created(() -> client.putJson(apiPath(reservedEntityName), testDescriptor.reservedEntityPayload()))
-        );
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            assertThat(client.putJson(apiPath(hiddenEntityName), testDescriptor.hiddenEntityPayload()), isCreated());
+            assertThat(client.putJson(apiPath(reservedEntityName), testDescriptor.reservedEntityPayload()), isCreated());
+        }
         return Pair.of(hiddenEntityName, reservedEntityName);
     }
 
-    @Test
-    public void availableForTLSAdminUser() throws Exception {
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::availableForSuperAdminUser);
+    public void availableForTLSAdminUser(LocalCluster localCluster) throws Exception {
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            availableForSuperAdminUser(client);
+        }
     }
 
-    @Test
-    public void availableForRESTAdminUser() throws Exception {
-        withUser(REST_ADMIN_USER, this::availableForSuperAdminUser);
-        if (testDescriptor.restAdminLimitedUser().isPresent()) {
-            withUser(testDescriptor.restAdminLimitedUser().get(), this::availableForSuperAdminUser);
+    public void availableForRESTAdminUser(LocalCluster localCluster) throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(REST_ADMIN_USER)) {
+            availableForSuperAdminUser(client);
         }
     }
 
@@ -182,7 +170,9 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
     }
 
     void verifyNoHiddenEntities(final CheckedSupplier<TestRestClient.HttpResponse, Exception> endpointCallback) throws Exception {
-        final var body = ok(endpointCallback).bodyAsJsonNode();
+        final var resp = endpointCallback.get();
+        assertThat(resp, isOk());
+        final var body = resp.bodyAsJsonNode();
         final var pretty = body.toPrettyString();
         final var it = body.elements();
         while (it.hasNext()) {
@@ -194,11 +184,11 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
     void creationOfReadOnlyEntityForbidden(final String entityName, final TestRestClient client, final ToXContentObject... entities)
         throws Exception {
         for (final var configEntity : entities) {
-            assertInvalidKeys(
-                badRequest(() -> client.putJson(apiPath(entityName), configEntity)),
-                is(oneOf("static", "hidden", "reserved"))
-            );
-            badRequest(() -> client.patch(apiPath(), patch(addOp("str1234567", configEntity))));
+            final var resp = client.putJson(apiPath(entityName), configEntity);
+            assertThat(resp, isBadRequest());
+            assertInvalidKeys(resp, is(oneOf("static", "hidden", "reserved")));
+            final var resp2 = client.patch(apiPath(), patch(addOp("str1234567", configEntity)));
+            assertThat(resp2, isBadRequest());
         }
     }
 
@@ -226,54 +216,60 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
             assertThat(response.getBody(), response.getTextFromJsonBody("/" + p.getKey()), is(p.getValue()));
     }
 
-    void assertSpecifyOneOf(final TestRestClient.HttpResponse response, final String expectedSpecifyOneOfKeys) {
-        assertThat(response.getBody(), response.getTextFromJsonBody("/status"), is("error"));
-        assertThat(response.getBody(), response.getTextFromJsonBody("/reason"), equalTo("Invalid configuration"));
-        assertThat(response.getBody(), response.getTextFromJsonBody("/specify_one_of/keys"), containsString(expectedSpecifyOneOfKeys));
-    }
-
-    void assertMissingMandatoryKeys(final TestRestClient.HttpResponse response, final String expectedKeys) {
-        assertThat(response.getBody(), response.getTextFromJsonBody("/status"), is("error"));
-        assertThat(response.getBody(), response.getTextFromJsonBody("/reason"), equalTo("Invalid configuration"));
-        assertThat(response.getBody(), response.getTextFromJsonBody("/missing_mandatory_keys/keys"), containsString(expectedKeys));
-    }
-
     void verifyUpdateAndDeleteHiddenConfigEntityForbidden(final String hiddenEntityName, final TestRestClient client) throws Exception {
         final var expectedErrorMessage = "Resource '" + hiddenEntityName + "' is not available.";
-        notFound(() -> client.putJson(apiPath(hiddenEntityName), testDescriptor.entityPayload()), expectedErrorMessage);
-        notFound(
-            () -> client.patch(
+        assertThat(
+            client.putJson(apiPath(hiddenEntityName), testDescriptor.entityPayload()),
+            isNotFound().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(
+            client.patch(
                 apiPath(hiddenEntityName),
                 patch(replaceOp(testDescriptor.entityJsonProperty(), testDescriptor.jsonPropertyPayload()))
             ),
-            expectedErrorMessage
+            isNotFound().withAttribute("/message", expectedErrorMessage)
         );
-        notFound(() -> client.patch(apiPath(), patch(replaceOp(hiddenEntityName, testDescriptor.entityPayload()))), expectedErrorMessage);
-        notFound(() -> client.patch(apiPath(hiddenEntityName), patch(removeOp(testDescriptor.entityJsonProperty()))), expectedErrorMessage);
-        notFound(() -> client.patch(apiPath(), patch(removeOp(hiddenEntityName))), expectedErrorMessage);
-        notFound(() -> client.delete(apiPath(hiddenEntityName)), expectedErrorMessage);
+        assertThat(
+            client.patch(apiPath(), patch(replaceOp(hiddenEntityName, testDescriptor.entityPayload()))),
+            isNotFound().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(
+            client.patch(apiPath(hiddenEntityName), patch(removeOp(testDescriptor.entityJsonProperty()))),
+            isNotFound().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(
+            client.patch(apiPath(), patch(removeOp(hiddenEntityName))),
+            isNotFound().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(client.delete(apiPath(hiddenEntityName)), isNotFound().withAttribute("/message", expectedErrorMessage));
     }
 
     void verifyUpdateAndDeleteReservedConfigEntityForbidden(final String reservedEntityName, final TestRestClient client) throws Exception {
         final var expectedErrorMessage = "Resource '" + reservedEntityName + "' is reserved.";
-        forbidden(() -> client.putJson(apiPath(reservedEntityName), testDescriptor.entityPayload()), expectedErrorMessage);
-        forbidden(
-            () -> client.patch(
+        assertThat(
+            client.putJson(apiPath(reservedEntityName), testDescriptor.entityPayload()),
+            isForbidden().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(
+            client.patch(
                 apiPath(reservedEntityName),
                 patch(replaceOp(testDescriptor.entityJsonProperty(), testDescriptor.entityJsonProperty()))
             ),
-            expectedErrorMessage
+            isForbidden().withAttribute("/message", expectedErrorMessage)
         );
-        forbidden(
-            () -> client.patch(apiPath(), patch(replaceOp(reservedEntityName, testDescriptor.entityPayload()))),
-            expectedErrorMessage
+        assertThat(
+            client.patch(apiPath(), patch(replaceOp(reservedEntityName, testDescriptor.entityPayload()))),
+            isForbidden().withAttribute("/message", expectedErrorMessage)
         );
-        forbidden(() -> client.patch(apiPath(), patch(removeOp(reservedEntityName))), expectedErrorMessage);
-        forbidden(
-            () -> client.patch(apiPath(reservedEntityName), patch(removeOp(testDescriptor.entityJsonProperty()))),
-            expectedErrorMessage
+        assertThat(
+            client.patch(apiPath(), patch(removeOp(reservedEntityName))),
+            isForbidden().withAttribute("/message", expectedErrorMessage)
         );
-        forbidden(() -> client.delete(apiPath(reservedEntityName)), expectedErrorMessage);
+        assertThat(
+            client.patch(apiPath(reservedEntityName), patch(removeOp(testDescriptor.entityJsonProperty()))),
+            isForbidden().withAttribute("/message", expectedErrorMessage)
+        );
+        assertThat(client.delete(apiPath(reservedEntityName)), isForbidden().withAttribute("/message", expectedErrorMessage));
     }
 
     void forbiddenToCreateEntityWithRestAdminPermissions(final TestRestClient client) throws Exception {}

--- a/src/integrationTest/java/org/opensearch/security/api/AccountRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AccountRestApiIntegrationTest.java
@@ -10,16 +10,25 @@
 
 package org.opensearch.security.api;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotFound;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+import static org.opensearch.test.framework.matcher.RestMatchers.isUnauthorized;
 
 public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
@@ -33,11 +42,12 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     public final static String TEST_USER_NEW_PASSWORD = randomAlphabetic(10);
 
-    static {
-        testSecurityConfig.user(new TestSecurityConfig.User(TEST_USER).password(TEST_USER_PASSWORD))
-            .user(new TestSecurityConfig.User(RESERVED_USER).reserved(true))
-            .user(new TestSecurityConfig.User(HIDDEN_USERS).hidden(true));
-    }
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().users(
+        new TestSecurityConfig.User(TEST_USER).password(TEST_USER_PASSWORD),
+        new TestSecurityConfig.User(RESERVED_USER).reserved(true),
+        new TestSecurityConfig.User(HIDDEN_USERS).hidden(true)
+    ).build();
 
     private String accountPath() {
         return super.apiPath("account");
@@ -45,10 +55,11 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     @Test
     public void accountInfo() throws Exception {
-        withUser(NEW_USER, client -> {
-            var response = ok(() -> client.get(accountPath()));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isOk());
             final var account = response.bodyAsJsonNode();
-            assertThat(response.getBody(), account.get("user_name").asText(), is(NEW_USER));
+            assertThat(response.getBody(), account.get("user_name").asText(), is(NEW_USER.getName()));
             assertThat(response.getBody(), not(account.get("is_reserved").asBoolean()));
             assertThat(response.getBody(), not(account.get("is_hidden").asBoolean()));
             assertThat(response.getBody(), account.get("is_internal_user").asBoolean());
@@ -57,69 +68,77 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
             assertThat(response.getBody(), account.get("custom_attribute_names").isArray());
             assertThat(response.getBody(), account.get("tenants").isObject());
             assertThat(response.getBody(), account.get("roles").isArray());
-        });
-        withUser(NEW_USER, "a", client -> unauthorized(() -> client.get(accountPath())));
-        withUser("a", "b", client -> unauthorized(() -> client.get(accountPath())));
+        }
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER.getName(), "a")) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isUnauthorized());
+        }
+        try (TestRestClient client = localCluster.getRestClient("a", "b")) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isUnauthorized());
+        }
     }
 
     @Test
     public void changeAccountPassword() throws Exception {
-        withUser(TEST_USER, TEST_USER_PASSWORD, this::verifyWrongPayload);
+        try (TestRestClient client = localCluster.getRestClient(TEST_USER, TEST_USER_PASSWORD)) {
+            verifyWrongPayload(client);
+        }
         verifyPasswordCanBeChanged();
 
-        withUser(RESERVED_USER, client -> {
-            var response = ok(() -> client.get(accountPath()));
-            assertThat(response.getBody(), response.getBooleanFromJsonBody("/is_reserved"));
-            forbidden(() -> client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))));
-        });
-        withUser(HIDDEN_USERS, client -> {
-            var response = ok(() -> client.get(accountPath()));
-            assertThat(response.getBody(), response.getBooleanFromJsonBody("/is_hidden"));
-            notFound(() -> client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))));
-        });
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> {
-            ok(() -> client.get(accountPath()));
-            notFound(() -> client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))));
-        });
+        try (TestRestClient client = localCluster.getRestClient(RESERVED_USER, DEFAULT_PASSWORD)) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isOk());
+            assertThat(response.getBooleanFromJsonBody("/is_reserved"), is(true));
+            assertThat(client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))), isForbidden());
+        }
+        try (TestRestClient client = localCluster.getRestClient(HIDDEN_USERS, DEFAULT_PASSWORD)) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isOk());
+            assertThat(response.getBooleanFromJsonBody("/is_hidden"), is(true));
+            assertThat(client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))), isNotFound());
+        }
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            HttpResponse response = client.get(accountPath());
+            assertThat(response, isOk());
+            assertThat(client.putJson(accountPath(), changePasswordPayload(DEFAULT_PASSWORD, randomAlphabetic(10))), isNotFound());
+        }
     }
 
     private void verifyWrongPayload(final TestRestClient client) throws Exception {
-        badRequest(() -> client.putJson(accountPath(), EMPTY_BODY));
-        badRequest(() -> client.putJson(accountPath(), changePasswordPayload(null, "new_password")));
-        badRequest(() -> client.putJson(accountPath(), changePasswordPayload("wrong-password", "some_new_pwd")));
-        badRequest(() -> client.putJson(accountPath(), changePasswordPayload(TEST_USER_PASSWORD, null)));
-        badRequest(() -> client.putJson(accountPath(), changePasswordPayload(TEST_USER_PASSWORD, "")));
-        badRequest(() -> client.putJson(accountPath(), changePasswordWithHashPayload(TEST_USER_PASSWORD, null)));
-        badRequest(() -> client.putJson(accountPath(), changePasswordWithHashPayload(TEST_USER_PASSWORD, "")));
-        badRequest(
-            () -> client.putJson(
+        assertThat(client.putJson(accountPath(), EMPTY_BODY), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordPayload(null, "new_password")), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordPayload("wrong-password", "some_new_pwd")), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordPayload(TEST_USER_PASSWORD, null)), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordPayload(TEST_USER_PASSWORD, "")), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordWithHashPayload(TEST_USER_PASSWORD, null)), isBadRequest());
+        assertThat(client.putJson(accountPath(), changePasswordWithHashPayload(TEST_USER_PASSWORD, "")), isBadRequest());
+        assertThat(
+            client.putJson(
                 accountPath(),
                 (builder, params) -> builder.startObject()
                     .field("current_password", TEST_USER_PASSWORD)
                     .startArray("backend_roles")
                     .endArray()
                     .endObject()
-            )
+            ),
+            isBadRequest()
         );
     }
 
     private void verifyPasswordCanBeChanged() throws Exception {
         final var newPassword = randomAlphabetic(10);
-        withUser(
-            TEST_USER,
-            TEST_USER_PASSWORD,
-            client -> ok(
-                () -> client.putJson(
-                    accountPath(),
-                    changePasswordWithHashPayload(TEST_USER_PASSWORD, passwordHasher.hash(newPassword.toCharArray()))
-                )
-            )
-        );
-        withUser(
-            TEST_USER,
-            newPassword,
-            client -> ok(() -> client.putJson(accountPath(), changePasswordPayload(newPassword, TEST_USER_NEW_PASSWORD)))
-        );
+        try (TestRestClient client = localCluster.getRestClient(TEST_USER, TEST_USER_PASSWORD)) {
+            HttpResponse resp = client.putJson(
+                accountPath(),
+                changePasswordWithHashPayload(TEST_USER_PASSWORD, passwordHasher.hash(newPassword.toCharArray()))
+            );
+            assertThat(resp, isOk());
+        }
+        try (TestRestClient client = localCluster.getRestClient(TEST_USER, newPassword)) {
+            HttpResponse resp = client.putJson(accountPath(), changePasswordPayload(newPassword, TEST_USER_NEW_PASSWORD));
+            assertThat(resp, isOk());
+        }
     }
 
     @Test
@@ -127,10 +146,9 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
         final var username = "test";
         final String password = randomAlphabetic(10);
         final String newPassword = randomAlphabetic(10);
-        withUser(
-            ADMIN_USER_NAME,
-            client -> created(
-                () -> client.putJson(
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(
+                client.putJson(
                     apiPath("internalusers", username),
                     (builder, params) -> builder.startObject()
                         .field("password", password)
@@ -140,24 +158,29 @@ public class AccountRestApiIntegrationTest extends AbstractApiIntegrationTest {
                         .endArray()
                         .field("opendistro_security_roles")
                         .startArray()
-                        .value("user_limited-user__limited-role")
+                        .value(EXAMPLE_ROLE.getName())
                         .endArray()
                         .field("attributes")
                         .startObject()
                         .field("foo", "bar")
                         .endObject()
                         .endObject()
-                )
-            )
-        );
-        withUser(username, password, client -> ok(() -> client.putJson(accountPath(), changePasswordPayload(password, newPassword))));
-        withUser(ADMIN_USER_NAME, client -> {
-            final var response = ok(() -> client.get(apiPath("internalusers", username)));
+                ),
+                isCreated()
+            );
+        }
+        try (TestRestClient client = localCluster.getRestClient(username, password)) {
+            HttpResponse resp = client.putJson(accountPath(), changePasswordPayload(password, newPassword));
+            assertThat(resp, isOk());
+        }
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            HttpResponse response = client.get(apiPath("internalusers", username));
+            assertThat(response, isOk());
             final var user = response.bodyAsJsonNode().get(username);
             assertThat(user.toPrettyString(), user.get("backend_roles").get(0).asText(), is("test-backend-role"));
-            assertThat(user.toPrettyString(), user.get("opendistro_security_roles").get(0).asText(), is("user_limited-user__limited-role"));
+            assertThat(user.toPrettyString(), user.get("opendistro_security_roles").get(0).asText(), is(EXAMPLE_ROLE.getName()));
             assertThat(user.toPrettyString(), user.get("attributes").get("foo").asText(), is("bar"));
-        });
+        }
     }
 
     private ToXContentObject changePasswordPayload(final String currentPassword, final String newPassword) {

--- a/src/integrationTest/java/org/opensearch/security/api/ConfigRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/ConfigRestApiIntegrationTest.java
@@ -10,38 +10,48 @@
  */
 package org.opensearch.security.api;
 
-import java.util.Map;
 import java.util.StringJoiner;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.api.Endpoint;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
 import static org.opensearch.security.api.PatchPayloadHelper.replaceOp;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.SECURITY_CONFIG_UPDATE;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotAllowed;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public class ConfigRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     final static String REST_API_ADMIN_CONFIG_UPDATE = "rest-api-admin-config-update";
 
-    static {
-        testSecurityConfig.withRestAdminUser(REST_ADMIN_USER, allRestAdminPermissions())
-            .withRestAdminUser(REST_API_ADMIN_CONFIG_UPDATE, restAdminPermission(Endpoint.CONFIG, SECURITY_CONFIG_UPDATE));
-    }
-
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> clusterSettings = super.getClusterSettings();
-        clusterSettings.put(SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION, true);
-        clusterSettings.put(SECURITY_RESTAPI_ADMIN_ENABLED, true);
-        return clusterSettings;
-    }
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().nodeSetting(
+        SECURITY_UNSUPPORTED_RESTAPI_ALLOW_SECURITYCONFIG_MODIFICATION,
+        true
+    )
+        .nodeSetting(SECURITY_RESTAPI_ADMIN_ENABLED, true)
+        .users(
+            new TestSecurityConfig.User(REST_API_ADMIN_CONFIG_UPDATE).referencedRoles(REST_ADMIN_REST_API_ACCESS_ROLE)
+                .roles(
+                    new TestSecurityConfig.Role("rest_admin_role").clusterPermissions(
+                        restAdminPermission(Endpoint.CONFIG, SECURITY_CONFIG_UPDATE)
+                    )
+                )
+        )
+        .build();
 
     private String securityConfigPath(final String... path) {
         final var fullPath = new StringJoiner("/").add(super.apiPath("securityconfig"));
@@ -52,44 +62,51 @@ public class ConfigRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     @Test
     public void forbiddenForRegularUsers() throws Exception {
-        withUser(NEW_USER, client -> {
-            forbidden(() -> client.get(securityConfigPath()));
-            forbidden(() -> client.putJson(securityConfigPath("config"), EMPTY_BODY));
-            forbidden(() -> client.patch(securityConfigPath(), EMPTY_BODY));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(securityConfigPath()), isForbidden());
+            assertThat(client.putJson(securityConfigPath("config"), EMPTY_BODY), isForbidden());
+            assertThat(client.patch(securityConfigPath(), EMPTY_BODY), isForbidden());
             verifyNotAllowedMethods(client);
-        });
+        }
     }
 
     @Test
     public void partiallyAvailableForAdminUser() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> ok(() -> client.get(securityConfigPath())));
-        withUser(ADMIN_USER_NAME, client -> {
-            badRequest(() -> client.putJson(securityConfigPath("xxx"), EMPTY_BODY));
-            forbidden(() -> client.putJson(securityConfigPath("config"), EMPTY_BODY));
-            forbidden(() -> client.patch(securityConfigPath(), EMPTY_BODY));
-        });
-        withUser(ADMIN_USER_NAME, this::verifyNotAllowedMethods);
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(client.get(securityConfigPath()), isOk());
+            assertThat(client.putJson(securityConfigPath("xxx"), EMPTY_BODY), isBadRequest());
+            assertThat(client.putJson(securityConfigPath("config"), EMPTY_BODY), isForbidden());
+            assertThat(client.patch(securityConfigPath(), EMPTY_BODY), isForbidden());
+            verifyNotAllowedMethods(client);
+        }
     }
 
     @Test
     public void availableForTlsAdminUser() throws Exception {
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> ok(() -> client.get(securityConfigPath())));
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifyUpdate);
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            assertThat(client.get(securityConfigPath()), isOk());
+            verifyUpdate(client);
+        }
     }
 
     @Test
     public void availableForRestAdminUser() throws Exception {
-        withUser(REST_ADMIN_USER, client -> ok(() -> client.get(securityConfigPath())));
-        withUser(REST_ADMIN_USER, this::verifyUpdate);
-        withUser(REST_API_ADMIN_CONFIG_UPDATE, this::verifyUpdate);
+        try (TestRestClient client = localCluster.getRestClient(REST_ADMIN_USER)) {
+            assertThat(client.get(securityConfigPath()), isOk());
+            verifyUpdate(client);
+        }
+        try (TestRestClient client = localCluster.getRestClient(REST_API_ADMIN_CONFIG_UPDATE, DEFAULT_PASSWORD)) {
+            verifyUpdate(client);
+        }
     }
 
     void verifyUpdate(final TestRestClient client) throws Exception {
-        badRequest(() -> client.putJson(securityConfigPath("xxx"), EMPTY_BODY));
+        assertThat(client.putJson(securityConfigPath("xxx"), EMPTY_BODY), isBadRequest());
         verifyNotAllowedMethods(client);
 
         TestRestClient.HttpResponse resp = client.get(securityConfigPath());
-        final var configJson = ok(() -> client.get(securityConfigPath())).bodyAsJsonNode();
+        assertThat(resp, isOk());
+        final var configJson = resp.bodyAsJsonNode();
         final var authFailureListeners = DefaultObjectMapper.objectMapper.createObjectNode();
         authFailureListeners.set(
             "ip_rate_limiting",
@@ -114,20 +131,31 @@ public class ConfigRestApiIntegrationTest extends AbstractApiIntegrationTest {
         );
         final var dynamicConfigJson = (ObjectNode) configJson.get("config").get("dynamic");
         dynamicConfigJson.set("auth_failure_listeners", authFailureListeners);
-        ok(() -> client.putJson(securityConfigPath("config"), DefaultObjectMapper.writeValueAsString(configJson.get("config"), false)));
+        assertThat(
+            client.putJson(securityConfigPath("config"), DefaultObjectMapper.writeValueAsString(configJson.get("config"), false)),
+            isOk()
+        );
         String originalHostResolverMode = configJson.get("config").get("dynamic").get("hosts_resolver_mode").asText();
         String nextOriginalHostResolverMode = originalHostResolverMode.equals("other") ? "ip-only" : "other";
-        ok(() -> client.patch(securityConfigPath(), patch(replaceOp("/config/dynamic/hosts_resolver_mode", nextOriginalHostResolverMode))));
-        ok(() -> client.patch(securityConfigPath(), patch(replaceOp("/config/dynamic/hosts_resolver_mode", originalHostResolverMode))));
-        ok(
-            () -> client.patch(securityConfigPath(), patch(replaceOp("/config/dynamic/hosts_resolver_mode", originalHostResolverMode))),
-            "No updates required"
+        assertThat(
+            client.patch(securityConfigPath(), patch(replaceOp("/config/dynamic/hosts_resolver_mode", nextOriginalHostResolverMode))),
+            isOk()
         );
+        assertThat(
+            client.patch(securityConfigPath(), patch(replaceOp("/config/dynamic/hosts_resolver_mode", originalHostResolverMode))),
+            isOk()
+        );
+        TestRestClient.HttpResponse last = client.patch(
+            securityConfigPath(),
+            patch(replaceOp("/config/dynamic/hosts_resolver_mode", originalHostResolverMode))
+        );
+        assertThat(last, isOk());
+        assertResponseBody(last.getBody(), "No updates required");
     }
 
-    void verifyNotAllowedMethods(final TestRestClient client) throws Exception {
-        methodNotAllowed(() -> client.postJson(securityConfigPath(), EMPTY_BODY));
-        methodNotAllowed(() -> client.delete(securityConfigPath()));
+    void verifyNotAllowedMethods(final TestRestClient client) {
+        assertThat(client.postJson(securityConfigPath(), EMPTY_BODY), isNotAllowed());
+        assertThat(client.delete(securityConfigPath()), isNotAllowed());
     }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DashboardsInfoTest.java
@@ -13,10 +13,13 @@ package org.opensearch.security.api;
 
 import java.util.List;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -24,29 +27,26 @@ import static org.opensearch.security.OpenSearchSecurityPlugin.LEGACY_OPENDISTRO
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.rest.DashboardsInfoAction.DEFAULT_PASSWORD_MESSAGE;
 import static org.opensearch.security.rest.DashboardsInfoAction.DEFAULT_PASSWORD_REGEX;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public class DashboardsInfoTest extends AbstractApiIntegrationTest {
 
-    static {
-        testSecurityConfig.user(
-            new TestSecurityConfig.User("dashboards_user").roles(
-                new Role("dashboards_role").indexPermissions("read").on("*").clusterPermissions("cluster_composite_ops")
-            )
-        );
-    }
+    static final TestSecurityConfig.User DASHBOARDS_USER = new TestSecurityConfig.User("dashboards_user").roles(
+        new Role("dashboards_role").indexPermissions("read").on("*").clusterPermissions("cluster_composite_ops")
+    );
 
-    private List<String> apiPaths() {
-        return List.of(PLUGINS_PREFIX + "/dashboardsinfo", LEGACY_OPENDISTRO_PREFIX + "/kibanainfo");
-    }
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().users(DASHBOARDS_USER).build();
 
     @Test
     public void testDashboardsInfoValidationMessage() throws Exception {
-        withUser("dashboards_user", client -> {
-            for (String path : apiPaths()) {
-                final var response = ok(() -> client.get(path));
+        try (TestRestClient client = localCluster.getRestClient(DASHBOARDS_USER)) {
+            for (String path : List.of(PLUGINS_PREFIX + "/dashboardsinfo", LEGACY_OPENDISTRO_PREFIX + "/kibanainfo")) {
+                final var response = client.get(path);
+                assertThat(response, isOk());
                 assertThat(response.getTextFromJsonBody("/password_validation_error_message"), equalTo(DEFAULT_PASSWORD_MESSAGE));
                 assertThat(response.getTextFromJsonBody("/password_validation_regex"), equalTo(DEFAULT_PASSWORD_REGEX));
             }
-        });
+        }
     }
 }

--- a/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/DefaultApiAvailabilityIntegrationTest.java
@@ -13,65 +13,87 @@ package org.opensearch.security.api;
 
 import java.util.List;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
 import static org.opensearch.security.api.PatchPayloadHelper.replaceOp;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotAllowed;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public class DefaultApiAvailabilityIntegrationTest extends AbstractApiIntegrationTest {
 
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().build();
+
     @Test
     public void nodesDnApiIsNotAvailableByDefault() throws Exception {
-        withUser(NEW_USER, this::verifyNodesDnApi);
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifyNodesDnApi);
-    }
-
-    private void verifyNodesDnApi(final TestRestClient client) throws Exception {
-        badRequest(() -> client.get(apiPath("nodesdn")));
-        badRequest(() -> client.putJson(apiPath("nodesdn", "cluster_1"), EMPTY_BODY));
-        badRequest(() -> client.delete(apiPath("nodesdn", "cluster_1")));
-        badRequest(() -> client.patch(apiPath("nodesdn", "cluster_1"), EMPTY_BODY));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(apiPath("nodesdn")), isBadRequest());
+            assertThat(client.putJson(apiPath("nodesdn", "cluster_1"), EMPTY_BODY), isBadRequest());
+            assertThat(client.delete(apiPath("nodesdn", "cluster_1")), isBadRequest());
+            assertThat(client.patch(apiPath("nodesdn", "cluster_1"), EMPTY_BODY), isBadRequest());
+        }
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(client.get(apiPath("nodesdn")), isBadRequest());
+            assertThat(client.putJson(apiPath("nodesdn", "cluster_1"), EMPTY_BODY), isBadRequest());
+            assertThat(client.delete(apiPath("nodesdn", "cluster_1")), isBadRequest());
+            assertThat(client.patch(apiPath("nodesdn", "cluster_1"), EMPTY_BODY), isBadRequest());
+        }
     }
 
     @Test
     public void securityConfigIsNotAvailableByDefault() throws Exception {
-        withUser(NEW_USER, client -> {
-            forbidden(() -> client.get(apiPath("securityconfig")));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(apiPath("securityconfig")), isForbidden());
             verifySecurityConfigApi(client);
-        });
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> {
-            ok(() -> client.get(apiPath("securityconfig")));
+        }
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            assertThat(client.get(apiPath("securityconfig")), isOk());
             verifySecurityConfigApi(client);
-        });
+        }
     }
 
     private void verifySecurityConfigApi(final TestRestClient client) throws Exception {
-        methodNotAllowed(() -> client.putJson(apiPath("securityconfig"), EMPTY_BODY));
-        methodNotAllowed(() -> client.postJson(apiPath("securityconfig"), EMPTY_BODY));
-        methodNotAllowed(() -> client.delete(apiPath("securityconfig")));
-        forbidden(() -> client.patch(apiPath("securityconfig"), patch(replaceOp("/a/b/c", "other"))));
+        assertThat(client.putJson(apiPath("securityconfig"), EMPTY_BODY), isNotAllowed());
+        assertThat(client.postJson(apiPath("securityconfig"), EMPTY_BODY), isNotAllowed());
+        assertThat(client.delete(apiPath("securityconfig")), isNotAllowed());
+        assertThat(client.patch(apiPath("securityconfig"), patch(replaceOp("/a/b/c", "other"))), isForbidden());
     }
 
     @Test
     public void securityHealth() throws Exception {
-        withUser(NEW_USER, client -> ok(() -> client.get(securityPath("health"))));
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> ok(() -> client.get(securityPath("health"))));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(securityPath("health")), isOk());
+        }
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            assertThat(client.get(securityPath("health")), isOk());
+        }
     }
 
     @Test
     public void securityAuthInfo() throws Exception {
-        withUser(NEW_USER, this::verifyAuthInfoApi);
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifyAuthInfoApi);
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            verifyAuthInfoApi(client);
+        }
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            verifyAuthInfoApi(client);
+        }
     }
 
     private void verifyAuthInfoApi(final TestRestClient client) throws Exception {
         for (boolean verbose : List.of(true, false)) {
+
             final TestRestClient.HttpResponse response;
-            if (verbose) response = ok(() -> client.get(securityPath("authinfo?verbose=" + verbose)));
-            else response = ok(() -> client.get(securityPath("authinfo")));
+            if (verbose) response = client.get(securityPath("authinfo?verbose=" + verbose));
+            else response = client.get(securityPath("authinfo"));
+            assertThat(response, isOk());
             final var body = response.bodyAsJsonNode();
             assertThat(response.getBody(), body.has("user"));
             assertThat(response.getBody(), body.has("user_name"));
@@ -91,18 +113,19 @@ public class DefaultApiAvailabilityIntegrationTest extends AbstractApiIntegratio
                 assertThat(response.getBody(), body.has("size_of_backendroles"));
             }
         }
+
     }
 
     @Test
     public void reloadSSLCertsNotAvailable() throws Exception {
-        withUser(NEW_USER, client -> {
-            forbidden(() -> client.putJson(apiPath("ssl", "http", "reloadcerts"), EMPTY_BODY));
-            forbidden(() -> client.putJson(apiPath("ssl", "transport", "reloadcerts"), EMPTY_BODY));
-        });
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), client -> {
-            badRequest(() -> client.putJson(apiPath("ssl", "http", "reloadcerts"), EMPTY_BODY));
-            badRequest(() -> client.putJson(apiPath("ssl", "transport", "reloadcerts"), EMPTY_BODY));
-        });
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.putJson(apiPath("ssl", "http", "reloadcerts"), EMPTY_BODY), isForbidden());
+            assertThat(client.putJson(apiPath("ssl", "transport", "reloadcerts"), EMPTY_BODY), isForbidden());
+        }
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            assertThat(client.putJson(apiPath("ssl", "http", "reloadcerts"), EMPTY_BODY), isBadRequest());
+            assertThat(client.putJson(apiPath("ssl", "transport", "reloadcerts"), EMPTY_BODY), isBadRequest());
+        }
     }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRegExpPasswordRulesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRegExpPasswordRulesRestApiIntegrationTest.java
@@ -11,37 +11,40 @@
 
 package org.opensearch.security.api;
 
-import java.util.Map;
 import java.util.StringJoiner;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.api.PatchPayloadHelper.addOp;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public class InternalUsersRegExpPasswordRulesRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     final static String PASSWORD_VALIDATION_ERROR_MESSAGE = "xxxxxxxx";
 
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> clusterSettings = super.getClusterSettings();
-        clusterSettings.put(ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE, PASSWORD_VALIDATION_ERROR_MESSAGE);
-        clusterSettings.put(
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().nodeSetting(
+        ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE,
+        PASSWORD_VALIDATION_ERROR_MESSAGE
+    )
+        .nodeSetting(
             ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_REGEX,
             "(?=.*[A-Z])(?=.*[^a-zA-Z\\\\d])(?=.*[0-9])(?=.*[a-z]).{8,}"
-        );
-        clusterSettings.put(
-            ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH,
-            PasswordValidator.ScoreStrength.FAIR.name()
-        );
-        return clusterSettings;
-    }
+        )
+        .nodeSetting(ConfigConstants.SECURITY_RESTAPI_PASSWORD_SCORE_BASED_VALIDATION_STRENGTH, PasswordValidator.ScoreStrength.FAIR.name())
+        .build();
 
     String internalUsers(String... path) {
         final var fullPath = new StringJoiner("/").add(super.apiPath("internalusers"));
@@ -61,46 +64,42 @@ public class InternalUsersRegExpPasswordRulesRestApiIntegrationTest extends Abst
 
     @Test
     public void canNotCreateUsersWithPassword() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             // validate short passwords
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("123")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("1234567")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("1Aa%")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("123456789")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("a123456789")));
-            badRequest(() -> client.putJson(internalUsers("tooshoort"), internalUserWithPassword("A123456789")));
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("123")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("1234567")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("1Aa%")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("123456789")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("a123456789")), isBadRequest());
+            assertThat(client.putJson(internalUsers("tooshoort"), internalUserWithPassword("A123456789")), isBadRequest());
             // validate that password same as user
-            badRequest(() -> client.putJson(internalUsers("$1aAAAAAAAAC"), internalUserWithPassword("$1aAAAAAAAAC")));
-            badRequest(() -> client.putJson(internalUsers("$1aAAAAAAAac"), internalUserWithPassword("$1aAAAAAAAAC")));
-            badRequestWithReason(
-                () -> client.patch(
-                    internalUsers(),
-                    patch(
-                        addOp("testuser1", internalUserWithPassword("$aA123456789")),
-                        addOp("testuser2", internalUserWithPassword("testpassword2"))
-                    )
-                ),
-                PASSWORD_VALIDATION_ERROR_MESSAGE
+            assertThat(client.putJson(internalUsers("$1aAAAAAAAAC"), internalUserWithPassword("$1aAAAAAAAAC")), isBadRequest());
+            assertThat(client.putJson(internalUsers("$1aAAAAAAAac"), internalUserWithPassword("$1aAAAAAAAAC")), isBadRequest());
+            final var r = client.patch(
+                internalUsers(),
+                patch(
+                    addOp("testuser1", internalUserWithPassword("$aA123456789")),
+                    addOp("testuser2", internalUserWithPassword("testpassword2"))
+                )
             );
+            assertThat(r, isBadRequest("/reason", PASSWORD_VALIDATION_ERROR_MESSAGE));
             // validate similarity
-            badRequestWithReason(
-                () -> client.putJson(internalUsers("some_user_name"), internalUserWithPassword("H3235,cc,some_User_Name")),
-                RequestContentValidator.ValidationError.SIMILAR_PASSWORD.message()
-            );
-        });
+            final var r2 = client.putJson(internalUsers("some_user_name"), internalUserWithPassword("H3235,cc,some_User_Name"));
+            assertThat(r2, isBadRequest("/reason", RequestContentValidator.ValidationError.SIMILAR_PASSWORD.message()));
+        }
     }
 
     @Test
     public void canCreateUsersWithPassword() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
-            created(() -> client.putJson(internalUsers("ok1"), internalUserWithPassword("$aA123456789")));
-            created(() -> client.putJson(internalUsers("ok2"), internalUserWithPassword("$Aa123456789")));
-            created(() -> client.putJson(internalUsers("ok3"), internalUserWithPassword("$1aAAAAAAAAA")));
-            ok(() -> client.putJson(internalUsers("ok3"), internalUserWithPassword("$1aAAAAAAAAC")));
-            ok(() -> client.patch(internalUsers(), patch(addOp("ok3", internalUserWithPassword("$1aAAAAAAAAB")))));
-            ok(() -> client.putJson(internalUsers("ok1"), internalUserWithPassword("Admin_123")));
-        });
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(client.putJson(internalUsers("ok1"), internalUserWithPassword("$aA123456789")), isCreated());
+            assertThat(client.putJson(internalUsers("ok2"), internalUserWithPassword("$Aa123456789")), isCreated());
+            assertThat(client.putJson(internalUsers("ok3"), internalUserWithPassword("$1aAAAAAAAAA")), isCreated());
+            assertThat(client.putJson(internalUsers("ok3"), internalUserWithPassword("$1aAAAAAAAAC")), isOk());
+            assertThat(client.patch(internalUsers(), patch(addOp("ok3", internalUserWithPassword("$1aAAAAAAAAB")))), isOk());
+            assertThat(client.putJson(internalUsers("ok1"), internalUserWithPassword("Admin_123")), isOk());
+        }
     }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.common.xcontent.XContentType;
@@ -34,21 +35,27 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.security.api.PatchPayloadHelper.addOp;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
 import static org.opensearch.security.api.PatchPayloadHelper.replaceOp;
 import static org.opensearch.security.dlic.rest.api.InternalUsersApiAction.RESTRICTED_FROM_USERNAME;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotAllowed;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotFound;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApiIntegrationTest {
 
-    private final static String REST_API_ADMIN_INTERNAL_USERS_ONLY = "rest_api_admin_iternal_users_only";
+    final static String REST_API_ADMIN_INTERNAL_USERS_ONLY = "rest_api_admin_iternal_users_only";
 
     private final static String SERVICE_ACCOUNT_USER = "service_account_user";
 
@@ -58,15 +65,20 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
 
     private final static String SOME_ROLE = "some-role";
 
-    static {
-        testSecurityConfig.withRestAdminUser(REST_API_ADMIN_INTERNAL_USERS_ONLY, restAdminPermission(Endpoint.INTERNALUSERS))
-            .user(new TestSecurityConfig.User(SERVICE_ACCOUNT_USER).attr("service", "true").attr("enabled", "true"))
-            .roles(
-                new TestSecurityConfig.Role(HIDDEN_ROLE).hidden(true),
-                new TestSecurityConfig.Role(RESERVED_ROLE).reserved(true),
-                new TestSecurityConfig.Role(SOME_ROLE)
-            );
-    }
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().users(
+        new TestSecurityConfig.User(SERVICE_ACCOUNT_USER).attr("service", "true").attr("enabled", "true"),
+        new TestSecurityConfig.User(REST_API_ADMIN_INTERNAL_USERS_ONLY).referencedRoles(
+            new TestSecurityConfig.Role(REST_API_ADMIN_INTERNAL_USERS_ONLY)
+        ).roles(new TestSecurityConfig.Role("rest_admin_role").clusterPermissions(restAdminPermission(Endpoint.INTERNALUSERS)))
+    )
+        .roles(
+            new TestSecurityConfig.Role(HIDDEN_ROLE).hidden(true),
+            new TestSecurityConfig.Role(RESERVED_ROLE).reserved(true),
+            new TestSecurityConfig.Role(SOME_ROLE),
+            new TestSecurityConfig.Role(REST_API_ADMIN_INTERNAL_USERS_ONLY)
+        )
+        .build();
 
     public InternalUsersRestApiIntegrationTest() {
         super("internalusers", new TestDescriptor() {
@@ -91,6 +103,26 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                 return Optional.of(REST_API_ADMIN_INTERNAL_USERS_ONLY);
             }
         });
+    }
+
+    @Test
+    public void forbiddenForRegularUsers() throws Exception {
+        super.forbiddenForRegularUsers(localCluster);
+    }
+
+    @Test
+    public void availableForAdminUser() throws Exception {
+        super.availableForAdminUser(localCluster);
+    }
+
+    @Test
+    public void availableForTLSAdminUser() throws Exception {
+        super.availableForTLSAdminUser(localCluster);
+    }
+
+    @Test
+    public void availableForRESTAdminUser() throws Exception {
+        super.availableForRESTAdminUser(localCluster);
     }
 
     static ToXContentObject internalUserWithPassword(final String password) {
@@ -194,60 +226,59 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
     @Override
     void verifyBadRequestOperations(TestRestClient client) throws Exception {
         // bad query string parameter name
-        badRequest(() -> client.get(apiPath() + "?aaaaa=bbbbb"));
+        assertThat(client.get(apiPath() + "?aaaaa=bbbbb"), isBadRequest());
         final var predefinedUserName = randomAsciiAlphanumOfLength(4);
-        created(
-            () -> client.putJson(
+        assertThat(
+            client.putJson(
                 apiPath(predefinedUserName),
                 internalUser(randomAsciiAlphanumOfLength(10), configJsonArray(generateArrayValues(false)), null, null)
-            )
+            ),
+            isCreated()
         );
         invalidJson(client, predefinedUserName);
     }
 
     void invalidJson(final TestRestClient client, final String predefinedUserName) throws Exception {
         // put
-        badRequest(() -> client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), EMPTY_BODY));
-        badRequest(() -> client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), (builder, params) -> {
+        assertThat(client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), EMPTY_BODY), isBadRequest());
+        assertThat(client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), (builder, params) -> {
             builder.startObject();
             builder.field("backend_roles");
             randomConfigArray(false).toXContent(builder, params);
             builder.field("backend_roles");
             randomConfigArray(false).toXContent(builder, params);
             return builder.endObject();
-        }));
-        assertInvalidKeys(badRequest(() -> client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), (builder, params) -> {
+        }), isBadRequest());
+        HttpResponse response = client.putJson(apiPath(randomAsciiAlphanumOfLength(5)), (builder, params) -> {
             builder.startObject();
             builder.field("unknown_json_property");
             configJsonArray("a", "b").toXContent(builder, params);
             builder.field("backend_roles");
             randomConfigArray(false).toXContent(builder, params);
             return builder.endObject();
-        })), "unknown_json_property");
-        assertWrongDataType(
-            client.putJson(
-                apiPath(randomAsciiAlphanumOfLength(10)),
-                (builder, params) -> builder.startObject()
-                    .field("password", configJsonArray("a", "b"))
-                    .field("hash")
-                    .nullValue()
-                    .field("backend_roles", "c")
-                    .field("attributes", "d")
-                    .field("opendistro_security_roles", "e")
-                    .endObject()
-            ),
-            Map.of(
-                "password",
-                "String expected",
-                "hash",
-                "String expected",
-                "backend_roles",
-                "Array expected",
-                "attributes",
-                "Object expected",
-                "opendistro_security_roles",
-                "Array expected"
-            )
+        });
+        assertThat(response, isBadRequest());
+        assertInvalidKeys(response, "unknown_json_property");
+
+        response = client.putJson(
+            apiPath(randomAsciiAlphanumOfLength(10)),
+            (builder, params) -> builder.startObject()
+                .field("password", configJsonArray("a", "b"))
+                .field("hash")
+                .nullValue()
+                .field("backend_roles", "c")
+                .field("attributes", "d")
+                .field("opendistro_security_roles", "e")
+                .endObject()
+        );
+        assertThat(
+            response,
+            isBadRequest().withAttribute("/status", "error")
+                .withAttribute("/password", "String expected")
+                .withAttribute("/hash", "String expected")
+                .withAttribute("/backend_roles", "Array expected")
+                .withAttribute("/attributes", "Object expected")
+                .withAttribute("/opendistro_security_roles", "Array expected")
         );
         assertNullValuesInArray(
             client.putJson(
@@ -262,18 +293,19 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
             )
         );
         // patch
-        badRequest(() -> client.patch(apiPath(), patch(addOp(randomAsciiAlphanumOfLength(10), EMPTY_BODY))));
+        assertThat(client.patch(apiPath(), patch(addOp(randomAsciiAlphanumOfLength(10), EMPTY_BODY))), isBadRequest());
         for (String field : List.of("opendistro_security_roles", "backend_roles", "attributes")) {
-            badRequest(() -> client.patch(apiPath(predefinedUserName), patch(replaceOp(field, EMPTY_BODY))));
+
+            assertThat(client.patch(apiPath(predefinedUserName), patch(replaceOp(field, EMPTY_BODY))), isBadRequest());
         }
-        badRequest(() -> client.patch(apiPath(), patch(addOp(randomAsciiAlphanumOfLength(5), (ToXContentObject) (builder, params) -> {
+        assertThat(client.patch(apiPath(), patch(addOp(randomAsciiAlphanumOfLength(5), (ToXContentObject) (builder, params) -> {
             builder.startObject();
             builder.field("unknown_json_property");
             configJsonArray("a", "b").toXContent(builder, params);
             builder.field("backend_roles");
             randomConfigArray(false).toXContent(builder, params);
             return builder.endObject();
-        }))));
+        }))), isBadRequest());
         assertWrongDataType(
             client.patch(
                 apiPath(),
@@ -350,7 +382,7 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
             attributes,
             securityRoles
         );
-        created(() -> client.putJson(apiPath(usernamePut), newUserJsonPut));
+        assertThat(client.putJson(apiPath(usernamePut), newUserJsonPut), isCreated());
         assertInternalUser(
             ok(() -> client.get(apiPath(usernamePut))).bodyAsJsonNode().get(usernamePut),
             hidden,
@@ -365,15 +397,15 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
             attributes,
             securityRoles
         );
-        ok(() -> client.putJson(apiPath(usernamePut), updatedUserJsonPut));
+        assertThat(client.putJson(apiPath(usernamePut), updatedUserJsonPut), isOk());
         assertInternalUser(
             ok(() -> client.get(apiPath(usernamePut))).bodyAsJsonNode().get(usernamePut),
             hidden,
             reserved,
             Strings.toString(XContentType.JSON, updatedUserJsonPut)
         );
-        ok(() -> client.delete(apiPath(usernamePut)));
-        notFound(() -> client.get(apiPath(usernamePut)));
+        assertThat(client.delete(apiPath(usernamePut)), isOk());
+        assertThat(client.get(apiPath(usernamePut)), isNotFound());
         // patch
         // TODO related to issue #4426
         final var usernamePatch = randomAsciiAlphanumOfLength(10);
@@ -385,22 +417,24 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
             (builder, params) -> builder.startObject().endObject(),
             configJsonArray()
         );
-        ok(() -> client.patch(apiPath(), patch(addOp(usernamePatch, newUserJsonPatch))));
+        assertThat(client.patch(apiPath(), patch(addOp(usernamePatch, newUserJsonPatch))), isOk());
         assertInternalUser(
             ok(() -> client.get(apiPath(usernamePatch))).bodyAsJsonNode().get(usernamePatch),
             hidden,
             reserved,
             Strings.toString(XContentType.JSON, newUserJsonPatch)
         );
-        ok(() -> client.patch(apiPath(usernamePatch), patch(replaceOp("backend_roles", configJsonArray("c", "d")))));
-        ok(
-            () -> client.patch(
+        assertThat(client.patch(apiPath(usernamePatch), patch(replaceOp("backend_roles", configJsonArray("c", "d")))), isOk());
+        assertThat(
+            client.patch(
                 apiPath(usernamePatch),
                 patch(addOp("attributes", (ToXContentObject) (builder, params) -> builder.startObject().field("a", "b").endObject()))
-            )
+            ),
+            isOk()
         );
-        ok(
-            () -> client.patch(apiPath(usernamePatch), patch(addOp("opendistro_security_roles", configJsonArray(RESERVED_ROLE, SOME_ROLE))))
+        assertThat(
+            client.patch(apiPath(usernamePatch), patch(addOp("opendistro_security_roles", configJsonArray(RESERVED_ROLE, SOME_ROLE)))),
+            isOk()
         );
     }
 
@@ -442,56 +476,58 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
 
     @Test
     public void filters() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             assertFilterByUsers(ok(() -> client.get(apiPath())), true, true);
             assertFilterByUsers(ok(() -> client.get(filterBy("any"))), true, true);
             assertFilterByUsers(ok(() -> client.get(filterBy("internal"))), false, true);
             assertFilterByUsers(ok(() -> client.get(filterBy("service"))), true, false);
             assertFilterByUsers(ok(() -> client.get(filterBy("something"))), true, true);
-        });
+        }
     }
 
     void assertFilterByUsers(final HttpResponse response, final boolean hasServiceUser, final boolean hasInternalUser) {
         assertThat(response.getBody(), response.bodyAsJsonNode().has(SERVICE_ACCOUNT_USER), is(hasServiceUser));
-        assertThat(response.getBody(), response.bodyAsJsonNode().has(NEW_USER), is(hasInternalUser));
+        assertThat(response.getBody(), response.bodyAsJsonNode().has(NEW_USER.getName()), is(hasInternalUser));
     }
 
     @Test
     public void verifyPOSTOnlyForAuthTokenEndpoint() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
-            badRequest(() -> client.post(apiPath(ADMIN_USER_NAME, "authtoken")));
-            ok(() -> client.post(apiPath(SERVICE_ACCOUNT_USER, "authtoken")));
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(client.post(apiPath(ADMIN_USER.getName(), "authtoken")), isBadRequest());
+            assertThat(client.post(apiPath(SERVICE_ACCOUNT_USER, "authtoken")), isOk());
             /*
               should be notImplement but the call doesn't reach {@link org.opensearch.security.dlic.rest.api.InternalUsersApiAction#withAuthTokenPath(RestRequest)}
              */
-            methodNotAllowed(() -> client.post(apiPath("randomPath")));
-        });
+            assertThat(client.post(apiPath("randomPath")), isNotAllowed());
+        }
     }
 
     @Test
     public void userApiWithDotsInName() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             for (final var dottedUserName : List.of(".my.dotuser0", ".my.dot.user0")) {
-                created(
-                    () -> client.putJson(
+                assertThat(
+                    client.putJson(
                         apiPath(dottedUserName),
                         (builder, params) -> builder.startObject().field("password", randomAsciiAlphanumOfLength(10)).endObject()
-                    )
+                    ),
+                    isCreated()
                 );
             }
             for (final var dottedUserName : List.of(".my.dotuser1", ".my.dot.user1")) {
-                created(
-                    () -> client.putJson(
+                assertThat(
+                    client.putJson(
                         apiPath(dottedUserName),
                         (builder, params) -> builder.startObject()
                             .field("hash", passwordHasher.hash(randomAsciiAlphanumOfLength(10).toCharArray()))
                             .endObject()
-                    )
+                    ),
+                    isCreated()
                 );
             }
             for (final var dottedUserName : List.of(".my.dotuser2", ".my.dot.user2")) {
-                ok(
-                    () -> client.patch(
+                assertThat(
+                    client.patch(
                         apiPath(),
                         patch(
                             addOp(
@@ -501,12 +537,13 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                                     .endObject()
                             )
                         )
-                    )
+                    ),
+                    isOk()
                 );
             }
             for (final var dottedUserName : List.of(".my.dotuser3", ".my.dot.user3")) {
-                ok(
-                    () -> client.patch(
+                assertThat(
+                    client.patch(
                         apiPath(),
                         patch(
                             addOp(
@@ -516,91 +553,98 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                                     .endObject()
                             )
                         )
-                    )
+                    ),
+                    isOk()
                 );
             }
-        });
+        }
     }
 
     @Test
     public void noPasswordChange() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
-            created(
-                () -> client.putJson(
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(
+                client.putJson(
                     apiPath("user1"),
                     (builder, params) -> builder.startObject()
                         .field("hash", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m")
                         .endObject()
-                )
+                ),
+                isCreated()
             );
-            badRequest(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath("user1"),
                     (builder, params) -> builder.startObject()
                         .field("hash", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m")
                         .field("password", "")
                         .field("backend_roles", configJsonArray("admin", "role_a"))
                         .endObject()
-                )
+                ),
+                isBadRequest()
             );
-            ok(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath("user1"),
                     (builder, params) -> builder.startObject()
                         .field("hash", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m")
                         .field("password", randomAsciiAlphanumOfLength(10))
                         .field("backend_roles", configJsonArray("admin", "role_a"))
                         .endObject()
-                )
+                ),
+                isOk()
             );
-            created(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath("user2"),
                     (builder, params) -> builder.startObject()
                         .field("hash", "$2a$12$n5nubfWATfQjSYHiWtUyeOxMIxFInUHOAx8VMmGmxFNPGpaBmeB.m")
                         .field("password", randomAsciiAlphanumOfLength(10))
                         .endObject()
-                )
+                ),
+                isCreated()
             );
-            badRequest(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath("user2"),
                     (builder, params) -> builder.startObject()
                         .field("password", "")
                         .field("backend_roles", configJsonArray("admin", "role_b"))
                         .endObject()
-                )
+                ),
+                isBadRequest()
             );
-            ok(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath("user2"),
                     (builder, params) -> builder.startObject()
                         .field("password", randomAsciiAlphanumOfLength(10))
                         .field("backend_roles", configJsonArray("admin", "role_b"))
                         .endObject()
-                )
+                ),
+                isOk()
             );
-        });
+        }
     }
 
     @Test
     public void securityRoles() throws Exception {
         final var userWithSecurityRoles = randomAsciiAlphanumOfLength(15);
         final var userWithSecurityRolesPassword = randomAsciiAlphanumOfLength(10);
-        withUser(
-            ADMIN_USER_NAME,
-            client -> ok(
-                () -> client.patch(
-                    apiPath(),
-                    patch(addOp(userWithSecurityRoles, internalUser(userWithSecurityRolesPassword, null, null, null)))
-                )
-            )
-        );
-        withUser(userWithSecurityRoles, userWithSecurityRolesPassword, client -> forbidden(() -> client.get(apiPath())));
-        withUser(
-            ADMIN_USER_NAME,
-            client -> ok(
-                () -> client.patch(
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(
+                client.patch(apiPath(), patch(addOp(userWithSecurityRoles, internalUser(userWithSecurityRolesPassword, null, null, null)))),
+                isOk()
+            );
+        }
+
+        try (TestRestClient client = localCluster.getRestClient(userWithSecurityRoles, userWithSecurityRolesPassword)) {
+            assertThat(client.get(apiPath()), isForbidden());
+        }
+
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(
+                client.patch(
                     apiPath(),
                     patch(
                         replaceOp(
@@ -613,38 +657,48 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                             )
                         )
                     )
-                )
-            )
-        );
-        withUser(userWithSecurityRoles, userWithSecurityRolesPassword, client -> ok(() -> client.get(apiPath())));
-        withUser(ADMIN_USER_NAME, client -> impossibleToSetHiddenRoleIsNotAllowed(userWithSecurityRoles, client));
-        withUser(ADMIN_USER_NAME, client -> settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client));
+                ),
+                isOk()
+            );
+        }
 
-        withUser(
-            ADMIN_USER_NAME,
-            localCluster.getAdminCertificate(),
-            client -> settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client)
-        );
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::canAssignedHiddenRole);
+        try (TestRestClient client = localCluster.getRestClient(userWithSecurityRoles, userWithSecurityRolesPassword)) {
+            assertThat(client.get(apiPath()), isOk());
+        }
 
-        for (final var restAdminUser : List.of(REST_ADMIN_USER, REST_API_ADMIN_INTERNAL_USERS_ONLY)) {
-            withUser(restAdminUser, client -> settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client));
-            withUser(restAdminUser, localCluster.getAdminCertificate(), this::canAssignedHiddenRole);
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            impossibleToSetHiddenRoleIsNotAllowed(userWithSecurityRoles, client);
+            settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client);
+        }
+
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client);
+            canAssignedHiddenRole(client);
+        }
+
+        try (TestRestClient client = localCluster.getRestClient(REST_ADMIN_USER)) {
+            settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client);
+            canAssignedHiddenRole(client);
+        }
+
+        try (TestRestClient client = localCluster.getRestClient(REST_API_ADMIN_INTERNAL_USERS_ONLY, DEFAULT_PASSWORD)) {
+            settingOfUnknownRoleIsNotAllowed(userWithSecurityRoles, client);
+            canAssignedHiddenRole(client);
         }
     }
 
     void impossibleToSetHiddenRoleIsNotAllowed(final String predefinedUserName, final TestRestClient client) throws Exception {
         // put
-        notFound(
-            () -> client.putJson(
+        assertThat(
+            client.putJson(
                 apiPath(randomAsciiAlphanumOfLength(10)),
                 internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray(HIDDEN_ROLE))
             ),
-            "Resource 'hidden-role' is not available."
+            isNotFound().withAttribute("/message", "Resource 'hidden-role' is not available.")
         );
         // patch
-        notFound(
-            () -> client.patch(
+        assertThat(
+            client.patch(
                 apiPath(),
                 patch(
                     addOp(
@@ -652,35 +706,34 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                         internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray(HIDDEN_ROLE))
                     )
                 )
-            )
+            ),
+            isNotFound()
         );
         // TODO related to issue #4426
-        notFound(
-            () -> client.patch(apiPath(predefinedUserName), patch(addOp("opendistro_security_roles", configJsonArray(HIDDEN_ROLE))))
-
+        assertThat(
+            client.patch(apiPath(predefinedUserName), patch(addOp("opendistro_security_roles", configJsonArray(HIDDEN_ROLE)))),
+            isNotFound()
         );
     }
 
     void canAssignedHiddenRole(final TestRestClient client) throws Exception {
         final var userNamePut = randomAsciiAlphanumOfLength(4);
-        created(
-            () -> client.putJson(
-                apiPath(userNamePut),
-                internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray(HIDDEN_ROLE))
-            )
+        assertThat(
+            client.putJson(apiPath(userNamePut), internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray(HIDDEN_ROLE))),
+            isCreated()
         );
     }
 
     void settingOfUnknownRoleIsNotAllowed(final String predefinedUserName, final TestRestClient client) throws Exception {
-        notFound(
-            () -> client.putJson(
+        assertThat(
+            client.putJson(
                 apiPath(randomAsciiAlphanumOfLength(10)),
                 internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray("unknown-role"))
             ),
-            "role 'unknown-role' not found."
+            isNotFound().withAttribute("/message", "role 'unknown-role' not found.")
         );
-        notFound(
-            () -> client.patch(
+        assertThat(
+            client.patch(
                 apiPath(),
                 patch(
                     addOp(
@@ -688,16 +741,18 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                         internalUser(randomAsciiAlphanumOfLength(10), null, null, configJsonArray("unknown-role"))
                     )
                 )
-            )
+            ),
+            isNotFound()
         );
-        notFound(
-            () -> client.patch(apiPath(predefinedUserName), patch(addOp("opendistro_security_roles", configJsonArray("unknown-role"))))
+        assertThat(
+            client.patch(apiPath(predefinedUserName), patch(addOp("opendistro_security_roles", configJsonArray("unknown-role")))),
+            isNotFound()
         );
     }
 
     @Test
     public void parallelPutRequests() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             final var userName = randomAsciiAlphanumOfLength(10);
             final var httpResponses = new HttpResponse[10];
 
@@ -732,40 +787,41 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                         break;
                 }
             }
-        });
+        }
     }
 
     @Test
     public void restrictedUsernameContents() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             {
                 for (final var restrictedTerm : RESTRICTED_FROM_USERNAME) {
                     for (final var username : List.of(
                         randomAsciiAlphanumOfLength(2) + restrictedTerm + randomAsciiAlphanumOfLength(3),
                         URLEncoder.encode(randomAsciiAlphanumOfLength(4) + ":" + randomAsciiAlphanumOfLength(3), StandardCharsets.UTF_8)
                     )) {
-                        final var putResponse = badRequest(
-                            () -> client.putJson(apiPath(username), internalUserWithPassword(randomAsciiAlphanumOfLength(10)))
+                        assertThat(
+                            client.putJson(apiPath(username), internalUserWithPassword(randomAsciiAlphanumOfLength(10))),
+                            isBadRequest("/message", restrictedTerm)
                         );
-                        assertThat(putResponse.getBody(), containsString(restrictedTerm));
-                        final var patchResponse = badRequest(
-                            () -> client.patch(apiPath(), patch(addOp(username, internalUserWithPassword(randomAsciiAlphanumOfLength(10)))))
+                        assertThat(
+                            client.patch(apiPath(), patch(addOp(username, internalUserWithPassword(randomAsciiAlphanumOfLength(10))))),
+                            isBadRequest("/message", restrictedTerm)
                         );
-                        assertThat(patchResponse.getBody(), containsString(restrictedTerm));
                     }
                 }
             }
-        });
+        }
     }
 
     @Test
     public void serviceUsers() throws Exception {
-        withUser(ADMIN_USER_NAME, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             // Add enabled service account then get it
             // TODO related to issue #4426 add default behave when enabled is true
             final var happyServiceLiveUserName = randomAsciiAlphanumOfLength(10);
-            created(() -> client.putJson(apiPath(happyServiceLiveUserName), serviceUser(true)));
-            final var serviceLiveResponse = ok(() -> client.get(apiPath(happyServiceLiveUserName)));
+            assertThat(client.putJson(apiPath(happyServiceLiveUserName), serviceUser(true)), isCreated());
+            final var serviceLiveResponse = client.get(apiPath(happyServiceLiveUserName));
+            assertThat(serviceLiveResponse, isOk());
             assertThat(
                 serviceLiveResponse.getBody(),
                 serviceLiveResponse.getBooleanFromJsonBody("/" + happyServiceLiveUserName + "/attributes/service")
@@ -777,8 +833,9 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
 
             // Add disabled service account
             final var happyServiceDeadUserName = randomAsciiAlphanumOfLength(10);
-            created(() -> client.putJson(apiPath(happyServiceDeadUserName), serviceUser(false)));
-            final var serviceDeadResponse = ok(() -> client.get(apiPath(happyServiceDeadUserName)));
+            assertThat(client.putJson(apiPath(happyServiceDeadUserName), serviceUser(false)), isCreated());
+            final var serviceDeadResponse = client.get(apiPath(happyServiceDeadUserName));
+            assertThat(serviceDeadResponse, isOk());
             assertThat(
                 serviceDeadResponse.getBody(),
                 serviceDeadResponse.getBooleanFromJsonBody("/" + happyServiceDeadUserName + "/attributes/service")
@@ -788,28 +845,28 @@ public class InternalUsersRestApiIntegrationTest extends AbstractConfigEntityApi
                 not(serviceDeadResponse.getBooleanFromJsonBody("/" + happyServiceDeadUserName + "/attributes/enabled"))
             );
             // Add service account with password -- Should Fail
-            badRequest(
-                () -> client.putJson(
-                    apiPath(randomAsciiAlphanumOfLength(10)),
-                    serviceUserWithPassword(true, randomAsciiAlphanumOfLength(10))
-                )
+            assertThat(
+                client.putJson(apiPath(randomAsciiAlphanumOfLength(10)), serviceUserWithPassword(true, randomAsciiAlphanumOfLength(10))),
+                isBadRequest()
             );
             // Add service with hash -- should fail
-            badRequest(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath(randomAsciiAlphanumOfLength(10)),
                     serviceUserWithHash(true, passwordHasher.hash(randomAsciiAlphanumOfLength(10).toCharArray()))
-                )
+                ),
+                isBadRequest()
             );
             // Add Service account with password & Hash -- should fail
             final var password = randomAsciiAlphanumOfLength(10);
-            badRequest(
-                () -> client.putJson(
+            assertThat(
+                client.putJson(
                     apiPath(randomAsciiAlphanumOfLength(10)),
                     serviceUser(true, password, passwordHasher.hash(password.toCharArray()))
-                )
+                ),
+                isBadRequest()
             );
-        });
+        }
     }
 
     private String randomAsciiAlphanumOfLength(int length) {

--- a/src/integrationTest/java/org/opensearch/security/api/RollbackVersionApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/RollbackVersionApiIntegrationTest.java
@@ -11,22 +11,26 @@
 
 package org.opensearch.security.api;
 
-import java.util.Map;
-
-import org.apache.http.HttpStatus;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.support.ConfigConstants.EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED;
+import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotFound;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+import static org.opensearch.test.framework.matcher.RestMatchers.isUnauthorized;
 
 public class RollbackVersionApiIntegrationTest extends AbstractApiIntegrationTest {
 
@@ -38,61 +42,57 @@ public class RollbackVersionApiIntegrationTest extends AbstractApiIntegrationTes
         return ROLLBACK_BASE + "/" + versionId;
     }
 
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> settings = super.getClusterSettings();
-        settings.put(EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED, true);
-        return settings;
-    }
+    @Rule
+    public LocalCluster localCluster = clusterBuilder().nodeSetting(EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED, true).build();
 
     @Before
     public void setupConfigVersionsIndex() throws Exception {
-        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
-            client.createUser(USER.getName(), USER).assertStatusCode(201);
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            assertThat(client.createUser(USER.getName(), USER), anyOf(isOk(), isCreated()));
         }
     }
 
     @Test
     public void testRollbackToPreviousVersion_success() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             var response = client.post(ROLLBACK_BASE);
-            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(response, isOk());
             assertThat(response.getTextFromJsonBody("/status"), equalTo("OK"));
             assertThat(response.getTextFromJsonBody("/message"), containsString("config rolled back to version"));
-        });
+        }
     }
 
     @Test
     public void testRollbackToSpecificVersion_success() throws Exception {
         String versionId = "v1";
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             var response = client.post(RollbackVersion(versionId));
-            assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
+            assertThat(response, isOk());
             assertThat(response.getTextFromJsonBody("/status"), equalTo("OK"));
             assertThat(response.getTextFromJsonBody("/message"), containsString("config rolled back to version " + versionId));
-        });
+        }
     }
 
     @Test
     public void testRollbackWithNonAdmin_shouldBeUnauthorized() throws Exception {
-        withUser(NEW_USER, DEFAULT_PASSWORD, client -> {
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
             var response = client.post(ROLLBACK_BASE);
-            assertThat(response.getStatusCode(), isOneOf(HttpStatus.SC_FORBIDDEN, HttpStatus.SC_UNAUTHORIZED));
-        });
+            assertThat(response, anyOf(isForbidden(), isUnauthorized()));
+        }
     }
 
     @Test
     public void testRollbackToInvalidVersion_shouldReturnNotFound() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             var response = client.post(RollbackVersion("does-not-exist"));
-            assertThat(response.getStatusCode(), is(HttpStatus.SC_NOT_FOUND));
+            assertThat(response, isNotFound());
             assertThat(response.getTextFromJsonBody("/message"), containsString("not found"));
-        });
+        }
     }
 
     @Test
     public void testRollbackWhenOnlyOneVersion_shouldFail() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             // To perform below test, delete all entries in .opensearch_security_config_versions index
             String deleteQuery = """
                     {
@@ -116,7 +116,7 @@ public class RollbackVersionApiIntegrationTest extends AbstractApiIntegrationTes
             var response = client.post(ROLLBACK_BASE);
             assertThat(response.getStatusCode(), is(404));
             assertThat(response.getBody(), containsString("No previous version available to rollback"));
-        });
+        }
     }
 
 }

--- a/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
@@ -10,34 +10,35 @@
  */
 package org.opensearch.security.api;
 
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.security.dlic.rest.api.Endpoint;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ADMIN_ENABLED;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 
 @Deprecated
 public class SslCertsRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     final static String REST_API_ADMIN_SSL_INFO = "rest-api-admin-ssl-info";
 
-    static {
-        testSecurityConfig.withRestAdminUser(REST_ADMIN_USER, allRestAdminPermissions())
-            .withRestAdminUser(REST_API_ADMIN_SSL_INFO, restAdminPermission(Endpoint.SSL, CERTS_INFO_ACTION));
-    }
-
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> clusterSettings = super.getClusterSettings();
-        clusterSettings.put(SECURITY_RESTAPI_ADMIN_ENABLED, true);
-        return clusterSettings;
-    }
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().nodeSetting(SECURITY_RESTAPI_ADMIN_ENABLED, true)
+        .users(
+            new TestSecurityConfig.User(REST_API_ADMIN_SSL_INFO).referencedRoles(REST_ADMIN_REST_API_ACCESS_ROLE)
+                .roles(
+                    new TestSecurityConfig.Role("rest_admin_role").clusterPermissions(restAdminPermission(Endpoint.SSL, CERTS_INFO_ACTION))
+                )
+        )
+        .build();
 
     protected String sslCertsPath() {
         return super.apiPath("ssl", "certs");
@@ -45,27 +46,38 @@ public class SslCertsRestApiIntegrationTest extends AbstractApiIntegrationTest {
 
     @Test
     public void certsInfoForbiddenForRegularUser() throws Exception {
-        withUser(NEW_USER, client -> forbidden(() -> client.get(sslCertsPath())));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(sslCertsPath()), isForbidden());
+        }
     }
 
     @Test
     public void certsInfoForbiddenForAdminUser() throws Exception {
-        withUser(NEW_USER, client -> forbidden(() -> client.get(sslCertsPath())));
+        try (TestRestClient client = localCluster.getRestClient(NEW_USER)) {
+            assertThat(client.get(sslCertsPath()), isForbidden());
+        }
     }
 
     @Test
     public void certsInfoAvailableForTlsAdmin() throws Exception {
-        withUser(ADMIN_USER_NAME, localCluster.getAdminCertificate(), this::verifySSLCertsInfo);
+        try (TestRestClient client = localCluster.getAdminCertRestClient()) {
+            verifySSLCertsInfo(client);
+        }
     }
 
     @Test
     public void certsInfoAvailableForRestAdmin() throws Exception {
-        withUser(REST_ADMIN_USER, this::verifySSLCertsInfo);
-        withUser(REST_API_ADMIN_SSL_INFO, this::verifySSLCertsInfo);
+        try (TestRestClient client = localCluster.getRestClient(REST_ADMIN_USER)) {
+            verifySSLCertsInfo(client);
+        }
+        try (TestRestClient client = localCluster.getRestClient(REST_API_ADMIN_SSL_INFO, DEFAULT_PASSWORD)) {
+            verifySSLCertsInfo(client);
+        }
     }
 
     private void verifySSLCertsInfo(final TestRestClient client) throws Exception {
-        final var response = ok(() -> client.get(sslCertsPath()));
+        final var response = client.get(sslCertsPath());
+        assertThat(response, isOk());
 
         final var body = response.bodyAsJsonNode();
         assertThat(response.getBody(), body.has("http_certificates_list"));

--- a/src/integrationTest/java/org/opensearch/security/api/ViewVersionApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/ViewVersionApiIntegrationTest.java
@@ -11,28 +11,33 @@
 
 package org.opensearch.security.api;
 
-import java.util.Map;
-
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isOneOf;
 import static org.opensearch.security.OpenSearchSecurityPlugin.PLUGINS_PREFIX;
 import static org.opensearch.security.support.ConfigConstants.EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.opensearch.test.framework.matcher.RestMatchers.isNotFound;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+import static org.opensearch.test.framework.matcher.RestMatchers.isUnauthorized;
 
 public class ViewVersionApiIntegrationTest extends AbstractApiIntegrationTest {
 
-    static {
-        testSecurityConfig.user(new TestSecurityConfig.User("limitedUser").password("limitedPass"));
-    }
+    @Rule
+    public LocalCluster localCluster = clusterBuilder().users(new TestSecurityConfig.User("limitedUser").password("limitedPass"))
+        .nodeSetting(EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED, true)
+        .build();
 
     private static final TestSecurityConfig.User USER = new TestSecurityConfig.User("user");
 
@@ -48,37 +53,32 @@ public class ViewVersionApiIntegrationTest extends AbstractApiIntegrationTest {
         return endpointPrefix() + "/version/" + versionId;
     }
 
-    @Override
-    protected Map<String, Object> getClusterSettings() {
-        Map<String, Object> settings = super.getClusterSettings();
-        settings.put(EXPERIMENTAL_SECURITY_CONFIGURATIONS_VERSIONS_ENABLED, true);
-        return settings;
-    }
-
     @Before
     public void setupIndexAndCerts() throws Exception {
-        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER_NAME, DEFAULT_PASSWORD)) {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
             client.createUser(USER.getName(), USER).assertStatusCode(201);
         }
     }
 
     @Test
     public void testViewAllVersions() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
-            var response = ok(() -> client.get(viewVersionBase()));
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            var response = client.get(viewVersionBase());
+            assertThat(response, isOk());
             var json = response.bodyAsJsonNode();
 
             assertThat(json.has("versions"), is(true));
             var versions = json.get("versions");
             assertThat(versions.isArray(), is(true));
             assertThat(versions.size(), greaterThan(0));
-        });
+        }
     }
 
     @Test
     public void testViewSpecificVersionFound() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
-            var response = ok(() -> client.get(viewVersion("v1")));
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            var response = client.get(viewVersion("v1"));
+            assertThat(response, isOk());
             var json = response.bodyAsJsonNode();
 
             assertThat(json.has("versions"), is(true));
@@ -88,13 +88,14 @@ public class ViewVersionApiIntegrationTest extends AbstractApiIntegrationTest {
 
             var ver = versions.get(0);
             assertThat(ver.get("version_id").asText(), equalTo("v1"));
-        });
+        }
     }
 
     @Test
     public void testViewSpecificVersionNotFound() throws Exception {
-        withUser(ADMIN_USER_NAME, DEFAULT_PASSWORD, client -> {
-            var response = notFound(() -> client.get(viewVersion("does-not-exist")));
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            var response = client.get(viewVersion("does-not-exist"));
+            assertThat(response, isNotFound());
             var json = response.bodyAsJsonNode();
 
             assertThat(json.has("status"), is(true));
@@ -102,14 +103,14 @@ public class ViewVersionApiIntegrationTest extends AbstractApiIntegrationTest {
 
             assertThat(json.has("message"), is(true));
             assertThat(json.get("message").asText(), containsString("not found"));
-        });
+        }
     }
 
     @Test
     public void testViewAllVersions_forbiddenWithoutAdminCert() throws Exception {
-        withUser("limitedUser", "limitedPass", client -> {
+        try (TestRestClient client = localCluster.getRestClient("limitedUser", "limitedPass")) {
             var response = client.get(viewVersionBase());
-            assertThat(response.getStatusCode(), isOneOf(401, 403));
-        });
+            assertThat(response, anyOf(isUnauthorized(), isForbidden()));
+        }
     }
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -94,8 +94,6 @@ import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE
 */
 public class TestSecurityConfig {
 
-    public static final String REST_ADMIN_REST_API_ACCESS = "rest_admin__rest_api_access";
-
     private static final Logger log = LogManager.getLogger(TestSecurityConfig.class);
 
     private static final PasswordHasher passwordHasher = PasswordHasherFactory.createPasswordHasher(
@@ -178,18 +176,6 @@ public class TestSecurityConfig {
     public TestSecurityConfig users(User... users) {
         for (User user : users) {
             this.user(user);
-        }
-        return this;
-    }
-
-    public TestSecurityConfig withRestAdminUser(final String name, final String... permissions) {
-        if (!internalUsers.containsKey(name)) {
-            user(new User(name).description("REST Admin with permissions: " + Arrays.toString(permissions)).reserved(true));
-            final var roleName = name + "__rest_admin_role";
-            roles(new Role(roleName).clusterPermissions(permissions));
-
-            rolesMapping.computeIfAbsent(roleName, RoleMapping::new).users(name);
-            rolesMapping.computeIfAbsent(REST_ADMIN_REST_API_ACCESS, RoleMapping::new).users(name);
         }
         return this;
     }

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalCluster.java
@@ -461,6 +461,11 @@ public class LocalCluster extends ExternalResource implements AutoCloseable, Ope
             return this;
         }
 
+        public Builder nodeSetting(String key, Object value) {
+            nodeOverrideSettingsBuilder.put(key, String.valueOf(value));
+            return this;
+        }
+
         public Builder nodeSpecificSettings(int nodeNumber, Map<String, Object> settings) {
             if (!nodeSpecificOverrideSettingsBuilder.containsKey(nodeNumber)) {
                 Settings.Builder builderCopy = Settings.builder();

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
@@ -66,6 +66,14 @@ public class RestMatchers {
         return new OpenSearchErrorHttpResponseMatcher(404, "Not Found");
     }
 
+    public static OpenSearchErrorHttpResponseMatcher isNotAllowed() {
+        return new OpenSearchErrorHttpResponseMatcher(405, "Not Allowed");
+    }
+
+    public static OpenSearchErrorHttpResponseMatcher isUnauthorized() {
+        return new OpenSearchErrorHttpResponseMatcher(401, "Unauthorized");
+    }
+
     public static class HttpResponseMatcher extends DiagnosingMatcher<HttpResponse> {
         final int statusCode;
         final String statusName;


### PR DESCRIPTION
### Description

In #5915, we discovered that the config REST API integration tests cause memory leaks as they use static references across test class boundaries in an unsafe manner.

This PR refactores these tests so that these no longer share static cluster or mutable static configuration references across test classes. IMHO, one should strive for abolishing the abstract super classes for these tests alltogether, but this is outside of my time availability.

* Category: Test fix
* Why these changes are required? 
  * Fixes memory leaks in integration tests
* What is the old behavior before changes and new behavior after changes?
  * No behavioral changes

### Issues Resolved

Fixes #5915

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
