### PR TITLE
[FIX] Fix for audit sink fails when using write alias as target index

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSink.java
@@ -64,6 +64,10 @@ public final class InternalOpenSearchSink extends AbstractInternalOpenSearchSink
             return true;
         }
 
+        if (clusterService.state().metadata().hasAlias(indexName)) {
+            return true;
+        }
+
         try {
             final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).settings(indexSettings);
             final boolean ok = clientProvider.admin().indices().create(createIndexRequest).actionGet().isAcknowledged();

--- a/src/test/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSinkTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSinkTest.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.auditlog.sink;
+
+import java.nio.file.Path;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.action.admin.indices.create.CreateIndexResponse;
+import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.AdminClient;
+import org.opensearch.transport.client.Client;
+import org.opensearch.transport.client.IndicesAdminClient;
+
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InternalOpenSearchSinkTest {
+
+    @Mock
+    private Client client;
+    @Mock
+    private AdminClient adminClient;
+    @Mock
+    private IndicesAdminClient indicesAdminClient;
+    @Mock
+    private ThreadPool threadPool;
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private ClusterState clusterState;
+    @Mock
+    private Metadata metadata;
+    @Mock
+    private Path configPath;
+
+    private InternalOpenSearchSink sink;
+
+    @Before
+    public void setUp() {
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(client.admin()).thenReturn(adminClient);
+        when(adminClient.indices()).thenReturn(indicesAdminClient);
+
+        Settings settings = Settings.builder()
+            .put("plugins.security.audit.config.index", "test-audit-index")
+            .build();
+
+        sink = new InternalOpenSearchSink(
+            "test",
+            settings,
+            "plugins.security.audit.config",
+            configPath,
+            client,
+            threadPool,
+            null,
+            clusterService
+        );
+    }
+
+    @Test
+    public void testCreateIndexIfAbsent_IndexExists() {
+        when(metadata.hasIndex("test-index")).thenReturn(true);
+
+        boolean result = sink.createIndexIfAbsent("test-index");
+
+        assertTrue(result);
+        verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class));
+    }
+
+    @Test
+    public void testCreateIndexIfAbsent_AliasExists() {
+        when(metadata.hasIndex("test-alias")).thenReturn(false);
+        when(metadata.hasAlias("test-alias")).thenReturn(true);
+
+        boolean result = sink.createIndexIfAbsent("test-alias");
+
+        assertTrue(result);
+        verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class));
+    }
+
+    @Test
+    public void testCreateIndexIfAbsent_NeitherExists_CreatesIndex() {
+        when(metadata.hasIndex("new-index")).thenReturn(false);
+        when(metadata.hasAlias("new-index")).thenReturn(false);
+
+        CreateIndexResponse createIndexResponse = new CreateIndexResponse(true, true, "new-index");
+        PlainActionFuture<CreateIndexResponse> future = PlainActionFuture.newFuture();
+        future.onResponse(createIndexResponse);
+        when(indicesAdminClient.create(any(CreateIndexRequest.class))).thenReturn(future);
+
+        boolean result = sink.createIndexIfAbsent("new-index");
+
+        assertTrue(result);
+        verify(indicesAdminClient).create(any(CreateIndexRequest.class));
+    }
+}


### PR DESCRIPTION
### Description
This PR fixes the audit log sink to support write aliases as the target index.
* Category: Bug fix

* Why these changes are required?
When users configure `plugins.security.audit.config.index` with a write alias name, the security plugin fails to recognize it and attempts to create an index with the same name as the alias, resulting in
InvalidIndexNameException.

* What is the old behavior before changes and new behavior after changes?

**Old behavior**: The createIndexIfAbsent() method only checks metadata().hasIndex(indexName). Since aliases are not indices, this returns false for write aliases, causing the plugin to attempt creating an index with
the alias name. This fails with:
InvalidIndexNameException: Invalid alias name [audit-write-alias], an index exists with the same name as the alias

**New behavior**: The method now also checks metadata().hasAlias(indexName). If a write alias exists with the configured name, the plugin uses it directly for indexing (OpenSearch automatically routes writes to the
backing index). Index creation is only attempted when neither an index nor an alias exists.

### Issues Resolved
- #5688 

### Testing
- Unit testing: Added InternalOpenSearchSinkTest with 3 test cases:
  - testCreateIndexIfAbsent_IndexExists - verifies existing index is used
  - testCreateIndexIfAbsent_AliasExists - verifies existing alias is used (new behavior)
  - testCreateIndexIfAbsent_NeitherExists_CreatesIndex - verifies index creation fallback
- Manual testing:
  - Configured plugins.security.audit.config.index: audit-write-alias
  - Created backing index audit-logs-000001 with write alias audit-write-alias
  - Verified audit logs are written to the backing index via the alias
  - Verified no spurious index named audit-write-alias is created

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
