### PR TITLE
update kafka to 3.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Always install demo certs if configured with demo certs ([#5517](https://github.com/opensearch-project/security/pull/5517))
 - Bump org.apache.zookeeper:zookeeper from 3.9.3 to 3.9.4 ([#5689](https://github.com/opensearch-project/security/pull/5689))
 - Bump org.lz4:lz4-java from 1.8.0 to 1.10.1 ([#5970](https://github.com/opensearch-project/security/pull/5970))
+- Bump kafka from 3.9.1 to 3.9.2 ([#6089](https://github.com/opensearch-project/security/pull/6089))

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         opensearch_build = version_tokens[0] + '.0'
 
         common_utils_version = System.getProperty("common_utils.version", '2.19.0.0')
-        kafka_version  = '3.9.1'
+        kafka_version  = '3.9.2'
         open_saml_version = '4.3.2'
         one_login_java_saml = '2.9.0'
         jjwt_version = '0.12.6'


### PR DESCRIPTION
### Description
this resolves CVE-2026-35554, amongst others,
see the full changelog: https://downloads.apache.org/kafka/3.9.2/RELEASE_NOTES.html

note: this only applies to 2.19.x, for 3.x we're already on kafka 4.2.0.

### Issues Resolved
n/a

### Testing
n/a (i let the CI handle this)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
