### PR TITLE
Fix NPE in LDAPAuthorizationBackend when rolesearch disabled

### DIFF
--- a/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -936,6 +936,10 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
             } else {
                 // DN roles, extract rolename according to config
+                if (connection == null) {
+                    connection = getConnection(settings, configPath);
+                }
+
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 

--- a/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -832,15 +832,15 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 userRoleAttributeValue = Utils.getSingleStringValue(userRoleAttribute);
             }
 
+            if (connection == null) {
+                connection = getConnection(settings, configPath);
+            }
+
             if (rolesearchEnabled) {
                 String escapedDn = dn;
 
                 if (isDebugEnabled) {
                     log.debug("DBGTRACE (8): escapedDn" + escapedDn);
-                }
-
-                if (connection == null) {
-                    connection = getConnection(settings, configPath);
                 }
 
                 for (Map.Entry<String, Settings> roleSearchSettingsEntry : roleBaseSettings) {
@@ -883,10 +883,6 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
             if (isTraceEnabled) {
                 log.trace("roles count total {}", ldapRoles.size());
-            }
-
-            if (connection == null) {
-                connection = getConnection(settings, configPath);
             }
 
             // nested roles, makes only sense for DN style role names

--- a/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
+++ b/src/main/java/org/opensearch/security/auth/ldap/backend/LDAPAuthorizationBackend.java
@@ -885,6 +885,10 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                 log.trace("roles count total {}", ldapRoles.size());
             }
 
+            if (connection == null) {
+                connection = getConnection(settings, configPath);
+            }
+
             // nested roles, makes only sense for DN style role names
             if (nestedRoleMatcher != null) {
 
@@ -900,10 +904,6 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
                     if (nameRoleSearchBaseKeys == null) {
                         log.error("Could not find roleSearchBaseKeys for " + roleLdapName + "; existing: " + resultRoleSearchBaseKeys);
                         continue;
-                    }
-
-                    if (connection == null) {
-                        connection = getConnection(settings, configPath);
                     }
 
                     final Set<LdapName> nestedRoles = resolveNestedRoles(
@@ -936,10 +936,6 @@ public class LDAPAuthorizationBackend implements AuthorizationBackend {
 
             } else {
                 // DN roles, extract rolename according to config
-                if (connection == null) {
-                    connection = getConnection(settings, configPath);
-                }
-
                 for (final LdapName roleLdapName : ldapRoles) {
                     final String role = getRoleFromEntry(connection, roleLdapName, roleName);
 

--- a/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestNewStyleConfig.java
+++ b/src/test/java/org/opensearch/security/auth/ldap/LdapBackendTestNewStyleConfig.java
@@ -726,6 +726,29 @@ public class LdapBackendTestNewStyleConfig {
     }
 
     @Test
+    public void testLdapAuthorizationRolesearchDisabledWithLdapAuthContext() throws Exception {
+        final Settings settings = Settings.builder()
+            .putList(ConfigConstants.LDAP_HOSTS, "localhost:" + ldapPort)
+            .put("users.u1.search", "(uid={0})")
+            .put("users.u1.base", "ou=people,o=TEST")
+            .put("roles.g1.base", "ou=groups,o=TEST")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLENAME, "cn")
+            .put(ConfigConstants.LDAP_AUTHZ_ROLESEARCH_ENABLED, false)
+            .put(ConfigConstants.LDAP_AUTHZ_USERROLENAME, "description")
+            .build();
+
+        AuthenticationContext context = ctx("spock", "spocksecret");
+        User user = new LDAPAuthenticationBackend(settings, null).authenticate(context);
+        user = new LDAPAuthorizationBackend(settings, null).addRoles(user, context);
+
+        Assert.assertNotNull(user);
+        assertThat(user.getName(), is("cn=Captain Spock,ou=people,o=TEST"));
+        assertThat(user.getRoles().size(), is(2));
+        Assert.assertTrue(user.getRoles().contains("dummyempty"));
+        Assert.assertTrue(user.getRoles().contains("rolemo4"));
+    }
+
+    @Test
     public void testCustomAttributes() throws Exception {
 
         Settings settings = Settings.builder()


### PR DESCRIPTION
### Description

* Bug fix

When `rolesearch_enabled: false` is configured and the user authenticated via ldap, an NPE is thrown:

```
Cannot invoke "org.ldaptive.Connection.getProviderConnection()" because
the return value of "org.ldaptive.SearchOperation.getConnection()" is null
```

This happens because a connection to ldap is never opened in the user lookup block as the user's DN is already known. The code then falls through to the else branch that calls `getRoleFromEntry()` to resolve role names, but connection is still null at this point, causing the NPE.

The rolesearch block (and the nested roles block) already have null guards which explains why enabling rolesearch worked as a workaround.

### Issues Resolved

Fixes #5832

Is this a backport? No

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? No

### Testing

Added `testLdapAuthorizationRolesearchDisabledWithLdapAuthContext` which authenticates the user with an `LDAPAuthenticationBackend` then calls `addRoles` with `rolesearch_enabled: false`.

### Check List

- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff