### PR TITLE
Make encryption_key truly optional for obo authenticator

### DIFF
--- a/src/main/java/org/opensearch/security/identity/SecurityTokenManager.java
+++ b/src/main/java/org/opensearch/security/identity/SecurityTokenManager.java
@@ -41,8 +41,6 @@ import org.opensearch.threadpool.ThreadPool;
 
 import org.greenrobot.eventbus.Subscribe;
 
-import static org.opensearch.security.util.AuthTokenUtils.isKeyNull;
-
 /**
  * This class is the Security Plugin's implementation of the TokenManager used by all Identity Plugins.
  * It handles the issuance of both Service Account Tokens and On Behalf Of tokens.

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigModelV7.java
@@ -370,7 +370,7 @@ public class DynamicConfigModelV7 extends DynamicConfigModel {
          * order: -1 - prioritize the OBO authentication when it gets enabled
          */
         Settings oboSettings = getDynamicOnBehalfOfSettings();
-        if (!isKeyNull(oboSettings, "signing_key") && !isKeyNull(oboSettings, "encryption_key")) {
+        if (!isKeyNull(oboSettings, "signing_key")) {
             final AuthDomain _ad = new AuthDomain(
                 new NoOpAuthenticationBackend(Settings.EMPTY, null),
                 new OnBehalfOfAuthenticator(getDynamicOnBehalfOfSettings(), this.cih.getClusterName()),

--- a/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
+++ b/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
@@ -267,21 +267,23 @@ public class SecurityTokenManagerTest {
     }
 
     @Test
-    public void testCreateJwtWithBadEncryptionKey() {
+    public void issueOnBehalfOfToken_successWithoutEncryptionKey() throws Exception {
+        doAnswer(invockation -> new ClusterName("cluster17")).when(cs).getClusterName();
         doAnswer(invocation -> true).when(tokenManager).issueOnBehalfOfTokenAllowed();
         final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("Jon"));
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
+        // encryption_key is absent — should still succeed, roles stored in plaintext
         createMockJwtVendorInTokenManager(false);
 
-        final Throwable exception = assertThrows(RuntimeException.class, () -> {
-            try {
-                tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 90000000L));
-            } catch (final Exception e) {
-                throw new RuntimeException(e);
-            }
-        });
-        assertThat(exception.getMessage(), is("java.lang.IllegalArgumentException: encryption_key cannot be null"));
+        final ExpiringBearerAuthToken authToken = mock(ExpiringBearerAuthToken.class);
+        when(jwtVendor.createJwt(any(), any(), any(), any())).thenReturn(authToken);
+        final AuthToken returnedToken = tokenManager.issueOnBehalfOfToken(null, new OnBehalfOfClaims("elmo", 450L));
+
+        assertThat(returnedToken, equalTo(authToken));
+
+        verify(cs).getClusterName();
+        verify(threadPool).getThreadContext();
     }
 }


### PR DESCRIPTION
### Description

Follow-up bugfix to https://github.com/opensearch-project/security/pull/6017

This PR fixes an issue seen on calling

```
POST /_plugins/_security/api/obo/token
{ 
   "description":"Testing",
   "durationSeconds":"180"
}
```

which throws an error is `encryption_key` is not present. In the prior PR, it made `encryption_key` optional for setting up the authenticator but there was a path on the issuing path missed.

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
