### PR TITLE
Fix EC JWKS authentication support

### DIFF
--- a/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/JwtVerifier.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/keybyoidc/JwtVerifier.java
@@ -25,8 +25,10 @@ import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.factories.DefaultJWSVerifierFactory;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.proc.SimpleSecurityContext;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -52,7 +54,6 @@ public class JwtVerifier {
     public SignedJWT getVerifiedJwtToken(String encodedJwt) throws BadCredentialsException {
         try {
             SignedJWT jwt = SignedJWT.parse(encodedJwt);
-
             String escapedKid = jwt.getHeader().getKeyID();
             String kid = escapedKid;
             if (!Strings.isNullOrEmpty(kid)) {
@@ -61,7 +62,6 @@ public class JwtVerifier {
                 log.debug("JWT token is missing 'kid' (Key ID) claim in header. This may cause key selection issues.");
             }
             JWK key = keyProvider.getKey(kid);
-
             JWSVerifier signatureVerifier = getInitializedSignatureVerifier(key, jwt);
             boolean signatureValid = jwt.verify(signatureVerifier);
 
@@ -104,10 +104,14 @@ public class JwtVerifier {
 
         validateSignatureAlgorithm(key, jwt);
         final JWSVerifier result;
-        if (key.getClass() == OctetSequenceKey.class) {
+        if (key instanceof OctetSequenceKey) {
             result = new DefaultJWSVerifierFactory().createJWSVerifier(jwt.getHeader(), key.toOctetSequenceKey().toSecretKey());
-        } else {
+        } else if (key instanceof RSAKey) {
             result = new DefaultJWSVerifierFactory().createJWSVerifier(jwt.getHeader(), key.toRSAKey().toRSAPublicKey());
+        } else if (key instanceof ECKey) {
+            result = new DefaultJWSVerifierFactory().createJWSVerifier(jwt.getHeader(), key.toECKey().toECPublicKey());
+        } else {
+            throw new IllegalArgumentException("Unsupported JWK key type: " + key.getClass());
         }
 
         if (result == null) {

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
@@ -54,6 +54,28 @@ public class HTTPJwtKeyByJWKSAuthenticatorTest {
     }
 
     @Test
+    public void testJwksAuthenticationWithEC() throws Exception {
+        MockJwksServer mockJwksServer = new MockJwksServer(TestJwk.Jwks.ALL);
+
+        try {
+            Settings settings = Settings.builder().put("jwks_uri", mockJwksServer.getJwksUri()).build();
+
+            HTTPJwtKeyByJWKSAuthenticator jwtAuth = new HTTPJwtKeyByJWKSAuthenticator(settings, null);
+
+            AuthCredentials creds = jwtAuth.extractCredentials(
+                new FakeRestRequest(ImmutableMap.of("Authorization", TestJwts.MC_COY_SIGNED_EC_1), new HashMap<>()).asSecurityRequest(),
+                null
+            );
+
+            Assert.assertNotNull(creds);
+            assertThat(creds.getUsername(), is(TestJwts.MCCOY_SUBJECT));
+
+        } finally {
+            mockJwksServer.close();
+        }
+    }
+
+    @Test
     public void testJwksAuthenticationWithBearerPrefix() throws Exception {
         MockJwksServer mockJwksServer = new MockJwksServer(TestJwk.Jwks.ALL);
 

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
@@ -76,6 +76,27 @@ public class HTTPJwtKeyByJWKSAuthenticatorTest {
     }
 
     @Test
+    public void testJwksAuthenticationWithInvalidECSignature() throws Exception {
+        MockJwksServer mockJwksServer = new MockJwksServer(TestJwk.Jwks.ALL);
+
+        try {
+            Settings settings = Settings.builder().put("jwks_uri", mockJwksServer.getJwksUri()).build();
+
+            HTTPJwtKeyByJWKSAuthenticator jwtAuth = new HTTPJwtKeyByJWKSAuthenticator(settings, null);
+
+            AuthCredentials creds = jwtAuth.extractCredentials(
+                new FakeRestRequest(ImmutableMap.of("Authorization", "Bearer invalid.jwt.token"), new HashMap<>()).asSecurityRequest(),
+                null
+            );
+
+            Assert.assertNull(creds);
+
+        } finally {
+            mockJwksServer.close();
+        }
+    }
+
+    @Test
     public void testJwksAuthenticationWithBearerPrefix() throws Exception {
         MockJwksServer mockJwksServer = new MockJwksServer(TestJwk.Jwks.ALL);
 

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwk.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwk.java
@@ -15,6 +15,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
@@ -47,6 +49,10 @@ class TestJwk {
         "hMSoV74FRtoaU7xpp0llsXbHE4oUseKoSNga-C_YIXuoGc3pajHh1WtJppZQNYM1Xy07nHchLJAdgqL2_q_Lk8cFHmmL1KTjwPflK9zZ9C0-8QTOrrqU9vkp3gT00jWWJ0HJbUvXIGxPGPnxoJoI--ToE0EWsYEWqWyx1TqYol--oUUPlY5r7vXRKIn5UZNz6VGkW8nI4fXaqDUpXH9uVM9A-nJX2B0Xjwu3VOn2zrgkCZeGTHjNgfLISOTFe9m8lHWLKcuxOWPuCZyCN0C6ZdWB1YP2NhxYFQwQfGV8yfnTImgL-DuV4WPSRVj7W_GJr213-oXBrBR0CnQEPbi_3w";
     static final String RSA_1_E = "AQAB";
 
+    static final String EC_1_X = "K9a34L6QkEkWggKi700OyBCRghR2Xt-0Wym8qz0GdsM";
+    static final String EC_1_Y = "NaINav68UqRb9D9MWkUJZN6acnuOYSb2iWAVI05iKpw";
+    static final String EC_1_D = "lkTOA6MmmMDUg44V0coRAHbB5Zw-0748N8l8EOK8-5A";
+
     static final String RSA_2_D =
         "QQ18k_buZHOSVYzkXL1FaqdodZVNZ_hrBtDcmCVUYjm3dfDVQYt70h8LUdLUCSUA2-_VEwqVdQ-L2FTg7NZVvZJXIyQXp3yrdY1vGKebs3oaIB_VQT8jt-64s12r_8V2ksK2myRrvfm2Fgqi32H5QkspuaQYb9s4NJwKSk7mVAz5dRWQdCx9JNVWknWDJxgHzh3Uku1tNwUOyvSYcRnSZ9X7oWNHaHkSGLEYE_mxD7YXs6HEdCDwc3WuvR5AiVKg2OGec0lL1hY_AWX5UxnR00mhAa0qPytFfaPe-Sc5tQ5regQRqRNDyDESVGIvqXsY8ePjZPOFyoxrcJ2wN3bt4Q";
     static final String RSA_2_N =
@@ -61,6 +67,9 @@ class TestJwk {
 
     static final JWK RSA_1 = createRsa("kid/1", "RS256", RSA_1_E, RSA_1_N, RSA_1_D);
 
+    static final JWK EC_1 = createEc("kid/ec1", "ES256", EC_1_X, EC_1_Y, EC_1_D);
+    static final JWK EC_1_PUBLIC = createEc("kid/ec1", "ES256", EC_1_X, EC_1_Y, null);
+
     static final JWK RSA_1_PUBLIC = createRsaPublic("kid/1", "RS256", RSA_1_E, RSA_1_N);
     static final JWK RSA_1_PUBLIC_NO_ALG = createRsaPublic("kid/1", null, RSA_1_E, RSA_1_N);
     static final JWK RSA_1_PUBLIC_WRONG_ALG = createRsaPublic("kid/1", "HS256", RSA_1_E, RSA_1_N);
@@ -74,9 +83,10 @@ class TestJwk {
     static final JWKSet RSA_1_2_PUBLIC = createJwks(RSA_1_PUBLIC, RSA_2_PUBLIC);
 
     static class Jwks {
-        static final JWKSet ALL = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, RSA_1_PUBLIC, RSA_2_PUBLIC);
+        static final JWKSet ALL = createJwks(OCT_1, OCT_2, OCT_3, FORWARD_SLASH_KID_OCT_1, RSA_1_PUBLIC, RSA_2_PUBLIC, EC_1_PUBLIC);
         static final JWKSet RSA_1 = createJwks(RSA_1_PUBLIC);
         static final JWKSet RSA_2 = createJwks(RSA_2_PUBLIC);
+        static final JWKSet EC_1 = createJwks(EC_1_PUBLIC);
         static final JWKSet RSA_1_NO_ALG = createJwks(RSA_1_PUBLIC_NO_ALG);
         static final JWKSet RSA_1_WRONG_ALG = createJwks(RSA_1_PUBLIC_WRONG_ALG);
     }
@@ -102,6 +112,18 @@ class TestJwk {
 
     private static JWK createRsaPublic(String keyId, String algorithm, String e, String n) {
         return createRsa(keyId, algorithm, e, n, null);
+    }
+
+    private static JWK createEc(String keyId, String algorithm, String x, String y, String d) {
+        ECKey.Builder builder = new ECKey.Builder(Curve.P_256, Base64URL.from(x), Base64URL.from(y)).keyUse(KeyUse.SIGNATURE)
+            .algorithm(algorithm == null ? null : JWSAlgorithm.parse(algorithm))
+            .keyID(keyId);
+
+        if (d != null) {
+            builder.d(Base64URL.from(d));
+        }
+
+        return builder.build();
     }
 
     private static JWKSet createJwks(JWK... array) {

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/TestJwts.java
@@ -104,6 +104,8 @@ class TestJwts {
 
     static final String MC_COY_SIGNED_RSA_1 = createSigned(MC_COY, TestJwk.RSA_1);
 
+    static final String MC_COY_SIGNED_EC_1 = createSigned(MC_COY, TestJwk.EC_1);
+
     static final String MC_COY_SIGNED_RSA_X = createSigned(MC_COY, TestJwk.RSA_X);
 
     static final String MC_COY_EXPIRED_SIGNED_OCT_1 = createSigned(MC_COY_EXPIRED, TestJwk.OCT_1);


### PR DESCRIPTION
### Description
This PR fixes EC-based JWKS authentication support as part of issue #6045.

* Category : Bug fix
* Why these changes are required?
EC-based JWT verification using JWKS was not handled correctly, leading to authentication failures for EC-signed tokens.
* What is the old behavior before changes and new behavior after changes?
Old behavior:
EC-signed JWTs using JWKS could fail validation due to missing or incorrect key handling.
New behavior:
EC JWKS keys are now properly parsed and used for JWT verification, enabling successful authentication for EC-signed tokens.

### Issues Resolved
Fixes #6045

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Validated locally using EC-signed JWTs with JWKS
Tested token verification flow end-to-end
Confirmed backward compatibility with existing RSA-based flows

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
