### PR TITLE
Set 3 runtimeOnly dependencies to testRuntimeOnly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -523,6 +523,7 @@ configurations {
 
             // For org.opensearch.plugin:transport-grpc
             force "com.google.guava:failureaccess:1.0.3"
+            force "org.scala-lang:scala3-library_3:3.8.2"
         }
     }
 }


### PR DESCRIPTION
### Description

Sets the following to testRuntimeOnly:

- com.google.guava:failureaccess
- org.checkerframework:checker-qual
- org.scala-lang.modules:scala-java8-compat_3

and removes

- com.google.j2objc:j2objc-annotations

Finally getting around to cleaning up the dependencies and following up on why https://github.com/opensearch-project/security/pull/5652 was introduced.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
