### PR TITLE
Add gradle.properties file to build security with -Pcrypto.standard=FIPS=140-3 by default

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -38,4 +38,4 @@ jobs:
           aws-region: us-east-1
       - name: publish snapshots to maven
         run: |
-          ./gradlew --no-daemon publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository -Pcrypto.standard=FIPS-140-3
+          ./gradlew --no-daemon publishPluginZipPublicationToSnapshotsRepository publishShadowPublicationToSnapshotsRepository

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -33,7 +33,7 @@ jobs:
         uses: gradle/gradle-build-action@v3
         with:
           cache-disabled: true
-          arguments: assemble -Pcrypto.standard=FIPS-140-3
+          arguments: assemble
 
       # Move and rename the plugin for installation
       - name: Move and rename the plugin for installation

--- a/build.gradle
+++ b/build.gradle
@@ -678,7 +678,7 @@ dependencies {
     implementation "com.google.guava:guava:${guava_version}"
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.11.0'
-    // When building with -Pcrypto.standard=FIPS-140-3, bcFips jars are provided by OpenSearch
+    // When building with crypto.standard=FIPS-140-3 (set in gradle.properties), bcFips jars are provided by OpenSearch
     if (FipsBuildParams.isInFipsMode()) {
         compileOnly "org.bouncycastle:bc-fips:${versions.bouncycastle_jce}"
         compileOnly "org.bouncycastle:bcpkix-fips:${versions.bouncycastle_pkix}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+crypto.standard=FIPS-140-3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -68,8 +68,8 @@ fi
 
 mkdir -p $OUTPUT
 
-./gradlew :assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
-./gradlew :opensearch-security-spi:assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew :assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew :opensearch-security-spi:assemble --no-daemon --refresh-dependencies -DskipTests=true -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
 zipPath=$(find . -path \*build/distributions/*.zip)
 distributions="$(dirname "${zipPath}")"
@@ -79,9 +79,9 @@ mkdir -p $OUTPUT/plugins
 cp ${distributions}/*.zip ./$OUTPUT/plugins
 
 # Publish jars
-./gradlew :opensearch-security-spi:publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
-./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew :opensearch-security-spi:publishToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishAllPublicationsToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 
-./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER -Pcrypto.standard=FIPS-140-3
+./gradlew publishPluginZipPublicationToZipStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
 mkdir -p $OUTPUT/maven/org/opensearch
 cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description

Inspired by https://github.com/opensearch-project/ml-commons/pull/4719, this PR adds a gradle.properties file so that we only need to declare `-Pcrypto.standard=FIPS-140-3` in a single place. Now its not necessary to pass the build param in commands like `./gradlew assemble -Pcrypto.standard=FIPS-140-3` as it passes the arg by default.

In order to build without the flag, you would need to override like so: `./gradlew assemble -Pcrypto.standard=any-supported
`
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Refactoring

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
