### PR TITLE
Refactor certificate revocation validation

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/ssl/util/SSLRequestHelperTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ssl/util/SSLRequestHelperTests.java
@@ -8,39 +8,17 @@
 
 package org.opensearch.security.ssl.util;
 
-import org.bouncycastle.asn1.x509.CRLReason;
-import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder;
-import org.bouncycastle.crypto.CryptoServicesRegistrar;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.rest.RestRequest.Method;
-import org.opensearch.security.filter.SecurityRequest;
-import org.opensearch.security.support.PemKeyReader;
-import org.opensearch.test.framework.certificate.CertificateData;
-import org.opensearch.test.framework.certificate.TestCertificates;
-
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLEngineResult.HandshakeStatus;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.TrustManagerFactory;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.net.InetSocketAddress;
-import java.security.KeyStoreException;
-import java.security.cert.CertPathBuilderException;
-import java.security.cert.CertPathValidatorException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.PrivateKey;
+import java.security.cert.CertPathBuilderException;
+import java.security.cert.CertPathValidatorException;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Date;
@@ -48,13 +26,36 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.support.PemKeyReader;
+import org.opensearch.test.framework.certificate.CertificateData;
+import org.opensearch.test.framework.certificate.TestCertificates;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertThrows;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_PASSWORD;
+import static org.junit.Assert.assertThrows;
 
 public class SSLRequestHelperTests {
 
@@ -89,11 +90,7 @@ public class SSLRequestHelperTests {
         Files.copy(wrongCerts.getRootCertificate().toPath(), configDir.resolve("wrong-ca.pem"));
 
         writeCrl(certs.getRootCertificateData(), configDir.resolve("empty.crl"));
-        writeCrl(
-            certs.getRootCertificateData(),
-            configDir.resolve("revoked.crl"),
-            certs.getAdminCertificateData().certificate()
-        );
+        writeCrl(certs.getRootCertificateData(), configDir.resolve("revoked.crl"), certs.getAdminCertificateData().certificate());
         writeTruststore(certs.getRootCertificateData().certificate(), configDir.resolve(STORE_NAME));
     }
 
@@ -122,7 +119,8 @@ public class SSLRequestHelperTests {
 
     /** Returns a post-handshake server engine using node-0 as server and admin cert as client. */
     private static SSLEngine handshake() throws Exception {
-        return handshake( //
+        return handshake(
+            //
             buildContext(certs.getNodeCertificateData(0), certs), //
             buildContext(certs.getAdminCertificateData(), certs) //
         );
@@ -209,28 +207,44 @@ public class SSLRequestHelperTests {
     private static SecurityRequest requestFor(SSLEngine engine) {
         return new SecurityRequest() {
             @Override
-            public SSLEngine getSSLEngine() {return engine;}
+            public SSLEngine getSSLEngine() {
+                return engine;
+            }
 
             @Override
-            public Map<String, List<String>> getHeaders() {return Collections.emptyMap();}
+            public Map<String, List<String>> getHeaders() {
+                return Collections.emptyMap();
+            }
 
             @Override
-            public String path() {return "/";}
+            public String path() {
+                return "/";
+            }
 
             @Override
-            public Method method() {return Method.GET;}
+            public Method method() {
+                return Method.GET;
+            }
 
             @Override
-            public Optional<InetSocketAddress> getRemoteAddress() {return Optional.empty();}
+            public Optional<InetSocketAddress> getRemoteAddress() {
+                return Optional.empty();
+            }
 
             @Override
-            public String uri() {return "/";}
+            public String uri() {
+                return "/";
+            }
 
             @Override
-            public Map<String, String> params() {return Collections.emptyMap();}
+            public Map<String, String> params() {
+                return Collections.emptyMap();
+            }
 
             @Override
-            public Set<String> getUnconsumedParams() {return Collections.emptySet();}
+            public Set<String> getUnconsumedParams() {
+                return Collections.emptySet();
+            }
         };
     }
 
@@ -271,8 +285,7 @@ public class SSLRequestHelperTests {
         SSLEngine serverEngine = handshake();
         Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false).build();
 
-        SSLRequestHelper.SSLInfo info =
-            SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null);
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null);
 
         assertThat(info, is(notNullValue()));
         assertThat(info.getX509Certs(), is(notNullValue()));        // peer (admin) certs

--- a/src/integrationTest/java/org/opensearch/security/ssl/util/SSLRequestHelperTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ssl/util/SSLRequestHelperTests.java
@@ -1,0 +1,403 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.ssl.util;
+
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.cert.jcajce.JcaX509v2CRLBuilder;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.rest.RestRequest.Method;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.support.PemKeyReader;
+import org.opensearch.test.framework.certificate.CertificateData;
+import org.opensearch.test.framework.certificate.TestCertificates;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult.HandshakeStatus;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.net.InetSocketAddress;
+import java.security.KeyStoreException;
+import java.security.cert.CertPathBuilderException;
+import java.security.cert.CertPathValidatorException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
+import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_PASSWORD;
+
+public class SSLRequestHelperTests {
+
+    private static final String STORE_NAME = CryptoServicesRegistrar.isInApprovedOnlyMode() ? "truststore.bcfks" : "truststore.jks";
+    private static final String STORE_TYPE = CryptoServicesRegistrar.isInApprovedOnlyMode() ? "BCFKS" : "JKS";
+    private static final char[] INTERNAL_STORE_PASSWORD = DEFAULT_STORE_PASSWORD.toCharArray();
+
+    /** Minimum TLS packet buffer size used when the engine reports a smaller value. */
+    private static final int MIN_NET_BUFFER_SIZE = 32_768;
+    /** Minimum TLS application buffer size used when the engine reports a smaller value. */
+    private static final int MIN_APP_BUFFER_SIZE = 4_096;
+    /** Maximum handshake loop iterations before giving up. */
+    private static final int MAX_HANDSHAKE_ITERATIONS = 200;
+    /** CRL validity window written by {@link #writeCrl}. */
+    private static final long CRL_VALIDITY_MS = 24 * 60 * 60 * 1_000L;
+
+    @ClassRule
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+    /** Resolved root of {@link #tempFolder}. */
+    private static Path configDir;
+    /** One CA + node-0 (server) + admin (client). Shared across all tests. */
+    private static TestCertificates certs;
+
+    @BeforeClass
+    public static void setUpCerts() throws Exception {
+        certs = new TestCertificates();
+        TestCertificates wrongCerts = new TestCertificates();
+
+        configDir = tempFolder.getRoot().toPath();
+
+        Files.copy(certs.getRootCertificate().toPath(), configDir.resolve("ca.pem"));
+        Files.copy(wrongCerts.getRootCertificate().toPath(), configDir.resolve("wrong-ca.pem"));
+
+        writeCrl(certs.getRootCertificateData(), configDir.resolve("empty.crl"));
+        writeCrl(
+            certs.getRootCertificateData(),
+            configDir.resolve("revoked.crl"),
+            certs.getAdminCertificateData().certificate()
+        );
+        writeTruststore(certs.getRootCertificateData().certificate(), configDir.resolve(STORE_NAME));
+    }
+
+    // ── SSLContext helpers ────────────────────────────────────────────────────
+
+    private static SSLContext buildContext(CertificateData identity, TestCertificates trustSource) throws Exception {
+        KeyStore ks = PemKeyReader.toKeystore(
+            "identity",
+            DEFAULT_STORE_PASSWORD.toCharArray(),
+            new java.security.cert.X509Certificate[] { identity.certificate() },
+            (PrivateKey) identity.getKey()
+        );
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, DEFAULT_STORE_PASSWORD.toCharArray());
+
+        KeyStore ts = PemKeyReader.toTruststore("ca", PemKeyReader.loadCertificatesFromFile(trustSource.getRootCertificate()));
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ts);
+
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return ctx;
+    }
+
+    // ── Handshake engine ──────────────────────────────────────────────────────
+
+    /** Returns a post-handshake server engine using node-0 as server and admin cert as client. */
+    private static SSLEngine handshake() throws Exception {
+        return handshake( //
+            buildContext(certs.getNodeCertificateData(0), certs), //
+            buildContext(certs.getAdminCertificateData(), certs) //
+        );
+    }
+
+    /**
+     * Drives a full TLS loopback handshake between two {@link SSLEngine} instances and
+     * returns the server-side engine after the handshake completes.
+     */
+    private static SSLEngine handshake(SSLContext serverCtx, SSLContext clientCtx) throws Exception {
+        SSLEngine server = serverCtx.createSSLEngine();
+        server.setUseClientMode(false);
+        server.setNeedClientAuth(true);
+
+        SSLEngine client = clientCtx.createSSLEngine();
+        client.setUseClientMode(true);
+
+        client.beginHandshake();
+        server.beginHandshake();
+
+        int netSize = Math.max(server.getSession().getPacketBufferSize(), MIN_NET_BUFFER_SIZE);
+        int appSize = Math.max(server.getSession().getApplicationBufferSize(), MIN_APP_BUFFER_SIZE);
+
+        ByteBuffer cToS = ByteBuffer.allocate(netSize * 4);
+        ByteBuffer sToC = ByteBuffer.allocate(netSize * 4);
+        ByteBuffer app = ByteBuffer.allocate(appSize);
+
+        for (int guard = 0; guard < MAX_HANDSHAKE_ITERATIONS; guard++) {
+            runTasks(server);
+            runTasks(client);
+
+            if (client.getHandshakeStatus() == HandshakeStatus.NEED_WRAP) {
+                ByteBuffer net = ByteBuffer.allocate(netSize);
+                client.wrap(app, net);
+                net.flip();
+                cToS.put(net);
+                runTasks(client);
+            }
+
+            if (server.getHandshakeStatus() == HandshakeStatus.NEED_UNWRAP && cToS.position() > 0) {
+                cToS.flip();
+                server.unwrap(cToS, app);
+                cToS.compact();
+                runTasks(server);
+            }
+
+            if (server.getHandshakeStatus() == HandshakeStatus.NEED_WRAP) {
+                ByteBuffer net = ByteBuffer.allocate(netSize);
+                server.wrap(app, net);
+                net.flip();
+                sToC.put(net);
+                runTasks(server);
+            }
+
+            if (client.getHandshakeStatus() == HandshakeStatus.NEED_UNWRAP && sToC.position() > 0) {
+                sToC.flip();
+                client.unwrap(sToC, app);
+                sToC.compact();
+                runTasks(client);
+            }
+
+            HandshakeStatus ss = server.getHandshakeStatus();
+            HandshakeStatus cs = client.getHandshakeStatus();
+            if ((ss == HandshakeStatus.FINISHED || ss == HandshakeStatus.NOT_HANDSHAKING) //
+                && (cs == HandshakeStatus.FINISHED || cs == HandshakeStatus.NOT_HANDSHAKING)) {
+                break;
+            }
+        }
+
+        return server;
+    }
+
+    private static void runTasks(SSLEngine engine) {
+        Runnable task;
+        while ((task = engine.getDelegatedTask()) != null) {
+            task.run();
+        }
+    }
+
+    /**
+     * Minimal {@link SecurityRequest} that supplies a real {@link SSLEngine} to
+     * {@code getSSLInfo}. All other interface methods are unused by {@code getSSLInfo}.
+     */
+    private static SecurityRequest requestFor(SSLEngine engine) {
+        return new SecurityRequest() {
+            @Override
+            public SSLEngine getSSLEngine() {return engine;}
+
+            @Override
+            public Map<String, List<String>> getHeaders() {return Collections.emptyMap();}
+
+            @Override
+            public String path() {return "/";}
+
+            @Override
+            public Method method() {return Method.GET;}
+
+            @Override
+            public Optional<InetSocketAddress> getRemoteAddress() {return Optional.empty();}
+
+            @Override
+            public String uri() {return "/";}
+
+            @Override
+            public Map<String, String> params() {return Collections.emptyMap();}
+
+            @Override
+            public Set<String> getUnconsumedParams() {return Collections.emptySet();}
+        };
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** Writes a truststore of the given {@code type} containing {@code caCert} with no password. */
+    private static void writeTruststore(X509Certificate caCert, Path target) throws Exception {
+        KeyStore ts = KeyStore.getInstance(STORE_TYPE);
+        ts.load(null, null);
+        ts.setCertificateEntry("ca", caCert);
+        try (FileOutputStream fos = new FileOutputStream(target.toFile())) {
+            ts.store(fos, INTERNAL_STORE_PASSWORD);
+        }
+    }
+
+    /**
+     * Writes a DER-encoded CRL signed by {@code ca}. Each cert in {@code revoked} is added as a
+     * revoked entry with reason {@code keyCompromise}. Pass no certs for an empty (no-revocations) CRL.
+     */
+    private static void writeCrl(CertificateData ca, Path target, X509Certificate... revoked) throws Exception {
+        Date now = new Date();
+
+        JcaX509v2CRLBuilder builder = new JcaX509v2CRLBuilder(ca.certificate(), now);
+        builder.setNextUpdate(new Date(now.getTime() + CRL_VALIDITY_MS));
+        for (X509Certificate cert : revoked) {
+            builder.addCRLEntry(cert.getSerialNumber(), now, CRLReason.keyCompromise);
+        }
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build((PrivateKey) ca.getKey());
+
+        Files.write(target, builder.build(signer).getEncoded());
+    }
+
+    // ── tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    public void getSSLInfo_returnsPopulatedSSLInfo_afterHandshakeWithClientAuth() throws Exception {
+        SSLEngine serverEngine = handshake();
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false).build();
+
+        SSLRequestHelper.SSLInfo info =
+            SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getX509Certs(), is(notNullValue()));        // peer (admin) certs
+        assertThat(info.getLocalCertificates(), is(notNullValue())); // server (node-0) certs
+    }
+
+    @Test
+    public void getSSLInfo_throwsSSLPeerUnverifiedException_whenCertPathCannotBeBuilt() throws Exception {
+        // The peer cert is signed by `certs` CA, but we tell the validator to trust a *different* CA.
+        // CertPathBuilder cannot find a valid path → CertPathBuilderException (GeneralSecurityException catch).
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "wrong-ca.pem")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, true)
+            .build();
+
+        SSLPeerUnverifiedException ex = assertThrows(
+            SSLPeerUnverifiedException.class,
+            () -> SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null)
+        );
+        assertThat(ex.getCause(), instanceOf(CertPathBuilderException.class));
+    }
+
+    @Test
+    public void getSSLInfo_throwsSSLPeerUnverifiedException_whenCrlFileIsMissing() throws Exception {
+        // loadCrls throws FileNotFoundException (IOException) when the CRL file does not exist.
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "nonexistent.crl")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "ca.pem")
+            .build();
+
+        SSLPeerUnverifiedException ex = assertThrows(
+            SSLPeerUnverifiedException.class,
+            () -> SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null)
+        );
+        assertThat(ex.getCause(), instanceOf(FileNotFoundException.class));
+    }
+
+    @Test
+    public void getSSLInfo_throwsSSLPeerUnverifiedException_whenKeystoreTypeIsInvalid() throws Exception {
+        // KeyStore.getInstance("INVALID_TYPE") throws KeyStoreException (GeneralSecurityException).
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, STORE_NAME)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, "INVALID_TYPE")
+            .build();
+
+        SSLPeerUnverifiedException ex = assertThrows(
+            SSLPeerUnverifiedException.class,
+            () -> SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null)
+        );
+        assertThat(ex.getCause(), instanceOf(KeyStoreException.class));
+    }
+
+    @Test
+    public void getSSLInfo_returnsPopulatedSSLInfo_whenCrlValidationPassesWithEmptyCrl() throws Exception {
+        // Happy path with CRL_VALIDATE=true: peer cert is valid, CRL lists no revocations → passes.
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "empty.crl")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "ca.pem")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, true)
+            .build();
+
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getX509Certs(), is(notNullValue()));
+        assertThat(info.getLocalCertificates(), is(notNullValue()));
+    }
+
+    @Test
+    public void getSSLInfo_throwsSSLPeerUnverifiedException_whenPeerCertIsRevoked() throws Exception {
+        // The admin (peer) cert's serial is listed in the CRL → CertPathValidatorException → SSLPeerUnverifiedException.
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "revoked.crl")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "ca.pem")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, true)
+            .build();
+
+        SSLPeerUnverifiedException ex = assertThrows(
+            SSLPeerUnverifiedException.class,
+            () -> SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null)
+        );
+        assertThat(ex.getCause(), instanceOf(CertPathValidatorException.class));
+    }
+
+    @Test
+    public void getSSLInfo_returnsPopulatedSSLInfo_whenCrlValidationPassesWithTruststore() throws Exception {
+        SSLEngine serverEngine = handshake();
+
+        Settings settings = Settings.builder()
+            .put("path.home", configDir.getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "empty.crl")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, STORE_NAME)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, STORE_TYPE)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, true)
+            .build();
+
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(settings, configDir, requestFor(serverEngine), null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getX509Certs(), is(notNullValue()));
+        assertThat(info.getLocalCertificates(), is(notNullValue()));
+    }
+}

--- a/src/main/java/org/opensearch/security/ssl/util/CertificateValidator.java
+++ b/src/main/java/org/opensearch/security/ssl/util/CertificateValidator.java
@@ -30,26 +30,22 @@ package org.opensearch.security.ssl.util;
 //
 
 import java.security.GeneralSecurityException;
-import java.security.InvalidParameterException;
-import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.CRL;
 import java.security.cert.CertPathBuilder;
 import java.security.cert.CertPathBuilderResult;
 import java.security.cert.CertPathValidator;
 import java.security.cert.CertStore;
-import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
 import java.security.cert.CollectionCertStoreParameters;
 import java.security.cert.PKIXBuilderParameters;
 import java.security.cert.PKIXRevocationChecker;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -80,8 +76,7 @@ public class CertificateValidator {
         this.checkOnlyEndEntities = checkOnlyEndEntities;
     }
 
-    private KeyStore _trustStore;
-    private X509Certificate[] _trustedCert;
+    private final Set<TrustAnchor> _trustAnchors;
     private Collection<? extends CRL> _crls;
 
     /** Maximum certification path length (n - number of intermediate certs, -1 for unlimited) */
@@ -90,149 +85,64 @@ public class CertificateValidator {
     private boolean _enableCRLDP = false;
     /** On-Line Certificate Status Protocol (OCSP) support */
     private boolean _enableOCSP = false;
-    /** Location of OCSP Responder */
-    private String _ocspResponderURL;
 
     private boolean preferCrl = false;
     private boolean checkOnlyEndEntities = true;
     private Date date = null; // current date
 
-    /**
-     * creates an instance of the certificate validator
-     *
-     * @param trustStore the truststore to use
-     * @param crls the Certificate Revocation List to use
-     */
-    public CertificateValidator(KeyStore trustStore, Collection<? extends CRL> crls) {
-        if (trustStore == null) {
-            throw new InvalidParameterException("TrustStore must be specified for CertificateValidator.");
-        }
-
-        _trustStore = trustStore;
+    public CertificateValidator(Set<TrustAnchor> trustAnchors, Collection<? extends CRL> crls) {
+        _trustAnchors = trustAnchors;
         _crls = crls;
     }
 
-    public CertificateValidator(X509Certificate[] trustedCert, Collection<? extends CRL> crls) {
-        if (trustedCert == null || trustedCert.length == 0) {
-            throw new InvalidParameterException("trustedCert must be specified for CertificateValidator.");
+    public void validate(X509Certificate[] certChain) throws GeneralSecurityException {
+        X509CertSelector certSelect = new X509CertSelector();
+        certSelect.setCertificate(certChain[0]);
+
+        CertStore chainStore = CertStore.getInstance("Collection", new CollectionCertStoreParameters(List.of(certChain)));
+
+        CertPathBuilder certPathBuilder = CertPathBuilder.getInstance("PKIX");
+        PKIXRevocationChecker revocationChecker = (PKIXRevocationChecker) certPathBuilder.getRevocationChecker();
+        PKIXBuilderParameters params = new PKIXBuilderParameters(_trustAnchors, certSelect);
+        params.setDate(date);
+        params.setMaxPathLength(_maxCertPathLength);
+        params.addCertStore(chainStore);
+        // Keeping revocation disabled here ensures CertPathBuilder.build() throws only
+        // CertPathBuilderException for structural failures (unknown CA, broken chain, etc.)
+        // and never conflates those with revocation failures.
+        params.setRevocationEnabled(false);
+        CertPathBuilderResult buildResult = certPathBuilder.build(params);
+
+        Set<PKIXRevocationChecker.Option> opts = new HashSet<>();
+        if (preferCrl) {
+            opts.add(PKIXRevocationChecker.Option.PREFER_CRLS);
+        }
+        if (checkOnlyEndEntities) {
+            opts.add(PKIXRevocationChecker.Option.ONLY_END_ENTITY);
+        }
+        revocationChecker.setOptions(opts);
+
+        params.setRevocationEnabled(true);
+        params.addCertPathChecker(revocationChecker);
+
+        if (_crls != null && !_crls.isEmpty()) {
+            params.addCertStore(CertStore.getInstance("Collection", new CollectionCertStoreParameters(_crls)));
         }
 
-        _trustedCert = trustedCert;
-        _crls = crls;
-    }
-
-    public void validate(Certificate[] certChain) throws CertificateException {
-        try {
-            ArrayList<X509Certificate> certList = new ArrayList<X509Certificate>();
-            for (Certificate item : certChain) {
-                if (item == null) continue;
-
-                if (!(item instanceof X509Certificate)) {
-                    throw new IllegalStateException("Invalid certificate type in chain");
-                }
-
-                certList.add((X509Certificate) item);
-            }
-
-            if (certList.isEmpty()) {
-                throw new IllegalStateException("Invalid certificate chain");
-
-            }
-
-            X509CertSelector certSelect = new X509CertSelector();
-            certSelect.setCertificate(certList.get(0));
-
-            CertPathBuilder certPathBuilder = CertPathBuilder.getInstance("PKIX");
-            PKIXRevocationChecker revocationChecker = (PKIXRevocationChecker) certPathBuilder.getRevocationChecker();
-
-            Set<PKIXRevocationChecker.Option> opts = new HashSet<>();
-
-            if (preferCrl) {
-                opts.add(PKIXRevocationChecker.Option.PREFER_CRLS);
-            }
-
-            // opts.add(PKIXRevocationChecker.Option.SOFT_FAIL);
-
-            // opts.add(PKIXRevocationChecker.Option.NO_FALLBACK);
-
-            if (checkOnlyEndEntities) {
-                opts.add(PKIXRevocationChecker.Option.ONLY_END_ENTITY);
-            }
-
-            revocationChecker.setOptions(opts);
-
-            // Configure certification path builder parameters
-            PKIXBuilderParameters pbParams = null;
-
-            if (_trustStore != null) {
-                pbParams = new PKIXBuilderParameters(_trustStore, certSelect);
-            } else {
-                Set<TrustAnchor> trustAnchors = new HashSet<TrustAnchor>();
-                for (int i = 0; i < _trustedCert.length; i++) {
-                    X509Certificate certificate = _trustedCert[i];
-                    TrustAnchor trustAnchor = new TrustAnchor(certificate, null);
-                    trustAnchors.add(trustAnchor);
-                }
-
-                pbParams = new PKIXBuilderParameters(trustAnchors, certSelect);
-            }
-
-            pbParams.addCertPathChecker(revocationChecker);
-
-            pbParams.setDate(date);
-
-            pbParams.addCertStore(CertStore.getInstance("Collection", new CollectionCertStoreParameters(certList)));
-
-            // Set maximum certification path length
-            pbParams.setMaxPathLength(_maxCertPathLength);
-
-            // Enable revocation checking
-            pbParams.setRevocationEnabled(true);
-
-            // Set static Certificate Revocation List
-            if (_crls != null && !_crls.isEmpty()) {
-                pbParams.addCertStore(CertStore.getInstance("Collection", new CollectionCertStoreParameters(_crls)));
-            }
-
-            // Enable On-Line Certificate Status Protocol (OCSP) support
-            if (_enableOCSP) {
-                Security.setProperty("ocsp.enable", "true");
-            }
-            // Enable Certificate Revocation List Distribution Points (CRLDP) support
-            if (_enableCRLDP) {
-                System.setProperty("com.sun.security.enableCRLDP", "true");
-            }
-
-            // Build certification path
-            CertPathBuilderResult buildResult = CertPathBuilder.getInstance("PKIX").build(pbParams);
-
-            // Validate certification path
-            CertPathValidator.getInstance("PKIX").validate(buildResult.getCertPath(), pbParams);
-        } catch (GeneralSecurityException gse) {
-            throw new CertificateException("Unable to validate certificate: " + gse.getMessage(), gse);
+        // Enable On-Line Certificate Status Protocol (OCSP) support
+        if (_enableOCSP) {
+            Security.setProperty("ocsp.enable", "true");
         }
+        // Enable Certificate Revocation List Distribution Points (CRLDP) support
+        if (_enableCRLDP) {
+            System.setProperty("com.sun.security.enableCRLDP", "true");
+        }
+
+        CertPathValidator.getInstance("PKIX").validate(buildResult.getCertPath(), params);
     }
 
     public Collection<? extends CRL> getCrls() {
         return _crls;
-    }
-
-    /**
-     * @return Maximum number of intermediate certificates in
-     * the certification path (-1 for unlimited)
-     */
-    public int getMaxCertPathLength() {
-        return _maxCertPathLength;
-    }
-
-    /* ------------------------------------------------------------ */
-    /**
-     * @param maxCertPathLength
-     *            maximum number of intermediate certificates in
-     *            the certification path (-1 for unlimited)
-     */
-    public void setMaxCertPathLength(int maxCertPathLength) {
-        _maxCertPathLength = maxCertPathLength;
     }
 
     /* ------------------------------------------------------------ */
@@ -265,22 +175,6 @@ public class CertificateValidator {
      */
     public void setEnableOCSP(boolean enableOCSP) {
         _enableOCSP = enableOCSP;
-    }
-
-    /* ------------------------------------------------------------ */
-    /**
-     * @return Location of the OCSP Responder
-     */
-    public String getOcspResponderURL() {
-        return _ocspResponderURL;
-    }
-
-    /* ------------------------------------------------------------ */
-    /** Set the location of the OCSP Responder.
-     * @param ocspResponderURL location of the OCSP Responder
-     */
-    public void setOcspResponderURL(String ocspResponderURL) {
-        _ocspResponderURL = ocspResponderURL;
     }
 
     public Date getDate() {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -49,6 +49,7 @@ import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.env.Environment;
+import org.opensearch.secure_sm.AccessController;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.ssl.transport.PrincipalExtractor.Type;
@@ -144,40 +145,7 @@ public class SSLRequestHelper {
 
             if (certs != null && certs.length > 0 && certs[0] instanceof X509Certificate) {
                 x509Certs = Arrays.copyOf(certs, certs.length, X509Certificate[].class);
-
-                try {
-                    validate(x509Certs, settings, configPath);
-                } catch (CertPathValidatorException e) {
-                    log.error(
-                        "Certificate is revoked or path invalid for '{}' (reason: {})",
-                        x509Certs[0].getSubjectX500Principal(),
-                        e.getReason()
-                    );
-                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
-                } catch (CertificateException e) {
-                    log.error(
-                        //
-                        "Certificate revocation check failed for '{}'", //
-                        x509Certs[0].getSubjectX500Principal(), //
-                        e
-                    );
-                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
-                } catch (IOException e) {
-                    log.warn(
-                        //
-                        "CRL/OCSP infrastructure unreachable (check CRL file path or OCSP/CRLDP network access): {}", //
-                        e.getMessage() //
-                    );
-                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
-                } catch (GeneralSecurityException e) {
-                    log.error(
-                        //
-                        "Certificate revocation check configuration error", //
-                        e
-                    );
-                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
-                }
-
+                validatePeerCerts(x509Certs, settings, configPath);
                 principal = principalExtractor == null ? null : principalExtractor.extractPrincipal(x509Certs[0], Type.HTTP);
             } else if (engine.getNeedClientAuth()) {
                 throw new OpenSearchException("No client certificates found but such are needed (SG 9).");
@@ -190,6 +158,31 @@ public class SSLRequestHelper {
         }
 
         return new SSLInfo(x509Certs, principal, protocol, cipher, localCerts);
+    }
+
+    private static void validatePeerCerts(final X509Certificate[] x509Certs, final Settings settings, final Path configPath)
+        throws SSLPeerUnverifiedException {
+        AccessController.doPrivilegedChecked(() -> {
+            try {
+                validate(x509Certs, settings, configPath);
+            } catch (CertPathValidatorException e) {
+                log.error(
+                    "Certificate is revoked or path invalid for '{}' (reason: {})",
+                    x509Certs[0].getSubjectX500Principal(),
+                    e.getReason()
+                );
+                throw new SSLPeerUnverifiedException(e.getMessage(), e);
+            } catch (CertificateException e) {
+                log.error("Certificate revocation check failed for '{}'", x509Certs[0].getSubjectX500Principal(), e);
+                throw new SSLPeerUnverifiedException(e.getMessage(), e);
+            } catch (IOException e) {
+                log.warn("CRL/OCSP infrastructure unreachable (check CRL file path or OCSP/CRLDP network access): {}", e.getMessage());
+                throw new SSLPeerUnverifiedException(e.getMessage(), e);
+            } catch (GeneralSecurityException e) {
+                log.error("Certificate revocation check configuration error", e);
+                throw new SSLPeerUnverifiedException(e.getMessage(), e);
+            }
+        });
     }
 
     public static boolean containsBadHeader(final ThreadContext context, String prefix) {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -24,10 +24,11 @@ import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.CRL;
-import java.security.cert.Certificate;
 import java.security.cert.CertPathValidatorException;
+import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
@@ -36,16 +37,14 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.security.cert.TrustAnchor;
-
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
 import org.bouncycastle.crypto.CryptoServicesRegistrar;
+
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -156,22 +155,24 @@ public class SSLRequestHelper {
                     );
                     throw new SSLPeerUnverifiedException(e.getMessage(), e);
                 } catch (CertificateException e) {
-                    // Log the full cause chain so the root reason from BC FIPS is visible
                     log.error(
-                        "Certificate revocation check failed for '{}'",
-                        x509Certs[0].getSubjectX500Principal(),
+                        //
+                        "Certificate revocation check failed for '{}'", //
+                        x509Certs[0].getSubjectX500Principal(), //
                         e
                     );
                     throw new SSLPeerUnverifiedException(e.getMessage(), e);
                 } catch (IOException e) {
                     log.warn(
-                        "CRL/OCSP infrastructure unreachable (check CRL file path or OCSP/CRLDP network access): {}",
-                        e.getMessage()
+                        //
+                        "CRL/OCSP infrastructure unreachable (check CRL file path or OCSP/CRLDP network access): {}", //
+                        e.getMessage() //
                     );
                     throw new SSLPeerUnverifiedException(e.getMessage(), e);
                 } catch (GeneralSecurityException e) {
                     log.error(
-                        "Certificate revocation check configuration error",
+                        //
+                        "Certificate revocation check configuration error", //
                         e
                     );
                     throw new SSLPeerUnverifiedException(e.getMessage(), e);
@@ -188,13 +189,7 @@ public class SSLRequestHelper {
             localCerts = Arrays.stream(session.getLocalCertificates()).map(X509Certificate.class::cast).toArray(X509Certificate[]::new);
         }
 
-        return new SSLInfo(
-            x509Certs,
-            principal,
-            protocol,
-            cipher,
-            localCerts
-        );
+        return new SSLInfo(x509Certs, principal, protocol, cipher, localCerts);
     }
 
     public static boolean containsBadHeader(final ThreadContext context, String prefix) {
@@ -209,8 +204,8 @@ public class SSLRequestHelper {
         return false;
     }
 
-    static void validate(X509Certificate[] x509Certs, final Settings settings, final Path configPath)
-        throws IOException, GeneralSecurityException {
+    static void validate(X509Certificate[] x509Certs, final Settings settings, final Path configPath) throws IOException,
+        GeneralSecurityException {
 
         final boolean validateCrl = settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false);
         log.trace("validateCrl: {}", validateCrl);
@@ -226,8 +221,7 @@ public class SSLRequestHelper {
         validator.validate(x509Certs);
     }
 
-    static Collection<? extends CRL> loadCrls(final Settings settings, final Environment env) throws IOException,
-        GeneralSecurityException {
+    static Collection<? extends CRL> loadCrls(final Settings settings, final Environment env) throws IOException, GeneralSecurityException {
         final String crlFile = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE);
         if (crlFile == null) {
             log.trace("no crl file configured");
@@ -242,11 +236,8 @@ public class SSLRequestHelper {
         }
     }
 
-    static CertificateValidator buildValidator(
-        final Settings settings,
-        final Environment env,
-        final Collection<? extends CRL> crls
-    ) throws IOException, GeneralSecurityException {
+    static CertificateValidator buildValidator(final Settings settings, final Environment env, final Collection<? extends CRL> crls)
+        throws IOException, GeneralSecurityException {
         final String truststore = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH);
         if (truststore != null) {
             return buildValidatorFromTruststore(settings, env, crls, truststore);
@@ -271,11 +262,8 @@ public class SSLRequestHelper {
         return new CertificateValidator(trustAnchorsFrom(ts), crls);
     }
 
-    static CertificateValidator buildValidatorFromPem(
-        final Settings settings,
-        final Environment env,
-        final Collection<? extends CRL> crls
-    ) throws IOException, GeneralSecurityException {
+    static CertificateValidator buildValidatorFromPem(final Settings settings, final Environment env, final Collection<? extends CRL> crls)
+        throws IOException, GeneralSecurityException {
         final File trustedCas = env.configDir()
             .resolve(settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, ""))
             .toAbsolutePath()
@@ -299,9 +287,7 @@ public class SSLRequestHelper {
     }
 
     public static Set<TrustAnchor> trustAnchorsFrom(final X509Certificate... certs) {
-        return Arrays.stream(certs)
-            .map(cert -> new TrustAnchor(cert, null))
-            .collect(Collectors.toSet());
+        return Arrays.stream(certs).map(cert -> new TrustAnchor(cert, null)).collect(Collectors.toSet());
     }
 
     static void configureValidator(final CertificateValidator validator, final Settings settings) {

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -19,16 +19,25 @@ package org.opensearch.security.ssl.util;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.cert.CRL;
 import java.security.cert.Certificate;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Map.Entry;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.security.cert.TrustAnchor;
+
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import javax.net.ssl.SSLSession;
@@ -36,11 +45,11 @@ import javax.net.ssl.SSLSession;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.env.Environment;
-import org.opensearch.secure_sm.AccessController;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.ssl.transport.PrincipalExtractor.Type;
@@ -57,10 +66,6 @@ public class SSLRequestHelper {
         private final String principal;
         private final String protocol;
         private final String cipher;
-
-        public SSLInfo(final X509Certificate[] x509Certs, final String principal, final String protocol, final String cipher) {
-            this(x509Certs, principal, protocol, cipher, null);
-        }
 
         public SSLInfo(
             final X509Certificate[] x509Certs,
@@ -129,48 +134,73 @@ public class SSLRequestHelper {
         final String protocol = session.getProtocol();
         final String cipher = session.getCipherSuite();
         String principal = null;
-        boolean validationFailure = false;
 
         if (engine.getNeedClientAuth() || engine.getWantClientAuth()) {
-
+            Certificate[] certs = null;
             try {
-                final Certificate[] certs = session.getPeerCertificates();
+                certs = session.getPeerCertificates();
+            } catch (SSLPeerUnverifiedException e) {
+                // deal with 'null' certs down below
+            }
 
-                if (certs != null && certs.length > 0 && certs[0] instanceof X509Certificate) {
-                    x509Certs = Arrays.copyOf(certs, certs.length, X509Certificate[].class);
-                    final X509Certificate[] x509CertsF = x509Certs;
+            if (certs != null && certs.length > 0 && certs[0] instanceof X509Certificate) {
+                x509Certs = Arrays.copyOf(certs, certs.length, X509Certificate[].class);
 
-                    validationFailure = AccessController.doPrivileged(() -> !validate(x509CertsF, settings, configPath));
-
-                    if (validationFailure) {
-                        throw new SSLPeerUnverifiedException("Unable to validate certificate (CRL)");
-                    }
-                    principal = principalExtractor == null ? null : principalExtractor.extractPrincipal(x509Certs[0], Type.HTTP);
-                } else if (engine.getNeedClientAuth()) {
-                    throw new OpenSearchException("No client certificates found but such are needed (SG 9).");
+                try {
+                    validate(x509Certs, settings, configPath);
+                } catch (CertPathValidatorException e) {
+                    log.error(
+                        "Certificate is revoked or path invalid for '{}' (reason: {})",
+                        x509Certs[0].getSubjectX500Principal(),
+                        e.getReason()
+                    );
+                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
+                } catch (CertificateException e) {
+                    // Log the full cause chain so the root reason from BC FIPS is visible
+                    log.error(
+                        "Certificate revocation check failed for '{}'",
+                        x509Certs[0].getSubjectX500Principal(),
+                        e
+                    );
+                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
+                } catch (IOException e) {
+                    log.warn(
+                        "CRL/OCSP infrastructure unreachable (check CRL file path or OCSP/CRLDP network access): {}",
+                        e.getMessage()
+                    );
+                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
+                } catch (GeneralSecurityException e) {
+                    log.error(
+                        "Certificate revocation check configuration error",
+                        e
+                    );
+                    throw new SSLPeerUnverifiedException(e.getMessage(), e);
                 }
 
-            } catch (final SSLPeerUnverifiedException e) {
-                if (engine.getNeedClientAuth() || validationFailure) {
-                    throw e;
-                }
+                principal = principalExtractor == null ? null : principalExtractor.extractPrincipal(x509Certs[0], Type.HTTP);
+            } else if (engine.getNeedClientAuth()) {
+                throw new OpenSearchException("No client certificates found but such are needed (SG 9).");
             }
         }
 
-        Certificate[] localCerts = session.getLocalCertificates();
+        X509Certificate[] localCerts = null;
+        if (session.getLocalCertificates() != null) {
+            localCerts = Arrays.stream(session.getLocalCertificates()).map(X509Certificate.class::cast).toArray(X509Certificate[]::new);
+        }
+
         return new SSLInfo(
             x509Certs,
             principal,
             protocol,
             cipher,
-            localCerts == null ? null : Arrays.copyOf(localCerts, localCerts.length, X509Certificate[].class)
+            localCerts
         );
     }
 
     public static boolean containsBadHeader(final ThreadContext context, String prefix) {
         if (context != null) {
-            for (final Entry<String, String> header : context.getHeaders().entrySet()) {
-                if (header != null && header.getKey() != null && header.getKey().trim().toLowerCase().startsWith(prefix)) {
+            for (final String key : context.getHeaders().keySet()) {
+                if (key.trim().toLowerCase().startsWith(prefix)) {
                     return true;
                 }
             }
@@ -179,88 +209,111 @@ public class SSLRequestHelper {
         return false;
     }
 
-    private static boolean validate(X509Certificate[] x509Certs, final Settings settings, final Path configPath) {
+    static void validate(X509Certificate[] x509Certs, final Settings settings, final Path configPath)
+        throws IOException, GeneralSecurityException {
 
         final boolean validateCrl = settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false);
-
-        final boolean isTraceEnabled = log.isTraceEnabled();
-        if (isTraceEnabled) {
-            log.trace("validateCrl: {}", validateCrl);
-        }
+        log.trace("validateCrl: {}", validateCrl);
 
         if (!validateCrl) {
-            return true;
+            return;
         }
 
         final Environment env = new Environment(settings, configPath);
+        final Collection<? extends CRL> crls = loadCrls(settings, env);
+        final CertificateValidator validator = buildValidator(settings, env, crls);
+        configureValidator(validator, settings);
+        validator.validate(x509Certs);
+    }
 
-        try {
-
-            Collection<? extends CRL> crls = null;
-            final String crlFile = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE);
-
-            if (crlFile != null) {
-                final File crl = env.configDir().resolve(crlFile).toAbsolutePath().toFile();
-                try (FileInputStream crlin = new FileInputStream(crl)) {
-                    crls = CertificateFactory.getInstance("X.509").generateCRLs(crlin);
-                }
-
-                if (isTraceEnabled) {
-                    log.trace("crls from file: {}", crls.size());
-                }
-            } else {
-                if (isTraceEnabled) {
-                    log.trace("no crl file configured");
-                }
-            }
-
-            final String truststore = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH);
-            CertificateValidator validator = null;
-
-            if (truststore != null) {
-                final String truststoreType = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, "JKS");
-                final String truststorePassword = SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings);
-                // final String truststoreAlias = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_ALIAS, null);
-
-                final KeyStore ts = KeyStore.getInstance(truststoreType);
-                try (FileInputStream fin = new FileInputStream(new File(env.configDir().resolve(truststore).toAbsolutePath().toString()))) {
-                    ts.load(
-                        fin,
-                        (truststorePassword == null || truststorePassword.length() == 0) ? null : truststorePassword.toCharArray()
-                    );
-                }
-                validator = new CertificateValidator(ts, crls);
-            } else {
-                final File trustedCas = env.configDir()
-                    .resolve(settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, ""))
-                    .toAbsolutePath()
-                    .toFile();
-                try (FileInputStream trin = new FileInputStream(trustedCas)) {
-                    Collection<? extends Certificate> cert = (Collection<? extends Certificate>) CertificateFactory.getInstance("X.509")
-                        .generateCertificates(trin);
-                    validator = new CertificateValidator(cert.toArray(new X509Certificate[0]), crls);
-                }
-            }
-
-            validator.setEnableCRLDP(!settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, false));
-            validator.setEnableOCSP(!settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, false));
-            validator.setCheckOnlyEndEntities(
-                settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_CHECK_ONLY_END_ENTITIES, true)
-            );
-            validator.setPreferCrl(settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_PREFER_CRLFILE_OVER_OCSP, false));
-            Long dateTimestamp = settings.getAsLong(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATION_DATE, null);
-            if (dateTimestamp != null && dateTimestamp.longValue() < 0) {
-                dateTimestamp = null;
-            }
-            validator.setDate(dateTimestamp == null ? null : new Date(dateTimestamp.longValue()));
-            validator.validate(x509Certs);
-
-            return true;
-
-        } catch (Exception e) {
-            log.warn("Unable to validate CRL: ", ExceptionUtils.getRootCause(e));
+    static Collection<? extends CRL> loadCrls(final Settings settings, final Environment env) throws IOException,
+        GeneralSecurityException {
+        final String crlFile = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE);
+        if (crlFile == null) {
+            log.trace("no crl file configured");
+            return null;
         }
 
-        return false;
+        final File crl = env.configDir().resolve(crlFile).toAbsolutePath().toFile();
+        try (FileInputStream crlin = new FileInputStream(crl)) {
+            final Collection<? extends CRL> crls = CertificateFactory.getInstance("X.509").generateCRLs(crlin);
+            log.trace("crls from file: {}", crls.size());
+            return crls;
+        }
+    }
+
+    static CertificateValidator buildValidator(
+        final Settings settings,
+        final Environment env,
+        final Collection<? extends CRL> crls
+    ) throws IOException, GeneralSecurityException {
+        final String truststore = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH);
+        if (truststore != null) {
+            return buildValidatorFromTruststore(settings, env, crls, truststore);
+        } else {
+            return buildValidatorFromPem(settings, env, crls);
+        }
+    }
+
+    static CertificateValidator buildValidatorFromTruststore(
+        final Settings settings,
+        final Environment env,
+        final Collection<? extends CRL> crls,
+        final String truststore
+    ) throws IOException, GeneralSecurityException {
+        final String defaultStoreType = CryptoServicesRegistrar.isInApprovedOnlyMode() ? "BCFKS" : "JKS";
+        final String truststoreType = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, defaultStoreType);
+        final String truststorePassword = SECURITY_SSL_HTTP_TRUSTSTORE_PASSWORD.getSetting(settings);
+        final KeyStore ts = KeyStore.getInstance(truststoreType);
+        try (FileInputStream fin = new FileInputStream(env.configDir().resolve(truststore).toAbsolutePath().toString())) {
+            ts.load(fin, (truststorePassword == null || truststorePassword.isEmpty()) ? null : truststorePassword.toCharArray());
+        }
+        return new CertificateValidator(trustAnchorsFrom(ts), crls);
+    }
+
+    static CertificateValidator buildValidatorFromPem(
+        final Settings settings,
+        final Environment env,
+        final Collection<? extends CRL> crls
+    ) throws IOException, GeneralSecurityException {
+        final File trustedCas = env.configDir()
+            .resolve(settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, ""))
+            .toAbsolutePath()
+            .toFile();
+        try (FileInputStream trin = new FileInputStream(trustedCas)) {
+            final Collection<? extends Certificate> certs = CertificateFactory.getInstance("X.509").generateCertificates(trin);
+            final X509Certificate[] trustedCerts = certs.stream().map(X509Certificate.class::cast).toArray(X509Certificate[]::new);
+            return new CertificateValidator(trustAnchorsFrom(trustedCerts), crls);
+        }
+    }
+
+    static Set<TrustAnchor> trustAnchorsFrom(final KeyStore trustStore) throws GeneralSecurityException {
+        final Set<TrustAnchor> anchors = new HashSet<>();
+        for (Enumeration<String> aliases = trustStore.aliases(); aliases.hasMoreElements();) {
+            final String alias = aliases.nextElement();
+            if (trustStore.isCertificateEntry(alias)) {
+                anchors.add(new TrustAnchor((X509Certificate) trustStore.getCertificate(alias), null));
+            }
+        }
+        return anchors;
+    }
+
+    public static Set<TrustAnchor> trustAnchorsFrom(final X509Certificate... certs) {
+        return Arrays.stream(certs)
+            .map(cert -> new TrustAnchor(cert, null))
+            .collect(Collectors.toSet());
+    }
+
+    static void configureValidator(final CertificateValidator validator, final Settings settings) {
+        validator.setEnableCRLDP(!settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, false));
+        validator.setEnableOCSP(!settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, false));
+        validator.setCheckOnlyEndEntities(settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_CHECK_ONLY_END_ENTITIES, true));
+        validator.setPreferCrl(settings.getAsBoolean(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_PREFER_CRLFILE_OVER_OCSP, false));
+
+        Long dateTimestamp = settings.getAsLong(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATION_DATE, null);
+        if (dateTimestamp != null && dateTimestamp < 0) {
+            dateTimestamp = null;
+        }
+        validator.setDate(dateTimestamp == null ? null : new Date(dateTimestamp));
     }
 }

--- a/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
@@ -19,9 +19,8 @@ package org.opensearch.security.ssl;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.security.cert.CRL;
 import java.security.GeneralSecurityException;
-import static org.hamcrest.MatcherAssert.assertThat;
+import java.security.cert.CRL;
 import java.security.cert.CertPathValidatorException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
@@ -34,15 +33,16 @@ import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.junit.Assert;
 import org.junit.Test;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
 
 import org.opensearch.security.ssl.util.CertificateValidator;
 import org.opensearch.security.ssl.util.ExceptionUtils;
 import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.test.helper.file.FileHelper;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 

--- a/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
+++ b/src/test/java/org/opensearch/security/ssl/CertificateValidatorTest.java
@@ -20,27 +20,30 @@ package org.opensearch.security.ssl;
 import java.io.File;
 import java.io.FileInputStream;
 import java.security.cert.CRL;
-import java.security.cert.CertPathBuilderException;
+import java.security.GeneralSecurityException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import java.security.cert.CertPathValidatorException;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
-import java.security.cert.CertificateRevokedException;
+import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.opensearch.ExceptionsHelper;
 import org.opensearch.security.ssl.util.CertificateValidator;
 import org.opensearch.security.ssl.util.ExceptionUtils;
+import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.test.helper.file.FileHelper;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class CertificateValidatorTest {
@@ -77,13 +80,17 @@ public class CertificateValidatorTest {
 
         assertThat(2, is(certsToValidate.size()));
 
-        CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), crls);
+        Set<TrustAnchor> trustAnchors = SSLRequestHelper.trustAnchorsFrom(rootCas.toArray(new X509Certificate[0]));
+        CertificateValidator validator = new CertificateValidator(trustAnchors, crls);
         validator.setDate(CRL_DATE);
         try {
             validator.validate(certsToValidate.toArray(new X509Certificate[0]));
             Assert.fail();
-        } catch (CertificateException e) {
-            Assert.assertTrue(ExceptionUtils.getRootCause(e) instanceof CertificateRevokedException);
+        } catch (GeneralSecurityException e) {
+            String expectedMessage = CryptoServicesRegistrar.isInApprovedOnlyMode()
+                ? "Certificate revocation after 2018-05-05"
+                : "Certificate has been revoked";
+            Assert.assertNotNull(ExceptionUtils.findMsg(e, expectedMessage));
         }
     }
 
@@ -116,12 +123,16 @@ public class CertificateValidatorTest {
 
         assertThat(3, is(certsToValidate.size()));
 
-        CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), crls);
+        Set<TrustAnchor> trustAnchors = SSLRequestHelper.trustAnchorsFrom(rootCas.toArray(new X509Certificate[0]));
+        CertificateValidator validator = new CertificateValidator(trustAnchors, crls);
         validator.setDate(CRL_DATE);
         try {
             validator.validate(certsToValidate.toArray(new X509Certificate[0]));
-        } catch (CertificateException e) {
-            Assert.fail(ExceptionsHelper.stackTrace(ExceptionUtils.getRootCause(e)));
+        } catch (GeneralSecurityException e) {
+            String expectedMessage = CryptoServicesRegistrar.isInApprovedOnlyMode()
+                ? "No CRLs found for issuer"
+                : "Certificate has been revoked";
+            Assert.assertNotNull(ExceptionUtils.findMsg(e, expectedMessage));
         }
     }
 
@@ -146,14 +157,18 @@ public class CertificateValidatorTest {
 
         assertThat(2, is(certsToValidate.size()));
 
-        CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), Collections.emptyList());
+        Set<TrustAnchor> trustAnchors = SSLRequestHelper.trustAnchorsFrom(rootCas.toArray(new X509Certificate[0]));
+        CertificateValidator validator = new CertificateValidator(trustAnchors, Collections.emptyList());
         validator.setDate(CRL_DATE);
         try {
             validator.validate(certsToValidate.toArray(new X509Certificate[0]));
             Assert.fail();
-        } catch (CertificateException e) {
-            Assert.assertTrue(e.getCause() instanceof CertPathBuilderException);
-            Assert.assertTrue(e.getCause().getMessage().contains("unable to find valid certification path to requested target"));
+        } catch (GeneralSecurityException e) {
+            assertThat(e, instanceOf(CertPathValidatorException.class));
+            String expectedMessage = CryptoServicesRegistrar.isInApprovedOnlyMode()
+                ? "No CRLs found for issuer"
+                : "Certificate has been revoked";
+            Assert.assertNotNull(ExceptionUtils.findMsg(e, expectedMessage));
         }
     }
 
@@ -179,15 +194,19 @@ public class CertificateValidatorTest {
 
         assertThat(2, is(certsToValidate.size()));
 
-        CertificateValidator validator = new CertificateValidator(rootCas.toArray(new X509Certificate[0]), Collections.emptyList());
+        Set<TrustAnchor> trustAnchors = SSLRequestHelper.trustAnchorsFrom(rootCas.toArray(new X509Certificate[0]));
+        CertificateValidator validator = new CertificateValidator(trustAnchors, Collections.emptyList());
         validator.setEnableCRLDP(true);
         validator.setEnableOCSP(true);
         validator.setDate(CRL_DATE);
         try {
             validator.validate(certsToValidate.toArray(new X509Certificate[0]));
             Assert.fail();
-        } catch (CertificateException e) {
-            Assert.assertTrue(ExceptionUtils.getRootCause(e) instanceof CertificateRevokedException);
+        } catch (GeneralSecurityException e) {
+            String expectedMessage = CryptoServicesRegistrar.isInApprovedOnlyMode()
+                ? "No CRLs found for issuer"
+                : "Certificate has been revoked";
+            Assert.assertNotNull(ExceptionUtils.findMsg(e, expectedMessage));
         }
     }
 }

--- a/src/test/java/org/opensearch/security/ssl/util/SSLRequestHelperTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLRequestHelperTest.java
@@ -1,0 +1,428 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.ssl.util;
+
+import org.junit.Test;
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.env.Environment;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.test.helper.file.FileHelper;
+import org.opensearch.security.util.FakeRestRequest;
+
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.CRL;
+import java.security.cert.CertPathValidatorException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.TrustAnchor;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SSLRequestHelperTest {
+
+    /** Matches the fixed validation date used in CertificateValidatorTest. */
+    private static final Date FIXED_CRL_DATE = new Date(1525546426000L);
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /** Returns the absolute path to src/test/resources/ssl, used as configDir. */
+    private static Path sslDir() {
+        return FileHelper.getAbsoluteFilePathFromClassPath("ssl");
+    }
+
+    /**
+     * Builds an Environment whose configDir() returns the given path.
+     * A dummy path.home is required by the Environment constructor even when
+     * configPath overrides the config directory.
+     */
+    private static Environment env(Path configDir) {
+        Settings base = Settings.builder().put("path.home", configDir.getParent().toString()).build();
+        return new Environment(base, configDir);
+    }
+
+    private static X509Certificate[] loadCerts(String classpathResource) throws Exception {
+        try (FileInputStream fis = new FileInputStream(FileHelper.getAbsoluteFilePathFromClassPath(classpathResource).toFile())) {
+            Collection<? extends java.security.cert.Certificate> certs = CertificateFactory.getInstance("X.509").generateCertificates(fis);
+            return certs.stream().map(X509Certificate.class::cast).toArray(X509Certificate[]::new);
+        }
+    }
+
+    private static Collection<? extends CRL> loadCrls(String classpathResource) throws Exception {
+        try (FileInputStream fis = new FileInputStream(FileHelper.getAbsoluteFilePathFromClassPath(classpathResource).toFile())) {
+            return CertificateFactory.getInstance("X.509").generateCRLs(fis);
+        }
+    }
+
+    // ── trustAnchorsFrom ─────────────────────────────────
+
+    @Test
+    public void trustAnchorsFromCerts_returnsOneAnchorPerCert_forMultipleCerts() throws Exception {
+        X509Certificate[] certs = loadCerts("ssl/chain-ca.pem"); // root + intermediate = 2 certs
+
+        Set<TrustAnchor> anchors = SSLRequestHelper.trustAnchorsFrom(certs);
+
+        assertThat(anchors.size(), is(certs.length));
+        Set<X509Certificate> anchorCerts = anchors.stream().map(TrustAnchor::getTrustedCert).collect(Collectors.toSet());
+        for (X509Certificate cert : certs) {
+            assertThat(anchorCerts.contains(cert), is(true));
+        }
+    }
+
+    @Test
+    public void trustAnchorsFromKeyStore_returnsAnchorForEachCertificateEntry() throws Exception {
+        KeyStore ts = KeyStore.getInstance("JKS");
+        try (FileInputStream fis = new FileInputStream(
+            FileHelper.getAbsoluteFilePathFromClassPath("ssl/truststore_valid.jks").toFile()
+        )) {
+            ts.load(fis, null);
+        }
+
+        Set<TrustAnchor> anchors = SSLRequestHelper.trustAnchorsFrom(ts);
+
+        assertThat(anchors.size(), is(ts.size()));
+        for (TrustAnchor anchor : anchors) {
+            assertThat(anchor.getTrustedCert(), is(notNullValue()));
+            assertThat(anchor.getNameConstraints(), is(nullValue()));
+        }
+    }
+
+    // ── configureValidator ───────────────────────────────────────────────────
+
+    @Test
+    public void configureValidator_appliesDefaults() throws Exception {
+        CertificateValidator validator = new CertificateValidator(SSLRequestHelper.trustAnchorsFrom(loadCerts("ssl/root-ca.pem")), null);
+
+        SSLRequestHelper.configureValidator(validator, Settings.EMPTY);
+
+        // !disable_crldp(false) → true;  !disable_ocsp(false) → true
+        assertThat(validator.isEnableCRLDP(), is(true));
+        assertThat(validator.isEnableOCSP(), is(true));
+        assertThat(validator.isCheckOnlyEndEntities(), is(true));
+        assertThat(validator.isPreferCrl(), is(false));
+        assertThat(validator.getDate(), is(nullValue()));
+    }
+
+    @Test
+    public void configureValidator_disablesCrldpAndOcsp_whenExplicitlyDisabled() throws Exception {
+        CertificateValidator validator = new CertificateValidator(SSLRequestHelper.trustAnchorsFrom(loadCerts("ssl/root-ca.pem")), null);
+        Settings settings = Settings.builder()
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_CRLDP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_DISABLE_OCSP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_PREFER_CRLFILE_OVER_OCSP, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATION_DATE, FIXED_CRL_DATE.getTime())
+            .build();
+
+        SSLRequestHelper.configureValidator(validator, settings);
+
+        assertThat(validator.isEnableCRLDP(), is(false));
+        assertThat(validator.isEnableOCSP(), is(false));
+        assertThat(validator.isPreferCrl(), is(true));
+        assertThat(validator.getDate(), is(FIXED_CRL_DATE));
+    }
+
+    @Test
+    public void configureValidator_leavesDateNull_whenTimestampIsNegative() throws Exception {
+        CertificateValidator validator = new CertificateValidator(SSLRequestHelper.trustAnchorsFrom(loadCerts("ssl/root-ca.pem")), null);
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATION_DATE, -1L).build();
+
+        SSLRequestHelper.configureValidator(validator, settings);
+
+        assertThat(validator.getDate(), is(nullValue()));
+    }
+
+    // ── SSLInfo.toString ──────────────────────────────────────────────────────
+
+    @Test
+    public void sslInfoToString_containsAllFields() {
+        SSLRequestHelper.SSLInfo info = new SSLRequestHelper.SSLInfo(null, "CN=test", "TLSv1.3", "TLS_AES_256_GCM_SHA384", null);
+
+        assertThat(info.toString(), is("SSLInfo [x509Certs=null, principal=CN=test, protocol=TLSv1.3, cipher=TLS_AES_256_GCM_SHA384]"));
+    }
+
+    // ── loadCrls ─────────────────────────────────────────────────────────────
+
+    @Test
+    public void loadCrls_returnsNull_whenNoCrlFileConfigured() throws Exception {
+        Collection<? extends CRL> crls = SSLRequestHelper.loadCrls(Settings.EMPTY, env(sslDir()));
+
+        assertThat(crls, is(nullValue()));
+    }
+
+    @Test
+    public void loadCrls_loadsCrlsFromFile_whenConfigured() throws Exception {
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "crl/revoked.crl").build();
+
+        Collection<? extends CRL> crls = SSLRequestHelper.loadCrls(settings, env(sslDir()));
+
+        assertThat(crls, is(notNullValue()));
+        assertThat(crls.size(), is(1));
+        assertThat(
+            crls.iterator().next().toString(),
+            containsString("CN=Example Com Inc. Signing CA, OU=Example Com Inc. Signing CA, O=Example Com Inc., DC=example, DC=com")
+        );
+    }
+
+    // ── buildValidatorFromPem ─────────────────────────────────────────────────
+
+    @Test
+    public void buildValidatorFromPem_buildsValidator_usingPemTrustedCAs() throws Exception {
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "chain-ca.pem").build();
+
+        CertificateValidator validator = SSLRequestHelper.buildValidatorFromPem(settings, env(sslDir()), null);
+
+        assertThat(validator, is(notNullValue()));
+    }
+
+    @Test
+    public void buildValidatorFromPem_propagatesCrls_toValidator() throws Exception {
+        Collection<? extends CRL> crls = loadCrls("ssl/crl/revoked.crl");
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "chain-ca.pem").build();
+
+        CertificateValidator validator = SSLRequestHelper.buildValidatorFromPem(settings, env(sslDir()), crls);
+
+        assertThat(validator.getCrls(), is(crls));
+    }
+
+    // ── buildValidatorFromTruststore ──────────────────────────────────────────
+
+    @Test
+    public void buildValidatorFromTruststore_buildsValidator_usingJksKeystore() throws Exception {
+        // truststore_valid.jks has no password — null is passed to KeyStore.load()
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, "JKS").build();
+
+        CertificateValidator validator =
+            SSLRequestHelper.buildValidatorFromTruststore(settings, env(sslDir()), null, "truststore_valid.jks");
+
+        assertThat(validator, is(notNullValue()));
+    }
+
+    // ── buildValidator (dispatcher) ───────────────────────────────────────────
+
+    @Test
+    public void buildValidator_dispatchesToTruststore_whenTruststoreFilepathSet() throws Exception {
+        Settings settings = Settings.builder()
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_FILEPATH, "truststore_valid.jks")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, "JKS")
+            .build();
+
+        CertificateValidator validator = SSLRequestHelper.buildValidator(settings, env(sslDir()), null);
+
+        assertThat(validator, is(notNullValue()));
+    }
+
+    @Test
+    public void buildValidator_dispatchesToPem_whenNoTruststoreFilepathSet() throws Exception {
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "chain-ca.pem").build();
+
+        CertificateValidator validator = SSLRequestHelper.buildValidator(settings, env(sslDir()), null);
+
+        assertThat(validator, is(notNullValue()));
+    }
+
+    // ── validate (orchestrator) ───────────────────────────────────────────────
+
+    @Test
+    public void validate_doesNotThrow_whenCrlValidationIsDisabled() throws Exception {
+        // Even a revoked cert must not cause an exception when validate=false
+        X509Certificate[] revokedChain = loadCerts("ssl/crl/revoked.crt.pem");
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false).build();
+
+        SSLRequestHelper.validate(revokedChain, settings, sslDir());
+        // no exception expected
+    }
+
+    @Test
+    public void validate_throwsCertificateException_forRevokedCert() throws Exception {
+        X509Certificate[] revokedChain = loadCerts("ssl/crl/revoked.crt.pem");
+        Settings settings = Settings.builder()
+            .put("path.home", sslDir().getParent().toString())
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, true)
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, "crl/revoked.crl")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, "chain-ca.pem")
+            .put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATION_DATE, FIXED_CRL_DATE.getTime())
+            .build();
+
+        try {
+            SSLRequestHelper.validate(revokedChain, settings, sslDir());
+            fail("Expected CertPathValidatorException for revoked certificate");
+        } catch (CertPathValidatorException e) {
+            // expected — revocation detected directly without wrapping
+        }
+    }
+
+    // ── containsBadHeader ─────────────────────────────────────────────────────
+
+    @Test
+    public void containsBadHeader_returnsFalse_whenContextIsNull() {
+        assertThat(SSLRequestHelper.containsBadHeader(null, "_opendistro"), is(false));
+    }
+
+    @Test
+    public void containsBadHeader_returnsFalse_whenNoHeaders() {
+        ThreadContext context = new ThreadContext(Settings.EMPTY);
+
+        assertThat(SSLRequestHelper.containsBadHeader(context, "_opendistro"), is(false));
+    }
+
+    @Test
+    public void containsBadHeader_returnsTrue_whenHeaderMatchesPrefix() {
+        ThreadContext context = new ThreadContext(Settings.EMPTY);
+        context.putHeader("_opendistro_security_user", "attacker");
+
+        assertThat(SSLRequestHelper.containsBadHeader(context, "_opendistro"), is(true));
+    }
+
+    @Test
+    public void containsBadHeader_isCaseInsensitiveOnHeaderName() {
+        ThreadContext context = new ThreadContext(Settings.EMPTY);
+        context.putHeader("_OPENDISTRO_Security_User", "attacker");
+
+        assertThat(SSLRequestHelper.containsBadHeader(context, "_opendistro"), is(true));
+    }
+
+    @Test
+    public void containsBadHeader_returnsFalse_whenNoPrefixMatch() {
+        ThreadContext context = new ThreadContext(Settings.EMPTY);
+        context.putHeader("Authorization", "Bearer token");
+        context.putHeader("Content-Type", "application/json");
+
+        assertThat(SSLRequestHelper.containsBadHeader(context, "_opendistro"), is(false));
+    }
+
+    // ── getSSLInfo ────────────────────────────────────────────────────────────
+
+    @Test
+    public void getSSLInfo_returnsNull_whenNoSslEngine() throws Exception {
+        SecurityRequest request = new FakeRestRequest(Collections.emptyMap(), Collections.emptyMap()).asSecurityRequest();
+
+        assertThat(SSLRequestHelper.getSSLInfo(Settings.EMPTY, sslDir(), request, null), is(nullValue()));
+    }
+
+    @Test
+    public void getSSLInfo_returnsSSLInfoWithProtocolAndCipher_whenNoClientAuthRequired() throws Exception {
+        SSLSession session = mock(SSLSession.class);
+        when(session.getProtocol()).thenReturn("TLSv1.3");
+        when(session.getCipherSuite()).thenReturn("TLS_AES_256_GCM_SHA384");
+        when(session.getLocalCertificates()).thenReturn(null);
+
+        SSLEngine engine = mock(SSLEngine.class);
+        when(engine.getSession()).thenReturn(session);
+        when(engine.getNeedClientAuth()).thenReturn(false);
+        when(engine.getWantClientAuth()).thenReturn(false);
+
+        SecurityRequest request = mock(SecurityRequest.class);
+        when(request.getSSLEngine()).thenReturn(engine);
+
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(Settings.EMPTY, sslDir(), request, null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getProtocol(), is("TLSv1.3"));
+        assertThat(info.getCipher(), is("TLS_AES_256_GCM_SHA384"));
+        assertThat(info.getX509Certs(), is(nullValue()));
+        assertThat(info.getLocalCertificates(), is(nullValue()));
+        assertThat(info.getPrincipal(), is(nullValue()));
+    }
+
+    @Test
+    public void getSSLInfo_throwsOpenSearchException_whenNeedClientAuth_andNoPeerCertificates() throws Exception {
+        SSLSession session = mock(SSLSession.class);
+        when(session.getProtocol()).thenReturn("TLSv1.3");
+        when(session.getCipherSuite()).thenReturn("TLS_AES_256_GCM_SHA384");
+        when(session.getPeerCertificates()).thenThrow(new SSLPeerUnverifiedException("no peer cert"));
+
+        SSLEngine engine = mock(SSLEngine.class);
+        when(engine.getSession()).thenReturn(session);
+        when(engine.getNeedClientAuth()).thenReturn(true);
+        when(engine.getWantClientAuth()).thenReturn(false);
+
+        SecurityRequest request = mock(SecurityRequest.class);
+        when(request.getSSLEngine()).thenReturn(engine);
+
+        try {
+            SSLRequestHelper.getSSLInfo(Settings.EMPTY, sslDir(), request, null);
+            fail("Expected OpenSearchException when no client certificate is present");
+        } catch (OpenSearchException e) {
+            assertThat(e.getMessage(), containsString("No client certificates found"));
+        }
+    }
+
+    @Test
+    public void getSSLInfo_returnsX509Certs_whenClientCertProvided() throws Exception {
+        // Use a real certificate loaded from test resources; only the SSL plumbing is mocked.
+        X509Certificate[] clientCerts = loadCerts("ssl/crl/revoked.crt.pem");
+
+        SSLSession session = mock(SSLSession.class);
+        when(session.getProtocol()).thenReturn("TLSv1.3");
+        when(session.getCipherSuite()).thenReturn("TLS_AES_256_GCM_SHA384");
+        when(session.getPeerCertificates()).thenReturn(clientCerts);
+        when(session.getLocalCertificates()).thenReturn(null);
+
+        SSLEngine engine = mock(SSLEngine.class);
+        when(engine.getSession()).thenReturn(session);
+        when(engine.getNeedClientAuth()).thenReturn(true);
+        when(engine.getWantClientAuth()).thenReturn(false);
+
+        SecurityRequest request = mock(SecurityRequest.class);
+        when(request.getSSLEngine()).thenReturn(engine);
+
+        // CRL validation disabled so we only test the cert-extraction path
+        Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false).build();
+
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(settings, sslDir(), request, null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getX509Certs(), is(notNullValue()));
+        assertThat(info.getX509Certs().length, is(clientCerts.length));
+        assertThat(info.getPrincipal(), is(nullValue()));
+    }
+
+    @Test
+    public void getSSLInfo_populatesLocalCertificates_whenSessionProvidesLocalCerts() throws Exception {
+        X509Certificate[] localCerts = loadCerts("ssl/node-0.crt.pem");
+
+        SSLSession session = mock(SSLSession.class);
+        when(session.getProtocol()).thenReturn("TLSv1.3");
+        when(session.getCipherSuite()).thenReturn("TLS_AES_256_GCM_SHA384");
+        when(session.getLocalCertificates()).thenReturn(localCerts);
+
+        SSLEngine engine = mock(SSLEngine.class);
+        when(engine.getSession()).thenReturn(session);
+        when(engine.getNeedClientAuth()).thenReturn(false);
+        when(engine.getWantClientAuth()).thenReturn(false);
+
+        SecurityRequest request = mock(SecurityRequest.class);
+        when(request.getSSLEngine()).thenReturn(engine);
+
+        SSLRequestHelper.SSLInfo info = SSLRequestHelper.getSSLInfo(Settings.EMPTY, sslDir(), request, null);
+
+        assertThat(info, is(notNullValue()));
+        assertThat(info.getLocalCertificates(), is(notNullValue()));
+        assertThat(info.getLocalCertificates().length, is(localCerts.length));
+        assertThat(info.getLocalCertificates()[0], is(localCerts[0]));
+    }
+}

--- a/src/test/java/org/opensearch/security/ssl/util/SSLRequestHelperTest.java
+++ b/src/test/java/org/opensearch/security/ssl/util/SSLRequestHelperTest.java
@@ -8,18 +8,6 @@
 
 package org.opensearch.security.ssl.util;
 
-import org.junit.Test;
-import org.opensearch.OpenSearchException;
-import org.opensearch.common.settings.Settings;
-import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.env.Environment;
-import org.opensearch.security.filter.SecurityRequest;
-import org.opensearch.security.test.helper.file.FileHelper;
-import org.opensearch.security.util.FakeRestRequest;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import javax.net.ssl.SSLSession;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.security.KeyStore;
@@ -33,6 +21,19 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+
+import org.junit.Test;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.env.Environment;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.test.helper.file.FileHelper;
+import org.opensearch.security.util.FakeRestRequest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -96,9 +97,7 @@ public class SSLRequestHelperTest {
     @Test
     public void trustAnchorsFromKeyStore_returnsAnchorForEachCertificateEntry() throws Exception {
         KeyStore ts = KeyStore.getInstance("JKS");
-        try (FileInputStream fis = new FileInputStream(
-            FileHelper.getAbsoluteFilePathFromClassPath("ssl/truststore_valid.jks").toFile()
-        )) {
+        try (FileInputStream fis = new FileInputStream(FileHelper.getAbsoluteFilePathFromClassPath("ssl/truststore_valid.jks").toFile())) {
             ts.load(fis, null);
         }
 
@@ -119,7 +118,7 @@ public class SSLRequestHelperTest {
 
         SSLRequestHelper.configureValidator(validator, Settings.EMPTY);
 
-        // !disable_crldp(false) → true;  !disable_ocsp(false) → true
+        // !disable_crldp(false) → true; !disable_ocsp(false) → true
         assertThat(validator.isEnableCRLDP(), is(true));
         assertThat(validator.isEnableOCSP(), is(true));
         assertThat(validator.isCheckOnlyEndEntities(), is(true));
@@ -215,8 +214,12 @@ public class SSLRequestHelperTest {
         // truststore_valid.jks has no password — null is passed to KeyStore.load()
         Settings settings = Settings.builder().put(SSLConfigConstants.SECURITY_SSL_HTTP_TRUSTSTORE_TYPE, "JKS").build();
 
-        CertificateValidator validator =
-            SSLRequestHelper.buildValidatorFromTruststore(settings, env(sslDir()), null, "truststore_valid.jks");
+        CertificateValidator validator = SSLRequestHelper.buildValidatorFromTruststore(
+            settings,
+            env(sslDir()),
+            null,
+            "truststore_valid.jks"
+        );
 
         assertThat(validator, is(notNullValue()));
     }


### PR DESCRIPTION
### Description

Refactor the existent certificate revocation validation. The original code mixed trust-source handling, CRL loading, and revocation configuration into a single untestable method. Running the application at _ERROR_ level results in a failure with zero diagnostic context, as the root cause is logged at _WARN_ inside `SSLRequestHelper` while the exception surfaces at _ERROR_ in `ValidatingDispatcher`.

### Issues Resolved

  - Refactor CertificateValidator to accept Set<TrustAnchor> directly, removing dual trust-source logic (KeyStore vs X509Certificate[])
  - Split SSLRequestHelper.validate() into focused package-private methods (loadCrls, buildValidator, buildValidatorFromPem, buildValidatorFromTruststore, trustAnchorsFrom, configureValidator) for testability
  - Replace boolean return + generic exception with typed exception propagation (CertPathValidatorException, CertificateException, IOException) chained into SSLPeerUnverifiedException with per-type log messages
  - Separate cert path building (structural validation) from revocation checking to distinguish chain failures from revocation failures
  - Remove AccessController.doPrivileged() dependency
  - Remove dead code
  - Add integration tests with real TLS loopback handshake and CRL files; add unit tests for all extracted methods

### Testing
Inc. manual testing with static CRL file as well as local OCSP and CRLDP server responses.

```
# static CRL file
plugins.security.ssl.http.crl.validate: true
plugins.security.ssl.http.crl.file_path: kishomelab-ca.crl
plugins.security.ssl.http.crl.prefer_crlfile_over_ocsp: true
plugins.security.ssl.http.crl.disable_ocsp: true
plugins.security.ssl.http.crl.disable_crldp: true
```

```
# CRLDP (Certificate Revocation List Distribution Point)
plugins.security.ssl.http.crl.validate: true
plugins.security.ssl.http.crl.disable_ocsp: true
```

```
# OCSP (Online Certificate Status Protocol)
plugins.security.ssl.http.crl.validate: true
plugins.security.ssl.http.crl.disable_crldp: true
```


<details>
<summary>OCSP revocation exception log before</summary>


```
[2026-03-30T15:14:59,141][WARN ][o.o.s.s.u.SSLRequestHelper] [xps139310] Unable to validate CRL:
java.security.cert.CertificateRevokedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:783)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:354)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:328)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:430)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:540)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.buildForward(SunCertPathBuilder.java:231)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.buildCertPath(SunCertPathBuilder.java:166)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:134)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:129)
	at java.base/java.security.cert.CertPathBuilder.build(CertPathBuilder.java:295)
	at org.opensearch.security.ssl.util.CertificateValidator.validate(CertificateValidator.java:207)
	at org.opensearch.security.ssl.util.SSLRequestHelper.validate(SSLRequestHelper.java:256)
	at org.opensearch.security.ssl.util.SSLRequestHelper.lambda$getSSLInfo$0(SSLRequestHelper.java:143)
	at org.opensearch.secure_sm.AccessController.doPrivileged(AccessController.java:76)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:143)
	at org.opensearch.security.filter.SecurityRestFilter.checkAndAuthenticateRequest(SecurityRestFilter.java:341)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:90)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
[2026-03-30T15:14:59,147][ERROR][o.o.s.f.SecurityRestFilter] [xps139310] No ssl info
javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:146)
	at org.opensearch.security.filter.SecurityRestFilter.checkAndAuthenticateRequest(SecurityRestFilter.java:341)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:90)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
[2026-03-30T15:14:59,170][WARN ][o.o.s.s.u.SSLRequestHelper] [xps139310] Unable to validate CRL:
java.security.cert.CertificateRevokedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:783)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:354)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:328)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:430)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.depthFirstSearchForward(SunCertPathBuilder.java:540)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.buildForward(SunCertPathBuilder.java:231)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.buildCertPath(SunCertPathBuilder.java:166)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.build(SunCertPathBuilder.java:134)
	at java.base/sun.security.provider.certpath.SunCertPathBuilder.engineBuild(SunCertPathBuilder.java:129)
	at java.base/java.security.cert.CertPathBuilder.build(CertPathBuilder.java:295)
	at org.opensearch.security.ssl.util.CertificateValidator.validate(CertificateValidator.java:207)
	at org.opensearch.security.ssl.util.SSLRequestHelper.validate(SSLRequestHelper.java:256)
	at org.opensearch.security.ssl.util.SSLRequestHelper.lambda$getSSLInfo$0(SSLRequestHelper.java:143)
	at org.opensearch.secure_sm.AccessController.doPrivileged(AccessController.java:76)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:143)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:87)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.dispatchRequest(ValidatingDispatcher.java:68)
	at org.opensearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:374)
	at org.opensearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:482)
	at org.opensearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:357)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:60)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:44)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:72)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:115)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:48)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:114)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
[2026-03-30T15:14:59,172][ERROR][o.o.s.s.h.n.ValidatingDispatcher] [xps139310] No client certificates found but such are needed (SG 8).
[2026-03-30T15:14:59,177][ERROR][o.o.h.n.s.SecureNetty4HttpServerTransport] [xps139310] Exception during establishing a SSL connection: OpenSearchException[javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)]; nested: SSLPeerUnverifiedException[Unable to validate certificate (CRL)];
org.opensearch.OpenSearchException: javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)
	at org.opensearch.ExceptionsHelper.convertToOpenSearchException(ExceptionsHelper.java:124)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:94)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.dispatchRequest(ValidatingDispatcher.java:68)
	at org.opensearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:374)
	at org.opensearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:482)
	at org.opensearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:357)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:60)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:44)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:72)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:115)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:48)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:114)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:146)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:87)
	... 85 more
[2026-03-30T15:14:59,181][WARN ][o.o.h.AbstractHttpServerTransport] [xps139310] caught exception while handling client http traffic, closing connection Netty4HttpChannel{localAddress=/192.168.33.19:9200, remoteAddress=/192.168.33.16:59560}
org.opensearch.OpenSearchException: javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)
	at org.opensearch.ExceptionsHelper.convertToOpenSearchException(ExceptionsHelper.java:124)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:94)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.dispatchRequest(ValidatingDispatcher.java:68)
	at org.opensearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:374)
	at org.opensearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:482)
	at org.opensearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:357)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:60)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:44)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:72)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:115)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:48)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:114)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: javax.net.ssl.SSLPeerUnverifiedException: Unable to validate certificate (CRL)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:146)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:87)
	... 85 more
```
</details>

<details>
<summary>OCSP revocation exception log after</summary>


```
[2026-03-30T11:05:05,536][ERROR][o.o.s.s.u.SSLRequestHelper] [xps139310] Certificate is revoked or path invalid for 'CN=client, O=kishomelab' (reason: REVOKED)
[2026-03-30T11:05:05,537][ERROR][o.o.s.f.SecurityRestFilter] [xps139310] No ssl info
javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:157)
	at org.opensearch.security.filter.SecurityRestFilter.checkAndAuthenticateRequest(SecurityRestFilter.java:341)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:90)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: java.security.cert.CertPathValidatorException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:135)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:224)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:144)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:83)
	at java.base/java.security.cert.CertPathValidator.validate(CertPathValidator.java:307)
	at org.opensearch.security.ssl.util.CertificateValidator.validate(CertificateValidator.java:143)
	at org.opensearch.security.ssl.util.SSLRequestHelper.validate(SSLRequestHelper.java:226)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:150)
	... 68 more
Caused by: java.security.cert.CertificateRevokedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:783)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:354)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:328)
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
	... 75 more
[2026-03-30T11:05:05,544][ERROR][o.o.s.s.u.SSLRequestHelper] [xps139310] Certificate is revoked or path invalid for 'CN=client, O=kishomelab' (reason: REVOKED)
[2026-03-30T11:05:05,544][ERROR][o.o.s.s.h.n.ValidatingDispatcher] [xps139310] No client certificates found but such are needed (SG 8).
[2026-03-30T11:05:05,545][ERROR][o.o.h.n.s.SecureNetty4HttpServerTransport] [xps139310] Exception during establishing a SSL connection: OpenSearchException[javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []]; nested: SSLPeerUnverifiedException[Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []]; nested: CertPathValidatorException[Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []]; nested: CertificateRevokedException[Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []];
org.opensearch.OpenSearchException: javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at org.opensearch.ExceptionsHelper.convertToOpenSearchException(ExceptionsHelper.java:124)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:94)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.dispatchRequest(ValidatingDispatcher.java:68)
	at org.opensearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:374)
	at org.opensearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:482)
	at org.opensearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:357)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:60)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:44)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:72)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:115)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:48)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:114)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:157)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:87)
	... 85 more
Caused by: java.security.cert.CertPathValidatorException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:135)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:224)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:144)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:83)
	at java.base/java.security.cert.CertPathValidator.validate(CertPathValidator.java:307)
	at org.opensearch.security.ssl.util.CertificateValidator.validate(CertificateValidator.java:143)
	at org.opensearch.security.ssl.util.SSLRequestHelper.validate(SSLRequestHelper.java:226)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:150)
	... 86 more
Caused by: java.security.cert.CertificateRevokedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:783)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:354)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:328)
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
	... 93 more
[2026-03-30T11:05:05,546][INFO ][o.o.i.MergeSchedulerConfig] [xps139310] Updating autoThrottle for index security-auditlog-2026.03.30 from [false] to [true]
[2026-03-30T11:05:05,546][INFO ][o.o.i.MergeSchedulerConfig] [xps139310] Updating maxThreadCount from [0] to [4] and maxMergeCount from [0] to [9] for index security-auditlog-2026.03.30.
[2026-03-30T11:05:05,546][INFO ][o.o.i.MergeSchedulerConfig] [xps139310] Initialized index security-auditlog-2026.03.30 with maxMergeCount=9, maxThreadCount=4, autoThrottleEnabled=true
[2026-03-30T11:05:05,547][INFO ][o.o.p.PluginsService     ] [xps139310] PluginService:onIndexModule index:[security-auditlog-2026.03.30/QbXCkIlXQL-1vfbB7Zfa2g]
[2026-03-30T11:05:05,548][WARN ][o.o.h.AbstractHttpServerTransport] [xps139310] caught exception while handling client http traffic, closing connection Netty4HttpChannel{localAddress=/192.168.33.19:9200, remoteAddress=/192.168.33.16:35526}
org.opensearch.OpenSearchException: javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at org.opensearch.ExceptionsHelper.convertToOpenSearchException(ExceptionsHelper.java:124)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:94)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.dispatchRequest(ValidatingDispatcher.java:68)
	at org.opensearch.http.AbstractHttpServerTransport.dispatchRequest(AbstractHttpServerTransport.java:374)
	at org.opensearch.http.AbstractHttpServerTransport.handleIncomingRequest(AbstractHttpServerTransport.java:482)
	at org.opensearch.http.AbstractHttpServerTransport.incomingRequest(AbstractHttpServerTransport.java:357)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:60)
	at org.opensearch.http.netty4.Netty4HttpRequestHandler.channelRead0(Netty4HttpRequestHandler.java:44)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.http.netty4.Netty4HttpPipeliningHandler.channelRead(Netty4HttpPipeliningHandler.java:72)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:115)
	at io.netty.handler.codec.http.HttpContentDecoder.decode(HttpContentDecoder.java:48)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:91)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:114)
	at org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier.channelRead0(Netty4HttpRequestHeaderVerifier.java:37)
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:120)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.logging.LoggingHandler.channelRead(LoggingHandler.java:280)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel$Http2ChannelUnsafe.doRead0(AbstractHttp2StreamChannel.java:981)
	at io.netty.handler.codec.http2.AbstractHttp2StreamChannel.fireChildRead(AbstractHttp2StreamChannel.java:601)
	at io.netty.handler.codec.http2.Http2MultiplexHandler.channelRead(Http2MultiplexHandler.java:188)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.http2.Http2FrameCodec.onHttp2Frame(Http2FrameCodec.java:723)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:645)
	at io.netty.handler.codec.http2.Http2FrameCodec$FrameListener.onHeadersRead(Http2FrameCodec.java:638)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2FrameListenerDecorator.onHeadersRead(Http2FrameListenerDecorator.java:46)
	at io.netty.handler.codec.http2.Http2EmptyDataFrameListener.onHeadersRead(Http2EmptyDataFrameListener.java:63)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:423)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$FrameReadListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:338)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder$PrefaceFrameListener.onHeadersRead(DefaultHttp2ConnectionDecoder.java:720)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader$2.processFragment(DefaultHttp2FrameReader.java:489)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readHeadersFrame(DefaultHttp2FrameReader.java:497)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.processPayloadState(DefaultHttp2FrameReader.java:257)
	at io.netty.handler.codec.http2.DefaultHttp2FrameReader.readFrame(DefaultHttp2FrameReader.java:174)
	at io.netty.handler.codec.http2.DefaultHttp2ConnectionDecoder.decodeFrame(DefaultHttp2ConnectionDecoder.java:186)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.DecoratingHttp2ConnectionDecoder.decodeFrame(DecoratingHttp2ConnectionDecoder.java:61)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$FrameDecoder.decode(Http2ConnectionHandler.java:402)
	at io.netty.handler.codec.http2.Http2ConnectionHandler$PrefaceDecoder.decode(Http2ConnectionHandler.java:248)
	at io.netty.handler.codec.http2.Http2ConnectionHandler.decode(Http2ConnectionHandler.java:462)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:288)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:355)
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:107)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1526)
	at io.netty.handler.ssl.SslHandler.decodeJdkCompatible(SslHandler.java:1384)
	at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1435)
	at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:545)
	at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:484)
	at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:296)
	at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1429)
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:918)
	at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:176)
	at io.netty.channel.nio.AbstractNioChannel$AbstractNioUnsafe.handle(AbstractNioChannel.java:445)
	at io.netty.channel.nio.NioIoHandler$DefaultNioRegistration.handle(NioIoHandler.java:388)
	at io.netty.channel.nio.NioIoHandler.processSelectedKey(NioIoHandler.java:596)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeysPlain(NioIoHandler.java:541)
	at io.netty.channel.nio.NioIoHandler.processSelectedKeys(NioIoHandler.java:514)
	at io.netty.channel.nio.NioIoHandler.run(NioIoHandler.java:484)
	at io.netty.channel.SingleThreadIoEventLoop.runIo(SingleThreadIoEventLoop.java:225)
	at io.netty.channel.SingleThreadIoEventLoop.run(SingleThreadIoEventLoop.java:196)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:1195)
	at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: javax.net.ssl.SSLPeerUnverifiedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:157)
	at org.opensearch.security.ssl.http.netty.ValidatingDispatcher.checkRequest(ValidatingDispatcher.java:87)
	... 85 more
Caused by: java.security.cert.CertPathValidatorException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:135)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:224)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.validate(PKIXCertPathValidator.java:144)
	at java.base/sun.security.provider.certpath.PKIXCertPathValidator.engineValidate(PKIXCertPathValidator.java:83)
	at java.base/java.security.cert.CertPathValidator.validate(CertPathValidator.java:307)
	at org.opensearch.security.ssl.util.CertificateValidator.validate(CertificateValidator.java:143)
	at org.opensearch.security.ssl.util.SSLRequestHelper.validate(SSLRequestHelper.java:226)
	at org.opensearch.security.ssl.util.SSLRequestHelper.getSSLInfo(SSLRequestHelper.java:150)
	... 86 more
Caused by: java.security.cert.CertificateRevokedException: Certificate has been revoked, reason: UNSPECIFIED, revocation date: Fri Mar 27 11:12:05 CET 2026, authority: O=kishomelab, CN=kishomelab OCSP Responder, extension OIDs: []
	at java.base/sun.security.provider.certpath.RevocationChecker.checkOCSP(RevocationChecker.java:783)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:354)
	at java.base/sun.security.provider.certpath.RevocationChecker.check(RevocationChecker.java:328)
	at java.base/sun.security.provider.certpath.PKIXMasterCertPathValidator.validate(PKIXMasterCertPathValidator.java:125)
	... 93 more
```
</details>

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
