### PR TITLE
Validate password hashing algorithm for FIPS

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -357,6 +357,24 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         return settings.getAsBoolean(SECURITY_SSL_CERTIFICATES_HOT_RELOAD_ENABLED, false);
     }
 
+    static void validateFipsMode(final String fipsModeEnvValue, final Settings settings) {
+        if ("true".equalsIgnoreCase(fipsModeEnvValue)) {
+            String hashingAlgorithm = settings.get(
+                ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM,
+                ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM_DEFAULT
+            );
+            if (!ConfigConstants.PBKDF2.equalsIgnoreCase(hashingAlgorithm)) {
+                throw new IllegalStateException(
+                    "FIPS mode is enabled (OPENSEARCH_FIPS_MODE=true) but password hashing algorithm is set to '"
+                        + hashingAlgorithm
+                        + "'. Only PBKDF2 is allowed in FIPS mode. Set '"
+                        + ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM
+                        + "' to 'pbkdf2'. Note: changing the hashing algorithm requires all existing passwords to be rehashed."
+                );
+            }
+        }
+    }
+
     public OpenSearchSecurityPlugin(final Settings settings, final Path configPath) {
         super(settings, configPath, isDisabled(settings));
 
@@ -488,6 +506,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 ConfigConstants.SECURITY_MASKED_FIELDS_ALGORITHM_DEFAULT
             );
         }
+
+        validateFipsMode(System.getenv("OPENSEARCH_FIPS_MODE"), settings);
 
         if (!client && !settings.getAsBoolean(ConfigConstants.SECURITY_ALLOW_UNSAFE_DEMOCERTIFICATES, false)) {
             // check for demo certificates

--- a/src/test/java/org/opensearch/security/OpenSearchSecurityPluginFIPSValidationTest.java
+++ b/src/test/java/org/opensearch/security/OpenSearchSecurityPluginFIPSValidationTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThrows;
+
+public class OpenSearchSecurityPluginFIPSValidationTest {
+
+    @Test
+    public void testFipsModeWithDefaultAlgorithmThrows() {
+        // Default algorithm is bcrypt, which is not FIPS-compliant
+        Settings settings = Settings.builder().build();
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> OpenSearchSecurityPlugin.validateFipsMode("true", settings)
+        );
+        assertThat(ex.getMessage(), containsString("FIPS mode is enabled"));
+        assertThat(ex.getMessage(), containsString("Only PBKDF2 is allowed in FIPS mode"));
+        assertThat(ex.getMessage(), containsString("changing the hashing algorithm requires all existing passwords to be rehashed"));
+    }
+
+    @Test
+    public void testFipsModeWithBcryptThrows() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "bcrypt").build();
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> OpenSearchSecurityPlugin.validateFipsMode("true", settings)
+        );
+        assertThat(ex.getMessage(), containsString("bcrypt"));
+        assertThat(ex.getMessage(), containsString("FIPS mode is enabled"));
+    }
+
+    @Test
+    public void testFipsModeWithArgon2Throws() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "argon2").build();
+
+        IllegalStateException ex = assertThrows(
+            IllegalStateException.class,
+            () -> OpenSearchSecurityPlugin.validateFipsMode("true", settings)
+        );
+        assertThat(ex.getMessage(), containsString("argon2"));
+    }
+
+    @Test
+    public void testFipsModeWithPbkdf2Succeeds() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "pbkdf2").build();
+
+        // Should not throw
+        OpenSearchSecurityPlugin.validateFipsMode("true", settings);
+    }
+
+    @Test
+    public void testFipsModeWithPbkdf2UpperCaseSucceeds() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "PBKDF2").build();
+
+        // Should not throw
+        OpenSearchSecurityPlugin.validateFipsMode("true", settings);
+    }
+
+    @Test
+    public void testFipsModeDisabledAllowsAnyAlgorithm() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "bcrypt").build();
+
+        // Should not throw when FIPS mode is not enabled
+        OpenSearchSecurityPlugin.validateFipsMode("false", settings);
+    }
+
+    @Test
+    public void testFipsModeNullEnvAllowsAnyAlgorithm() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_PASSWORD_HASHING_ALGORITHM, "bcrypt").build();
+
+        // Should not throw when env var is null
+        OpenSearchSecurityPlugin.validateFipsMode(null, settings);
+    }
+}


### PR DESCRIPTION
### Description
* Category (Enhancement)
* Only PBKDF2 is FIPS-compliant

### Issues Resolved
https://github.com/opensearch-project/security/issues/3420

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Longer-term more rationalization of the FIPS mode flags may be required.
See https://github.com/opensearch-project/OpenSearch/issues/20738

### Testing
Tests added

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
