### PR TITLE
Support Jackson 3.x release line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -483,7 +483,11 @@ configurations {
             force 'commons-logging:commons-logging:1.3.6'
             force 'org.slf4j:slf4j-api:1.7.36'
             force 'org.scala-lang:scala-library:2.13.18'
-            force "com.fasterxml.jackson:jackson-bom:${versions.jackson}"
+            force "tools.jackson:jackson-bom:${versions.jackson3}"
+            force "tools.jackson.core:jackson-core:${versions.jackson3}"
+            force "tools.jackson.datatype:jackson-datatype-jdk8:${versions.jackson3}"
+            force "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
+            // Keeping Jackson 2.x since Kafka clients and etc still need it
             force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
             force "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:${versions.jackson}"
             force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
@@ -597,10 +601,10 @@ allprojects {
                 integrationTestImplementation "com.password4j:password4j:${versions.password4j}"
                 integrationTestImplementation "com.google.guava:guava:${guava_version}"
                 integrationTestImplementation "org.apache.commons:commons-lang3:${versions.commonslang}"
-                integrationTestImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+                integrationTestImplementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
                 integrationTestImplementation 'org.greenrobot:eventbus-java:3.3.1'
                 integrationTestImplementation "org.apache.commons:commons-collections4:${versions.commonscollections4}"
-                integrationTestImplementation('com.flipkart.zjsonpatch:zjsonpatch:0.4.16'){
+                integrationTestImplementation('io.github.vishwakarma:zjsonpatch:0.6.2'){
                     exclude(group:'com.fasterxml.jackson.core')
                     exclude(group: 'org.apache.commons', module: 'commons-collections4')
                 }
@@ -706,8 +710,11 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
     implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"
     implementation "io.jsonwebtoken:jjwt-jackson:${jjwt_version}"
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+
     // JSON patch
-    implementation 'com.flipkart.zjsonpatch:zjsonpatch:0.4.16'
+    implementation 'io.github.vishwakarma:zjsonpatch:0.6.2'
     implementation "org.apache.commons:commons-collections4:${versions.commonscollections4}"
 
     //Password generation
@@ -816,7 +823,7 @@ dependencies {
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"
 
     implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
 
     compileOnly "org.opensearch:opensearch:${opensearch_version}"
 

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -74,7 +74,7 @@ dependencies {
     testImplementation "org.opensearch.test:framework:${opensearch_version}"
     testImplementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
     testImplementation "org.opensearch:common-utils:${common_utils_version}"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    testImplementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
     testImplementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
 
 }

--- a/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/SecurityBackwardsCompatibilityIT.java
@@ -21,7 +21,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.net.ssl.SSLContext;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
@@ -54,6 +53,8 @@ import org.opensearch.common.xcontent.support.XContentMapValues;
 import org.opensearch.commons.rest.SecureRestClientBuilder;
 import org.opensearch.security.bwc.helper.RestHelper;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
+
+import tools.jackson.databind.ObjectMapper;
 
 import static org.apache.hc.core5.http.ContentType.APPLICATION_NDJSON;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/bwc-test/src/test/java/org/opensearch/security/bwc/Song.java
+++ b/bwc-test/src/test/java/org/opensearch/security/bwc/Song.java
@@ -13,10 +13,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.opensearch.common.Randomness;
+
+import tools.jackson.databind.ObjectMapper;
 
 public class Song {
 
@@ -104,7 +103,7 @@ public class Song {
         return Map.of(FIELD_ARTIST, artist, FIELD_TITLE, title, FIELD_LYRICS, lyrics, FIELD_STARS, stars, FIELD_GENRE, genre);
     }
 
-    public String asJson() throws JsonProcessingException {
+    public String asJson() {
         return new ObjectMapper().writeValueAsString(this.asMap());
     }
 

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -31,7 +31,7 @@ configurations.all {
         force "org.bouncycastle:bcpkix-jdk18on:1.83"
         force "org.bouncycastle:bcprov-jdk18on:1.83"
         force "org.apache.commons:commons-lang3:${versions.commonslang}"
-        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+        force "tools.jackson.core:jackson-core:${versions.jackson3}"
     }
 }
 

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
     implementation "org.opensearch:common-utils:${common_utils_version}"
     implementation "org.opensearch.client:opensearch-rest-client:${opensearch_version}"
-    implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+    implementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
 
     integrationTestImplementation 'org.ldaptive:ldaptive:1.2.3' // for running multinode tests
 

--- a/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
+++ b/sample-resource-plugin/src/integrationTest/java/org/opensearch/sample/resource/securityapis/MigrateApiTests.java
@@ -16,9 +16,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.junit.After;
@@ -35,6 +32,10 @@ import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.matcher.RestMatchers;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -653,10 +654,10 @@ public class MigrateApiTests {
             ArrayNode hitsNode = (ArrayNode) sharingResponse.bodyAsJsonNode().get("hits").get("hits");
             assertThat(hitsNode.size(), equalTo(1));
 
-            com.fasterxml.jackson.databind.JsonNode source = hitsNode.get(0).get("_source");
-            assertThat(source.get("resource_id").asText(), equalTo(resourceId));
-            assertThat(source.get("parent_id").asText(), equalTo(garbageGroupId));
-            assertThat(source.get("parent_type").asText(), equalTo(RESOURCE_GROUP_TYPE));
+            tools.jackson.databind.JsonNode source = hitsNode.get(0).get("_source");
+            assertThat(source.get("resource_id").asString(), equalTo(resourceId));
+            assertThat(source.get("parent_id").asString(), equalTo(garbageGroupId));
+            assertThat(source.get("parent_type").asString(), equalTo(RESOURCE_GROUP_TYPE));
 
             // Access check for the owner should still work gracefully — the nonexistent parent
             // simply contributes no additional resource IDs, so the resource remains owner-accessible
@@ -690,18 +691,18 @@ public class MigrateApiTests {
             assertThat(hitsNode.size(), equalTo(2));
 
             // Find the resource hit (not the group) and verify parent fields
-            com.fasterxml.jackson.databind.JsonNode resourceSource = null;
-            for (com.fasterxml.jackson.databind.JsonNode hit : hitsNode) {
-                com.fasterxml.jackson.databind.JsonNode src = hit.get("_source");
-                if (RESOURCE_TYPE.equals(src.get("resource_type").asText())) {
+            tools.jackson.databind.JsonNode resourceSource = null;
+            for (tools.jackson.databind.JsonNode hit : hitsNode) {
+                tools.jackson.databind.JsonNode src = hit.get("_source");
+                if (RESOURCE_TYPE.equals(src.get("resource_type").asString())) {
                     resourceSource = src;
                     break;
                 }
             }
             assertThat("Expected a sharing record for resource type " + RESOURCE_TYPE, resourceSource != null);
-            assertThat(resourceSource.get("resource_id").asText(), equalTo(resourceId));
-            assertThat(resourceSource.get("parent_type").asText(), equalTo(RESOURCE_GROUP_TYPE));
-            assertThat(resourceSource.get("parent_id").asText(), equalTo(groupId));
+            assertThat(resourceSource.get("resource_id").asString(), equalTo(resourceId));
+            assertThat(resourceSource.get("parent_type").asString(), equalTo(RESOURCE_GROUP_TYPE));
+            assertThat(resourceSource.get("parent_id").asString(), equalTo(groupId));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/AbstractDefaultConfigurationTests.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.HttpStatus;
 import org.awaitility.Awaitility;
 import org.junit.Test;
@@ -22,6 +21,8 @@ import org.junit.Test;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
@@ -226,7 +227,7 @@ public abstract class AbstractDefaultConfigurationTests {
 
     private Set<String> extractFieldNames(final JsonNode json) {
         final var set = new HashSet<String>();
-        json.fieldNames().forEachRemaining(set::add);
+        json.propertyNames().spliterator().forEachRemaining(set::add);
         return set;
     }
 

--- a/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ParentChildRelationTests.java
@@ -12,7 +12,6 @@ package org.opensearch.security;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,6 +26,8 @@ import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/integrationTest/java/org/opensearch/security/api/AbstractConfigEntityApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/AbstractConfigEntityApiIntegrationTest.java
@@ -174,7 +174,7 @@ public abstract class AbstractConfigEntityApiIntegrationTest extends AbstractApi
         assertThat(resp, isOk());
         final var body = resp.bodyAsJsonNode();
         final var pretty = body.toPrettyString();
-        final var it = body.elements();
+        final var it = body.values().iterator();
         while (it.hasNext()) {
             final var e = it.next();
             assertThat(pretty, not(e.get("hidden").asBoolean()));

--- a/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/CertificatesRestApiIntegrationTest.java
@@ -18,7 +18,6 @@ import java.util.Random;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -29,6 +28,8 @@ import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;

--- a/src/integrationTest/java/org/opensearch/security/api/ConfigRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/ConfigRestApiIntegrationTest.java
@@ -12,7 +12,6 @@ package org.opensearch.security.api;
 
 import java.util.StringJoiner;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -21,6 +20,8 @@ import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.api.PatchPayloadHelper.patch;
@@ -107,10 +108,11 @@ public class ConfigRestApiIntegrationTest extends AbstractApiIntegrationTest {
         TestRestClient.HttpResponse resp = client.get(securityConfigPath());
         assertThat(resp, isOk());
         final var configJson = resp.bodyAsJsonNode();
-        final var authFailureListeners = DefaultObjectMapper.objectMapper.createObjectNode();
+        final var authFailureListeners = DefaultObjectMapper.objectMapper().createObjectNode();
         authFailureListeners.set(
             "ip_rate_limiting",
-            DefaultObjectMapper.objectMapper.createObjectNode()
+            DefaultObjectMapper.objectMapper()
+                .createObjectNode()
                 .put("type", "ip")
                 .put("allowed_tries", 10)
                 .put("time_window_seconds", 3_600)
@@ -120,7 +122,8 @@ public class ConfigRestApiIntegrationTest extends AbstractApiIntegrationTest {
         );
         authFailureListeners.set(
             "internal_authentication_backend_limiting",
-            DefaultObjectMapper.objectMapper.createObjectNode()
+            DefaultObjectMapper.objectMapper()
+                .createObjectNode()
                 .put("type", "username")
                 .put("authentication_backend", "intern")
                 .put("allowed_tries", 10)

--- a/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/InternalUsersRestApiIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -38,6 +37,8 @@ import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;

--- a/src/integrationTest/java/org/opensearch/security/api/RolesMappingRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/RolesMappingRestApiIntegrationTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -31,6 +30,7 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 
 import com.nimbusds.jose.util.Pair;
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/integrationTest/java/org/opensearch/security/api/RolesRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/RolesRestApiIntegrationTest.java
@@ -17,8 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -30,6 +28,9 @@ import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -331,16 +332,16 @@ public class RolesRestApiIntegrationTest extends AbstractConfigEntityApiIntegrat
             is(expectedObjectNode.get("cluster_permissions"))
         );
         // TODO related to issue #4426
-        for (Iterator<JsonNode> it = expectedObjectNode.get("index_permissions").elements(); it.hasNext();) {
+        for (Iterator<JsonNode> it = expectedObjectNode.get("index_permissions").values().iterator(); it.hasNext();) {
             final var indexPermission = (ObjectNode) it.next();
             if (indexPermission.has("dls") && indexPermission.get("dls").isNull()) {
                 indexPermission.remove("dls");
             }
             if (indexPermission.has("fls") && indexPermission.get("fls").isNull()) {
-                indexPermission.set("fls", DefaultObjectMapper.objectMapper.createArrayNode());
+                indexPermission.set("fls", DefaultObjectMapper.objectMapper().createArrayNode());
             }
             if (indexPermission.has("masked_fields") && indexPermission.get("masked_fields").isNull()) {
-                indexPermission.set("masked_fields", DefaultObjectMapper.objectMapper.createArrayNode());
+                indexPermission.set("masked_fields", DefaultObjectMapper.objectMapper().createArrayNode());
             }
         }
 

--- a/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/SslCertsRestApiIntegrationTest.java
@@ -10,7 +10,6 @@
  */
 package org.opensearch.security.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -18,6 +17,8 @@ import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;

--- a/src/integrationTest/java/org/opensearch/security/api/TenantsRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/TenantsRestApiIntegrationTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.api;
 
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -22,6 +21,8 @@ import org.opensearch.security.dlic.rest.api.Endpoint;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/integrationTest/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSinkIntegrationTestAuditAlias.java
+++ b/src/integrationTest/java/org/opensearch/security/auditlog/sink/InternalOpenSearchSinkIntegrationTestAuditAlias.java
@@ -12,7 +12,6 @@ package org.opensearch.security.auditlog.sink;
 
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -24,6 +23,8 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.test.framework.data.TestAlias;
 import org.opensearch.test.framework.data.TestIndex;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
@@ -94,7 +95,7 @@ public class InternalOpenSearchSinkIntegrationTestAuditAlias {
             JsonNode aliasBody = aliasResponse.bodyAsJsonNode();
             assertThat("Write alias must exist in cluster metadata", aliasBody.isEmpty(), is(false));
 
-            String concreteIndex = aliasBody.fieldNames().next();
+            String concreteIndex = aliasBody.propertyNames().iterator().next();
             assertThat(
                 "Alias must resolve to a backing index, not a concrete index with the alias name",
                 concreteIndex,

--- a/src/integrationTest/java/org/opensearch/security/privileges/RestEndpointPermissionTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/RestEndpointPermissionTests.java
@@ -37,8 +37,6 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -55,6 +53,9 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.util.MockPrivilegeEvaluationContextBuilder;
+
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.CERTS_INFO_ACTION;
 import static org.opensearch.security.dlic.rest.api.RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS;
@@ -98,9 +99,10 @@ public class RestEndpointPermissionTests {
     }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
     static ObjectNode role(final String... clusterPermissions) {
-        final ArrayNode clusterPermissionsArrayNode = DefaultObjectMapper.objectMapper.createArrayNode();
+        final ArrayNode clusterPermissionsArrayNode = DefaultObjectMapper.objectMapper().createArrayNode();
         Arrays.stream(clusterPermissions).forEach(clusterPermissionsArrayNode::add);
-        return DefaultObjectMapper.objectMapper.createObjectNode()
+        return DefaultObjectMapper.objectMapper()
+            .createObjectNode()
             .put("reserved", true)
             .set("cluster_permissions", clusterPermissionsArrayNode);
     }
@@ -253,11 +255,11 @@ public class RestEndpointPermissionTests {
     }
 
     static ObjectNode meta(final String type) {
-        return DefaultObjectMapper.objectMapper.createObjectNode().put("type", type).put("config_version", 2);
+        return DefaultObjectMapper.objectMapper().createObjectNode().put("type", type).put("config_version", 2);
     }
 
     static SecurityDynamicConfiguration<RoleV7> createRolesConfig() throws IOException {
-        final ObjectNode rolesNode = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode rolesNode = DefaultObjectMapper.objectMapper().createObjectNode();
         rolesNode.set("_meta", meta("roles"));
         NO_REST_ADMIN_PERMISSIONS_ROLES.forEach(rolesNode::set);
         REST_ADMIN_PERMISSIONS_FULL_ACCESS_ROLES.forEach(rolesNode::set);

--- a/src/integrationTest/java/org/opensearch/security/privileges/TenantPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/TenantPrivilegesTest.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -196,26 +195,22 @@ public class TenantPrivilegesTest {
             }
 
             SecurityDynamicConfiguration<RoleV7> toRolesConfig() {
-                try {
-                    if (!isEmpty()) {
-                        return SecurityDynamicConfiguration.fromMap(
+                if (!isEmpty()) {
+                    return SecurityDynamicConfiguration.fromMap(
+                        ImmutableMap.of(
+                            "test_role",
                             ImmutableMap.of(
-                                "test_role",
-                                ImmutableMap.of(
-                                    "tenant_permissions",
-                                    List.of(ImmutableMap.of("tenant_patterns", this.tenantPatterns, "allowed_actions", this.allowedActions))
-                                )
-                            ),
-                            CType.ROLES
-                        );
-                    } else {
-                        return SecurityDynamicConfiguration.fromMap(
-                            ImmutableMap.of("test_role", ImmutableMap.of("description", "empty role")),
-                            CType.ROLES
-                        );
-                    }
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
+                                "tenant_permissions",
+                                List.of(ImmutableMap.of("tenant_patterns", this.tenantPatterns, "allowed_actions", this.allowedActions))
+                            )
+                        ),
+                        CType.ROLES
+                    );
+                } else {
+                    return SecurityDynamicConfiguration.fromMap(
+                        ImmutableMap.of("test_role", ImmutableMap.of("description", "empty role")),
+                        CType.ROLES
+                    );
                 }
             }
 

--- a/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivilegesTest.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -753,22 +752,16 @@ public class RoleBasedActionPrivilegesTest {
             }
 
             SecurityDynamicConfiguration<RoleV7> toRolesConfig(ActionSpec actionSpec) {
-                try {
-                    return SecurityDynamicConfiguration.fromMap(
+                return SecurityDynamicConfiguration.fromMap(
+                    ImmutableMap.of(
+                        "test_role",
                         ImmutableMap.of(
-                            "test_role",
-                            ImmutableMap.of(
-                                "index_permissions",
-                                Arrays.asList(
-                                    ImmutableMap.of("index_patterns", this.givenIndexPrivs, "allowed_actions", actionSpec.givenPrivs)
-                                )
-                            )
-                        ),
-                        CType.ROLES
-                    );
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                            "index_permissions",
+                            Arrays.asList(ImmutableMap.of("index_patterns", this.givenIndexPrivs, "allowed_actions", actionSpec.givenPrivs))
+                        )
+                    ),
+                    CType.ROLES
+                );
             }
 
             @Override
@@ -1285,48 +1278,44 @@ public class RoleBasedActionPrivilegesTest {
         }
 
         static SecurityDynamicConfiguration<RoleV7> createRoles(int numberOfRoles, int numberOfIndices) {
-            try {
-                Random random = new Random(1);
-                Map<String, Object> rolesDocument = new HashMap<>();
-                List<String> allowedActions = Arrays.asList(
-                    "indices:data/read*",
-                    "indices:admin/mappings/fields/get*",
-                    "indices:admin/resolve/index",
-                    "indices:data/write*",
-                    "indices:admin/mapping/put"
+            Random random = new Random(1);
+            Map<String, Object> rolesDocument = new HashMap<>();
+            List<String> allowedActions = Arrays.asList(
+                "indices:data/read*",
+                "indices:admin/mappings/fields/get*",
+                "indices:admin/resolve/index",
+                "indices:data/write*",
+                "indices:admin/mapping/put"
+            );
+
+            for (int i = 0; i < numberOfRoles; i++) {
+                List<String> indexPatterns = new ArrayList<>();
+                int numberOfIndexPatterns = Math.min(
+                    (int) ((Math.abs(random.nextGaussian() + 0.3)) * 0.5 * numberOfIndices),
+                    numberOfIndices
                 );
 
-                for (int i = 0; i < numberOfRoles; i++) {
-                    List<String> indexPatterns = new ArrayList<>();
-                    int numberOfIndexPatterns = Math.min(
-                        (int) ((Math.abs(random.nextGaussian() + 0.3)) * 0.5 * numberOfIndices),
-                        numberOfIndices
-                    );
+                int numberOfIndexPatterns10th = numberOfIndexPatterns / 10;
 
-                    int numberOfIndexPatterns10th = numberOfIndexPatterns / 10;
-
-                    if (numberOfIndexPatterns10th > 0) {
-                        for (int k = 0; k < numberOfIndexPatterns10th; k++) {
-                            indexPatterns.add("index_" + random.nextInt(numberOfIndices / 10) + "*");
-                        }
-                    } else {
-                        for (int k = 0; k < numberOfIndexPatterns; k++) {
-                            indexPatterns.add("index_" + random.nextInt(numberOfIndices));
-                        }
+                if (numberOfIndexPatterns10th > 0) {
+                    for (int k = 0; k < numberOfIndexPatterns10th; k++) {
+                        indexPatterns.add("index_" + random.nextInt(numberOfIndices / 10) + "*");
                     }
-
-                    Map<String, Object> roleDocument = ImmutableMap.of(
-                        "index_permissions",
-                        Arrays.asList(ImmutableMap.of("index_patterns", indexPatterns, "allowed_actions", allowedActions))
-                    );
-
-                    rolesDocument.put("role_" + i, roleDocument);
+                } else {
+                    for (int k = 0; k < numberOfIndexPatterns; k++) {
+                        indexPatterns.add("index_" + random.nextInt(numberOfIndices));
+                    }
                 }
 
-                return SecurityDynamicConfiguration.fromMap(rolesDocument, CType.ROLES);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
+                Map<String, Object> roleDocument = ImmutableMap.of(
+                    "index_permissions",
+                    Arrays.asList(ImmutableMap.of("index_patterns", indexPatterns, "allowed_actions", allowedActions))
+                );
+
+                rolesDocument.put("role_" + i, roleDocument);
             }
+
+            return SecurityDynamicConfiguration.fromMap(rolesDocument, CType.ROLES);
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/SubjectBasedActionPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/SubjectBasedActionPrivilegesTest.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -574,22 +573,16 @@ public class SubjectBasedActionPrivilegesTest {
             }
 
             RoleV7 toConfig(ActionSpec actionSpec) {
-                try {
-                    return SecurityDynamicConfiguration.fromMap(
+                return SecurityDynamicConfiguration.fromMap(
+                    ImmutableMap.of(
+                        "test_role",
                         ImmutableMap.of(
-                            "test_role",
-                            ImmutableMap.of(
-                                "index_permissions",
-                                Arrays.asList(
-                                    ImmutableMap.of("index_patterns", this.givenIndexPrivs, "allowed_actions", actionSpec.givenPrivs)
-                                )
-                            )
-                        ),
-                        CType.ROLES
-                    ).getCEntry("test_role");
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
-                }
+                            "index_permissions",
+                            Arrays.asList(ImmutableMap.of("index_patterns", this.givenIndexPrivs, "allowed_actions", actionSpec.givenPrivs))
+                        )
+                    ),
+                    CType.ROLES
+                ).getCEntry("test_role");
             }
 
             @Override

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilterTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilterTest.java
@@ -11,10 +11,11 @@
 package org.opensearch.security.privileges.dlsfls;
 
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -45,9 +45,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.collect.Streams;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -76,6 +73,10 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.cluster.OpenSearchClientProvider.UserCredentialsHolder;
 import org.opensearch.test.framework.data.TestIndex;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
 
 import static java.util.Arrays.asList;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
@@ -253,18 +254,14 @@ public class TestSecurityConfig {
      * Can be used to simulate invalid configuration or legacy configuration.
      */
     public TestSecurityConfig rawConfigurationDocumentYaml(String configTypeId, String configDocumentAsYaml) {
-        try {
-            if (this.rawConfigurationDocuments == null) {
-                this.rawConfigurationDocuments = new LinkedHashMap<>();
-            }
-
-            JsonNode node = new ObjectMapper(new YAMLFactory()).readTree(configDocumentAsYaml);
-
-            this.rawConfigurationDocuments.put(configTypeId, new ObjectMapper().writeValueAsString(node));
-            return this;
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if (this.rawConfigurationDocuments == null) {
+            this.rawConfigurationDocuments = new LinkedHashMap<>();
         }
+
+        JsonNode node = new ObjectMapper(new YAMLFactory()).readTree(configDocumentAsYaml);
+
+        this.rawConfigurationDocuments.put(configTypeId, new ObjectMapper().writeValueAsString(node));
+        return this;
     }
 
     public static class Config implements ToXContentObject {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -44,9 +44,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.net.ssl.SSLContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.client5.http.classic.methods.HttpDelete;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
@@ -75,6 +72,8 @@ import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.security.DefaultObjectMapper;
 
 import com.nimbusds.jose.shaded.gson.Gson;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -442,8 +441,8 @@ public class TestRestClient implements AutoCloseable {
             }
         }
 
-        private JsonNode toJsonNode() throws JsonProcessingException, IOException {
-            return DefaultObjectMapper.objectMapper.readTree(getBody());
+        private JsonNode toJsonNode() throws IOException {
+            return DefaultObjectMapper.objectMapper().readTree(getBody());
         }
 
         @Override

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestIndexMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestIndexMatchers.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 import org.hamcrest.Matcher;
@@ -39,8 +38,9 @@ import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
 import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import tools.jackson.core.JacksonException;
 
-import static com.fasterxml.jackson.core.JsonToken.START_ARRAY;
+import static tools.jackson.core.JsonToken.START_ARRAY;
 
 /**
  * This class provides Hamcrest matchers that can be used as test oracles on the HTTP responses of index REST APIs.
@@ -289,11 +289,11 @@ public class RestIndexMatchers {
 
                 try {
                     if (response.getBody().startsWith(START_ARRAY.asString())) {
-                        item = DefaultObjectMapper.objectMapper.readValue(response.getBody(), List.class);
+                        item = DefaultObjectMapper.objectMapper().readValue(response.getBody(), List.class);
                     } else {
-                        item = DefaultObjectMapper.objectMapper.readValue(response.getBody(), Map.class);
+                        item = DefaultObjectMapper.objectMapper().readValue(response.getBody(), Map.class);
                     }
-                } catch (JsonProcessingException e) {
+                } catch (JacksonException e) {
                     mismatchDescription.appendText("Unable to parse body: ").appendValue(e.getMessage());
                     return false;
                 }

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/RestMatchers.java
@@ -12,11 +12,12 @@ package org.opensearch.test.framework.matcher;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.hamcrest.Description;
 import org.hamcrest.DiagnosingMatcher;
 
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
 
 public class RestMatchers {
 

--- a/src/main/java/org/opensearch/security/DefaultObjectMapper.java
+++ b/src/main/java/org/opensearch/security/DefaultObjectMapper.java
@@ -31,25 +31,31 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.exc.MismatchedInputException;
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import org.opensearch.secure_sm.AccessController;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.InjectableValues;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.exc.InvalidFormatException;
+import tools.jackson.databind.exc.MismatchedInputException;
+import tools.jackson.databind.introspect.AnnotatedClass;
+import tools.jackson.databind.introspect.BeanPropertyDefinition;
+import tools.jackson.databind.introspect.ClassIntrospector;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.module.SimpleModule;
+import tools.jackson.databind.ser.std.StdSerializer;
+import tools.jackson.databind.type.TypeFactory;
+import tools.jackson.dataformat.yaml.YAMLFactory;
 
 class ConfigMapSerializer extends StdSerializer<Map<String, Object>> {
     private static final Set<String> SENSITIVE_CONFIG_KEYS = Set.of("password");
@@ -61,13 +67,13 @@ class ConfigMapSerializer extends StdSerializer<Map<String, Object>> {
     }
 
     @Override
-    public void serialize(Map<String, Object> value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(Map<String, Object> value, JsonGenerator gen, SerializationContext serializers) {
         gen.writeStartObject();
         for (Map.Entry<String, Object> entry : value.entrySet()) {
             if (SENSITIVE_CONFIG_KEYS.contains(entry.getKey())) {
-                gen.writeStringField(entry.getKey(), "******"); // Redact
+                gen.writeStringProperty(entry.getKey(), "******"); // Redact
             } else {
-                gen.writeObjectField(entry.getKey(), entry.getValue());
+                gen.writeName(entry.getKey()).writePOJO(entry.getValue());
             }
         }
         gen.writeEndObject();
@@ -75,34 +81,70 @@ class ConfigMapSerializer extends StdSerializer<Map<String, Object>> {
 }
 
 public class DefaultObjectMapper {
-    public static final ObjectMapper objectMapper = new ObjectMapper();
-    public final static ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory());
-    private static final ObjectMapper defaulOmittingObjectMapper = new ObjectMapper();
+    private static volatile ObjectMapper objectMapper;
+    private static volatile ObjectMapper YAML_MAPPER;
+    private static volatile ObjectMapper defaulOmittingObjectMapper;
 
     static {
-        objectMapper.setSerializationInclusion(Include.NON_NULL);
         // exclude sensitive information from the request body,
         // if jackson cant parse the entity, e.g. passwords, hashes and so on,
         // but provides which property is unknown
-        objectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
-        defaulOmittingObjectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
-        YAML_MAPPER.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
-        // objectMapper.enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
-        objectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
-        defaulOmittingObjectMapper.setSerializationInclusion(Include.NON_DEFAULT);
-        defaulOmittingObjectMapper.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
-        YAML_MAPPER.enable(JsonParser.Feature.STRICT_DUPLICATE_DETECTION);
+
+        objectMapper = JsonMapper.builder()
+            .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL))
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+            .configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+            .build();
+
+        defaulOmittingObjectMapper = JsonMapper.builder()
+            .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_DEFAULT))
+            .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_DEFAULT))
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+            .configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+            .build();
+
+        // Why not YAMLMapper? It causes classloading issues (it inherits from
+        // ObjectMapper but comes from server's lib, whereas ObjectMapper comes from
+        // security plugin dependencies).
+        YAML_MAPPER = new ObjectMapper(
+            YAMLFactory.builder()
+                .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+                .enable(StreamReadFeature.STRICT_DUPLICATE_DETECTION)
+                .build()
+        ).rebuild()
+            .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true)
+            .configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+            .build();
     }
 
     private DefaultObjectMapper() {}
 
-    public static void inject(final InjectableValues.Std injectableValues) {
-        objectMapper.setInjectableValues(injectableValues);
-        YAML_MAPPER.setInjectableValues(injectableValues);
-        defaulOmittingObjectMapper.setInjectableValues(injectableValues);
+    public static ObjectMapper objectMapper() {
+        return objectMapper;
     }
 
-    public static boolean getOrDefault(Map<String, Object> properties, String key, boolean defaultValue) throws JsonProcessingException {
+    public static ObjectMapper yamlMapper() {
+        return YAML_MAPPER;
+    }
+
+    public static void inject(final InjectableValues.Std injectableValues) {
+        objectMapper = objectMapper.rebuild().injectableValues(injectableValues).build();
+        YAML_MAPPER = YAML_MAPPER.rebuild().injectableValues(injectableValues).build();
+        defaulOmittingObjectMapper = defaulOmittingObjectMapper.rebuild().injectableValues(injectableValues).build();
+    }
+
+    public static boolean getOrDefault(Map<String, Object> properties, String key, boolean defaultValue) {
         Object value = properties.get(key);
         if (value == null) {
             return defaultValue;
@@ -140,7 +182,7 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.treeToValue(node, clazz));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
     }
 
@@ -148,7 +190,7 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.readValue(string, clazz));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
     }
 
@@ -156,32 +198,34 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.readTree(string));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
     }
 
-    public static String writeValueAsString(Object value, boolean omitDefaults) throws JsonProcessingException {
+    public static String writeValueAsString(Object value, boolean omitDefaults) {
         try {
             return AccessController.doPrivilegedChecked(
                 () -> (omitDefaults ? defaulOmittingObjectMapper : objectMapper).writeValueAsString(value)
             );
         } catch (final Exception e) {
-            throw (JsonProcessingException) e;
+            throw (JacksonException) e;
         }
 
     }
 
-    public static String writeValueAsStringAndRedactSensitive(Object value) throws JsonProcessingException {
+    public static String writeValueAsStringAndRedactSensitive(Object value) {
 
         SimpleModule module = new SimpleModule();
         module.addSerializer(new ConfigMapSerializer());
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.registerModule(module);
+        ObjectMapper mapper = JsonMapper.builder()
+            .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .addModule(module)
+            .build();
 
         try {
             return AccessController.doPrivilegedChecked(() -> mapper.writeValueAsString(value));
         } catch (final Exception e) {
-            throw (JsonProcessingException) e;
+            throw (JacksonException) e;
         }
 
     }
@@ -190,7 +234,7 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.readValue(string, tr));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
 
     }
@@ -200,7 +244,7 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.readValue(string, jt));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
     }
 
@@ -208,7 +252,7 @@ public class DefaultObjectMapper {
         try {
             return AccessController.doPrivilegedChecked(() -> objectMapper.convertValue(jsonNode, jt));
         } catch (final Exception e) {
-            throw (IOException) e;
+            throw new IOException((JacksonException) e);
         }
     }
 
@@ -217,8 +261,10 @@ public class DefaultObjectMapper {
     }
 
     public static Set<String> getFields(Class<?> cls) {
-        return objectMapper.getSerializationConfig()
-            .introspect(getTypeFactory().constructType(cls))
+        final ClassIntrospector introspector = objectMapper.serializationConfig().classIntrospectorInstance();
+        final JavaType javaType = getTypeFactory().constructType(cls);
+        final AnnotatedClass annotatedClass = introspector.introspectClassAnnotations(javaType);
+        return introspector.introspectForSerialization(javaType, annotatedClass)
             .findProperties()
             .stream()
             .map(BeanPropertyDefinition::getName)

--- a/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
+++ b/src/main/java/org/opensearch/security/NonValidatingObjectMapper.java
@@ -28,29 +28,38 @@ package org.opensearch.security;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import org.opensearch.secure_sm.AccessController;
 
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.InjectableValues;
+import tools.jackson.databind.JavaType;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.type.TypeFactory;
+
 public class NonValidatingObjectMapper {
-    private static final ObjectMapper nonValidatingObjectMapper = new ObjectMapper();
+    private static volatile ObjectMapper nonValidatingObjectMapper;
 
     static {
-        nonValidatingObjectMapper.disable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
-        nonValidatingObjectMapper.setSerializationInclusion(Include.NON_NULL);
-        nonValidatingObjectMapper.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, false);
-        nonValidatingObjectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-        nonValidatingObjectMapper.configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false);
+        nonValidatingObjectMapper = JsonMapper.builder()
+            .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+            .disable(StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION)
+            .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+            .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL))
+            .configure(StreamReadFeature.STRICT_DUPLICATE_DETECTION, false)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+            .configure(DeserializationFeature.FAIL_ON_TRAILING_TOKENS, false)
+            .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+            .build();
     }
 
     public static void inject(final InjectableValues.Std injectableValues) {
-        nonValidatingObjectMapper.setInjectableValues(injectableValues);
+        nonValidatingObjectMapper = nonValidatingObjectMapper.rebuild().injectableValues(injectableValues).build();
     }
 
     public static <T> T readValue(String string, JavaType jt) throws IOException {

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -25,8 +25,6 @@ import com.google.common.collect.Sets;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.common.settings.Settings;
@@ -36,6 +34,8 @@ import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
+
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 import static org.opensearch.security.DefaultObjectMapper.getOrDefault;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT;
@@ -95,7 +95,7 @@ public class AuditConfig {
     private final boolean auditLogEnabled;
     @JsonProperty("audit")
     private final Filter filter;
-
+    @JsonProperty("compliance")
     private final ComplianceConfig compliance;
 
     public boolean isEnabled() {
@@ -224,7 +224,7 @@ public class AuditConfig {
 
         @JsonCreator
         @VisibleForTesting
-        public static Filter from(Map<String, Object> properties) throws JsonProcessingException {
+        public static Filter from(Map<String, Object> properties) {
             if (!FIELDS.containsAll(properties.keySet())) {
                 throw new UnrecognizedPropertyException(
                     null,

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -31,7 +31,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -79,8 +78,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportRequest;
 
 import com.flipkart.zjsonpatch.DiffFlags;
-import com.flipkart.zjsonpatch.JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
 import org.greenrobot.eventbus.Subscribe;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
@@ -616,9 +616,9 @@ public abstract class AbstractAuditLog implements AuditLog {
                     } catch (Exception e) {
                         log.error(e.toString());
                     }
-                    final JsonNode diffnode = JsonDiff.asJson(
-                        DefaultObjectMapper.objectMapper.readTree(originalSource),
-                        DefaultObjectMapper.objectMapper.readTree(currentSource)
+                    final JsonNode diffnode = Jackson3JsonDiff.asJson(
+                        DefaultObjectMapper.objectMapper().readTree(originalSource),
+                        DefaultObjectMapper.objectMapper().readTree(currentSource)
                     );
                     msg.addSecurityConfigWriteDiffSource(diffnode.size() == 0 ? "" : diffnode.toString(), id);
                 } else {
@@ -626,9 +626,9 @@ public abstract class AbstractAuditLog implements AuditLog {
                         originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
                     }
                     currentSource = XContentHelper.convertToJson(currentIndex.source(), false, XContentType.JSON);
-                    final JsonNode diffnode = JsonDiff.asJson(
-                        DefaultObjectMapper.objectMapper.readTree(originalSource),
-                        DefaultObjectMapper.objectMapper.readTree(currentSource)
+                    final JsonNode diffnode = Jackson3JsonDiff.asJson(
+                        DefaultObjectMapper.objectMapper().readTree(originalSource),
+                        DefaultObjectMapper.objectMapper().readTree(currentSource)
                     );
                     msg.addComplianceWriteDiffSource(diffnode.size() == 0 ? "" : diffnode.toString());
                 }
@@ -730,9 +730,9 @@ public abstract class AbstractAuditLog implements AuditLog {
 
                     // For delete, the "current" state is empty
                     String currentSource = "{}";
-                    final JsonNode diffnode = JsonDiff.asJson(
-                        DefaultObjectMapper.objectMapper.readTree(originalSource),
-                        DefaultObjectMapper.objectMapper.readTree(currentSource),
+                    final JsonNode diffnode = Jackson3JsonDiff.asJson(
+                        DefaultObjectMapper.objectMapper().readTree(originalSource),
+                        DefaultObjectMapper.objectMapper().readTree(currentSource),
                         EnumSet.noneOf(DiffFlags.class)
                     );
                     msg.addSecurityConfigWriteDiffSource(diffnode.size() == 0 ? "" : diffnode.toString(), id);
@@ -741,9 +741,9 @@ public abstract class AbstractAuditLog implements AuditLog {
 
                     // For delete, the "current" state is empty
                     String currentSource = "{}";
-                    final JsonNode diffnode = JsonDiff.asJson(
-                        DefaultObjectMapper.objectMapper.readTree(originalSource),
-                        DefaultObjectMapper.objectMapper.readTree(currentSource),
+                    final JsonNode diffnode = Jackson3JsonDiff.asJson(
+                        DefaultObjectMapper.objectMapper().readTree(originalSource),
+                        DefaultObjectMapper.objectMapper().readTree(currentSource),
                         EnumSet.noneOf(DiffFlags.class)
                     );
                     msg.addComplianceWriteDiffSource(diffnode.size() == 0 ? "" : diffnode.toString());

--- a/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/KeySetRetriever.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/KeySetRetriever.java
@@ -232,10 +232,8 @@ public class KeySetRetriever implements KeySetProvider {
                     throw new AuthenticatorUnavailableException("Error while getting " + openIdConnectEndpoint + ": Empty response entity");
                 }
 
-                OpenIdProviderConfiguration parsedEntity = DefaultObjectMapper.objectMapper.readValue(
-                    httpEntity.getContent(),
-                    OpenIdProviderConfiguration.class
-                );
+                OpenIdProviderConfiguration parsedEntity = DefaultObjectMapper.objectMapper()
+                    .readValue(httpEntity.getContent(), OpenIdProviderConfiguration.class);
 
                 return parsedEntity.getJwksUri();
 

--- a/src/main/java/org/opensearch/security/auth/http/saml/AuthTokenProcessorHandler.java
+++ b/src/main/java/org/opensearch/security/auth/http/saml/AuthTokenProcessorHandler.java
@@ -24,10 +24,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.xml.xpath.XPathExpressionException;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.logging.log4j.LogManager;
@@ -45,6 +41,7 @@ import org.opensearch.secure_sm.AccessController;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.api.AuthTokenProcessorAction;
 import org.opensearch.security.filter.SecurityResponse;
+import org.opensearch.tools.jackson.core.JsonParseException;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -59,6 +56,9 @@ import com.onelogin.saml2.exception.ValidationError;
 import com.onelogin.saml2.settings.Saml2Settings;
 import com.onelogin.saml2.util.Util;
 import org.joda.time.DateTime;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.security.authtoken.jwt.KeyPaddingUtil.padSecret;
 
@@ -176,10 +176,10 @@ class AuthTokenProcessorHandler {
 
             BytesReference bytesReference = restRequest.requiredContent();
 
-            JsonNode jsonRoot = DefaultObjectMapper.objectMapper.readTree(BytesReference.toBytes(bytesReference));
+            JsonNode jsonRoot = DefaultObjectMapper.objectMapper().readTree(BytesReference.toBytes(bytesReference));
 
             if (!(jsonRoot instanceof ObjectNode)) {
-                throw new JsonParseException(null, "Unexpected json format: " + jsonRoot);
+                throw new JsonParseException("Unexpected json format: " + jsonRoot);
             }
 
             if (((ObjectNode) jsonRoot).get("SAMLResponse") == null) {
@@ -189,14 +189,14 @@ class AuthTokenProcessorHandler {
 
             }
 
-            String samlResponseBase64 = ((ObjectNode) jsonRoot).get("SAMLResponse").asText();
+            String samlResponseBase64 = ((ObjectNode) jsonRoot).get("SAMLResponse").asString();
             String samlRequestId = ((ObjectNode) jsonRoot).get("RequestId") != null
-                ? ((ObjectNode) jsonRoot).get("RequestId").textValue()
+                ? ((ObjectNode) jsonRoot).get("RequestId").stringValue()
                 : null;
             String acsEndpoint = saml2Settings.getSpAssertionConsumerServiceUrl().toString();
 
-            if (((ObjectNode) jsonRoot).get("acsEndpoint") != null && ((ObjectNode) jsonRoot).get("acsEndpoint").textValue() != null) {
-                acsEndpoint = getAbsoluteAcsEndpoint(((ObjectNode) jsonRoot).get("acsEndpoint").textValue());
+            if (((ObjectNode) jsonRoot).get("acsEndpoint") != null && ((ObjectNode) jsonRoot).get("acsEndpoint").stringValue() != null) {
+                acsEndpoint = getAbsoluteAcsEndpoint(((ObjectNode) jsonRoot).get("acsEndpoint").stringValue());
             }
 
             AuthTokenProcessorAction.Response responseBody = this.handleImpl(
@@ -211,10 +211,10 @@ class AuthTokenProcessorHandler {
                 return Optional.empty();
             }
 
-            String responseBodyString = DefaultObjectMapper.objectMapper.writeValueAsString(responseBody);
+            String responseBodyString = DefaultObjectMapper.objectMapper().writeValueAsString(responseBody);
 
             return Optional.of(new SecurityResponse(HttpStatus.SC_OK, null, responseBodyString, XContentType.JSON.mediaType()));
-        } catch (JsonProcessingException e) {
+        } catch (JacksonException e) {
             log.warn("Error while parsing JSON for {}", restRequest.path(), e);
             return Optional.of(new SecurityResponse(HttpStatus.SC_BAD_REQUEST, "JSON could not be parsed"));
         }

--- a/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceConfig.java
@@ -47,8 +47,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -63,6 +61,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 import static org.opensearch.security.DefaultObjectMapper.getOrDefault;
 
@@ -228,7 +227,7 @@ public class ComplianceConfig {
 
     @VisibleForTesting
     @JsonCreator
-    public static ComplianceConfig from(Map<String, Object> properties, @JacksonInject Settings settings) throws JsonProcessingException {
+    public static ComplianceConfig from(Map<String, Object> properties, @JacksonInject Settings settings) {
         if (!FIELDS.containsAll(properties.keySet())) {
             throw new UnrecognizedPropertyException(
                 null,

--- a/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
+++ b/src/main/java/org/opensearch/security/configuration/ConfigurationLoaderSecurity7.java
@@ -34,7 +34,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -60,6 +59,8 @@ import org.opensearch.security.support.ConfigHelper;
 import org.opensearch.security.support.SecurityUtils;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 

--- a/src/main/java/org/opensearch/security/configuration/SecurityConfigDiffCalculator.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityConfigDiffCalculator.java
@@ -14,8 +14,6 @@ package org.opensearch.security.configuration;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,7 +21,9 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.configuration.SecurityConfigVersionDocument.HistoricSecurityConfig;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 
-import com.flipkart.zjsonpatch.JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Utility class to compute differences between two versions of security configurations
@@ -34,7 +34,7 @@ import com.flipkart.zjsonpatch.JsonDiff;
 public class SecurityConfigDiffCalculator {
     private static final Logger LOGGER = LogManager.getLogger(SecurityConfigDiffCalculator.class);
 
-    private static final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
+    private static final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper();
 
     public static boolean hasSecurityConfigChanged(
         Map<String, HistoricSecurityConfig<?>> oldConfig,
@@ -49,7 +49,7 @@ public class SecurityConfigDiffCalculator {
             JsonNode oldNode = buildConfigDataNode(oldConfig);
             JsonNode newNode = buildConfigDataNode(newConfig);
 
-            JsonNode diff = JsonDiff.asJson(oldNode, newNode);
+            JsonNode diff = Jackson3JsonDiff.asJson(oldNode, newNode);
 
             if (diff.isEmpty()) {
                 LOGGER.info("No changes detected in security configuration.");

--- a/src/main/java/org/opensearch/security/configuration/SecurityConfigVersionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/SecurityConfigVersionHandler.java
@@ -249,7 +249,7 @@ public class SecurityConfigVersionHandler implements ConfigurationChangeListener
                 }
 
                 if (dynamicConfig.get_meta() != null) {
-                    Map<String, Object> metaMap = DefaultObjectMapper.objectMapper.convertValue(dynamicConfig.get_meta(), Map.class);
+                    Map<String, Object> metaMap = DefaultObjectMapper.objectMapper().convertValue(dynamicConfig.get_meta(), Map.class);
                     configData.put("_meta", metaMap);
                 }
             }
@@ -309,7 +309,7 @@ public class SecurityConfigVersionHandler implements ConfigurationChangeListener
     private void writeSecurityConfigVersion(SecurityConfigVersionDocument document, long currentSeqNo, long currentPrimaryTerm)
         throws IOException {
         Map<String, Object> updatedDocMap = document.toMap();
-        String json = DefaultObjectMapper.objectMapper.writeValueAsString(updatedDocMap);
+        String json = DefaultObjectMapper.objectMapper().writeValueAsString(updatedDocMap);
 
         var indexRequest = new org.opensearch.action.index.IndexRequest(securityConfigVersionsIndex).id(
             "opensearch_security_config_versions"

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -19,10 +19,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -67,9 +63,13 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.node.NodeClient;
 
-import com.flipkart.zjsonpatch.JsonDiff;
-import com.flipkart.zjsonpatch.JsonPatch;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonPatch;
 import com.flipkart.zjsonpatch.JsonPatchApplicationException;
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.security.dlic.rest.api.RequestHandler.methodNotImplementedHandler;
 import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;
@@ -205,7 +205,7 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
                     final var entityAsJson = (ObjectNode) configurationAsJson.get(entityName);
                     return withJsonPatchException(
                         () -> endpointValidator.createRequestContentValidator(entityName)
-                            .validate(request, JsonPatch.apply(patchContent, entityAsJson), configurationAsJson.get(entityName))
+                            .validate(request, Jackson3JsonPatch.apply(patchContent, entityAsJson), configurationAsJson.get(entityName))
                             .map(
                                 patchedEntity -> endpointValidator.onConfigChange(
                                     SecurityConfiguration.of(patchedEntity, entityName, configuration)
@@ -239,8 +239,8 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
         final var configuration = securityConfiguration.configuration();
         final var configurationAsJson = (ObjectNode) Utils.convertJsonToJackson(configuration, true);
         return withIOException(() -> withJsonPatchException(() -> {
-            final var patchedConfigurationAsJson = JsonPatch.apply(patchContent, configurationAsJson);
-            JsonNode patch = JsonDiff.asJson(configurationAsJson, patchedConfigurationAsJson);
+            final var patchedConfigurationAsJson = Jackson3JsonPatch.apply(patchContent, configurationAsJson);
+            JsonNode patch = Jackson3JsonDiff.asJson(configurationAsJson, patchedConfigurationAsJson);
             if (patch.isEmpty()) {
                 return ValidationResult.error(RestStatus.OK, payload(RestStatus.OK, "No updates required"));
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -19,8 +19,6 @@ import java.util.Set;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
@@ -37,6 +35,10 @@ import org.opensearch.security.dlic.rest.validation.RequestContentValidator.Data
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.security.dlic.rest.api.RequestHandler.methodNotImplementedHandler;
 import static org.opensearch.security.dlic.rest.api.Responses.conflictMessage;
@@ -211,17 +213,16 @@ public class AuditApiAction extends AbstractApiAction {
 
     private static List<String> readReadonlyFieldsFromFile() {
         try {
-            final var readonlyFields = DefaultObjectMapper.YAML_MAPPER.readValue(
-                AuditApiAction.class.getResourceAsStream(STATIC_RESOURCE),
-                new TypeReference<Map<String, List<String>>>() {
-                }
-            ).get(READONLY_FIELD);
+            final var readonlyFields = DefaultObjectMapper.yamlMapper()
+                .readValue(AuditApiAction.class.getResourceAsStream(STATIC_RESOURCE), new TypeReference<Map<String, List<String>>>() {
+                })
+                .get(READONLY_FIELD);
             if (!AuditConfig.FIELD_PATHS.containsAll(readonlyFields)) {
                 throw new StaticResourceException("Invalid read-only field paths provided in static resource file " + STATIC_RESOURCE);
             }
             return readonlyFields;
 
-        } catch (IOException e) {
+        } catch (JacksonException e) {
             throw new StaticResourceException("Unable to load audit static resource file", e);
         }
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
@@ -25,10 +25,6 @@ import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,7 +54,11 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import com.flipkart.zjsonpatch.DiffFlags;
-import com.flipkart.zjsonpatch.JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;
 import static org.opensearch.security.dlic.rest.api.Responses.response;
@@ -222,7 +222,7 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
         return withIOException(() -> loadConfiguration(configType, false, false).map(activeRoles -> {
             final var activeRolesJson = Utils.convertJsonToJackson(activeRoles, true);
             final var defaultRolesJson = loadConfigFileAsJson(configType);
-            final var rawDiff = JsonDiff.asJson(activeRolesJson, defaultRolesJson, EnumSet.of(DiffFlags.OMIT_VALUE_ON_REMOVE));
+            final var rawDiff = Jackson3JsonDiff.asJson(activeRolesJson, defaultRolesJson, EnumSet.of(DiffFlags.OMIT_VALUE_ON_REMOVE));
             return ValidationResult.success(new Tuple<>(configType, filterRemoveOperations(rawDiff)));
         }));
     }
@@ -235,9 +235,9 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
                     filteredRoles.put(entity, (RoleV7) activeRoles.getCEntry(entity));
                 }
             }
-            final var filteredRolesJson = DefaultObjectMapper.objectMapper.valueToTree(filteredRoles);
+            final var filteredRolesJson = DefaultObjectMapper.objectMapper().valueToTree(filteredRoles);
             final var defaultRolesJson = loadEntitiesFromConfigFileAsJson(configType, entities);
-            final var rawDiff = JsonDiff.asJson(filteredRolesJson, defaultRolesJson, EnumSet.of(DiffFlags.OMIT_VALUE_ON_REMOVE));
+            final var rawDiff = Jackson3JsonDiff.asJson(filteredRolesJson, defaultRolesJson, EnumSet.of(DiffFlags.OMIT_VALUE_ON_REMOVE));
             return ValidationResult.success(new Tuple<>(configType, filterRemoveOperations(rawDiff)));
         }));
     }
@@ -294,16 +294,16 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
     }
 
     private static String pathRoot(final JsonNode node) {
-        return node.get("path").asText().split("/")[1];
+        return node.get("path").asString().split("/")[1];
     }
 
     private static boolean hasRootLevelPath(final JsonNode node) {
-        final var jsonPath = node.get("path").asText();
+        final var jsonPath = node.get("path").asString();
         return jsonPath.charAt(0) == '/' && !jsonPath.substring(1).contains("/");
     }
 
     private static boolean isRemoveOperation(final JsonNode node) {
-        return node.get("op").asText().equals("remove");
+        return node.get("op").asString().equals("remove");
     }
 
     private <T> SecurityDynamicConfiguration<T> loadYamlFile(final String filepath, final CType<T> cType) throws IOException {
@@ -336,7 +336,7 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
                         filteredEntities.put(entity, loadedConfiguration.getCEntry(entity));
                     }
                 }
-                return DefaultObjectMapper.objectMapper.valueToTree(filteredEntities);
+                return DefaultObjectMapper.objectMapper().valueToTree(filteredEntities);
             });
         } catch (final Exception e) {
             LOGGER.error("Error when loading configuration from file", e);
@@ -453,7 +453,7 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
             final var items = new HashMap<String, String>();
             differences.forEach(node -> {
                 final var item = pathRoot(node);
-                final var operation = node.get("op").asText();
+                final var operation = node.get("op").asString();
                 if (items.containsKey(item) && !items.get(item).equals(operation)) {
                     items.put(item, "modify");
                 } else {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -17,7 +17,6 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
@@ -40,6 +39,8 @@ import org.opensearch.security.user.UserFilterType;
 import org.opensearch.security.user.UserService;
 import org.opensearch.security.user.UserServiceException;
 import org.opensearch.threadpool.ThreadPool;
+
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.security.dlic.rest.api.Responses.badRequest;
 import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MultiTenancyConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MultiTenancyConfigApiAction.java
@@ -22,7 +22,6 @@ import java.util.stream.IntStream;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.cluster.service.ClusterService;
@@ -42,6 +41,8 @@ import org.opensearch.security.securityconf.impl.v7.ConfigV7.Authc;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.PUT;
@@ -222,10 +223,10 @@ public class MultiTenancyConfigApiAction extends AbstractApiAction {
 
     private void updateAndValidatesValues(final ConfigV7 config, final JsonNode jsonContent) {
         if (Objects.nonNull(jsonContent.findValue(DEFAULT_TENANT_JSON_PROPERTY))) {
-            config.dynamic.kibana.default_tenant = jsonContent.findValue(DEFAULT_TENANT_JSON_PROPERTY).asText();
+            config.dynamic.kibana.default_tenant = jsonContent.findValue(DEFAULT_TENANT_JSON_PROPERTY).asString();
         }
         if (Objects.nonNull(jsonContent.findValue(PRIVATE_TENANT_ENABLED_JSON_PROPERTY))) {
-            config.dynamic.kibana.private_tenant_enabled = jsonContent.findValue(PRIVATE_TENANT_ENABLED_JSON_PROPERTY).booleanValue();
+            config.dynamic.kibana.private_tenant_enabled = jsonContent.findValue(PRIVATE_TENANT_ENABLED_JSON_PROPERTY).asBoolean();
         }
         if (Objects.nonNull(jsonContent.findValue(MULTITENANCY_ENABLED_JSON_PROPERTY))) {
             config.dynamic.kibana.multitenancy_enabled = jsonContent.findValue(MULTITENANCY_ENABLED_JSON_PROPERTY).asBoolean();

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.cluster.service.ClusterService;
@@ -35,6 +34,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.v7.ConfigV7;
 import org.opensearch.security.support.SecurityJsonNode;
 import org.opensearch.threadpool.ThreadPool;
+
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.rest.RestRequest.Method.DELETE;
 import static org.opensearch.rest.RestRequest.Method.GET;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -19,8 +19,6 @@ import java.util.stream.StreamSupport;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.opensearch.cluster.service.ClusterService;
@@ -37,6 +35,9 @@ import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
+
+import tools.jackson.core.JsonPointer;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.security.dlic.rest.api.RequestHandler.methodNotImplementedHandler;
 import static org.opensearch.security.dlic.rest.support.Utils.OPENDISTRO_API_DEPRECATION_MESSAGE;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RollbackVersionApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RollbackVersionApiAction.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import com.google.common.collect.ImmutableList;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,7 +45,8 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
-import com.flipkart.zjsonpatch.JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR;
 import static org.opensearch.core.rest.RestStatus.NOT_FOUND;
@@ -340,10 +340,10 @@ public class RollbackVersionApiAction extends AbstractApiAction {
         }
 
         try {
-            JsonNode currentJson = DefaultObjectMapper.objectMapper.valueToTree(currentConfig.getCEntries());
-            JsonNode targetJson = DefaultObjectMapper.objectMapper.valueToTree(targetConfig.getCEntries());
+            JsonNode currentJson = DefaultObjectMapper.objectMapper().valueToTree(currentConfig.getCEntries());
+            JsonNode targetJson = DefaultObjectMapper.objectMapper().valueToTree(targetConfig.getCEntries());
 
-            JsonNode diff = JsonDiff.asJson(currentJson, targetJson);
+            JsonNode diff = Jackson3JsonDiff.asJson(currentJson, targetJson);
 
             if (!diff.isEmpty()) {
                 log.debug("Config difference detected: {}", diff.toString());

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfiguration.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfiguration.java
@@ -14,9 +14,9 @@ package org.opensearch.security.dlic.rest.api;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
+
+import tools.jackson.databind.JsonNode;
 
 public class SecurityConfiguration {
 

--- a/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/support/Utils.java
@@ -20,9 +20,6 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.opensearch.ExceptionsHelper;
@@ -45,6 +42,12 @@ import org.opensearch.secure_sm.AccessController;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.user.User;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.introspect.DefaultAccessorNamingStrategy;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 
@@ -69,7 +72,9 @@ public class Utils {
     public final static String OPENDISTRO_API_DEPRECATION_MESSAGE =
         "[_opendistro/_security] is a deprecated endpoint path. Please use _plugins/_security instead.";
 
-    private static final ObjectMapper internalMapper = new ObjectMapper();
+    private static final ObjectMapper internalMapper = JsonMapper.builder()
+        .accessorNaming(new DefaultAccessorNamingStrategy.Provider().withFirstCharAcceptance(true, true))
+        .build();
 
     public static Map<String, Object> convertJsonToxToStructuredMap(ToXContent jsonContent) {
         Map<String, Object> map = null;

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
@@ -22,9 +22,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -36,7 +33,11 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.DefaultObjectMapper;
 
-import com.flipkart.zjsonpatch.JsonDiff;
+import com.flipkart.zjsonpatch.Jackson3JsonDiff;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.security.dlic.rest.api.Responses.payload;
 import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_PASSWORD_VALIDATION_ERROR_MESSAGE;
@@ -61,12 +62,12 @@ public class RequestContentValidator implements ToXContent {
     }) {
         @Override
         public ValidationResult<JsonNode> validate(RestRequest request) {
-            return ValidationResult.success(DefaultObjectMapper.objectMapper.createObjectNode());
+            return ValidationResult.success(DefaultObjectMapper.objectMapper().createObjectNode());
         }
 
         @Override
         public ValidationResult<JsonNode> validate(RestRequest request, JsonNode jsonNode) {
-            return ValidationResult.success(DefaultObjectMapper.objectMapper.createObjectNode());
+            return ValidationResult.success(DefaultObjectMapper.objectMapper().createObjectNode());
         }
     };
 
@@ -221,7 +222,7 @@ public class RequestContentValidator implements ToXContent {
 
     public ValidationResult<JsonNode> validate(final RestRequest request, final JsonNode patchedContent, final JsonNode originalContent)
         throws IOException {
-        JsonNode patch = JsonDiff.asJson(originalContent, patchedContent);
+        JsonNode patch = Jackson3JsonDiff.asJson(originalContent, patchedContent);
         if (patch.isEmpty()) {
             return ValidationResult.error(RestStatus.OK, payload(RestStatus.OK, "No updates required"));
         }
@@ -251,7 +252,7 @@ public class RequestContentValidator implements ToXContent {
 
     protected ValidationResult<JsonNode> validateJsonKeys(final JsonNode jsonContent) {
         final Set<String> requestedKeys = new HashSet<>();
-        jsonContent.fieldNames().forEachRemaining(requestedKeys::add);
+        jsonContent.propertyNames().spliterator().forEachRemaining(requestedKeys::add);
         // mandatory settings, one of ...
         if (Collections.disjoint(requestedKeys, validationContext.mandatoryOrKeys())) {
             missingMandatoryOrKeys.addAll(validationContext.mandatoryOrKeys());
@@ -283,10 +284,10 @@ public class RequestContentValidator implements ToXContent {
         final Map<String, FieldConfiguration> fieldConfigs = validationContext.allowedKeysWithConfig();
         final boolean useEnhancedValidation = (fieldConfigs != null);
 
-        try (final JsonParser parser = DefaultObjectMapper.objectMapper.treeAsTokens(jsonContent)) {
+        try (final JsonParser parser = DefaultObjectMapper.objectMapper().treeAsTokens(jsonContent)) {
             JsonToken token;
             while ((token = parser.nextToken()) != null) {
-                if (token.equals(JsonToken.FIELD_NAME)) {
+                if (token.equals(JsonToken.PROPERTY_NAME)) {
                     String currentName = parser.currentName();
 
                     // Get data type from either FieldConfiguration or simple DataType map
@@ -367,7 +368,7 @@ public class RequestContentValidator implements ToXContent {
                     }
                 }
             }
-        } catch (final IOException ioe) {
+        } catch (final JacksonException ioe) {
             LOGGER.error("Couldn't create JSON for payload {}", jsonContent, ioe);
             this.validationError = ValidationError.BODY_NOT_PARSEABLE;
             return ValidationResult.error(RestStatus.BAD_REQUEST, this);
@@ -402,7 +403,7 @@ public class RequestContentValidator implements ToXContent {
                 if (node.isArray()) {
                     return true;
                 }
-            } else if (element.isContainerNode()) {
+            } else if (element.isContainer()) {
                 if (hasNullOrBlankArrayElement(element)) {
                     return true;
                 }
@@ -414,7 +415,7 @@ public class RequestContentValidator implements ToXContent {
     private ValidationResult<JsonNode> validatePassword(final RestRequest request, final JsonNode jsonContent) {
         if (jsonContent.has("password")) {
             final PasswordValidator passwordValidator = PasswordValidator.of(validationContext.settings());
-            final String password = jsonContent.get("password").asText();
+            final String password = jsonContent.get("password").asString();
             if (Strings.isNullOrEmpty(password)) {
                 this.validationError = ValidationError.INVALID_PASSWORD_TOO_SHORT;
                 return ValidationResult.error(RestStatus.BAD_REQUEST, this);
@@ -669,13 +670,13 @@ public class RequestContentValidator implements ToXContent {
             throw new IllegalArgumentException(fieldName + " must be an object");
         }
 
-        if (!node.fieldNames().hasNext()) {
+        if (!node.propertyNames().iterator().hasNext()) {
             throw new IllegalArgumentException(fieldName + " cannot be empty");
         }
 
-        node.fields().forEachRemaining(entry -> {
+        node.properties().spliterator().forEachRemaining(entry -> {
             JsonNode val = entry.getValue();
-            if (!val.isTextual() || val.asText().isEmpty()) {
+            if (!val.isString() || val.asString().isEmpty()) {
                 throw new IllegalArgumentException(fieldName + " for key [" + entry.getKey() + "] must be a non-empty string");
             }
         });

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilter.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/FlsDocumentFilter.java
@@ -19,10 +19,13 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Set;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonToken;
+import org.opensearch.common.xcontent.XObjectReadContext;
+import org.opensearch.common.xcontent.XObjectWriteContext;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.JsonToken;
+import tools.jackson.core.json.JsonFactory;
 
 /**
  * Implements document transformation for FLS and field masking using a chained streaming parser and generator.
@@ -55,7 +58,10 @@ class FlsDocumentFilter {
         FieldMasking.FieldMaskingRule fieldMaskingRule,
         Set<String> metaFields
     ) throws IOException {
-        try (JsonParser parser = JSON_FACTORY.createParser(in); JsonGenerator generator = JSON_FACTORY.createGenerator(out)) {
+        try (
+            JsonParser parser = JSON_FACTORY.createParser(XObjectReadContext.create(), in);
+            JsonGenerator generator = JSON_FACTORY.createGenerator(XObjectWriteContext.create(false), out)
+        ) {
             new FlsDocumentFilter(parser, generator, flsRule, fieldMaskingRule, metaFields).copy();
         }
     }
@@ -117,7 +123,7 @@ class FlsDocumentFilter {
                 if (metaFields.contains(fullQueuedFieldName)
                     || flsRule.isAllowedAssumingParentsAreAllowed(fullQueuedFieldName)
                     || (startOfObjectOrArray && flsRule.isObjectAllowedAssumingParentsAreAllowed(fullQueuedFieldName))) {
-                    generator.writeFieldName(parser.currentName());
+                    generator.writeName(parser.currentName());
                     fullCurrentName = fullQueuedFieldName;
                 } else {
                     // If the current field name is disallowed by FLS, we will skip the next token.
@@ -130,7 +136,7 @@ class FlsDocumentFilter {
             }
 
             switch (token) {
-                case FIELD_NAME:
+                case PROPERTY_NAME:
                     // We do not immediately write field names, because we need to know the type of the value
                     // when checking FLS rules
                     queuedFieldName = parser.currentName();
@@ -186,9 +192,9 @@ class FlsDocumentFilter {
                     FieldMasking.FieldMaskingRule.Field field = fieldMaskingRule.get(fullCurrentName);
 
                     if (field != null) {
-                        generator.writeString(field.apply(parser.getText()));
+                        generator.writeString(field.apply(parser.getString()));
                     } else {
-                        generator.writeString(parser.getText());
+                        generator.writeString(parser.getString());
                     }
                     break;
 

--- a/src/main/java/org/opensearch/security/resources/PluginDefaultRolesHelper.java
+++ b/src/main/java/org/opensearch/security/resources/PluginDefaultRolesHelper.java
@@ -13,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,6 +22,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
 import org.opensearch.security.spi.SecurityConfigExtension;
+
+import tools.jackson.databind.JsonNode;
 
 /**
  * Loads {@code default-roles.yml} from each plugin that implements {@link SecurityConfigExtension}.
@@ -64,7 +65,7 @@ public class PluginDefaultRolesHelper {
 
             try (var in = url.openStream()) {
                 String yaml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-                JsonNode node = DefaultObjectMapper.YAML_MAPPER.readTree(yaml);
+                JsonNode node = DefaultObjectMapper.yamlMapper().readTree(yaml);
                 if (node == null || node.isEmpty()) {
                     log.debug("Empty {} for {}", DEFAULT_ROLES_FILE, ext.getClass().getName());
                     continue;

--- a/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -64,6 +63,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.spi.resources.ResourceProvider;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.rest.RestRequest.Method.POST;
 import static org.opensearch.security.dlic.rest.api.Responses.badRequestMessage;

--- a/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
+++ b/src/main/java/org/opensearch/security/securityconf/DynamicConfigFactory.java
@@ -35,7 +35,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -69,6 +68,7 @@ import org.opensearch.transport.client.Client;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.EventBusBuilder;
 import org.greenrobot.eventbus.Logger.JavaLogger;
+import tools.jackson.databind.JsonNode;
 
 public class DynamicConfigFactory implements Initializable, ConfigurationChangeListener {
 
@@ -88,19 +88,16 @@ public class DynamicConfigFactory implements Initializable, ConfigurationChangeL
     }
 
     private void loadStaticConfig() throws IOException {
-        JsonNode staticRolesJsonNode = DefaultObjectMapper.YAML_MAPPER.readTree(
-            DynamicConfigFactory.class.getResourceAsStream("/static_config/static_roles.yml")
-        );
+        JsonNode staticRolesJsonNode = DefaultObjectMapper.yamlMapper()
+            .readTree(DynamicConfigFactory.class.getResourceAsStream("/static_config/static_roles.yml"));
         staticRoles = SecurityDynamicConfiguration.fromNode(staticRolesJsonNode, CType.ROLES, 2, 0, 0);
 
-        JsonNode staticActionGroupsJsonNode = DefaultObjectMapper.YAML_MAPPER.readTree(
-            DynamicConfigFactory.class.getResourceAsStream("/static_config/static_action_groups.yml")
-        );
+        JsonNode staticActionGroupsJsonNode = DefaultObjectMapper.yamlMapper()
+            .readTree(DynamicConfigFactory.class.getResourceAsStream("/static_config/static_action_groups.yml"));
         staticActionGroups = SecurityDynamicConfiguration.fromNode(staticActionGroupsJsonNode, CType.ACTIONGROUPS, 2, 0, 0);
 
-        JsonNode staticTenantsJsonNode = DefaultObjectMapper.YAML_MAPPER.readTree(
-            DynamicConfigFactory.class.getResourceAsStream("/static_config/static_tenants.yml")
-        );
+        JsonNode staticTenantsJsonNode = DefaultObjectMapper.yamlMapper()
+            .readTree(DynamicConfigFactory.class.getResourceAsStream("/static_config/static_tenants.yml"));
         staticTenants = SecurityDynamicConfiguration.fromNode(staticTenantsJsonNode, CType.TENANTS, 2, 0, 0);
     }
 

--- a/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfiguration.java
@@ -39,9 +39,6 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.core.xcontent.ToXContent;
@@ -51,6 +48,9 @@ import org.opensearch.security.securityconf.DynamicConfigFactory;
 import org.opensearch.security.securityconf.Hashed;
 import org.opensearch.security.securityconf.Hideable;
 import org.opensearch.security.securityconf.StaticDefinable;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
 public class SecurityDynamicConfiguration<T> implements ToXContent {
 
@@ -122,11 +122,12 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
     /**
      * For testing only
      */
-    public static <T> SecurityDynamicConfiguration<T> fromMap(Map<String, Object> map, CType<T> ctype) throws JsonProcessingException {
-        SecurityDynamicConfiguration<T> result = DefaultObjectMapper.objectMapper.convertValue(
-            map,
-            DefaultObjectMapper.getTypeFactory().constructParametricType(SecurityDynamicConfiguration.class, ctype.getConfigClass())
-        );
+    public static <T> SecurityDynamicConfiguration<T> fromMap(Map<String, Object> map, CType<T> ctype) {
+        SecurityDynamicConfiguration<T> result = DefaultObjectMapper.objectMapper()
+            .convertValue(
+                map,
+                DefaultObjectMapper.getTypeFactory().constructParametricType(SecurityDynamicConfiguration.class, ctype.getConfigClass())
+            );
         result.ctype = ctype;
         return result;
     }
@@ -160,12 +161,13 @@ public class SecurityDynamicConfiguration<T> implements ToXContent {
     /**
      * For testing only
      */
-    public static <T> SecurityDynamicConfiguration<T> fromYaml(String yaml, CType<T> ctype) throws JsonProcessingException {
+    public static <T> SecurityDynamicConfiguration<T> fromYaml(String yaml, CType<T> ctype) {
         Class<T> implementationClass = ctype.getConfigClass();
-        SecurityDynamicConfiguration<T> result = DefaultObjectMapper.YAML_MAPPER.readValue(
-            yaml,
-            DefaultObjectMapper.getTypeFactory().constructParametricType(SecurityDynamicConfiguration.class, implementationClass)
-        );
+        SecurityDynamicConfiguration<T> result = DefaultObjectMapper.yamlMapper()
+            .readValue(
+                yaml,
+                DefaultObjectMapper.getTypeFactory().constructParametricType(SecurityDynamicConfiguration.class, implementationClass)
+            );
         result.ctype = ctype;
         result.version = 2;
         return result;

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/ConfigV7.java
@@ -39,14 +39,13 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auth.internal.InternalAuthenticationBackend;
 import org.opensearch.security.securityconf.impl.DashboardSignInOption;
 import org.opensearch.security.setting.DeprecatedSettings;
+
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 public class ConfigV7 {
 
@@ -221,11 +220,7 @@ public class ConfigV7 {
 
         @JsonIgnore
         public String asJson() {
-            try {
-                return DefaultObjectMapper.writeValueAsString(this, false);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            return DefaultObjectMapper.writeValueAsString(this, false);
         }
     }
 
@@ -302,7 +297,7 @@ public class ConfigV7 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+        public void unknownPropertiesHandler(String name, Object value) {
             switch (name) {
                 case "transport_enabled":
                     DeprecatedSettings.logCustomDeprecationMessage(
@@ -340,11 +335,7 @@ public class ConfigV7 {
 
         @JsonIgnore
         public String configAsJson() {
-            try {
-                return DefaultObjectMapper.writeValueAsString(config, false);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            return DefaultObjectMapper.writeValueAsString(config, false);
         }
 
         @Override
@@ -364,11 +355,7 @@ public class ConfigV7 {
 
         @JsonIgnore
         public String configAsJson() {
-            try {
-                return DefaultObjectMapper.writeValueAsString(config, false);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            return DefaultObjectMapper.writeValueAsString(config, false);
         }
 
         @Override
@@ -388,11 +375,7 @@ public class ConfigV7 {
 
         @JsonIgnore
         public String configAsJson() {
-            try {
-                return DefaultObjectMapper.writeValueAsString(config, false);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            return DefaultObjectMapper.writeValueAsString(config, false);
         }
 
         @Override
@@ -445,7 +428,7 @@ public class ConfigV7 {
         }
 
         @JsonAnySetter
-        public void unknownPropertiesHandler(String name, Object value) throws JsonMappingException {
+        public void unknownPropertiesHandler(String name, Object value) {
             switch (name) {
                 case "transport_enabled":
                     DeprecatedSettings.logCustomDeprecationMessage(
@@ -476,11 +459,7 @@ public class ConfigV7 {
 
         @JsonIgnore
         public String configAsJson() {
-            try {
-                return DefaultObjectMapper.writeValueAsString(this, false);
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException(e);
-            }
+            return DefaultObjectMapper.writeValueAsString(this, false);
         }
 
         public Boolean isEnabled() {

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
@@ -85,7 +85,7 @@ public class RoleV7 implements Hideable, StaticDefinable {
     }
 
     public static RoleV7 fromYaml(Reader yamlReader) throws IOException {
-        return DefaultObjectMapper.YAML_MAPPER.readValue(yamlReader, RoleV7.class);
+        return DefaultObjectMapper.yamlMapper().readValue(yamlReader, RoleV7.class);
     }
 
     /**

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -30,7 +30,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
@@ -92,6 +91,7 @@ import org.opensearch.watcher.ResourceWatcherService;
 
 import io.netty.handler.ssl.OpenSsl;
 import io.netty.util.internal.PlatformDependent;
+import tools.jackson.databind.InjectableValues;
 
 import static org.opensearch.common.network.NetworkModule.TRANSPORT_SSL_ENFORCE_HOSTNAME_VERIFICATION_KEY;
 import static org.opensearch.security.ssl.util.SSLConfigConstants.SECURITY_SSL_AUX_CLIENTAUTH_MODE;

--- a/src/main/java/org/opensearch/security/support/ConfigHelper.java
+++ b/src/main/java/org/opensearch/security/support/ConfigHelper.java
@@ -132,7 +132,7 @@ public class ConfigHelper {
     }
 
     public static String createEmptySdcYaml(CType<?> cType, int configVersion) throws Exception {
-        return DefaultObjectMapper.YAML_MAPPER.writeValueAsString(createEmptySdc(cType, configVersion));
+        return DefaultObjectMapper.yamlMapper().writeValueAsString(createEmptySdc(cType, configVersion));
     }
 
     public static BytesReference readXContent(final Reader reader, final MediaType mediaType) throws IOException {
@@ -161,7 +161,7 @@ public class ConfigHelper {
     ) throws IOException {
         try {
             return SecurityDynamicConfiguration.fromNode(
-                DefaultObjectMapper.YAML_MAPPER.readTree(yamlReader),
+                DefaultObjectMapper.yamlMapper().readTree(yamlReader),
                 ctype,
                 version,
                 seqNo,

--- a/src/main/java/org/opensearch/security/support/JsonFlattener.java
+++ b/src/main/java/org/opensearch/security/support/JsonFlattener.java
@@ -10,14 +10,14 @@
 
 package org.opensearch.security.support;
 
-import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-
 import org.opensearch.core.common.Strings;
 import org.opensearch.security.DefaultObjectMapper;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
 
 public class JsonFlattener {
 
@@ -25,11 +25,11 @@ public class JsonFlattener {
         try {
             final TypeReference<Map<String, Object>> typeReference = new TypeReference<>() {
             };
-            final Map<String, Object> jsonMap = DefaultObjectMapper.objectMapper.readValue(jsonString, typeReference);
+            final Map<String, Object> jsonMap = DefaultObjectMapper.objectMapper().readValue(jsonString, typeReference);
             final Map<String, Object> flattenMap = new LinkedHashMap<>();
             flattenEntries("", jsonMap.entrySet(), flattenMap);
             return flattenMap;
-        } catch (final IOException ioe) {
+        } catch (final JacksonException ioe) {
             throw new IllegalArgumentException("Unparseable json", ioe);
         }
     }

--- a/src/main/java/org/opensearch/security/support/SecurityJsonNode.java
+++ b/src/main/java/org/opensearch/security/support/SecurityJsonNode.java
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeType;
-
 import org.opensearch.security.DefaultObjectMapper;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.JsonNodeType;
 
 public final class SecurityJsonNode {
 

--- a/src/main/java/org/opensearch/security/support/YamlConfigReader.java
+++ b/src/main/java/org/opensearch/security/support/YamlConfigReader.java
@@ -84,11 +84,11 @@ public final class YamlConfigReader {
     }
 
     public static String emptyYamlConfigFor(final CType<?> cType) throws IOException {
-        return DefaultObjectMapper.YAML_MAPPER.writeValueAsString(emptyConfigFor(cType));
+        return DefaultObjectMapper.yamlMapper().writeValueAsString(emptyConfigFor(cType));
     }
 
     private static void validateYamlContent(final CType<?> cType, final InputStream in) throws IOException {
-        SecurityDynamicConfiguration.fromNode(DefaultObjectMapper.YAML_MAPPER.readTree(in), cType, DEFAULT_CONFIG_VERSION, -1, -1);
+        SecurityDynamicConfiguration.fromNode(DefaultObjectMapper.yamlMapper().readTree(in), cType, DEFAULT_CONFIG_VERSION, -1, -1);
     }
 
 }

--- a/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
+++ b/src/main/java/org/opensearch/security/tools/AuditConfigMigrater.java
@@ -103,7 +103,7 @@ public class AuditConfigMigrater {
             );
 
             // write audit.yml.example
-            DefaultObjectMapper.YAML_MAPPER.writeValue(new File(auditOutput), result);
+            DefaultObjectMapper.yamlMapper().writeValue(new File(auditOutput), result);
 
             // remove all deprecated values opensearch.yml
             System.out.println("Looking for deprecated keys in " + source);

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -60,8 +60,6 @@ import com.google.common.collect.Iterators;
 import com.google.common.io.ByteSource;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Files;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -129,6 +127,9 @@ import org.opensearch.security.support.ConfigHelper;
 import org.opensearch.security.support.PemKeyReader;
 import org.opensearch.security.support.SecurityJsonNode;
 import org.opensearch.transport.client.transport.NoNodeAvailableException;
+
+import tools.jackson.databind.InjectableValues;
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.core.xcontent.DeprecationHandler.THROW_UNSUPPORTED_OPERATION;
 import static org.opensearch.security.support.SecurityUtils.replaceEnvVars;
@@ -542,7 +543,7 @@ public class SecurityAdmin {
                 return (-1);
             }
 
-            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper.readTree(whoAmIRes.getEntity().getContent());
+            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getEntity().getContent());
             System.out.println("Connected as " + whoAmIResNode.get("dn"));
 
             if (!whoAmIResNode.get("is_admin").asBoolean()) {
@@ -590,7 +591,7 @@ public class SecurityAdmin {
                     return (-1);
                 }
 
-                JsonNode resNode = DefaultObjectMapper.objectMapper.readTree(res.getEntity().getContent());
+                JsonNode resNode = DefaultObjectMapper.objectMapper().readTree(res.getEntity().getContent());
 
                 if (resNode.get("configupdate_response").get("has_failures").asBoolean()) {
                     System.out.println("ERR: Unable to reload config due to " + responseToString(res, false) + "/" + resNode);
@@ -611,7 +612,7 @@ public class SecurityAdmin {
                     return (-1);
                 }
 
-                JsonNode resNode = DefaultObjectMapper.objectMapper.readTree(res.getEntity().getContent());
+                JsonNode resNode = DefaultObjectMapper.objectMapper().readTree(res.getEntity().getContent());
                 if (resNode.get("configupdate_response").get("has_failures").asBoolean()) {
                     System.out.println("ERR: Unable to reload config due to " + responseToString(res, false) + "/" + resNode);
                     return -1;
@@ -641,7 +642,7 @@ public class SecurityAdmin {
                     return (-1);
                 }
 
-                JsonNode resNode = DefaultObjectMapper.objectMapper.readTree(res.getEntity().getContent());
+                JsonNode resNode = DefaultObjectMapper.objectMapper().readTree(res.getEntity().getContent());
 
                 if (resNode.get("configupdate_response").get("has_failures").asBoolean()) {
                     System.out.println("ERR: Unable to reload config due to " + responseToString(res, false) + "/" + resNode);
@@ -897,7 +898,7 @@ public class SecurityAdmin {
             System.out.println("Unable to check configupdate response because return code was " + response.getStatusLine());
         }
 
-        JsonNode resNode = DefaultObjectMapper.objectMapper.readTree(response.getEntity().getContent());
+        JsonNode resNode = DefaultObjectMapper.objectMapper().readTree(response.getEntity().getContent());
 
         if (resNode.at("/configupdate_response/has_failures").asBoolean()) {
             System.out.println(
@@ -1251,7 +1252,7 @@ public class SecurityAdmin {
             return -1;
         }
 
-        JsonNode resNode = DefaultObjectMapper.objectMapper.readTree(res.getEntity().getContent());
+        JsonNode resNode = DefaultObjectMapper.objectMapper().readTree(res.getEntity().getContent());
 
         int nodeCount = Iterators.size(resNode.at("/nodes").iterator());
 
@@ -1261,15 +1262,17 @@ public class SecurityAdmin {
 
             Version maxVersion = Version.fromString(
                 Arrays.stream(nodeVersions)
-                    .max((n1, n2) -> Version.fromString(n1.asText()).compareTo(Version.fromString(n2.asText())))
+                    .map(n -> n.at("/version"))
+                    .max((n1, n2) -> Version.fromString(n1.asString()).compareTo(Version.fromString(n2.asString())))
                     .get()
-                    .asText()
+                    .asString()
             );
             Version minVersion = Version.fromString(
                 Arrays.stream(nodeVersions)
-                    .min((n1, n2) -> Version.fromString(n1.asText()).compareTo(Version.fromString(n2.asText())))
+                    .map(n -> n.at("/version"))
+                    .min((n1, n2) -> Version.fromString(n1.asString()).compareTo(Version.fromString(n2.asString())))
                     .get()
-                    .asText()
+                    .asString()
             );
 
             if (!maxVersion.equals(minVersion)) {
@@ -1397,7 +1400,7 @@ public class SecurityAdmin {
             System.out.println("ERR: No such file " + file.getAbsolutePath());
             return null;
         }
-        final JsonNode jsonNode = DefaultObjectMapper.YAML_MAPPER.readTree(file);
+        final JsonNode jsonNode = DefaultObjectMapper.yamlMapper().readTree(file);
         return new SecurityJsonNode(jsonNode).get("_meta").get("type").asString();
     }
 
@@ -1594,7 +1597,7 @@ public class SecurityAdmin {
             String value = byteSource.asCharSource(Charsets.UTF_8).read();
 
             if (prettyJson) {
-                return DefaultObjectMapper.objectMapper.readTree(value).toPrettyString();
+                return DefaultObjectMapper.objectMapper().readTree(value).toPrettyString();
             }
 
             return value;

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -22,9 +22,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.Strings;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
@@ -35,8 +32,11 @@ import org.opensearch.security.support.ConfigConstants;
 
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
 
-import static org.opensearch.security.DefaultObjectMapper.YAML_MAPPER;
+import static org.opensearch.security.DefaultObjectMapper.yamlMapper;
 import static org.opensearch.security.tools.democonfig.Installer.certificateGenerator;
 
 /**
@@ -245,9 +245,9 @@ public class SecuritySettingsConfigurer {
      * @throws IOException if there was an error while reading the file
      */
     private boolean isAdminPasswordSetToAdmin(String internalUsersFile) throws IOException {
-        JsonNode internalUsers = YAML_MAPPER.readTree(new FileInputStream(internalUsersFile));
+        JsonNode internalUsers = yamlMapper().readTree(new FileInputStream(internalUsersFile));
         return internalUsers.has("admin")
-            && passwordHasher.check(DEFAULT_ADMIN_PASSWORD.toCharArray(), internalUsers.get("admin").get("hash").asText());
+            && passwordHasher.check(DEFAULT_ADMIN_PASSWORD.toCharArray(), internalUsers.get("admin").get("hash").asString());
     }
 
     /**
@@ -265,7 +265,7 @@ public class SecuritySettingsConfigurer {
         }
 
         try {
-            var map = YAML_MAPPER.readValue(new File(internalUsersFile), new TypeReference<Map<String, LinkedHashMap<String, Object>>>() {
+            var map = yamlMapper().readValue(new File(internalUsersFile), new TypeReference<Map<String, LinkedHashMap<String, Object>>>() {
             });
             var admin = map.get("admin");
             if (admin != null) {
@@ -274,8 +274,8 @@ public class SecuritySettingsConfigurer {
             }
 
             // Write the updated map back to the internal_users.yml file
-            YAML_MAPPER.writeValue(new File(internalUsersFile), map);
-        } catch (IOException e) {
+            yamlMapper().writeValue(new File(internalUsersFile), map);
+        } catch (JacksonException e) {
             throw new IOException("Unable to update the internal users file with the hashed password.");
         }
     }
@@ -389,13 +389,7 @@ public class SecuritySettingsConfigurer {
      * @throws IOException if there was exception reading the file
      */
     static boolean isKeyPresentInYMLFile(String filePath, String key) throws IOException {
-        JsonNode node;
-        try {
-            node = YAML_MAPPER.readTree(new File(filePath));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
+        final JsonNode node = yamlMapper().readTree(new File(filePath));
         return node.has(key);
     }
 

--- a/src/main/java/org/opensearch/security/user/UserService.java
+++ b/src/main/java/org/opensearch/security/user/UserService.java
@@ -25,9 +25,6 @@ import java.util.Random;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -57,6 +54,9 @@ import org.opensearch.transport.client.Client;
 import org.passay.CharacterRule;
 import org.passay.EnglishCharacterData;
 import org.passay.PasswordGenerator;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * This class handles user registration and operations on behalf of the Security Plugin.
@@ -301,7 +301,7 @@ public class UserService {
             authToken = Base64.getUrlEncoder().encodeToString((accountName + ":" + plainTextPassword).getBytes(StandardCharsets.UTF_8));
             return new BasicAuthToken("Basic " + authToken);
 
-        } catch (JsonProcessingException ex) {
+        } catch (JacksonException ex) {
             throw new UserServiceException(FAILED_ACCOUNT_RETRIEVAL_MESSAGE);
         } catch (Exception e) {
             throw new UserServiceException(AUTH_TOKEN_GENERATION_MESSAGE);

--- a/src/test/java/org/opensearch/security/HttpIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/HttpIntegrationTests.java
@@ -30,7 +30,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.core5.http.NoHttpResponseException;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.http.HttpStatus;
@@ -56,6 +55,8 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -29,7 +29,6 @@ package org.opensearch.security;
 import java.io.File;
 import java.util.Iterator;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpVersion;
@@ -60,6 +59,8 @@ import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -145,7 +146,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
             // Should be using HTTP/2 by default
             assertThat(HttpVersion.HTTP_2, is(whoAmIRes.getStatusLine().getProtocolVersion()));
-            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper.readTree(whoAmIRes.getEntity().getContent());
+            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getEntity().getContent());
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
             assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_admin").asBoolean());
@@ -179,7 +180,7 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
             // The HTTP/1.1 is forced and should be used instead
             assertThat(whoAmIRes.getStatusLine().getProtocolVersion(), is(HttpVersion.HTTP_1_1));
-            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper.readTree(whoAmIRes.getEntity().getContent());
+            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getEntity().getContent());
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
             assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_admin").asBoolean());

--- a/src/test/java/org/opensearch/security/IntegrationTests.java
+++ b/src/test/java/org/opensearch/security/IntegrationTests.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -62,6 +61,7 @@ import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.transport.client.Client;
 
 import org.mockito.Mockito;
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/UserServiceUnitTests.java
+++ b/src/test/java/org/opensearch/security/UserServiceUnitTests.java
@@ -17,9 +17,6 @@ import java.nio.file.Files;
 import java.util.Optional;
 
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,6 +39,9 @@ import org.passay.CharacterRule;
 import org.passay.EnglishCharacterData;
 import org.passay.LengthRule;
 import org.passay.PasswordData;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.dataformat.yaml.YAMLFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogUnitTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AbstractAuditlogUnitTest.java
@@ -14,8 +14,6 @@ package org.opensearch.security.auditlog;
 import java.util.Arrays;
 import java.util.Collection;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.config.AuditConfig;
@@ -25,6 +23,8 @@ import org.opensearch.security.test.DynamicSecurityConfig;
 import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.opensearch.security.auditlog.config.AuditConfig.DEPRECATED_KEYS;
 
@@ -106,10 +106,10 @@ public abstract class AbstractAuditlogUnitTest extends SingleClusterTest {
             throw new IllegalArgumentException("json is either null or empty");
         }
 
-        JsonNode node = DefaultObjectMapper.objectMapper.readTree(json);
+        JsonNode node = DefaultObjectMapper.objectMapper().readTree(json);
 
         if (node.get("audit_request_body") != null) {
-            DefaultObjectMapper.objectMapper.readTree(node.get("audit_request_body").asText());
+            DefaultObjectMapper.objectMapper().readTree(node.get("audit_request_body").asText());
         }
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/AuditTestUtils.java
+++ b/src/test/java/org/opensearch/security/auditlog/AuditTestUtils.java
@@ -13,8 +13,6 @@ package org.opensearch.security.auditlog;
 
 import java.nio.file.Path;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
@@ -26,6 +24,8 @@ import org.opensearch.security.auditlog.impl.AuditLogImpl;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -46,13 +46,13 @@ public class AuditTestUtils {
         rh.keystore = keystore;
     }
 
-    public static String createAuditPayload(final Settings settings) throws JsonProcessingException {
+    public static String createAuditPayload(final Settings settings) {
         final ObjectMapper objectMapper = new ObjectMapper();
         final AuditConfig audit = AuditConfig.from(settings);
         return objectMapper.writeValueAsString(audit);
     }
 
-    public static String createAuditPayload(final AuditConfig audit) throws JsonProcessingException {
+    public static String createAuditPayload(final AuditConfig audit) {
         final ObjectMapper objectMapper = new ObjectMapper();
         return objectMapper.writeValueAsString(audit);
     }

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -17,10 +17,6 @@ import java.util.EnumSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,6 +28,11 @@ import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.WildcardMatcher;
 
+import tools.jackson.databind.InjectableValues;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.opensearch.security.auditlog.impl.AuditCategory.AUTHENTICATED;
@@ -42,14 +43,14 @@ import static org.junit.Assert.assertTrue;
 
 public class AuditConfigSerializeTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private ObjectMapper objectMapper;
     private final WildcardMatcher DEFAULT_IGNORED_USER = WildcardMatcher.from(AuditConfig.DEFAULT_IGNORED_USERS);
 
     @Before
     public void setUp() {
         InjectableValues.Std iv = new InjectableValues.Std();
         iv.addValue(Settings.class, Settings.EMPTY);
-        objectMapper.setInjectableValues(iv);
+        objectMapper = JsonMapper.builder().injectableValues(iv).build();
     }
 
     @Test
@@ -336,10 +337,9 @@ public class AuditConfigSerializeTest {
                 "test-auditlog-index"
             )
             .build();
-        final ObjectMapper customObjectMapper = new ObjectMapper();
         InjectableValues.Std iv = new InjectableValues.Std();
         iv.addValue(Settings.class, settings);
-        customObjectMapper.setInjectableValues(iv);
+        final ObjectMapper customObjectMapper = JsonMapper.builder().injectableValues(iv).build();
 
         final XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()
             .startObject()
@@ -381,7 +381,7 @@ public class AuditConfigSerializeTest {
         assertThat(configCompliance.getAuditLogIndex(), is("test-auditlog-index"));
     }
 
-    private boolean compareJson(final String json1, final String json2) throws JsonProcessingException {
+    private boolean compareJson(final String json1, final String json2) {
         ObjectNode objectNode1 = objectMapper.readValue(json1, ObjectNode.class);
         ObjectNode objectNode2 = objectMapper.readValue(json2, ObjectNode.class);
         return objectNode1.equals(objectNode2);

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditMessageTest.java
@@ -19,8 +19,6 @@ import java.util.Map;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,6 +38,8 @@ import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.security.filter.SecurityRequestFactory;
 import org.opensearch.security.securityconf.impl.CType;
+
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -237,11 +237,7 @@ public class AuditMessageTest {
     }
 
     private static String getSplitMessageId(final String message) {
-        try {
-            return objectMapper.readTree(message).get(SPLIT_MESSAGE_IDENTIFIER).asText();
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return objectMapper.readTree(message).get(SPLIT_MESSAGE_IDENTIFIER).asText();
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/auth/http/saml/HTTPSamlAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/saml/HTTPSamlAuthenticatorTest.java
@@ -32,7 +32,6 @@ import java.util.regex.Pattern;
 import javax.net.ssl.KeyManagerFactory;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -60,6 +59,7 @@ import org.opensearch.security.util.FakeRestRequest;
 
 import com.nimbusds.jwt.SignedJWT;
 import org.opensaml.saml.saml2.core.NameIDType;
+import tools.jackson.core.type.TypeReference;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -148,11 +148,9 @@ public class HTTPSamlAuthenticatorTest {
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
 
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -190,11 +188,9 @@ public class HTTPSamlAuthenticatorTest {
             RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
 
             String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-            HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-                responseJson,
-                new TypeReference<HashMap<String, Object>>() {
-                }
-            );
+            HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+                .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+                });
             String authorization = (String) response.get("authorization");
 
             Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -244,11 +240,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -287,11 +281,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -333,11 +325,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -378,11 +368,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -423,11 +411,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -465,11 +451,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -525,11 +509,9 @@ public class HTTPSamlAuthenticatorTest {
             "/opendistrosecurity/saml/acs/idpinitiated"
         );
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -659,11 +641,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -701,11 +681,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -750,11 +728,9 @@ public class HTTPSamlAuthenticatorTest {
 
         RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
         String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-        HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-            responseJson,
-            new TypeReference<HashMap<String, Object>>() {
-            }
-        );
+        HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+            .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+            });
         String authorization = (String) response.get("authorization");
 
         Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);
@@ -870,11 +846,9 @@ public class HTTPSamlAuthenticatorTest {
 
             RestRequest tokenRestRequest = buildTokenExchangeRestRequest(encodedSamlResponse, authenticateHeaders);
             String responseJson = getResponse(samlAuthenticator, tokenRestRequest);
-            HashMap<String, Object> response = DefaultObjectMapper.objectMapper.readValue(
-                responseJson,
-                new TypeReference<HashMap<String, Object>>() {
-                }
-            );
+            HashMap<String, Object> response = DefaultObjectMapper.objectMapper()
+                .readValue(responseJson, new TypeReference<HashMap<String, Object>>() {
+                });
             String authorization = (String) response.get("authorization");
 
             Assert.assertNotNull("Expected authorization attribute in JSON: " + responseJson, authorization);

--- a/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
+++ b/src/test/java/org/opensearch/security/configuration/ConfigurationRepositoryTest.java
@@ -20,7 +20,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,6 +76,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.OngoingStubbing;
+import tools.jackson.databind.InjectableValues;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractApiActionValidationTest.java
@@ -14,8 +14,6 @@ package org.opensearch.security.dlic.rest.api;
 import java.io.IOException;
 import java.util.List;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +36,8 @@ import org.opensearch.threadpool.ThreadPool;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +65,7 @@ public abstract class AbstractApiActionValidationTest {
 
     SecurityDynamicConfiguration<RoleV7> rolesConfiguration;
 
-    ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
+    ObjectMapper objectMapper = DefaultObjectMapper.objectMapper();
 
     PasswordHasher passwordHasher;
 
@@ -87,7 +87,7 @@ public abstract class AbstractApiActionValidationTest {
     }
 
     void setupRolesConfiguration() throws IOException {
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         final var config = objectMapper.createObjectNode();
         config.set("_meta", objectMapper.createObjectNode().put("type", CType.ROLES.toLCString()).put("config_version", 2));
         config.set("kibana_read_only", objectMapper.createObjectNode().put("reserved", true));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AbstractRestApiUnitTest.java
@@ -15,9 +15,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hc.core5.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -31,6 +28,9 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -247,14 +247,14 @@ public abstract class AbstractRestApiUnitTest extends SingleClusterTest {
         assertThat(HttpStatus.SC_OK, is(rh.executeGetRequest("*/_search?pretty", encodeBasicHeader("admin", "admin")).getStatusCode()));
     }
 
-    String createRestAdminPermissionsPayload(String... additionPerms) throws JsonProcessingException {
-        final ObjectNode rootNode = DefaultObjectMapper.objectMapper.createObjectNode();
+    String createRestAdminPermissionsPayload(String... additionPerms) {
+        final ObjectNode rootNode = DefaultObjectMapper.objectMapper().createObjectNode();
         rootNode.set("cluster_permissions", clusterPermissionsForRestAdmin(additionPerms));
-        return DefaultObjectMapper.objectMapper.writeValueAsString(rootNode);
+        return DefaultObjectMapper.objectMapper().writeValueAsString(rootNode);
     }
 
     ArrayNode clusterPermissionsForRestAdmin(String... additionPerms) {
-        final ArrayNode permissionsArray = DefaultObjectMapper.objectMapper.createArrayNode();
+        final ArrayNode permissionsArray = DefaultObjectMapper.objectMapper().createArrayNode();
         for (final Map.Entry<
             Endpoint,
             RestApiAdminPrivilegesEvaluator.PermissionBuilder> entry : RestApiAdminPrivilegesEvaluator.ENDPOINTS_WITH_PERMISSIONS

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AccountApiActionConfigValidationsTest.java
@@ -9,13 +9,13 @@
  */
 package org.opensearch.security.dlic.rest.api;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.securityconf.impl.v7.InternalUserV7;
 
 import org.mockito.Mockito;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AllowlistApiTest.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.hc.core5.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
@@ -31,6 +30,8 @@ import org.opensearch.security.filter.SecurityRestFilter;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.fasterxml.jackson.databind.InjectableValues;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -27,6 +26,8 @@ import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.util.FakeRestRequest;
+
+import tools.jackson.databind.InjectableValues;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
@@ -20,10 +20,6 @@ import java.util.stream.Collectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.hc.core5.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.After;
@@ -38,6 +34,11 @@ import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anyOf;
@@ -112,7 +113,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             AuditConfig.Filter.from(ImmutableMap.of("disabled_rest_categories", testCategories)),
             ComplianceConfig.DEFAULT
         );
-        final ObjectNode json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
+        final ObjectNode json = DefaultObjectMapper.objectMapper().valueToTree(auditConfig);
 
         testPutRequest(json, HttpStatus.SC_OK, true);
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
@@ -133,7 +134,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             AuditConfig.Filter.from(ImmutableMap.of("disabled_rest_categories", ImmutableList.of("INDEX_EVENT", "COMPLIANCE_DOC_READ"))),
             ComplianceConfig.DEFAULT
         );
-        ObjectNode json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
+        ObjectNode json = DefaultObjectMapper.objectMapper().valueToTree(auditConfig);
         RestHelper.HttpResponse response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
@@ -155,7 +156,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             ),
             ComplianceConfig.DEFAULT
         );
-        json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
+        json = DefaultObjectMapper.objectMapper().valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
 
@@ -167,7 +168,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             ),
             ComplianceConfig.DEFAULT
         );
-        json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
+        json = DefaultObjectMapper.objectMapper().valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_BAD_REQUEST));
 
@@ -191,7 +192,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
             ),
             ComplianceConfig.DEFAULT
         );
-        json = DefaultObjectMapper.objectMapper.valueToTree(auditConfig);
+        json = DefaultObjectMapper.objectMapper().valueToTree(auditConfig);
         response = rh.executePutRequest(CONFIG_ENDPOINT, writeValueAsString(json, false));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
     }
@@ -207,7 +208,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
         updateStaticResourceReadonly(readonlyFields);
 
         setupWithRestRoles(null);
-        final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
+        final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper();
 
         // test get
         RestHelper.HttpResponse response = rh.executeGetRequest(ENDPOINT, adminCredsHeader);
@@ -251,10 +252,8 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
     private void updateStaticResourceReadonly(List<String> readonly) throws IOException {
         // create audit config
         final Map<String, Object> result = ImmutableMap.of(AuditApiAction.READONLY_FIELD, readonly);
-        DefaultObjectMapper.YAML_MAPPER.writeValue(
-            FileHelper.getAbsoluteFilePathFromClassPath(AuditApiAction.STATIC_RESOURCE.substring(1)).toFile(),
-            result
-        );
+        DefaultObjectMapper.yamlMapper()
+            .writeValue(FileHelper.getAbsoluteFilePathFromClassPath(AuditApiAction.STATIC_RESOURCE.substring(1)).toFile(), result);
     }
 
     private void testPutRequest(final JsonNode json, final int expectedStatus, final boolean sendAdminCertificate, final Header... header)

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiActionUnitTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiActionUnitTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.common.collect.ImmutableList;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,6 +33,7 @@ import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.transport.client.Client;
 
 import org.mockito.Mock;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -71,7 +71,7 @@ public class ConfigUpgradeApiActionUnitTest extends AbstractApiActionValidationT
 
         configUpgradeApiAction = spy(new ConfigUpgradeApiAction(clusterService, threadPool, securityApiDependencies));
 
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         final var config = objectMapper.createObjectNode();
         config.set("_meta", objectMapper.createObjectNode().put("type", CType.ROLES.toLCString()).put("config_version", 2));
         config.set("kibana_read_only", objectMapper.createObjectNode().put("reserved", true));

--- a/src/test/java/org/opensearch/security/dlic/rest/api/GetConfigurationApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/GetConfigurationApiTest.java
@@ -11,7 +11,6 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
@@ -20,6 +19,8 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/InternalUsersApiActionValidationTest.java
@@ -63,7 +63,7 @@ public class InternalUsersApiActionValidationTest extends AbstractApiActionValid
         c.putCEntry("some_role_with_reserved_mapping", allClusterPermissions);
         c.putCEntry("some_role_with_hidden_mapping", allClusterPermissions);
 
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         final var config = objectMapper.createObjectNode();
         config.set("_meta", objectMapper.createObjectNode().put("type", CType.ROLESMAPPING.toLCString()).put("config_version", 2));
         config.set("kibana_read_only", objectMapper.createObjectNode());

--- a/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/NodesDnApiTest.java
@@ -17,8 +17,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableMap;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.core5.http.Header;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
@@ -32,6 +30,9 @@ import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RolesApiActionRequestContentValidatorTest.java
@@ -13,11 +13,12 @@ package org.opensearch.security.dlic.rest.api;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 
 import org.opensearch.core.common.bytes.BytesArray;
 import org.opensearch.security.util.FakeRestRequest;
+
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/RollbackVersionApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/RollbackVersionApiTest.java
@@ -11,13 +11,14 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;

--- a/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigurationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/SecurityConfigurationTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.dlic.rest.api;
 
 import java.util.List;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +20,8 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.RoleV7;
+
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -32,7 +33,7 @@ public class SecurityConfigurationTest {
 
     SecurityDynamicConfiguration<?> configuration;
 
-    private final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
+    private final ObjectMapper objectMapper = DefaultObjectMapper.objectMapper();
 
     @Before
     public void setConfiguration() throws Exception {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/ViewVersionApiTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/ViewVersionApiTest.java
@@ -11,14 +11,15 @@
 
 package org.opensearch.security.dlic.rest.api;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/EndpointValidatorTest.java
@@ -348,7 +348,7 @@ public class EndpointValidatorTest {
         final var role = new RoleV7();
         role.setCluster_permissions(restAdminPermissions());
 
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         final var array = objectMapper.createArrayNode();
         restAdminPermissions().forEach(array::add);
 
@@ -383,7 +383,7 @@ public class EndpointValidatorTest {
         when(configuration.exists("some_ag")).thenReturn(false);
         when(restApiAdminPrivilegesEvaluator.containsRestApiAdminPermissions(any(Object.class))).thenCallRealMethod();
 
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         final var array = objectMapper.createArrayNode();
         restAdminPermissions().forEach(array::add);
 

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
@@ -21,9 +21,6 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +37,9 @@ import org.opensearch.security.DefaultObjectMapper;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -153,7 +153,8 @@ public class RequestContentValidatorTest {
             }
         });
 
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode()
+        final JsonNode payload = DefaultObjectMapper.objectMapper()
+            .createObjectNode()
             .put("a", 1)
             .put("b", "[]")
             .put("c", "{}")
@@ -195,7 +196,7 @@ public class RequestContentValidatorTest {
             }
         });
 
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("c", "aaa").put("d", "aaa");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("c", "aaa").put("d", "aaa");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         final JsonNode errorMessage = xContentToJsonNode(validationResult.errorMessage());
@@ -228,7 +229,7 @@ public class RequestContentValidatorTest {
                 return ImmutableMap.of("a", RequestContentValidator.DataType.ARRAY);
             }
         });
-        final ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode().putObject("a");
+        final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode().putObject("a");
         payload.putArray("a").add(NullNode.getInstance()).add("b").add("c");
         when(request.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
@@ -253,7 +254,7 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.DataType.ARRAY);
             }
         });
-        final ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
         payload.putArray("a").add("  ").add("b");
         when(request.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
@@ -283,7 +284,7 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.DataType.STRING, "b", RequestContentValidator.DataType.STRING);
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "value");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertTrue(validationResult.isValid());
@@ -319,7 +320,7 @@ public class RequestContentValidatorTest {
                 );
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("c", "value");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("c", "value");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertFalse(validationResult.isValid());
@@ -350,7 +351,7 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.FieldConfiguration.of(RequestContentValidator.DataType.STRING, 5));
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "toolong");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "toolong");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertFalse(validationResult.isValid());
@@ -388,7 +389,7 @@ public class RequestContentValidatorTest {
                 );
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "bad_value");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "bad_value");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertFalse(validationResult.isValid());
@@ -426,7 +427,7 @@ public class RequestContentValidatorTest {
                 );
             }
         });
-        final ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
         payload.putArray("a").add("1").add("2").add("3");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
@@ -465,7 +466,7 @@ public class RequestContentValidatorTest {
                 );
             }
         });
-        final ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
         payload.putObject("a").put("other", "value");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
@@ -492,8 +493,8 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.DataType.STRING);
             }
         });
-        final JsonNode original = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "value");
-        final JsonNode patched = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "value");
+        final JsonNode original = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value");
+        final JsonNode patched = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value");
         final ValidationResult<JsonNode> validationResult = validator.validate(request, patched, original);
         assertFalse(validationResult.isValid());
     }
@@ -516,8 +517,8 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.DataType.STRING);
             }
         });
-        final JsonNode original = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "value1");
-        final JsonNode patched = DefaultObjectMapper.objectMapper.createObjectNode().put("a", "value2");
+        final JsonNode original = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value1");
+        final JsonNode patched = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value2");
         final ValidationResult<JsonNode> validationResult = validator.validate(request, patched, original);
         assertTrue(validationResult.isValid());
     }
@@ -530,7 +531,7 @@ public class RequestContentValidatorTest {
 
     @Test
     public void testNoopValidatorWithJsonNode() throws Exception {
-        final JsonNode jsonNode = DefaultObjectMapper.objectMapper.createObjectNode();
+        final JsonNode jsonNode = DefaultObjectMapper.objectMapper().createObjectNode();
         final ValidationResult<JsonNode> validationResult = RequestContentValidator.NOOP_VALIDATOR.validate(request, jsonNode);
         assertTrue(validationResult.isValid());
     }
@@ -553,7 +554,7 @@ public class RequestContentValidatorTest {
                 return Map.of("password", RequestContentValidator.DataType.STRING);
             }
         });
-        final JsonNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("password", "");
+        final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("password", "");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         final ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertErrorMessage(validationResult.errorMessage(), RequestContentValidator.ValidationError.INVALID_PASSWORD_TOO_SHORT);
@@ -577,7 +578,7 @@ public class RequestContentValidatorTest {
                 return Map.of("a", RequestContentValidator.DataType.OBJECT);
             }
         });
-        final ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
         final ObjectNode nested = payload.putObject("a");
         nested.putArray("inner").add(NullNode.getInstance());
         when(request.content()).thenReturn(new BytesArray(payload.toString()));
@@ -618,14 +619,14 @@ public class RequestContentValidatorTest {
 
     @Test
     public void testArraySizeValidatorWithJsonNode() {
-        final ObjectNode node = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode node = DefaultObjectMapper.objectMapper().createObjectNode();
         node.putArray("arr").add("1").add("2");
         RequestContentValidator.ARRAY_SIZE_VALIDATOR.validate("arr", node.get("arr"));
     }
 
     @Test
     public void testArraySizeValidatorRejectsLargeArray() {
-        final ObjectNode node = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode node = DefaultObjectMapper.objectMapper().createObjectNode();
         final var arr = node.putArray("arr");
         for (int i = 0; i <= RequestContentValidator.MAX_ARRAY_SIZE; i++) {
             arr.add(String.valueOf(i));
@@ -649,21 +650,21 @@ public class RequestContentValidatorTest {
     @Test
     public void testArraySizeValidatorFactoryUsesCustomLimit() {
         final RequestContentValidator.FieldValidator validator = RequestContentValidator.arraySizeValidator(2);
-        final ObjectNode node = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode node = DefaultObjectMapper.objectMapper().createObjectNode();
         node.putArray("arr").add("1").add("2").add("3");
         expectThrows(IllegalArgumentException.class, () -> validator.validate("arr", node.get("arr")));
     }
 
     @Test
     public void testArrayOfStringsValidatorAcceptsStringArray() {
-        final ObjectNode node = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode node = DefaultObjectMapper.objectMapper().createObjectNode();
         node.putArray("arr").add("one").add("two");
         RequestContentValidator.ARRAY_OF_STRINGS_VALIDATOR.validate("arr", node.get("arr"));
     }
 
     @Test
     public void testArrayOfStringsValidatorRejectsNonStringElement() {
-        final ObjectNode node = DefaultObjectMapper.objectMapper.createObjectNode();
+        final ObjectNode node = DefaultObjectMapper.objectMapper().createObjectNode();
         node.putArray("arr").add("one").add(2);
         expectThrows(
             IllegalArgumentException.class,
@@ -722,7 +723,7 @@ public class RequestContentValidatorTest {
                 return ImmutableMap.of("password", RequestContentValidator.DataType.STRING);
             }
         });
-        ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode().put("password", "a");
+        ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("password", "a");
         when(httpRequest.content()).thenReturn(new BytesArray(payload.toString()));
         ValidationResult<JsonNode> validationResult = validator.validate(request);
         assertErrorMessage(validationResult.errorMessage(), RequestContentValidator.ValidationError.NO_USERNAME);
@@ -765,7 +766,7 @@ public class RequestContentValidatorTest {
             }
         });
 
-        ObjectNode payload = DefaultObjectMapper.objectMapper.createObjectNode().putObject("a");
+        ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode().putObject("a");
         payload.putArray("a").add("arrray");
         payload.put("b", true).put("d", "some_string").put("e", false).put("f", 1);
         payload.putObject("c");

--- a/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluatorTest.java
@@ -20,7 +20,6 @@ import java.util.TreeMap;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Test;
@@ -123,42 +122,32 @@ public class SystemIndexAccessEvaluatorTest {
         ThreadContext threadContext = createThreadContext();
         indexNameExpressionResolver = createIndexNameExpressionResolver(threadContext);
 
-        try {
-            SecurityDynamicConfiguration<RoleV7> rolesConfig = SecurityDynamicConfiguration.fromMap(
+        SecurityDynamicConfiguration<RoleV7> rolesConfig = SecurityDynamicConfiguration.fromMap(
+            ImmutableMap.of(
+                "role_a",
                 ImmutableMap.of(
-                    "role_a",
-                    ImmutableMap.of(
-                        "index_permissions",
-                        Arrays.asList(
-                            ImmutableMap.of(
-                                "index_patterns",
-                                Arrays.asList(index),
-                                "allowed_actions",
-                                createIndexPatternWithSystemIndexPermission ? Set.of("*", SYSTEM_INDEX_PERMISSION) : Set.of("*")
-                            )
-                        ),
-                        "cluster_permissions",
-                        Arrays.asList("*")
-                    )
-                ),
-                CType.ROLES
-            );
+                    "index_permissions",
+                    Arrays.asList(
+                        ImmutableMap.of(
+                            "index_patterns",
+                            Arrays.asList(index),
+                            "allowed_actions",
+                            createIndexPatternWithSystemIndexPermission ? Set.of("*", SYSTEM_INDEX_PERMISSION) : Set.of("*")
+                        )
+                    ),
+                    "cluster_permissions",
+                    Arrays.asList("*")
+                )
+            ),
+            CType.ROLES
+        );
 
-            this.actionPrivileges = new RoleBasedActionPrivileges(
-                new CompiledRoles(
-                    rolesConfig,
-                    FlattenedActionGroups.EMPTY,
-                    NamedXContentRegistry.EMPTY,
-                    FieldMasking.Config.DEFAULT,
-                    false
-                ),
-                RuntimeOptimizedActionPrivileges.SpecialIndexProtection.NONE,
-                Settings.EMPTY,
-                true
-            );
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        this.actionPrivileges = new RoleBasedActionPrivileges(
+            new CompiledRoles(rolesConfig, FlattenedActionGroups.EMPTY, NamedXContentRegistry.EMPTY, FieldMasking.Config.DEFAULT, false),
+            RuntimeOptimizedActionPrivileges.SpecialIndexProtection.NONE,
+            Settings.EMPTY,
+            true
+        );
 
         // create a user and associate them with the role
         user = new User("user_a").withSecurityRoles(List.of("role_a"));

--- a/src/test/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfigurationTest.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/SecurityDynamicConfigurationTest.java
@@ -13,13 +13,13 @@ package org.opensearch.security.securityconf.impl;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.security.DefaultObjectMapper;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -29,11 +29,11 @@ import static org.hamcrest.Matchers.sameInstance;
 public class SecurityDynamicConfigurationTest {
 
     private SecurityDynamicConfiguration<?> securityDynamicConfiguration;
-    private ObjectMapper objectMapper = DefaultObjectMapper.objectMapper;
+    private ObjectMapper objectMapper = DefaultObjectMapper.objectMapper();
     private ObjectNode objectNode = objectMapper.createObjectNode();
 
     @Before
-    public void setUp() throws JsonProcessingException, IOException {
+    public void setUp() throws IOException {
         objectNode.set("_meta", objectMapper.createObjectNode().put("type", CType.ROLES.toLCString()).put("config_version", 2));
         securityDynamicConfiguration = SecurityDynamicConfiguration.fromJson(
             objectMapper.writeValueAsString(objectNode),

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/ConfigV7Test.java
@@ -15,13 +15,14 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import com.google.common.collect.ImmutableList;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import org.opensearch.security.DefaultObjectMapper;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;

--- a/src/test/java/org/opensearch/security/securityconf/impl/v7/RoleV7Test.java
+++ b/src/test/java/org/opensearch/security/securityconf/impl/v7/RoleV7Test.java
@@ -13,9 +13,10 @@ package org.opensearch.security.securityconf.impl.v7;
 
 import java.net.URL;
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import org.junit.Before;
 import org.junit.Test;
+
+import tools.jackson.databind.exc.UnrecognizedPropertyException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
+++ b/src/test/java/org/opensearch/security/setting/DeprecatedSettingsTest.java
@@ -5,7 +5,8 @@
 
 package org.opensearch.security.setting;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import java.io.IOException;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -154,7 +155,7 @@ public class DeprecatedSettingsTest {
                 0,
                 0
             );
-        } catch (JsonMappingException e) {
+        } catch (IOException e) {
             verifyNoInteractions(logger);
         }
     }

--- a/src/test/java/org/opensearch/security/ssl/SecuritySSLReloadCertsActionTests.java
+++ b/src/test/java/org/opensearch/security/ssl/SecuritySSLReloadCertsActionTests.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -31,6 +30,8 @@ import org.opensearch.security.test.SingleClusterTest;
 import org.opensearch.security.test.helper.cluster.ClusterConfiguration;
 import org.opensearch.security.test.helper.file.FileHelper;
 import org.opensearch.security.test.helper.rest.RestHelper;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -216,7 +217,7 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         RestHelper.HttpResponse reloadCertsResponse = rh.executePutRequest(RELOAD_HTTP_CERTS_ENDPOINT, null);
 
         assertThat(reloadCertsResponse.getStatusCode(), is(200));
-        final var expectedJsonResponse = DefaultObjectMapper.objectMapper.createObjectNode();
+        final var expectedJsonResponse = DefaultObjectMapper.objectMapper().createObjectNode();
         expectedJsonResponse.put("message", "updated http certs");
         assertThat(reloadCertsResponse.getBody(), is(expectedJsonResponse.toString()));
 
@@ -289,7 +290,7 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         RestHelper.HttpResponse reloadCertsResponse = rh.executePutRequest(RELOAD_TRANSPORT_CERTS_ENDPOINT, null);
 
         assertThat(reloadCertsResponse.getStatusCode(), is(200));
-        final var expectedJsonResponse = DefaultObjectMapper.objectMapper.createObjectNode();
+        final var expectedJsonResponse = DefaultObjectMapper.objectMapper().createObjectNode();
         expectedJsonResponse.put("message", "updated transport certs");
         assertThat(reloadCertsResponse.getBody(), is(expectedJsonResponse.toString()));
 
@@ -361,7 +362,7 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
 
         RestHelper.HttpResponse reloadCertsResponse = rh.executePutRequest(reloadEndpoint, null);
         assertThat(reloadCertsResponse.getStatusCode(), is(200));
-        final var expectedJsonResponse = DefaultObjectMapper.objectMapper.createObjectNode();
+        final var expectedJsonResponse = DefaultObjectMapper.objectMapper().createObjectNode();
         expectedJsonResponse.put("message", String.format("updated %s certs", updateChannel));
         assertThat(reloadCertsResponse.getBody(), is(expectedJsonResponse.toString()));
 
@@ -377,7 +378,7 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
         List<Map<String, String>> httpCertDetails,
         List<Map<String, String>> transportCertDetails
     ) {
-        final var updatedCertDetailsResponse = DefaultObjectMapper.objectMapper.createObjectNode();
+        final var updatedCertDetailsResponse = DefaultObjectMapper.objectMapper().createObjectNode();
         updatedCertDetailsResponse.set("http_certificates_list", buildCertsInfoNode(httpCertDetails));
         updatedCertDetailsResponse.set("transport_certificates_list", buildCertsInfoNode(transportCertDetails));
         return updatedCertDetailsResponse;
@@ -388,9 +389,9 @@ public class SecuritySSLReloadCertsActionTests extends SingleClusterTest {
     }
 
     private JsonNode buildCertsInfoNode(final List<Map<String, String>> certsInfo) {
-        final var nodeCertDetailsArray = DefaultObjectMapper.objectMapper.createArrayNode();
+        final var nodeCertDetailsArray = DefaultObjectMapper.objectMapper().createArrayNode();
         certsInfo.forEach(m -> {
-            final var o = DefaultObjectMapper.objectMapper.createObjectNode();
+            final var o = DefaultObjectMapper.objectMapper().createObjectNode();
             m.forEach(o::put);
             nodeCertDetailsArray.add(o);
         });

--- a/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
+++ b/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
@@ -48,7 +48,7 @@ public class ConfigReaderTest {
 
     @Test
     public void testCreateReaderForNonMandatoryCTypes() throws IOException {
-        final var yamlMapper = DefaultObjectMapper.YAML_MAPPER;
+        final var yamlMapper = DefaultObjectMapper.yamlMapper();
         for (final var cType : CType.notRequiredConfigTypes()) {
             try (final var reader = new BufferedReader(YamlConfigReader.newReader(cType, configDir.toPath()))) {
                 final var emptyYaml = yamlMapper.readTree(reader);

--- a/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
+++ b/src/test/java/org/opensearch/security/support/SecurityIndexHandlerTest.java
@@ -17,7 +17,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,6 +54,7 @@ import org.opensearch.transport.client.IndicesAdminClient;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -386,7 +386,7 @@ public class SecurityIndexHandlerTest {
         );
         doAnswer(invocation -> {
 
-            final var objectMapper = DefaultObjectMapper.objectMapper;
+            final var objectMapper = DefaultObjectMapper.objectMapper();
 
             ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
             final var getResult = mock(GetResult.class);
@@ -421,7 +421,7 @@ public class SecurityIndexHandlerTest {
             }
         }, e -> fail("Unexpected behave")));
         doAnswer(invocation -> {
-            final var objectMapper = DefaultObjectMapper.objectMapper;
+            final var objectMapper = DefaultObjectMapper.objectMapper();
             ActionListener<MultiGetResponse> actionListener = invocation.getArgument(1);
 
             final var responses = new MultiGetItemResponse[CType.values().size()];
@@ -462,7 +462,7 @@ public class SecurityIndexHandlerTest {
     }
 
     private ObjectNode minimumRequiredConfig(final CType<?> cType) {
-        final var objectMapper = DefaultObjectMapper.objectMapper;
+        final var objectMapper = DefaultObjectMapper.objectMapper();
         return objectMapper.createObjectNode()
             .set("_meta", objectMapper.createObjectNode().put("type", cType.toLCString()).put("config_version", DEFAULT_CONFIG_VERSION));
     }

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -41,8 +41,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
@@ -87,6 +85,8 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.test.helper.cluster.ClusterInfo;
 import org.opensearch.security.test.helper.file.FileHelper;
+
+import tools.jackson.databind.JsonNode;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -456,8 +456,8 @@ public class RestHelper {
             }
         }
 
-        private JsonNode toJsonNode() throws JsonProcessingException, IOException {
-            return DefaultObjectMapper.objectMapper.readTree(getBody());
+        private JsonNode toJsonNode() throws IOException {
+            return DefaultObjectMapper.objectMapper().readTree(getBody());
         }
 
         public SimpleHttpResponse getInner() {


### PR DESCRIPTION
### Description
Support Jackson 3.x release line

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/6075

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Covered by existing test suites

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
