### PR TITLE
Fix SSL hot-reload to rebuild trust store instead of validating all CA dates

### DIFF
--- a/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
+++ b/src/main/java/org/opensearch/security/ssl/SslContextHandler.java
@@ -141,7 +141,7 @@ public class SslContextHandler {
         if (notSameCertificates(loadedAuthorityCertificates, newAuthorityCertificates)) {
             LOGGER.debug("Certification authority has changed");
             hasChanges = true;
-            validateDates(newAuthorityCertificates);
+            sslConfiguration.trustStoreFactory();
         }
 
         if (notSameCertificates(loadedKeyMaterialCertificates, newKeyMaterialCertificates)) {

--- a/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
+++ b/src/test/java/org/opensearch/security/ssl/SslContextHandlerTest.java
@@ -28,6 +28,7 @@ import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.cert.X509CertificateHolder;
 
+import org.opensearch.OpenSearchException;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.ssl.config.CertType;
 import org.opensearch.security.ssl.config.KeyStoreConfiguration;
@@ -116,7 +117,7 @@ public class SslContextHandlerTest {
 
         writeCertificates(newCaCertificate, certificatesRule.accessCertificateHolder(), certificatesRule.accessCertificatePrivateKey());
 
-        assertThrows(CertificateException.class, sslContextHandler::reloadSslContext);
+        assertThrows(OpenSearchException.class, sslContextHandler::reloadSslContext);
 
         newCaCertificate = certificatesRule.generateCaCertificate(
             keyPair,
@@ -125,7 +126,42 @@ public class SslContextHandlerTest {
         );
         writeCertificates(newCaCertificate, certificatesRule.accessCertificateHolder(), certificatesRule.accessCertificatePrivateKey());
 
-        assertThrows(CertificateException.class, sslContextHandler::reloadSslContext);
+        assertThrows(OpenSearchException.class, sslContextHandler::reloadSslContext);
+    }
+
+    @Test
+    public void sslContextReloadSucceedsWithValidIssuerAndExpiredIrrelevantCertificates() throws Exception {
+        final var sslContextHandler = sslContextHandler();
+
+        final var keyPair = certificatesRule.generateKeyPair();
+        final var validRelevantCA = certificatesRule.generateCaCertificate(
+            keyPair,
+            "CN=some_access,OU=client,O=client,L=test,C=de",
+            certificatesRule.generateSerialNumber(),
+            certificatesRule.caCertificateHolder().getNotBefore().toInstant(),
+            certificatesRule.caCertificateHolder().getNotAfter().toInstant()
+        );
+
+        final var newAccessCertificate = certificatesRule.generateAccessCertificate(keyPair);
+
+        final var irrelevantKeyPair = certificatesRule.generateKeyPair();
+        final var expiredIrrelevantCA = certificatesRule.generateCaCertificate(
+            irrelevantKeyPair,
+            "CN=irrelevant-ca,OU=irrelevant,O=irrelevant,L=irrelevant,C=XX",
+            certificatesRule.generateSerialNumber(),
+            certificatesRule.caCertificateHolder().getNotAfter().toInstant().minus(30, ChronoUnit.DAYS),
+            certificatesRule.caCertificateHolder().getNotAfter().toInstant().minus(10, ChronoUnit.DAYS)
+        );
+
+        writePemContent(accessCertificatePath, newAccessCertificate.v2());
+        writePemContent(
+            accessCertificatePrivateKeyPath,
+            privateKeyToPemObject(newAccessCertificate.v1(), certificatesRule.privateKeyPassword())
+        );
+        writePemContent(caCertificatePath, validRelevantCA, expiredIrrelevantCA);
+
+        final boolean hasChanges = sslContextHandler.reloadSslContext();
+        assertThat("SSL context should reload successfully", hasChanges, is(true));
     }
 
     @Test


### PR DESCRIPTION
### Description

PR #4979 fixed certificate validation during node bootup to only check certs in the chain of the node certificates. However, the hot-reload path in `SslContextHandler.reloadSslContext()` still calls `validateDates()` on all authority certificates. This causes hot-reload to fail when the trust store contains expired certificates that are not part of the node certificate's chain.

This PR replaces `validateDates(newAuthorityCertificates)` with `sslConfiguration.trustStoreFactory()` in the hot-reload path, which rebuilds the trust store and delegates validation to the trust store factory that already handles chain filtering per #4979.

### Issues Resolved

Related: #4949

### Testing

- Unit test added: `sslContextReloadSucceedsWithValidIssuerAndExpiredIrrelevantCertificates`
- Manually verified:
  - Expired cert **not in chain** → hot-reload succeeds
  - Expired cert **in chain** → hot-reload correctly fails

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff