### PR TITLE
Add BCFKS keystore generation utilities

### DIFF
--- a/src/test/resources/bcfks-generation/ConvertKeystore.java
+++ b/src/test/resources/bcfks-generation/ConvertKeystore.java
@@ -9,8 +9,14 @@
  * Modifications Copyright OpenSearch Contributors. See
  * GitHub history for details.
  */
-import java.io.*;
-import java.security.*;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.Security;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.util.Enumeration;
 

--- a/src/test/resources/bcfks-generation/ConvertKeystore.java
+++ b/src/test/resources/bcfks-generation/ConvertKeystore.java
@@ -1,0 +1,68 @@
+
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+import java.io.*;
+import java.security.*;
+import java.security.cert.Certificate;
+import java.util.Enumeration;
+
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+
+public class ConvertKeystore {
+    public static void main(String[] args) throws Exception {
+        if (args.length < 4) {
+            System.err.println("Usage: ConvertKeystore <srcFile> <srcType> <srcPass> <destFile> [destPass]");
+            System.exit(1);
+        }
+        String srcFile = args[0];
+        String srcType = args[1];
+        String srcPass = args[2];
+        String destFile = args[3];
+        String destPass = args.length > 4 ? args[4] : srcPass;
+
+        Security.addProvider(new BouncyCastleFipsProvider());
+
+        KeyStore srcKs = KeyStore.getInstance(srcType);
+        try (InputStream is = new FileInputStream(srcFile)) {
+            srcKs.load(is, srcPass.toCharArray());
+        }
+
+        KeyStore destKs = KeyStore.getInstance("BCFKS");
+        destKs.load(null, destPass.toCharArray());
+
+        Enumeration<String> aliases = srcKs.aliases();
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            if (srcKs.isKeyEntry(alias)) {
+                Key key = null;
+                for (String kpass : new String[] { srcPass, "" }) {
+                    try {
+                        key = srcKs.getKey(alias, kpass.toCharArray());
+                        if (key != null) break;
+                    } catch (UnrecoverableKeyException ignored) {}
+                }
+                if (key == null) {
+                    System.err.println("WARN: could not recover key for alias '" + alias + "' – skipping");
+                    continue;
+                }
+                Certificate[] chain = srcKs.getCertificateChain(alias);
+                destKs.setKeyEntry(alias, key, destPass.toCharArray(), chain);
+            } else if (srcKs.isCertificateEntry(alias)) {
+                destKs.setCertificateEntry(alias, srcKs.getCertificate(alias));
+            }
+        }
+
+        try (OutputStream os = new FileOutputStream(destFile)) {
+            destKs.store(os, destPass.toCharArray());
+        }
+        System.out.println("OK  " + srcFile + " -> " + destFile);
+    }
+}

--- a/src/test/resources/bcfks-generation/README.md
+++ b/src/test/resources/bcfks-generation/README.md
@@ -1,0 +1,25 @@
+# BCFKS keystore generation
+
+Generates BCFKS counterparts for every JKS/PKCS12 keystore under `src/test/resources/`.
+BCFKS (Bouncy Castle FIPS Keystore) files are required when running tests in FIPS approved-only mode.
+
+## Prerequisites
+
+- `bc-fips-*.jar` — set `BC_FIPS_JAR` to its path before running
+
+## Usage
+
+```bash
+export BC_FIPS_JAR=/path/to/bc-fips-2.1.2.jar
+./src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
+```
+
+Each `.bcfks` file is written alongside its source keystore. Re-run whenever a source JKS or PKCS12 file is added or regenerated.
+
+## How it works
+
+`ConvertKeystore.java` is compiled on-the-fly against the `bc-fips` JAR and used to copy all key and certificate entries from the source keystore into a new BCFKS store.
+
+When both a `.p12` and a `.jks` share the same base name, only the PKCS12 is used as the source — PKCS12 is the IETF-standardized format and the more faithful input for FIPS-compliant keystores.
+
+`sslConfigurator/` keystores use the password `secret` instead of the default `changeit`.

--- a/src/test/resources/bcfks-generation/README.md
+++ b/src/test/resources/bcfks-generation/README.md
@@ -5,13 +5,23 @@ BCFKS (Bouncy Castle FIPS Keystore) files are required when running tests in FIP
 
 ## Prerequisites
 
-- `bc-fips-*.jar` — set `BC_FIPS_JAR` to its path before running
+- Java on `PATH`
+- `bc-fips-*.jar` — set `BC_FIPS_JAR` to its path before running (see Usage)
 
 ## Usage
+
+### Linux / macOS
 
 ```bash
 export BC_FIPS_JAR=/path/to/bc-fips-2.1.2.jar
 ./src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
+```
+
+### Windows
+
+```bat
+set BC_FIPS_JAR=C:\path\to\bc-fips-2.1.2.jar
+src\test\resources\bcfks-generation\generate_bcfks_keystores.bat
 ```
 
 Each `.bcfks` file is written alongside its source keystore. Re-run whenever a source JKS or PKCS12 file is added or regenerated.

--- a/src/test/resources/bcfks-generation/generate_bcfks_keystores.bat
+++ b/src/test/resources/bcfks-generation/generate_bcfks_keystores.bat
@@ -1,0 +1,146 @@
+@echo off
+::
+:: Copyright OpenSearch Contributors
+:: SPDX-License-Identifier: Apache-2.0
+::
+:: Generates BCFKS counterparts for every JKS / PKCS12 keystore under
+:: src\test\resources\.  See README.md for usage and prerequisites.
+
+setlocal enabledelayedexpansion
+
+if "%BC_FIPS_JAR%"=="" (
+    echo ERROR: BC_FIPS_JAR is not set. Point it to the bc-fips-*.jar, e.g.: >&2
+    echo   set BC_FIPS_JAR=C:\path\to\bc-fips-2.1.2.jar >&2
+    exit /b 1
+)
+
+set SCRIPT_DIR=%~dp0
+set RESOURCES=%SCRIPT_DIR%..
+:: Resolve to absolute path
+pushd "%RESOURCES%"
+set RESOURCES=%CD%
+popd
+
+set BC_FIPS=%BC_FIPS_JAR%
+
+:: ── Compile the converter ─────────────────────────────────────────────────────
+
+set CONVERT_DIR=%TEMP%\bcfks-convert-%RANDOM%
+mkdir "%CONVERT_DIR%"
+
+javac -cp "%BC_FIPS%" "%SCRIPT_DIR%ConvertKeystore.java" -d "%CONVERT_DIR%"
+if errorlevel 1 (
+    echo ERROR: Compilation failed. >&2
+    rmdir /s /q "%CONVERT_DIR%"
+    exit /b 1
+)
+
+set CONVERTED=0
+
+:: ── JKS-only keystores ────────────────────────────────────────────────────────
+
+echo === Converting JKS-only keystores ===
+
+for %%F in (
+    cache\kirk-keystore.jks
+    cache\node-0-keystore.jks
+    cache\spock-keystore.jks
+    cache\truststore.jks
+    dlsfls\kirk-keystore.jks
+    dlsfls\node-0-keystore.jks
+    dlsfls\spock-keystore.jks
+    dlsfls\truststore.jks
+    jwt\kirk-keystore.jks
+    jwt\node-0-keystore.jks
+    jwt\spock-keystore.jks
+    jwt\truststore.jks
+    ldap\kirk-keystore.jks
+    ldap\node-0-keystore.jks
+    ldap\spock-keystore.jks
+    ldap\truststore.jks
+    migration\kirk-keystore.jks
+    migration\node-0-keystore.jks
+    migration\spock-keystore.jks
+    migration\truststore.jks
+    multitenancy\kirk-keystore.jks
+    multitenancy\node-0-keystore.jks
+    multitenancy\spock-keystore.jks
+    multitenancy\truststore.jks
+    restapi\kirk-keystore.jks
+    restapi\node-0-keystore.jks
+    restapi\spock-keystore.jks
+    restapi\truststore.jks
+    sanity-tests\kirk-keystore.jks
+    ssl\extended_key_usage\node-0-keystore.jks
+    ssl\extended_key_usage\truststore.jks
+    ssl\reload\kirk-keystore.jks
+    ssl\reload\spock-keystore.jks
+    ssl\reload\truststore.jks
+    ssl\truststore.jks
+    ssl\truststore_fail.jks
+    ssl\truststore_invalid.jks
+    ssl\truststore_valid.jks
+    auditlog\truststore.jks
+    auditlog\truststore_fail.jks
+    kirk-keystore.jks
+    node-0-keystore.jks
+    node-1-keystore.jks
+    node-2-keystore.jks
+    spock-keystore.jks
+    truststore.jks
+    truststore_fail.jks
+) do (
+    set SRC=%RESOURCES%\%%F
+    set DEST=!SRC:.jks=.bcfks!
+    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" JKS changeit "!DEST!" changeit
+    set /a CONVERTED+=1
+)
+
+:: ── PKCS12 keystores ──────────────────────────────────────────────────────────
+
+echo.
+echo === Converting PKCS12 keystores (preferred source for shared base names) ===
+
+for %%F in (
+    auditlog\kirk-keystore.p12
+    auditlog\node-0-keystore.p12
+    auditlog\spock-keystore.p12
+    ssl\kirk-keystore.p12
+    ssl\node-0-keystore.p12
+    ssl\node-1-keystore.p12
+    ssl\node-2-keystore.p12
+    ssl\spock-keystore.p12
+    ssl\node-untspec5-keystore.p12
+    node-untspec5-keystore.p12
+    node-untspec6-keystore.p12
+) do (
+    set SRC=%RESOURCES%\%%F
+    set DEST=!SRC:.p12=.bcfks!
+    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" PKCS12 changeit "!DEST!" changeit
+    set /a CONVERTED+=1
+)
+
+:: ── sslConfigurator keystores (password: secret) ──────────────────────────────
+
+echo.
+echo === Converting sslConfigurator keystores (password: secret) ===
+
+for %%F in (
+    sslConfigurator\jks\node1-keystore.jks
+    sslConfigurator\jks\other-root-ca.jks
+    sslConfigurator\jks\truststore.jks
+    sslConfigurator\pem\node-wrong-hostname-keystore.jks
+    sslConfigurator\pem\node1-keystore.jks
+    sslConfigurator\pem\truststore.jks
+) do (
+    set SRC=%RESOURCES%\%%F
+    set DEST=!SRC:.jks=.bcfks!
+    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" JKS secret "!DEST!" secret
+    set /a CONVERTED+=1
+)
+
+echo.
+echo Done. %CONVERTED% BCFKS files written alongside their source keystores.
+
+rmdir /s /q "%CONVERT_DIR%"
+endlocal

--- a/src/test/resources/bcfks-generation/generate_bcfks_keystores.bat
+++ b/src/test/resources/bcfks-generation/generate_bcfks_keystores.bat
@@ -23,18 +23,6 @@ popd
 
 set BC_FIPS=%BC_FIPS_JAR%
 
-:: ── Compile the converter ─────────────────────────────────────────────────────
-
-set CONVERT_DIR=%TEMP%\bcfks-convert-%RANDOM%
-mkdir "%CONVERT_DIR%"
-
-javac -cp "%BC_FIPS%" "%SCRIPT_DIR%ConvertKeystore.java" -d "%CONVERT_DIR%"
-if errorlevel 1 (
-    echo ERROR: Compilation failed. >&2
-    rmdir /s /q "%CONVERT_DIR%"
-    exit /b 1
-)
-
 set CONVERTED=0
 
 :: ── JKS-only keystores ────────────────────────────────────────────────────────
@@ -92,7 +80,7 @@ for %%F in (
 ) do (
     set SRC=%RESOURCES%\%%F
     set DEST=!SRC:.jks=.bcfks!
-    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" JKS changeit "!DEST!" changeit
+    java --enable-native-access=ALL-UNNAMED -cp "%BC_FIPS%" "%SCRIPT_DIR%ConvertKeystore.java" "!SRC!" JKS changeit "!DEST!" changeit
     set /a CONVERTED+=1
 )
 
@@ -116,7 +104,7 @@ for %%F in (
 ) do (
     set SRC=%RESOURCES%\%%F
     set DEST=!SRC:.p12=.bcfks!
-    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" PKCS12 changeit "!DEST!" changeit
+    java --enable-native-access=ALL-UNNAMED -cp "%BC_FIPS%" "%SCRIPT_DIR%ConvertKeystore.java" "!SRC!" PKCS12 changeit "!DEST!" changeit
     set /a CONVERTED+=1
 )
 
@@ -135,12 +123,11 @@ for %%F in (
 ) do (
     set SRC=%RESOURCES%\%%F
     set DEST=!SRC:.jks=.bcfks!
-    java --enable-native-access=ALL-UNNAMED -cp "%CONVERT_DIR%;%BC_FIPS%" ConvertKeystore "!SRC!" JKS secret "!DEST!" secret
+    java --enable-native-access=ALL-UNNAMED -cp "%BC_FIPS%" "%SCRIPT_DIR%ConvertKeystore.java" "!SRC!" JKS secret "!DEST!" secret
     set /a CONVERTED+=1
 )
 
 echo.
 echo Done. %CONVERTED% BCFKS files written alongside their source keystores.
 
-rmdir /s /q "%CONVERT_DIR%"
 endlocal

--- a/src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
+++ b/src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generates BCFKS counterparts for every JKS / PKCS12 keystore under
+# src/test/resources/.  See README.md for usage and prerequisites.
+
+set -euo pipefail
+
+if [[ -z "${BC_FIPS_JAR:-}" ]]; then
+  echo "ERROR: BC_FIPS_JAR is not set. Point it to the bc-fips-*.jar, e.g.:" >&2
+  echo "  export BC_FIPS_JAR=/path/to/bc-fips-2.1.2.jar" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RESOURCES="$(cd "$SCRIPT_DIR/.." && pwd)"
+BC_FIPS="$BC_FIPS_JAR"
+
+# ── Compile the converter ─────────────────────────────────────────────────────
+
+CONVERT_DIR=$(mktemp -d)
+trap 'rm -rf "$CONVERT_DIR"' EXIT
+
+javac -cp "$BC_FIPS" "$SCRIPT_DIR/ConvertKeystore.java" -d "$CONVERT_DIR"
+
+CONVERTED=0
+
+convert() {
+  local src="$1"
+  local type="$2"   # JKS | PKCS12
+  local pass="${3:-changeit}"
+  local dest="${src%.*}.bcfks"
+  java --enable-native-access=ALL-UNNAMED \
+       -cp "$CONVERT_DIR:$BC_FIPS" \
+       ConvertKeystore "$src" "$type" "$pass" "$dest" "$pass"
+  CONVERTED=$(( CONVERTED + 1 ))
+}
+
+# ── JKS-only keystores (no PKCS12 counterpart exists) ────────────────────────
+
+JKS_ONLY=(
+  cache/kirk-keystore.jks
+  cache/node-0-keystore.jks
+  cache/spock-keystore.jks
+  cache/truststore.jks
+
+  dlsfls/kirk-keystore.jks
+  dlsfls/node-0-keystore.jks
+  dlsfls/spock-keystore.jks
+  dlsfls/truststore.jks
+
+  jwt/kirk-keystore.jks
+  jwt/node-0-keystore.jks
+  jwt/spock-keystore.jks
+  jwt/truststore.jks
+
+  ldap/kirk-keystore.jks
+  ldap/node-0-keystore.jks
+  ldap/spock-keystore.jks
+  ldap/truststore.jks
+
+  migration/kirk-keystore.jks
+  migration/node-0-keystore.jks
+  migration/spock-keystore.jks
+  migration/truststore.jks
+
+  multitenancy/kirk-keystore.jks
+  multitenancy/node-0-keystore.jks
+  multitenancy/spock-keystore.jks
+  multitenancy/truststore.jks
+
+  restapi/kirk-keystore.jks
+  restapi/node-0-keystore.jks
+  restapi/spock-keystore.jks
+  restapi/truststore.jks
+
+  sanity-tests/kirk-keystore.jks
+
+  ssl/extended_key_usage/node-0-keystore.jks
+  ssl/extended_key_usage/truststore.jks
+
+  ssl/reload/kirk-keystore.jks
+  ssl/reload/spock-keystore.jks
+  ssl/reload/truststore.jks
+
+  ssl/truststore.jks
+  ssl/truststore_fail.jks
+  ssl/truststore_invalid.jks
+  ssl/truststore_valid.jks
+
+  # sslConfigurator keystores use password 'secret' – passed explicitly below
+
+  kirk-keystore.jks
+  node-0-keystore.jks
+  node-1-keystore.jks
+  node-2-keystore.jks
+  spock-keystore.jks
+  truststore.jks
+  truststore_fail.jks
+
+  # auditlog/ JKS files intentionally omitted: PKCS12 counterparts exist
+  auditlog/truststore.jks
+  auditlog/truststore_fail.jks
+)
+
+echo "=== Converting JKS-only keystores ==="
+for rel in "${JKS_ONLY[@]}"; do
+  [[ "$rel" =~ ^# ]] && continue
+  convert "$RESOURCES/$rel" JKS
+done
+
+# ── PKCS12 keystores (preferred source when JKS counterpart also exists) ─────
+#
+# For the pairs listed in the header comment the BCFKS file is produced
+# exclusively from the PKCS12 source; the JKS files are deliberately skipped.
+
+P12_FILES=(
+  # auditlog/ – PKCS12 preferred over JKS counterparts
+  auditlog/kirk-keystore.p12
+  auditlog/node-0-keystore.p12
+  auditlog/spock-keystore.p12
+
+  # ssl/ – PKCS12 preferred over JKS counterparts
+  ssl/kirk-keystore.p12
+  ssl/node-0-keystore.p12
+  ssl/node-1-keystore.p12
+  ssl/node-2-keystore.p12
+  ssl/spock-keystore.p12
+
+  # ssl/ – PKCS12-only (no JKS counterpart)
+  ssl/node-untspec5-keystore.p12
+
+  # root-level – PKCS12-only
+  node-untspec5-keystore.p12
+  node-untspec6-keystore.p12
+)
+
+echo ""
+echo "=== Converting PKCS12 keystores (preferred source for shared base names) ==="
+for rel in "${P12_FILES[@]}"; do
+  [[ "$rel" =~ ^# ]] && continue
+  convert "$RESOURCES/$rel" PKCS12
+done
+
+# ── sslConfigurator keystores (password: 'secret', not 'changeit') ───────────
+#
+# These keystores were generated with a different password.  They are listed
+# separately so the non-default password is explicit rather than buried in the
+# arrays above.
+
+echo ""
+echo "=== Converting sslConfigurator keystores (password: secret) ==="
+for rel in \
+  sslConfigurator/jks/node1-keystore.jks \
+  sslConfigurator/jks/other-root-ca.jks \
+  sslConfigurator/jks/truststore.jks \
+  sslConfigurator/pem/node-wrong-hostname-keystore.jks \
+  sslConfigurator/pem/node1-keystore.jks \
+  sslConfigurator/pem/truststore.jks
+do
+  convert "$RESOURCES/$rel" JKS secret
+done
+
+echo ""
+echo "Done. $CONVERTED BCFKS files written alongside their source keystores."

--- a/src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
+++ b/src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
@@ -18,13 +18,6 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 RESOURCES="$(cd "$SCRIPT_DIR/.." && pwd)"
 BC_FIPS="$BC_FIPS_JAR"
 
-# ── Compile the converter ─────────────────────────────────────────────────────
-
-CONVERT_DIR=$(mktemp -d)
-trap 'rm -rf "$CONVERT_DIR"' EXIT
-
-javac -cp "$BC_FIPS" "$SCRIPT_DIR/ConvertKeystore.java" -d "$CONVERT_DIR"
-
 CONVERTED=0
 
 convert() {
@@ -33,8 +26,8 @@ convert() {
   local pass="${3:-changeit}"
   local dest="${src%.*}.bcfks"
   java --enable-native-access=ALL-UNNAMED \
-       -cp "$CONVERT_DIR:$BC_FIPS" \
-       ConvertKeystore "$src" "$type" "$pass" "$dest" "$pass"
+       -cp "$BC_FIPS" \
+       "$SCRIPT_DIR/ConvertKeystore.java" "$src" "$type" "$pass" "$dest" "$pass"
   CONVERTED=$(( CONVERTED + 1 ))
 }
 


### PR DESCRIPTION
### Description
This PR includes documentation and utilities on how BCFKS keystores and truststore where created for https://github.com/opensearch-project/security/pull/6059

<details>
<summary>The script log should look like this</summary>


```
❯ env BC_FIPS_JAR=/home/iigonin/.gradle/caches/modules-2/files-2.1/org.bouncycastle/bc-fips/2.1.2/61fbe8383f70489dda95a11a2a4739eb818ff2c/bc-fips-2.1.2.jar ./src/test/resources/bcfks-generation/generate_bcfks_keystores.sh
=== Converting JKS-only keystores ===
OK  /home/iigonin/workspace/securitySternad/src/test/resources/cache/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/cache/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/cache/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/cache/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/cache/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/cache/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/cache/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/cache/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/dlsfls/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/jwt/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/jwt/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/jwt/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/jwt/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/jwt/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/jwt/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/jwt/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/jwt/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ldap/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ldap/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ldap/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ldap/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ldap/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ldap/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ldap/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ldap/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/migration/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/migration/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/migration/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/migration/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/migration/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/migration/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/migration/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/migration/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/multitenancy/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/restapi/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/restapi/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/restapi/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/restapi/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/restapi/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/restapi/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/restapi/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/restapi/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sanity-tests/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sanity-tests/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/extended_key_usage/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/extended_key_usage/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/extended_key_usage/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/extended_key_usage/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/reload/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_fail.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_fail.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_invalid.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_invalid.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_valid.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/truststore_valid.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/kirk-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/node-0-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/node-1-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/node-1-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/node-2-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/node-2-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/spock-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/truststore_fail.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/truststore_fail.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/truststore_fail.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/truststore_fail.bcfks

=== Converting PKCS12 keystores (preferred source for shared base names) ===
OK  /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/kirk-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/node-0-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/spock-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/auditlog/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/kirk-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/kirk-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-0-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-0-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-1-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-1-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-2-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-2-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/spock-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/spock-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-untspec5-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/ssl/node-untspec5-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/node-untspec5-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/node-untspec5-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/node-untspec6-keystore.p12 -> /home/iigonin/workspace/securitySternad/src/test/resources/node-untspec6-keystore.bcfks

=== Converting sslConfigurator keystores (password: secret) ===
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/node1-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/node1-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/other-root-ca.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/other-root-ca.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/jks/truststore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/node-wrong-hostname-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/node-wrong-hostname-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/node1-keystore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/node1-keystore.bcfks
OK  /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/truststore.jks -> /home/iigonin/workspace/securitySternad/src/test/resources/sslConfigurator/pem/truststore.bcfks

Done. 64 BCFKS files written alongside their source keystores.
```
</details>

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
