### PR TITLE
[2.19] Bump commons-text to 1.15.0 and log4j-core to 2.25.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ plugins {
     id 'com.netflix.nebula.ospackage' version "11.10.1"
     id "org.gradle.test-retry" version "1.6.1"
     id 'eclipse'
-    id "com.github.spotbugs" version "6.4.8"
+    id "com.github.spotbugs" version "5.2.5"
     id "com.google.osdetector" version "1.7.3"
 }
 
@@ -381,7 +381,7 @@ jacocoTestReport {
 }
 
 checkstyle {
-    toolVersion "11.0.0"
+    toolVersion "10.26.1"
     showViolations true
     configDirectory.set(rootProject.file("checkstyle/"))
 }
@@ -509,6 +509,8 @@ configurations {
             force "org.checkerframework:checker-qual:3.48.3"
             force "ch.qos.logback:logback-classic:1.5.16"
             force "commons-io:commons-io:2.18.0"
+            force "org.apache.commons:commons-text:1.15.0"
+            force "org.apache.logging.log4j:log4j-core:2.25.3"
 
             exclude group: "org.lz4", module: "lz4-java"
         }


### PR DESCRIPTION
### Description

1. commons-text:1.15.0 - fixes CVE-2025-46295 (was 1.3 from checkstyle transitive)
2. log4j-core:2.25.3 - fixes CVE-2025-68161 (was 2.25.2 from spotbugs transitive)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
