### PR TITLE
Fix automatic-merges to ensure Github workflows run automatically

### DIFF
--- a/.github/workflows/automatic-merges.yml
+++ b/.github/workflows/automatic-merges.yml
@@ -14,15 +14,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v2.1.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - id: find-triggering-pr
         uses: peternied/find-triggering-pr@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.github_app_token.outputs.token }}
 
       - uses: peternied/discerning-merger@v3
         if: steps.find-triggering-pr.outputs.pr-number != null
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.github_app_token.outputs.token }}
           pull-request-number: ${{ steps.find-triggering-pr.outputs.pr-number }}
           allowed-authors: |
             dependabot[bot]


### PR DESCRIPTION
### Description

Fixes automatic Maven snapshot publication after bot-managed auto-merge commits.

The `automatic-merges` workflow previously merged eligible bot PRs using `secrets.GITHUB_TOKEN`. GitHub does not trigger most downstream workflows from events created by `GITHUB_TOKEN`, so the resulting push to `main` did not trigger the `Publish snapshots to maven` workflow.

This caused Maven snapshot publication to be skipped for auto-merged version bump commits, such as:

https://github.com/opensearch-project/security/commit/4581a082c5dc67b44893ac6da04a123c04def05f

This change updates the auto-merge workflow to use the repository’s GitHub App token instead. The token is generated with the existing `APP_ID`, `APP_PRIVATE_KEY`, and installation ID already used by the release workflow. The same app token is then passed to:

- `peternied/find-triggering-pr`
- `peternied/discerning-merger`

Using the GitHub App token for the merge should allow the resulting push event to trigger downstream workflows, including Maven snapshot publication.

* Category

Maintenance

### Issues Resolved

Ensure workflows run on automatically merged PRs such as https://github.com/opensearch-project/security/commit/4581a082c5dc67b44893ac6da04a123c04def05f

^ With that the security repo's maven snapshot publication failed so there are no 3.6.1 artifacts despite the 3.6 branch bumping to 3.6.1

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
