### PR TITLE
Only call doCache one per request

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/dlsfls/DoCacheMemoizationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/dlsfls/DoCacheMemoizationTest.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.dlsfls;
+
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.log.LogCapturingAppender;
+import org.opensearch.test.framework.log.LogsRule;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+/**
+ * Regression test verifying that hasFlsOrFieldMasking() is memoized per request in doCache().
+ *
+ * Without the fix, doCache() calls hasFlsOrFieldMasking() once per BooleanQuery filter clause
+ * per shard. With the fix, the result is cached in the ThreadContext for the duration of the
+ * request so only 1 call is made per shard per request, and subsequent calls hit the memoized path.
+ */
+public class DoCacheMemoizationTest {
+
+    static final String INDEX_NAME = "test-index";
+    static final int NUM_FILTER_CLAUSES = 50;
+
+    // Field masking causes hasFlsOrFieldMasking() to return true, exercising the memoization path.
+    static final TestSecurityConfig.User MASKED_USER = new TestSecurityConfig.User("masked_user").roles(
+        new TestSecurityConfig.Role("masked_role").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .maskedFields("field_a")
+            .on(INDEX_NAME)
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(MASKED_USER)
+        .build();
+
+    @Rule
+    public LogsRule logsRule = new LogsRule("org.opensearch.security.OpenSearchSecurityPlugin");
+
+    @BeforeClass
+    public static void setupIndex() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.index(new IndexRequest(INDEX_NAME).setRefreshPolicy(IMMEDIATE).source(Map.of("field_a", "value", "field_b", "other")))
+                .actionGet();
+        }
+    }
+
+    /**
+     * filter clauses → scoreMode=COMPLETE_NO_SCORES → doCache() called per clause per shard.
+     * should/must clauses would set needsScores=true and bypass doCache() entirely.
+     */
+    private SearchRequest buildFilterQuery() {
+        var bool = QueryBuilders.boolQuery();
+        IntStream.range(0, NUM_FILTER_CLAUSES).forEach(i -> bool.filter(QueryBuilders.termQuery("field_b", "other_" + i)));
+        return new SearchRequest(INDEX_NAME).source(new SearchSourceBuilder().query(bool).size(10));
+    }
+
+    @Test
+    public void doCacheUsedMemoizedValueForSubsequentClauses() throws Exception {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(MASKED_USER)) {
+            SearchResponse response = client.search(buildFilterQuery(), DEFAULT);
+            assertThat("search must succeed", response.getFailedShards(), lessThan(1));
+        }
+
+        // First clause evaluates fresh and populates the ThreadContext transient
+        logsRule.assertThatContain("doCache: evaluated hasFlsOrFieldMasking(test-index)=true");
+        // Subsequent clauses (49 of them) hit the memoized value instead of re-evaluating
+        logsRule.assertThatContain("doCache: memoized hasFlsOrFieldMasking(test-index)=true");
+        // Exactly 1 fresh evaluation and NUM_FILTER_CLAUSES-1 memoized hits
+        long evaluatedCount = LogCapturingAppender.getLogMessagesAsString()
+            .stream()
+            .filter(m -> m.contains("doCache: evaluated hasFlsOrFieldMasking"))
+            .count();
+        assertThat("expected exactly 1 fresh evaluation per request", evaluatedCount, equalTo(1L));
+    }
+}

--- a/src/integrationTest/resources/log4j2-test.properties
+++ b/src/integrationTest/resources/log4j2-test.properties
@@ -53,3 +53,8 @@ logger.securenetty4transport.name = org.opensearch.transport.netty4.ssl.SecureNe
 logger.securenetty4transport.level = error
 logger.securenetty4transport.appenderRef.capturing.ref = logCapturingAppender
 
+# Logger required by test org.opensearch.security.dlsfls.DoCacheMemoizationTest
+logger.opensearchsecurityplugin.name = org.opensearch.security.OpenSearchSecurityPlugin
+logger.opensearchsecurityplugin.level = debug
+logger.opensearchsecurityplugin.appenderRef.capturing.ref = logCapturingAppender
+

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -820,6 +820,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                         if (cached == null) {
                             cached = dlsFlsValve.hasFlsOrFieldMasking(index().getName());
                             threadPool.getThreadContext().putTransient(cacheKey, cached);
+                            log.debug("doCache: evaluated hasFlsOrFieldMasking({})={}", index().getName(), cached);
+                        } else {
+                            log.debug("doCache: memoized hasFlsOrFieldMasking({})={}", index().getName(), cached);
                         }
                         if (cached) {
                             // Do not cache

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -16,7 +16,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.StreamSupport;
@@ -538,11 +537,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         return dlsFlsProcessedConfig.get();
     }
 
-    public static final AtomicLong HAS_FLS_OR_FIELD_MASKING_CALL_COUNT = new AtomicLong();
-
     @Override
     public boolean hasFlsOrFieldMasking(String index) throws PrivilegesEvaluationException {
-        HAS_FLS_OR_FIELD_MASKING_CALL_COUNT.incrementAndGet();
         PrivilegesEvaluationContext privilegesEvaluationContext = this.dlsFlsBaseContext.getPrivilegesEvaluationContext();
         if (privilegesEvaluationContext == null) {
             return false;


### PR DESCRIPTION
### Description

We recently saw this method in the hotthreads output of a cluster that had many aliases pointing to the same concrete index.

```
   100.4% (502.1ms out of 500ms) cpu usage by thread 'opensearch[...][search][T#11]'
     3/10 snapshots sharing following 49 elements
       org.opensearch.security.privileges.dlsfls.AbstractRuleBasedPrivileges.hasRestrictedRulesExplicit(AbstractRuleBasedPrivileges.java:286)
       org.opensearch.security.privileges.dlsfls.AbstractRuleBasedPrivileges.isUnrestricted(AbstractRuleBasedPrivileges.java:212)
       org.opensearch.security.privileges.dlsfls.FieldMasking.isUnrestricted(FieldMasking.java:53)
       org.opensearch.security.configuration.DlsFlsValveImpl.hasFlsOrFieldMasking(DlsFlsValveImpl.java:519)
       org.opensearch.security.OpenSearchSecurityPlugin$4.doCache(OpenSearchSecurityPlugin.java:839)
       app//org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:981)
       app//org.opensearch.search.internal.ContextIndexSearcher.createWeight(ContextIndexSearcher.java:239)
       app//org.apache.lucene.search.BooleanWeight.<init>(BooleanWeight.java:58)
       app//org.apache.lucene.search.BooleanQuery.createWeight(BooleanQuery.java:265)
       app//org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:979)
       app//org.opensearch.search.internal.ContextIndexSearcher.createWeight(ContextIndexSearcher.java:239)
       app//org.apache.lucene.search.BooleanWeight.<init>(BooleanWeight.java:58)
       app//org.apache.lucene.search.BooleanQuery.createWeight(BooleanQuery.java:265)
       app//org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:979)
       app//org.opensearch.search.internal.ContextIndexSearcher.createWeight(ContextIndexSearcher.java:239)
       app//org.apache.lucene.search.BooleanWeight.<init>(BooleanWeight.java:58)
       app//org.apache.lucene.search.BooleanQuery.createWeight(BooleanQuery.java:265)
       app//org.apache.lucene.search.IndexSearcher.createWeight(IndexSearcher.java:979)
       app//org.opensearch.search.internal.ContextIndexSearcher.createWeight(ContextIndexSearcher.java:239)
```

On further investigation, I found that `doCache` can sometimes be called many times per query when I would expect it to run once per request. The changes in this PR ensure that its called once per request per shard, stores the result in the threadcontext and uses that for subsequent clauses.

For instance, in the query below `doCache` would be called 5x per shard

```
{
  "query": {
    "bool": {
      "filter": [
        { "term": { "field_b": "other_0" } },
        { "term": { "field_b": "other_1" } },
        { "term": { "field_b": "other_2" } },
        { "term": { "field_b": "other_3" } },
        { "term": { "field_b": "other_4" } }
      ]
    }
  }
}
```

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Issues Resolved

To be filed

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
