### PR TITLE
[Maintenance] Fix bc-fips dependency jarhell for maven publish

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -38,4 +38,4 @@ jobs:
           aws-region: us-east-1
       - name: publish snapshots to maven
         run: |
-          ./gradlew --no-daemon publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository
+          ./gradlew --no-daemon publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository -Pcrypto.standard=FIPS-140-3


### PR DESCRIPTION
### Description
The FIPS flag (`-Pcrypto.standard=FIPS-140-3`) was added to `plugin_install.yml` and `scripts/build.sh`, but it's missing from `maven-publish.yml`. This means the published snapshots are still built without the flag, so `bc-fips`, `bcpkix-fips`, and  `bcutil-fips` are bundled as `implementation` instead of `compileOnly`. This causes jar hell for downstream plugins (like SQL) that download the security snapshot for integration tests, since those jars already exist in OpenSearch core's `lib/` directory.

### Issues Resolved
* Relate https://github.com/opensearch-project/security/pull/5962
* Relate https://github.com/opensearch-project/sql/pull/5158

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
