### PR TITLE
Fix issue in RolesRestApiIntegrationTest with invalid DLS clause

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/RolesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/RolesRestApiIntegrationTest.java
@@ -524,7 +524,8 @@ public class RolesRestApiIntegrationTest extends AbstractConfigEntityApiIntegrat
     }
 
     List<ToXContentObject> dlsOptions() {
-        return List.of((builder, params) -> builder.value("str1234567"), (builder, params) -> builder.nullValue());
+        // DLS must be a valid query JSON string, not arbitrary text
+        return List.of((builder, params) -> builder.value("{\"match_all\": {}}"), (builder, params) -> builder.nullValue());
     }
 
     List<ToXContentObject> flsOptions(final boolean useNullValues) {


### PR DESCRIPTION
### Description

Fix issue in RolesRestApiIntegrationTest with invalid DLS clause

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Test fix

### Issues Resolved

Fixes: https://github.com/opensearch-project/security/pull/5934#issuecomment-3835602965

```
2026-01-31T16:09:15.6734273Z 2026-01-31 16:09:15 opensearch[cluster_manager_0][ConfigurationRepository#ReloadThread][T#1] ERROR AbstractRuleBasedPrivileges:644 - Unexpected exception while processing role: new_role_for_patch=RoleV7 [reserved=false, hidden=true, _static=false, description=null, cluster_permissions=[a, b, c], index_permissions=[Index [index_patterns=[ARoqhKffJL], dls=str1234567, fls=[aiZ1yaPda5, 7Dst9H8EK4], masked_fields=[zF4tUpaM6G, IvOISkCct1], allowed_actions=[J5qGGqhMTe, wNanvnOHhp, 8IH7tzLbfr, 9siK7L6Wxe, qsxsQvTD82]]], tenant_permissions=[]]
2026-01-31T16:09:15.6737247Z Ignoring role.
2026-01-31T16:09:15.6738005Z org.opensearch.security.privileges.PrivilegesConfigurationValidationException: Invalid DLS query: str1234567
2026-01-31T16:09:15.6739256Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges$DlsQuery.parseQuery(DocumentPrivileges.java:132)
2026-01-31T16:09:15.6740531Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges$DlsQuery$Constant.<init>(DocumentPrivileges.java:154)
2026-01-31T16:09:15.6741816Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges$DlsQuery.create(DocumentPrivileges.java:141)
2026-01-31T16:09:15.6743093Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges.roleToRule(DocumentPrivileges.java:66)
2026-01-31T16:09:15.6744299Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges.lambda$new$0(DocumentPrivileges.java:57)
2026-01-31T16:09:15.6745692Z 	at org.opensearch.security.privileges.dlsfls.AbstractRuleBasedPrivileges$StaticRules.roleToRule(AbstractRuleBasedPrivileges.java:660)
2026-01-31T16:09:15.6747287Z 	at org.opensearch.security.privileges.dlsfls.AbstractRuleBasedPrivileges$StaticRules.<init>(AbstractRuleBasedPrivileges.java:619)
2026-01-31T16:09:15.6748706Z 	at org.opensearch.security.privileges.dlsfls.AbstractRuleBasedPrivileges.<init>(AbstractRuleBasedPrivileges.java:108)
2026-01-31T16:09:15.6749944Z 	at org.opensearch.security.privileges.dlsfls.DocumentPrivileges.<init>(DocumentPrivileges.java:57)
2026-01-31T16:09:15.6751104Z 	at org.opensearch.security.privileges.dlsfls.DlsFlsProcessedConfig.<init>(DlsFlsProcessedConfig.java:45)
2026-01-31T16:09:15.6752291Z 	at org.opensearch.security.configuration.DlsFlsValveImpl.updateConfiguration(DlsFlsValveImpl.java:772)
2026-01-31T16:09:15.6753535Z 	at org.opensearch.security.OpenSearchSecurityPlugin.lambda$createComponents$13(OpenSearchSecurityPlugin.java:1243)
2026-01-31T16:09:15.6754932Z 	at org.opensearch.security.configuration.ConfigurationRepository.notifyAboutChanges(ConfigurationRepository.java:567)
2026-01-31T16:09:15.6756463Z 	at org.opensearch.security.configuration.ConfigurationRepository.notifyConfigurationListeners(ConfigurationRepository.java:556)
2026-01-31T16:09:15.6757967Z 	at org.opensearch.security.configuration.ConfigurationRepository.doReload(ConfigurationRepository.java:551)
2026-01-31T16:09:15.6759276Z 	at org.opensearch.security.configuration.ConfigurationRepository$ReloadThread.run(ConfigurationRepository.java:854)
2026-01-31T16:09:15.6760191Z 	at java.base/java.lang.Thread.run(Thread.java:1583)
```

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
