### PR TITLE
Add log4j forced resolution (spotbugs conflict)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -499,6 +499,8 @@ configurations {
 
             // for spotbugs dependency conflict
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
+            force "org.apache.logging.log4j:log4j-api:${versions.log4j}"
+            force "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
             // for spotless transitive dependency CVE
             force "org.eclipse.platform:org.eclipse.core.runtime:3.34.200"


### PR DESCRIPTION
### Description
Add log4j forced resolution (spotbugs conflict), as reported by https://advisories.opensearch.org/advisories/CVE-2025-68161

<img width="447" height="166" alt="image" src="https://github.com/user-attachments/assets/feb3f0d0-5a0e-4357-9d30-78eaf7b8ca70" />

### Issues Resolved
See please https://advisories.opensearch.org/advisories/CVE-2025-68161


Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
