### PR TITLE
fixed throw exception for DLS user attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix the issue of unprocessed X-Request-Id ([#5954](https://github.com/opensearch-project/security/pull/5954))
 - Improve DLS error message to identify undefined user attributes when query substitution fails ([#5975](https://github.com/opensearch-project/security/pull/5975))
-
 - Fix the issue of unprocessed X-Request-Id ([#5976](https://github.com/opensearch-project/security/pull/5976))
 ### Refactoring
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Fix audit log writing errors for rollover-enabled alias indices ([#5878](https://github.com/opensearch-project/security/pull/5878)
 
 - Fix the issue of unprocessed X-Request-Id ([#5954](https://github.com/opensearch-project/security/pull/5954))
+- Improve DLS error message to identify undefined user attributes when query substitution fails ([#5975](https://github.com/opensearch-project/security/pull/5975))
+
+- Fix the issue of unprocessed X-Request-Id ([#5976](https://github.com/opensearch-project/security/pull/5976))
 ### Refactoring
 
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - Fix the issue of unprocessed X-Request-Id ([#5954](https://github.com/opensearch-project/security/pull/5954))
 - Improve DLS error message to identify undefined user attributes when query substitution fails ([#5975](https://github.com/opensearch-project/security/pull/5975))
-- Fix the issue of unprocessed X-Request-Id ([#5976](https://github.com/opensearch-project/security/pull/5976))
 ### Refactoring
 
 ### Maintenance

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
@@ -64,6 +64,7 @@ import org.opensearch.security.util.MockPrivilegeEvaluationContextBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.opensearch.security.util.MockIndexMetadataBuilder.dataStreams;
 import static org.opensearch.security.util.MockIndexMetadataBuilder.indices;
 import static org.junit.Assert.assertEquals;
@@ -1173,6 +1174,18 @@ public class DocumentPrivilegesTest {
         public void invalidTemplatedQuery() throws Exception {
             DocumentPrivileges.DlsQuery.create("{\"invalid\": \"totally ${attr.foo}\"}", xContentRegistry)
                 .evaluate(MockPrivilegeEvaluationContextBuilder.ctx().get());
+        }
+
+        @Test
+        public void invalidTemplatedQuery_errorMessageIdentifiesUndefinedAttribute() throws Exception {
+            try {
+                DocumentPrivileges.DlsQuery.create("{\"terms\":{\"arr\":[${attr.jwt.array}]}}", xContentRegistry)
+                    .evaluate(MockPrivilegeEvaluationContextBuilder.ctx().attr("attr.jwt.other", "x").get());
+                fail("Expected PrivilegesEvaluationException");
+            } catch (PrivilegesEvaluationException e) {
+                assertThat(e.getMessage(), containsString("attr.jwt.array"));
+                assertThat(e.getMessage(), containsString("attr.jwt.other"));
+            }
         }
 
         @Test

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
@@ -1189,6 +1189,21 @@ public class DocumentPrivilegesTest {
         }
 
         @Test
+        public void invalidTemplatedQuery_errorMessageTruncatesWhenMoreThanTenAvailableAttributes() throws Exception {
+            MockPrivilegeEvaluationContextBuilder ctx = MockPrivilegeEvaluationContextBuilder.ctx();
+            for (int i = 1; i <= 12; i++) {
+                ctx.attr("attr.jwt.attr" + i, "v" + i);
+            }
+            try {
+                DocumentPrivileges.DlsQuery.create("{\"term\":{\"dept\":\"${attr.jwt.missing}\"}}", xContentRegistry).evaluate(ctx.get());
+                fail("Expected PrivilegesEvaluationException");
+            } catch (PrivilegesEvaluationException e) {
+                assertThat(e.getMessage(), containsString("attr.jwt.missing"));
+                assertThat(e.getMessage(), containsString("... and 2 more"));
+            }
+        }
+
+        @Test
         public void equals() throws Exception {
             DocumentPrivileges.DlsQuery query1a = DocumentPrivileges.DlsQuery.create(
                 Strings.toString(MediaTypeRegistry.JSON, QueryBuilders.termQuery("foo", "1")),

--- a/src/main/java/org/opensearch/security/privileges/UserAttributes.java
+++ b/src/main/java/org/opensearch/security/privileges/UserAttributes.java
@@ -10,8 +10,13 @@
  */
 package org.opensearch.security.privileges;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
@@ -25,8 +30,23 @@ import org.opensearch.security.user.User;
  * This code was moved over from ConfigModelV7.
  */
 public class UserAttributes {
+    private static final Pattern UNRESOLVED_ATTRIBUTE_PATTERN = Pattern.compile("\\$\\{([^}]+)\\}");
+
     public static boolean needsAttributeSubstitution(String patternString) {
         return patternString.contains("${");
+    }
+
+    /**
+     * Returns the names of all unresolved ${...} attribute references remaining
+     * in {@code s} after substitution has been performed.
+     */
+    public static List<String> findUnresolvedAttributes(String s) {
+        List<String> result = new ArrayList<>();
+        Matcher matcher = UNRESOLVED_ATTRIBUTE_PATTERN.matcher(s);
+        while (matcher.find()) {
+            result.add(matcher.group(1));
+        }
+        return Collections.unmodifiableList(result);
     }
 
     public static String replaceProperties(String orig, PrivilegesEvaluationContext context) {

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.logging.log4j.util.Strings;
 
@@ -176,8 +177,11 @@ public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPriv
             RenderedDlsQuery evaluate(PrivilegesEvaluationContext context) throws PrivilegesEvaluationException {
                 String effectiveQueryString = UserAttributes.replaceProperties(this.queryString, context);
                 if (UserAttributes.needsAttributeSubstitution(effectiveQueryString)) {
+                    List<String> unresolved = UserAttributes.findUnresolvedAttributes(effectiveQueryString);
+                    Set<String> available = context.getUser().getCustomAttributesMap().keySet();
                     throw new PrivilegesEvaluationException(
-                        "Invalid DLS query: " + effectiveQueryString,
+                        "DLS query references undefined user attributes: " + unresolved
+                            + ". Available attributes are: " + available,
                         new OpenSearchSecurityException("User attribute substitution failed")
                     );
                 }

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
@@ -48,6 +48,8 @@ import org.opensearch.security.securityconf.impl.v7.RoleV7;
  * Instances of this class are managed by DlsFlsProcessedConfig.
  */
 public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPrivileges.DlsQuery, DlsRestriction> {
+    private static final int MAX_ATTRIBUTES_IN_ERROR_MESSAGE = 10;
+
     private final NamedXContentRegistry xContentRegistry;
 
     public DocumentPrivileges(
@@ -180,12 +182,14 @@ public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPriv
                 if (UserAttributes.needsAttributeSubstitution(effectiveQueryString)) {
                     List<String> unresolved = UserAttributes.findUnresolvedAttributes(effectiveQueryString);
                     Set<String> available = context.getUser().getCustomAttributesMap().keySet();
-                    String availableStr = available.size() > 10
-                        ? available.stream().limit(10).collect(Collectors.joining(", ")) + " ... and " + (available.size() - 10) + " more"
+                    String availableStr = available.size() > MAX_ATTRIBUTES_IN_ERROR_MESSAGE
+                        ? available.stream().limit(MAX_ATTRIBUTES_IN_ERROR_MESSAGE).collect(Collectors.joining(", "))
+                            + " ... and "
+                            + (available.size() - MAX_ATTRIBUTES_IN_ERROR_MESSAGE)
+                            + " more"
                         : String.join(", ", available);
                     throw new PrivilegesEvaluationException(
-                        "DLS query references undefined user attributes: " + unresolved
-                            + ". Available attributes are: " + availableStr,
+                        "DLS query references undefined user attributes: " + unresolved + ". Available attributes are: " + availableStr,
                         new OpenSearchSecurityException("User attribute substitution failed")
                     );
                 }

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.util.Strings;
 
@@ -179,9 +180,12 @@ public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPriv
                 if (UserAttributes.needsAttributeSubstitution(effectiveQueryString)) {
                     List<String> unresolved = UserAttributes.findUnresolvedAttributes(effectiveQueryString);
                     Set<String> available = context.getUser().getCustomAttributesMap().keySet();
+                    String availableStr = available.size() > 10
+                        ? available.stream().limit(10).collect(Collectors.joining(", ")) + " ... and " + (available.size() - 10) + " more"
+                        : String.join(", ", available);
                     throw new PrivilegesEvaluationException(
                         "DLS query references undefined user attributes: " + unresolved
-                            + ". Available attributes are: " + available,
+                            + ". Available attributes are: " + availableStr,
                         new OpenSearchSecurityException("User attribute substitution failed")
                     );
                 }

--- a/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
@@ -25,9 +25,11 @@ import static org.junit.Assert.assertTrue;
 public class UserAttributesUnitTest {
     @Test
     public void testNeedsAttributeSubstitution() {
-        assertTrue(UserAttributes.needsAttributeSubstitution("{\"foo\": \"${user.name}}\""));
+        assertTrue(UserAttributes.needsAttributeSubstitution("""
+            {"foo": "${user.name}}"}"""));
         assertTrue(UserAttributes.needsAttributeSubstitution("${attr1.proxy.foo}"));
-        assertFalse(UserAttributes.needsAttributeSubstitution("{\"foo\": \"bar\"}"));
+        assertFalse(UserAttributes.needsAttributeSubstitution("""
+            {"foo": "bar"}"""));
     }
 
     @Test
@@ -74,25 +76,27 @@ public class UserAttributesUnitTest {
 
     @Test
     public void testFindUnresolvedAttributes_noTokens() {
-        assertTrue(UserAttributes.findUnresolvedAttributes("{\"term\": {\"dept\": \"value\"}}").isEmpty());
+        assertTrue(UserAttributes.findUnresolvedAttributes("""
+            {"term": {"dept": "value"}}""").isEmpty());
     }
 
     @Test
     public void testFindUnresolvedAttributes_singleToken() {
-        assertEquals(
-            List.of("attr.jwt.array"),
-            UserAttributes.findUnresolvedAttributes("{\"terms\":{\"arr\":[${attr.jwt.array}]}}")
-        );
+        assertEquals(List.of("attr.jwt.array"), UserAttributes.findUnresolvedAttributes("""
+            {"terms": {"arr": [${attr.jwt.array}]}}"""));
     }
 
     @Test
     public void testFindUnresolvedAttributes_multipleTokens() {
-        assertEquals(
-            List.of("attr.jwt.dept", "attr.proxy.region"),
-            UserAttributes.findUnresolvedAttributes(
-                "{\"bool\":{\"must\":[{\"term\":{\"dept\":\"${attr.jwt.dept}\"}},{\"term\":{\"region\":\"${attr.proxy.region}\"}}]}}"
-            )
-        );
+        assertEquals(List.of("attr.jwt.dept", "attr.proxy.region"), UserAttributes.findUnresolvedAttributes("""
+            {
+                "bool": {
+                    "must": [
+                        {"term": {"dept": "${attr.jwt.dept}"}},
+                        {"term": {"region": "${attr.proxy.region}"}}
+                    ]
+                }
+            }"""));
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
@@ -71,4 +71,32 @@ public class UserAttributesUnitTest {
             """;
         assertEquals(expectedString, UserAttributes.replaceProperties(stringWithPlaceholders, ctx));
     }
+
+    @Test
+    public void testFindUnresolvedAttributes_noTokens() {
+        assertTrue(UserAttributes.findUnresolvedAttributes("{\"term\": {\"dept\": \"value\"}}").isEmpty());
+    }
+
+    @Test
+    public void testFindUnresolvedAttributes_singleToken() {
+        assertEquals(
+            List.of("attr.jwt.array"),
+            UserAttributes.findUnresolvedAttributes("{\"terms\":{\"arr\":[${attr.jwt.array}]}}")
+        );
+    }
+
+    @Test
+    public void testFindUnresolvedAttributes_multipleTokens() {
+        assertEquals(
+            List.of("attr.jwt.dept", "attr.proxy.region"),
+            UserAttributes.findUnresolvedAttributes(
+                "{\"bool\":{\"must\":[{\"term\":{\"dept\":\"${attr.jwt.dept}\"}},{\"term\":{\"region\":\"${attr.proxy.region}\"}}]}}"
+            )
+        );
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testFindUnresolvedAttributes_returnsUnmodifiableList() {
+        UserAttributes.findUnresolvedAttributes("${attr.foo}").add("extra");
+    }
 }


### PR DESCRIPTION
### Description
When a DLS query references a user attribute ${attr.jwt.array} that is not present in the authenticated user's JWT/custom attributes, UserAttributes.replaceProperties() leaves the placeholder in the query string. The guard in DocumentPrivileges.Dynamic.evaluate() correctly detects this and throws a PrivilegesEvaluationException, but the previous error message ("Invalid DLS query: <full query string>") gave operators no indication of which attribute was missing or what attributes were available — forcing manual inspection of both the query and the user's token.
- Before: PrivilegesEvaluationException: Invalid DLS query: {"terms":{"arr":["${attr.jwt.array}"]}}
- Fixed: PrivilegesEvaluationException: DLS query references undefined user attributes: [attr.jwt.array]. Available attributes are: [attr.jwt.roles, attr.proxy.department]

### Issues Resolved
- #1310 


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
