### PR TITLE
Fix `copyExtraTestResources` task to make it work after `clean`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -241,23 +241,23 @@ task listTasksAsJSON {
     }
 }
 
-task copyExtraTestResources(dependsOn: testClasses) {
+tasks.register('copyExtraTestResources', Copy.class) {
+    dependsOn testClasses
 
-    copy {
-        from 'src/test/resources'
-        into 'build/testrun/test/src/test/resources'
+    into "build/testrun" // base dir for all `into` below
+
+    from("src/test/resources") {
+        into("test/src/test/resources")
     }
 
     taskNames.each { testName ->
-        copy {
-            from 'src/test/resources'
-            into "build/testrun/${testName}/src/test/resources"
+        from("src/test/resources") {
+            into("${testName}/src/test/resources")
         }
     }
 
-    copy {
-        from 'src/test/resources'
-        into 'build/testrun/citest/src/test/resources'
+    from("src/test/resources") {
+        into "citest/src/test/resources"
     }
 }
 


### PR DESCRIPTION
### Description

We recently onboarded this repo into our CI and started seeing various errors in the tests. The common cause for those was the absence of files in `build/testrun` subdirectories. Which is weird as there’s a `copyExtraTestResources` task that is responsible for copying those files and there are no problems with that in GitHub.com actions.

Looking closer at `copyExtraTestResources` I was able to figure out the cause. Our typical flow in CI is `gradle clean test/check` and it turns out that `clean` is the trigger.

The way `copyExtraTestResources` is defined now puts all those `copy` clusures into [the configuration phase](https://docs.gradle.org/current/userguide/build_lifecycle.html#build_phases).:

```groovy
task copyExtraTestResources(dependsOn: testClasses) {
    copy {
        from 'src/test/resources'
        into 'build/testrun/test/src/test/resources'
    }

    taskNames.each { testName ->
        copy {
            from 'src/test/resources'
            into "build/testrun/${testName}/src/test/resources"
        }
    }

    copy {
        from 'src/test/resources'
        into 'build/testrun/citest/src/test/resources'
    }
}
```

And `clean` task is executed during _the execution phase_, after the configuration is done, and deletes all the files produced by `copyExtraTestResources`.

```
❯ ./gradlew copyExtraTestResources
...
❯ ls -al build/testrun

Permissions Size User     Group Date Modified Git Name
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  ciSecurityIntegrationTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  citest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  crossClusterTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  dlicDlsflsTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  dlicRestApiTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  indicesTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  sslTest
drwxr-xr-x     - mstepura staff 26 Feb 21:02   -I  test

❯ ./gradlew clean copyExtraTestResources
...
❯ ls -al build/testrun

"build/testrun": No such file or directory (os error 2)
```


* Category : Test fix
* Why these changes are required?
  * To be able to use `./gradlew clean test`
* What is the old behavior before changes and new behavior after changes?
  *  The old behavior was causing `clean` to delete required test files (copy -> clean -> test). The new behavior fixes the sequence (i.e. clean -> copy -> test)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
