### PR TITLE
Add Finnegan Carroll (gh: finnegancarroll) as a co-maintainer of the Security repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @derek-ho @nibix @RyanL1997 @reta @shikharj05 @willyborankin
+* @cwperks @DarshitChanpura @derek-ho @finnegancarroll @nibix @RyanL1997 @reta @shikharj05 @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Shikhar Jain     | [shikharj05](https://github.com/shikharj05)           | Amazon      |
+| Finnegan Carroll | [finnegancarroll](https://github.com/finnegancarroll) | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Independent |
 | Andrey Pleskach  | [willyborankin](https://github.com/willyborankin)     | Aiven       |
 | Nils Bandener    | [nibix](https://github.com/nibix)                     | Eliatra     |


### PR DESCRIPTION
### Description

I have nominated and maintainers have agreed to add @finnegancarroll as a co-maintainer of the security repo.

Finnegan has made strong and sustained contributions to the repo, especially in the gRPC / auxiliary transport area, and has helped move several important security capabilities from design through implementation. In addition to code contributions, he has also opened and driven multiple well-scoped feature and meta issues that have helped shape the roadmap for this area.

Some notable code contributions include:

- JWT authentication for gRPC transport: [#5916](https://github.com/opensearch-project/security/pull/5916)
- [Bugfix] Make gRPC JWT header keys case insensitive: [#5929](https://github.com/opensearch-project/security/pull/5929)
- TLS support for auxiliary transports: [#5375](https://github.com/opensearch-project/security/pull/5375)
- Bump gradle to 8.14.3 and move gRPC transport out of experimental: [#5542](https://github.com/opensearch-project/security/pull/5542)
- Bump test only protobuf to 0.13.0: [#5553](https://github.com/opensearch-project/security/pull/5553)
Format SSLConfigConstants.java and fix typos: [#5145](https://github.com/opensearch-project/security/pull/5145)

Finnegan has also contributed valuable design and roadmap work through issues and meta tracking items, including:

- [Meta] Authn/Authz support for gRPC/Auxiliary transports in security plugin: [#5813](https://github.com/opensearch-project/security/issues/5813)
- [FEATURE] JWT support for auxiliary transports (gRPC): [#5812](https://github.com/opensearch-project/security/issues/5812)
- [FEATURE] Provide gRPC interceptor alternative to RestHandler: [#5785](https://github.com/opensearch-project/security/issues/5785)
- [FEATURE] Enable hot reload of gRPC certificates: [#5531](https://github.com/opensearch-project/security/issues/5531)
- [META] Testing strategy for auxiliary transports: [#5524](https://github.com/opensearch-project/security/issues/5524)
- [FEATURE] Migrate all SecureTransportSettingsProviders to SSLContexts: [#5258](https://github.com/opensearch-project/security/issues/5258)
[FEATURE] Provide SSL configuration for auxiliary transports: [#5104](https://github.com/opensearch-project/security/issues/5104)

His contribution history shows both breadth and depth: he has authored merged PRs across security transport, TLS, dependency maintenance, and release-related work, and his recent work has been especially important for enabling security support around auxiliary transports and gRPC.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
