### PR TITLE
Make sure Netty4Http3ServerTransport uses configured HeaderVerifier and Decompressor instances

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -614,6 +614,8 @@ allprojects {
                 integrationTestImplementation ('com.jayway.jsonpath:json-path:2.10.0') {
                     exclude(group: 'net.minidev', module: 'json-smart')
                 }
+                integrationTestImplementation "io.projectreactor.netty:reactor-netty-core:${versions.reactor_netty}"
+                integrationTestImplementation "io.projectreactor.netty:reactor-netty-http:${versions.reactor_netty}"
             }
         }
     }

--- a/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
+++ b/src/integrationTest/java/org/opensearch/security/ResourceFocusedTests.java
@@ -13,6 +13,9 @@ package org.opensearch.security;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -31,13 +34,21 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.http.HttpTransportSettings;
 import org.opensearch.test.framework.AsyncActions;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.ReactorHttpClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.transport.client.Client;
+
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import reactor.netty.http.HttpProtocol;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -64,11 +75,13 @@ public class ResourceFocusedTests {
             )
             .on("*")
     );
+    private static Map<String, Object> NODE_SETTINGS = Map.of(HttpTransportSettings.SETTING_HTTP_HTTP3_ENABLED.getKey(), true);
 
     @ClassRule
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
         .authc(AUTHC_HTTPBASIC_INTERNAL)
         .users(ADMIN_USER, LIMITED_USER)
+        .nodeSettings(NODE_SETTINGS)
         .anonymousAuth(false)
         .doNotFailOnForbidden(true)
         .build();
@@ -86,10 +99,11 @@ public class ResourceFocusedTests {
         // Tweaks:
         final RequestBodySize size = RequestBodySize.XLarge;
         final String requestPath = "/*/_search";
-        final int parrallelism = 5;
+        final int parallelism = 5;
         final int totalNumberOfRequests = 100;
 
-        runResourceTest(size, requestPath, parrallelism, totalNumberOfRequests);
+        runResourceTest(size, requestPath, parallelism, totalNumberOfRequests);
+        runResourceTestWithGenericClient(size, requestPath, parallelism, totalNumberOfRequests);
     }
 
     @Test
@@ -97,10 +111,11 @@ public class ResourceFocusedTests {
         // Tweaks:
         final RequestBodySize size = RequestBodySize.Medium;
         final String requestPath = "/*/_search";
-        final int parrallelism = 20;
+        final int parallelism = 20;
         final int totalNumberOfRequests = 10_000;
 
-        runResourceTest(size, requestPath, parrallelism, totalNumberOfRequests);
+        runResourceTest(size, requestPath, parallelism, totalNumberOfRequests);
+        runResourceTestWithGenericClient(size, requestPath, parallelism, totalNumberOfRequests);
     }
 
     @Test
@@ -108,16 +123,17 @@ public class ResourceFocusedTests {
         // Tweaks:
         final RequestBodySize size = RequestBodySize.Small;
         final String requestPath = "/*/_search";
-        final int parrallelism = 100;
+        final int parallelism = 100;
         final int totalNumberOfRequests = 15_000;
 
-        runResourceTest(size, requestPath, parrallelism, totalNumberOfRequests);
+        runResourceTest(size, requestPath, parallelism, totalNumberOfRequests);
+        runResourceTestWithGenericClient(size, requestPath, parallelism, totalNumberOfRequests);
     }
 
     private void runResourceTest(
         final RequestBodySize size,
         final String requestPath,
-        final int parrallelism,
+        final int parallelism,
         final int totalNumberOfRequests
     ) {
         final byte[] compressedRequestBody = createCompressedRequestBody(size);
@@ -127,11 +143,37 @@ public class ResourceFocusedTests {
                 post.setEntity(new ByteArrayEntity(compressedRequestBody, ContentType.APPLICATION_JSON));
                 TestRestClient.HttpResponse response = client.executeRequest(post);
                 return response.getStatusCode();
-            }, parrallelism, totalNumberOfRequests);
+            }, parallelism, totalNumberOfRequests);
 
             AsyncActions.getAll(requests, 2, TimeUnit.MINUTES).forEach((responseCode) -> {
                 assertThat(responseCode, equalTo(HttpStatus.SC_UNAUTHORIZED));
             });
+        }
+    }
+
+    private void runResourceTestWithGenericClient(
+        final RequestBodySize size,
+        final String requestPath,
+        final int parallelism,
+        final int totalNumberOfRequests
+    ) {
+        final byte[] compressedRequestBody = createCompressedRequestBody(size);
+        try (
+            final ReactorHttpClient client = cluster.getGenericClient(
+                HttpProtocol.HTTP3,
+                true,
+                Settings.builder().loadFromMap(NODE_SETTINGS).build()
+            )
+        ) {
+            List<Tuple<String, byte[]>> requestUris = new ArrayList<>();
+            for (int i = 0; i < totalNumberOfRequests; i++) {
+                requestUris.add(Tuple.tuple(requestPath, compressedRequestBody));
+            }
+
+            final Collection<FullHttpResponse> responses = client.post(requestUris, parallelism);
+            responses.stream()
+                .map(FullHttpResponse::status)
+                .forEach(responseCode -> assertThat(responseCode, equalTo(HttpResponseStatus.UNAUTHORIZED)));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
@@ -65,9 +65,12 @@ import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.opensearch.client.RestClient;
 import org.opensearch.client.RestClientBuilder;
 import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.PemKeyReader;
 import org.opensearch.test.framework.certificate.CertificateData;
 import org.opensearch.test.framework.certificate.TestCertificates;
+
+import reactor.netty.http.HttpProtocol;
 
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_TYPE;
 import static org.opensearch.test.framework.cluster.TestRestClientConfiguration.getBasicAuthHeader;
@@ -227,13 +230,19 @@ public interface OpenSearchClientProvider {
         return getRestClient(Arrays.asList(headers), useCertificateData);
     }
 
+    /**
+     * Returns a generic HTTP/1.1/HTTP 2.0/HTTP 3.0 client.
+     */
+    default ReactorHttpClient getGenericClient(HttpProtocol protocol, boolean secure, Settings settings) {
+        return new ReactorHttpClient(true, true, settings, getHttpAddress());
+    }
+
     default TestRestClient getRestClient(Header... headers) {
         return getRestClient((CertificateData) null, headers);
     }
 
     default TestRestClient getRestClient(List<Header> headers) {
         return createGenericClientRestClient(new TestRestClientConfiguration().headers(headers));
-
     }
 
     default TestRestClient getRestClient(List<Header> headers, CertificateData useCertificateData) {

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/ReactorHttpClient.java
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/*
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.test.framework.cluster;
+
+import java.io.Closeable;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.opensearch.common.collect.Tuple;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.http.netty4.http3.Http3Utils;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.EmptyHttpHeaders;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http2.HttpConversionUtil;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import io.netty.resolver.DefaultAddressResolverGroup;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.ParallelFlux;
+import reactor.netty.http.Http11SslContextSpec;
+import reactor.netty.http.Http2SslContextSpec;
+import reactor.netty.http.Http3SslContextSpec;
+import reactor.netty.http.HttpProtocol;
+import reactor.netty.http.client.HttpClient;
+
+import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_HTTP3_ENABLED;
+import static org.opensearch.http.HttpTransportSettings.SETTING_HTTP_MAX_CONTENT_LENGTH;
+
+/**
+ * Tiny helper to send http requests over netty.
+ */
+public class ReactorHttpClient implements Closeable {
+    private static final java.util.Random RAND = new java.util.Random();
+
+    private final boolean compression;
+    private final boolean secure;
+    private final HttpProtocol protocol;
+    private final Settings settings;
+    private final InetSocketAddress remoteAddress;
+
+    public ReactorHttpClient(boolean compression, boolean secure, Settings settings, InetSocketAddress remoteAddress) {
+        this.compression = compression;
+        this.secure = secure;
+        this.protocol = randomProtocol(secure, settings);
+        this.settings = settings;
+        this.remoteAddress = remoteAddress;
+    }
+
+    public final Collection<FullHttpResponse> post(List<Tuple<String, byte[]>> urisAndBodies, int parallelism) {
+        return processRequestsWithBody(HttpMethod.POST, remoteAddress, urisAndBodies, parallelism);
+    }
+
+    private List<FullHttpResponse> processRequestsWithBody(
+        HttpMethod method,
+        InetSocketAddress remoteAddress,
+        List<Tuple<String, byte[]>> urisAndBodies,
+        int parallelism
+    ) {
+        List<FullHttpRequest> requests = new ArrayList<>(urisAndBodies.size());
+        for (int i = 0; i < urisAndBodies.size(); ++i) {
+            final Tuple<String, byte[]> uriAndBody = urisAndBodies.get(i);
+            ByteBuf content = Unpooled.copiedBuffer(uriAndBody.v2());
+            FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, method, uriAndBody.v1(), content);
+            request.headers().add(HttpHeaderNames.HOST, "localhost");
+            request.headers().add(HttpHeaderNames.CONTENT_LENGTH, content.readableBytes());
+            request.headers().add(HttpHeaderNames.CONTENT_TYPE, "application/json");
+            request.headers().add(HttpHeaderNames.CONTENT_ENCODING, "gzip");
+            request.headers().add(HttpConversionUtil.ExtensionHeaderNames.SCHEME.text(), secure ? "https" : "http");
+            requests.add(request);
+        }
+        return sendRequests(remoteAddress, requests, false, parallelism);
+    }
+
+    private List<FullHttpResponse> sendRequests(
+        final InetSocketAddress remoteAddress,
+        final Collection<FullHttpRequest> requests,
+        boolean ordered,
+        int parallelism
+    ) {
+        final EventLoopGroup eventLoopGroup = new MultiThreadIoEventLoopGroup(parallelism, NioIoHandler.newFactory());
+        try {
+            final HttpClient client = createClient(remoteAddress, eventLoopGroup);
+
+            @SuppressWarnings("unchecked")
+            final Mono<FullHttpResponse>[] monos = requests.stream()
+                .map(
+                    request -> client.headers(h -> h.add(request.headers()))
+                        .baseUrl(request.uri())
+                        .request(request.method())
+                        .send(Mono.fromSupplier(() -> request.content()))
+                        .responseSingle(
+                            (r, body) -> body.switchIfEmpty(Mono.just(Unpooled.EMPTY_BUFFER))
+                                .map(
+                                    b -> new DefaultFullHttpResponse(
+                                        r.version(),
+                                        r.status(),
+                                        b.retain(),
+                                        r.responseHeaders(),
+                                        EmptyHttpHeaders.INSTANCE
+                                    )
+                                )
+                        )
+                )
+                .toArray(Mono[]::new);
+
+            if (ordered == false) {
+                return ParallelFlux.from(monos).sequential().collectList().block();
+            } else {
+                return Flux.concat(monos).flatMapSequential(r -> Mono.just(r)).collectList().block(Duration.ofMinutes(2));
+            }
+        } finally {
+            eventLoopGroup.shutdownGracefully().awaitUninterruptibly();
+        }
+    }
+
+    private HttpClient createClient(final InetSocketAddress remoteAddress, final EventLoopGroup eventLoopGroup) {
+        final HttpClient client = HttpClient.newConnection()
+            .resolver(DefaultAddressResolverGroup.INSTANCE)
+            .runOn(eventLoopGroup)
+            .host(remoteAddress.getHostString())
+            .port(remoteAddress.getPort())
+            .compress(compression);
+
+        if (secure) {
+            if (protocol == HttpProtocol.HTTP11) {
+                return client.protocol(protocol)
+                    .secure(
+                        spec -> spec.sslContext(
+                            Http11SslContextSpec.forClient()
+                                .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
+                        ).handshakeTimeout(Duration.ofSeconds(30))
+                    );
+            } else if (protocol == HttpProtocol.H2) {
+                return client.protocol(new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2 })
+                    .secure(
+                        spec -> spec.sslContext(
+                            Http2SslContextSpec.forClient()
+                                .configure(s -> s.clientAuth(ClientAuth.NONE).trustManager(InsecureTrustManagerFactory.INSTANCE))
+                        ).handshakeTimeout(Duration.ofSeconds(30))
+                    );
+            } else {
+                return client.protocol(protocol)
+                    .secure(
+                        spec -> spec.sslContext(
+                            Http3SslContextSpec.forClient().configure(s -> s.trustManager(InsecureTrustManagerFactory.INSTANCE))
+                        ).handshakeTimeout(Duration.ofSeconds(30))
+                    )
+                    .http3Settings(
+                        spec -> spec.idleTimeout(Duration.ofSeconds(5))
+                            .maxData(SETTING_HTTP_MAX_CONTENT_LENGTH.get(settings).getBytes())
+                            .maxStreamDataBidirectionalLocal(1000000)
+                            .maxStreamDataBidirectionalRemote(1000000)
+                            .maxStreamsBidirectional(100L)
+                    );
+            }
+        } else {
+            if (protocol == HttpProtocol.HTTP11) {
+                return client.protocol(protocol);
+            } else {
+                return client.protocol(new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2C });
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    public HttpProtocol protocol() {
+        return protocol;
+    }
+
+    private static HttpProtocol randomProtocol(boolean secure, Settings settings) {
+        HttpProtocol[] values = null;
+
+        if (secure) {
+            if (Http3Utils.isHttp3Available() && SETTING_HTTP_HTTP3_ENABLED.get(settings).booleanValue() == true) {
+                values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2, HttpProtocol.HTTP3 };
+            } else {
+                values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2 };
+            }
+        } else {
+            values = new HttpProtocol[] { HttpProtocol.HTTP11, HttpProtocol.H2C };
+        }
+
+        return values[RAND.nextInt(values.length - 1)];
+    }
+
+}

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -23,6 +23,7 @@ import javax.net.ssl.TrustManagerFactory;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.http.HttpServerTransport;
+import org.opensearch.http.netty4.Netty4Http3ServerTransport;
 import org.opensearch.http.netty4.ssl.SecureNetty4HttpServerTransport;
 import org.opensearch.plugins.SecureAuxTransportSettingsProvider;
 import org.opensearch.plugins.SecureHttpTransportSettingsProvider;
@@ -199,12 +200,15 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                     @SuppressWarnings("unchecked")
                     @Override
                     public <C> Optional<C> create(Settings settings, HttpServerTransport transport, Class<C> adapterClass) {
-                        if (transport instanceof SecureNetty4HttpServerTransport
-                            && ChannelInboundHandlerAdapter.class.isAssignableFrom(adapterClass)) {
+                        if (transportSupported(transport) && ChannelInboundHandlerAdapter.class.isAssignableFrom(adapterClass)) {
                             return Optional.of((C) new Netty4ConditionalDecompressor());
                         } else {
                             return Optional.empty();
                         }
+                    }
+
+                    private boolean transportSupported(HttpServerTransport transport) {
+                        return transport instanceof SecureNetty4HttpServerTransport || transport instanceof Netty4Http3ServerTransport;
                     }
                 }, new TransportAdapterProvider<HttpServerTransport>() {
                     @Override
@@ -215,12 +219,15 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                     @SuppressWarnings("unchecked")
                     @Override
                     public <C> Optional<C> create(Settings settings, HttpServerTransport transport, Class<C> adapterClass) {
-                        if (transport instanceof SecureNetty4HttpServerTransport
-                            && ChannelInboundHandlerAdapter.class.isAssignableFrom(adapterClass)) {
+                        if (transportSupported(transport) && ChannelInboundHandlerAdapter.class.isAssignableFrom(adapterClass)) {
                             return Optional.of((C) new Netty4HttpRequestHeaderVerifier(restFilter, threadPool, settings));
                         } else {
                             return Optional.empty();
                         }
+                    }
+
+                    private boolean transportSupported(HttpServerTransport transport) {
+                        return transport instanceof SecureNetty4HttpServerTransport || transport instanceof Netty4Http3ServerTransport;
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecureSettingsFactory.java
@@ -207,9 +207,6 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                         }
                     }
 
-                    private boolean transportSupported(HttpServerTransport transport) {
-                        return transport instanceof SecureNetty4HttpServerTransport || transport instanceof Netty4Http3ServerTransport;
-                    }
                 }, new TransportAdapterProvider<HttpServerTransport>() {
                     @Override
                     public String name() {
@@ -224,10 +221,6 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
                         } else {
                             return Optional.empty();
                         }
-                    }
-
-                    private boolean transportSupported(HttpServerTransport transport) {
-                        return transport instanceof SecureNetty4HttpServerTransport || transport instanceof Netty4Http3ServerTransport;
                     }
                 });
             }
@@ -245,6 +238,10 @@ public class OpenSearchSecureSettingsFactory implements SecureSettingsFactory {
             @Override
             public Optional<SSLEngine> buildSecureHttpServerEngine(Settings settings, HttpServerTransport transport) throws SSLException {
                 return sslSettingsManager.sslContextHandler(CertType.HTTP).map(SslContextHandler::createSSLEngine);
+            }
+
+            private static boolean transportSupported(HttpServerTransport transport) {
+                return transport instanceof SecureNetty4HttpServerTransport || transport instanceof Netty4Http3ServerTransport;
             }
         });
     }

--- a/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
+++ b/src/main/java/org/opensearch/security/ssl/http/netty/Netty4HttpRequestHeaderVerifier.java
@@ -14,6 +14,7 @@ import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.http.netty4.Netty4Http3ServerTransport;
 import org.opensearch.http.netty4.Netty4HttpChannel;
 import org.opensearch.http.netty4.Netty4HttpServerTransport;
 import org.opensearch.security.filter.SecurityRequestChannel;
@@ -31,6 +32,7 @@ import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.quic.QuicStreamChannel;
 import io.netty.util.AttributeKey;
 import io.netty.util.ReferenceCountUtil;
 
@@ -79,7 +81,7 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
         ctx.channel().attr(Netty4HttpRequestHeaderVerifier.SHOULD_DECOMPRESS).set(Boolean.FALSE);
         ctx.channel().attr(Netty4HttpRequestHeaderVerifier.IS_AUTHENTICATED).set(Boolean.FALSE);
 
-        final Netty4HttpChannel httpChannel = ctx.channel().attr(Netty4HttpServerTransport.HTTP_CHANNEL_KEY).get();
+        final Netty4HttpChannel httpChannel = getHttpChannel(ctx);
 
         final SecurityRequestChannel requestChannel = SecurityRequestFactory.from(msg, httpChannel);
         ThreadContext threadContext = threadPool.getThreadContext();
@@ -112,6 +114,14 @@ public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler
             // Use defaults for unsupported channels
         } finally {
             ctx.fireChannelRead(msg);
+        }
+    }
+
+    private Netty4HttpChannel getHttpChannel(ChannelHandlerContext ctx) {
+        if (ctx.channel() instanceof QuicStreamChannel /* HTTP/3 */) {
+            return ctx.channel().attr(Netty4Http3ServerTransport.HTTP_CHANNEL_KEY).get();
+        } else {
+            return ctx.channel().attr(Netty4HttpServerTransport.HTTP_CHANNEL_KEY).get();
         }
     }
 


### PR DESCRIPTION
### Description
Make sure Netty4Http3ServerTransport uses configured HeaderVerifier and Decompressor instances

### Issues Resolved
Reflecting changes in https://github.com/opensearch-project/OpenSearch/pull/21281

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Tests added

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
