### PR TITLE
Add generateonbehalfoftoken to list of routes to associate uniqueName to the route

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/OnBehalfOfJwtAuthenticationTest.java
@@ -60,6 +60,7 @@ public class OnBehalfOfJwtAuthenticationTest {
     static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
 
     private static final String CREATE_OBO_TOKEN_PATH = "_plugins/_security/api/obo/token";
+    private static final String DEPRECATED_OBO_TOKEN_PATH = "_plugins/_security/api/generateonbehalfoftoken";
     private static final String signingKey = Base64.getEncoder()
         .encodeToString(
             "jwt signing key for an on behalf of token authentication backend for testing of OBO authentication".getBytes(
@@ -186,6 +187,32 @@ public class OnBehalfOfJwtAuthenticationTest {
         String oboToken = generateOboToken(OBO_USER_NAME_WITH_PERM, DEFAULT_PASSWORD);
         Header oboAuthHeader = new BasicHeader("Authorization", "Bearer " + oboToken);
         authenticateWithOboToken(oboAuthHeader, OBO_USER_NAME_WITH_PERM, HttpStatus.SC_OK);
+    }
+
+    @Test
+    public void nonAdminUserWithOboPermissionCanCreateTokenViaNewRoute() {
+        try (TestRestClient client = cluster.getRestClient(OBO_USER)) {
+            TestRestClient.HttpResponse response = client.postJson(CREATE_OBO_TOKEN_PATH, OBO_TOKEN_REASON);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(response.getTextFromJsonBody("/authenticationToken"), notNullValue());
+        }
+    }
+
+    @Test
+    public void nonAdminUserWithOboPermissionCanCreateTokenViaDeprecatedRoute() {
+        try (TestRestClient client = cluster.getRestClient(OBO_USER)) {
+            TestRestClient.HttpResponse response = client.postJson(DEPRECATED_OBO_TOKEN_PATH, OBO_TOKEN_REASON);
+            response.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(response.getTextFromJsonBody("/authenticationToken"), notNullValue());
+        }
+    }
+
+    @Test
+    public void nonAdminUserWithoutOboPermissionIsRejectedOnDeprecatedRoute() {
+        try (TestRestClient client = cluster.getRestClient(OBO_USER_NO_PERM)) {
+            TestRestClient.HttpResponse response = client.postJson(DEPRECATED_OBO_TOKEN_PATH, OBO_TOKEN_REASON);
+            response.assertStatusCode(HttpStatus.SC_UNAUTHORIZED);
+        }
     }
 
     @Test

--- a/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
+++ b/src/main/java/org/opensearch/security/action/onbehalf/CreateOnBehalfOfTokenAction.java
@@ -27,25 +27,22 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.NamedRoute;
 import org.opensearch.rest.RestChannel;
-import org.opensearch.rest.RestHandler.DeprecatedRoute;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.identity.SecurityTokenManager;
 import org.opensearch.transport.client.node.NodeClient;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.security.dlic.rest.support.Utils.PLUGIN_API_ROUTE_PREFIX;
-import static org.opensearch.security.dlic.rest.support.Utils.addDeprecatedRoutesPrefix;
 import static org.opensearch.security.dlic.rest.support.Utils.addRoutesPrefix;
 
 public class CreateOnBehalfOfTokenAction extends BaseRestHandler {
 
     private static final List<Route> routes = addRoutesPrefix(
-        ImmutableList.of(new NamedRoute.Builder().method(POST).path("/obo/token").uniqueName("security:obo/create").build()),
+        ImmutableList.of(
+            new NamedRoute.Builder().method(POST).path("/obo/token").uniqueName("security:obo/create").build(),
+            new NamedRoute.Builder().method(POST).path("/generateonbehalfoftoken").uniqueName("security:obo/create").build()
+        ),
         PLUGIN_API_ROUTE_PREFIX
-    );
-
-    private static final List<DeprecatedRoute> deprecatedRoutes = addDeprecatedRoutesPrefix(
-        ImmutableList.of(new DeprecatedRoute(POST, "/generateonbehalfoftoken", "Use /obo/token instead"))
     );
 
     public static final long OBO_DEFAULT_EXPIRY_SECONDS = 5 * 60;
@@ -63,11 +60,6 @@ public class CreateOnBehalfOfTokenAction extends BaseRestHandler {
     @Override
     public String getName() {
         return getClass().getSimpleName();
-    }
-
-    @Override
-    public List<DeprecatedRoute> deprecatedRoutes() {
-        return deprecatedRoutes;
     }
 
     @Override


### PR DESCRIPTION
### Description

This PR is a follow-up to https://github.com/opensearch-project/security/pull/6017 to add `_plugins/_security/api/generateonbehalfoftoken` back to the list of routes in order to be able to associate a `uniqueName` to the route which is not currently supported with DeprecatedRoute. A change would need to be contributed to core to allow naming routes for DeprecatedRoute and ReplacedRoute.

* Category 

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
