### PR TITLE
Improve cluster cleanup for in-memory integTest nodes

### DIFF
--- a/src/test/java/org/opensearch/security/test/SingleClusterTest.java
+++ b/src/test/java/org/opensearch/security/test/SingleClusterTest.java
@@ -167,26 +167,28 @@ public abstract class SingleClusterTest extends AbstractSecurityUnitTest {
 
     @After
     public void tearDown() {
+        Exception firstFailure = null;
 
         if (remoteClusterInfo != null) {
             try {
                 remoteClusterHelper.stopCluster();
             } catch (Exception e) {
                 log.error("Failed to stop remote cluster {}.", remoteClusterInfo.clustername, e);
-                Assert.fail("Failed to stop remote cluster " + remoteClusterInfo.clustername + ".");
+                firstFailure = e;
             }
             remoteClusterInfo = null;
         }
 
-        if (clusterInfo != null) {
-            try {
-                clusterHelper.stopCluster();
-            } catch (Exception e) {
-                log.error("Failed to stop cluster {}.", clusterInfo.clustername, e);
-                Assert.fail("Failed to stop cluster " + clusterInfo.clustername + ".");
-            }
-            clusterInfo = null;
+        try {
+            clusterHelper.stopCluster();
+        } catch (Exception e) {
+            log.error("Failed to stop cluster.", e);
+            if (firstFailure == null) firstFailure = e;
         }
+        clusterInfo = null;
 
+        if (firstFailure != null) {
+            Assert.fail("Cluster cleanup failed: " + firstFailure.getMessage());
+        }
     }
 }

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -271,6 +271,7 @@ public final class ClusterHelper {
         latch.await();
 
         if (err.get() != null) {
+            closeAllNodes();
             throw new RuntimeException("Could not start all nodes " + err.get(), err.get());
         }
 
@@ -342,7 +343,7 @@ public final class ClusterHelper {
     private static void closeNode(Node node) {
         try {
             node.close();
-            node.awaitClose(250, TimeUnit.MILLISECONDS);
+            node.awaitClose(5, TimeUnit.SECONDS);
         } catch (Throwable e) {
             // ignore
         }


### PR DESCRIPTION
  ### Description

  Fixes test infrastructure issues that cause cascading flaky failures — specifically thread leaks and port conflicts caused by incomplete cleanup after partial cluster startup failures.

  **Root cause**: When a test cluster node fails to start (e.g., `BindHttpException: Address already in use`), already-started nodes were not being shut down. Their thread pools and port bindings leaked into subsequent tests, causing `ThreadLeakError` and further `BindHttpException` failures.

  Example: https://github.com/opensearch-project/security/actions/runs/25217779716/job/73942275556

  ### Changes

  **`ClusterHelper.java`**:
  - Call `closeAllNodes()` before throwing when `startCluster()` fails partway through. Previously, nodes that started successfully before the failure were abandoned — their management thread pools and port bindings leaked.
  - Increase `awaitClose` timeout from 250ms to 5 seconds. The previous timeout was too short for thread pools to drain, causing silent thread leaks even during normal shutdown.

  **`SingleClusterTest.java`**:
  - Always call `clusterHelper.stopCluster()` in `tearDown()`, regardless of whether `clusterInfo` was set. Previously, cleanup was skipped entirely after a failed startup because `clusterInfo` is only assigned on success.
  - Defer `Assert.fail` until after both clusters are cleaned up. Previously, if remote cluster stop failed, `Assert.fail` threw immediately and prevented local cluster cleanup from running.

  ### Testing

  - Verified compilation
  - Changes are to test infrastructure only — no production code modified

  ### Check List
  - [x] Commits are signed per the DCO using --signoff