### PR TITLE
Fix plugin install workflow by adding -Pcrypto.standard=FIPS-140-3

### DIFF
--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -33,7 +33,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           cache-disabled: true
-          arguments: assemble
+          arguments: assemble -Pcrypto.standard=FIPS-140-3
 
       # Move and rename the plugin for installation
       - name: Move and rename the plugin for installation


### PR DESCRIPTION
### Description

Fix plugin install workflow by adding -Pcrypto.standard=FIPS-140-3.

Fixes jar hell now that min distro is building with this by default.

```
-> Failed installing file:/home/runner/work/security/security/opensearch-security.zip
-> Rolling back file:/home/runner/work/security/security/opensearch-security.zip
-> Rolled back file:/home/runner/work/security/security/opensearch-security.zip
Error: Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-security due to jar hell
	at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:779)
	at org.opensearch.plugins.PluginsService.checkJarHellForPlugin(PluginsService.java:404)
	at org.opensearch.tools.cli.plugin.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:834)
	at org.opensearch.tools.cli.plugin.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:811)
	at org.opensearch.tools.cli.plugin.InstallPluginCommand.installPlugin(InstallPluginCommand.java:846)
	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:277)
	at org.opensearch.tools.cli.plugin.InstallPluginCommand.execute(InstallPluginCommand.java:251)
	at org.opensearch.common.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:110)
	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
	at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
	at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
	at org.opensearch.cli.Command.main(Command.java:101)
	at org.opensearch.tools.cli.plugin.PluginCli.main(PluginCli.java:66)
Caused by: java.lang.IllegalStateException: jar hell!
class: org.bouncycastle.cert.AttributeCertificateHolder
jar1: /home/runner/work/security/security/opensearch-3.6.0-SNAPSHOT9200/plugins/.installing-4014912968827480493/bcpkix-fips-2.1.9.jar
jar2: /home/runner/work/security/security/opensearch-3.6.0-SNAPSHOT9200/lib/bcpkix-fips-2.1.9.jar
	at org.opensearch.common.bootstrap.JarHell.checkClass(JarHell.java:316)
	at org.opensearch.common.bootstrap.JarHell.checkJarHell(JarHell.java:215)
	at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:777)
	... 12 more
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
