### PR TITLE
Fix ClassCastException for otherName SAN entries during inter-cluster handshake

### DIFF
--- a/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
+++ b/src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
@@ -31,7 +31,6 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -124,34 +123,33 @@ public final class DefaultInterClusterRequestEvaluator implements InterClusterRe
 
                 for (final List<?> ian : ianList) {
 
-                    if (ian == null) {
+                    if (ian == null || ian.size() < 2) {
                         continue;
                     }
 
-                    for (@SuppressWarnings("rawtypes")
-                    final Iterator iterator = ian.iterator(); iterator.hasNext();) {
-                        final int id = (int) iterator.next();
-                        if (id == 8) { // id 8 = OID, id 1 = name (as string or
-                                       // ASN.1 encoded byte[])
-                            Object value = iterator.next();
+                    final Object typeId = ian.get(0);
+                    if (!(typeId instanceof Integer)) {
+                        continue;
+                    }
+                    final int id = (Integer) typeId;
+                    if (id == 8) { // id 8 = OID, id 1 = name (as string or
+                                   // ASN.1 encoded byte[])
+                        Object value = ian.get(1);
 
-                            if (value == null) {
-                                continue;
-                            }
+                        if (value == null) {
+                            continue;
+                        }
 
-                            if (value instanceof String) {
-                                sb.append(id + "::" + value);
-                            } else if (value instanceof byte[]) {
-                                log.error(
-                                    "Unable to handle OID san {} with value {} of type byte[] (ASN.1 DER not supported here)",
-                                    id,
-                                    Arrays.toString((byte[]) value)
-                                );
-                            } else {
-                                log.error("Unable to handle OID san {} with value {} of type {}", id, value, value.getClass());
-                            }
+                        if (value instanceof String) {
+                            sb.append(id + "::" + value);
+                        } else if (value instanceof byte[]) {
+                            log.error(
+                                "Unable to handle OID san {} with value {} of type byte[] (ASN.1 DER not supported here)",
+                                id,
+                                Arrays.toString((byte[]) value)
+                            );
                         } else {
-                            iterator.next();
+                            log.error("Unable to handle OID san {} with value {} of type {}", id, value, value.getClass());
                         }
                     }
                 }

--- a/src/test/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluatorTest.java
@@ -38,13 +38,8 @@ public class DefaultInterClusterRequestEvaluatorTest {
 
     @Test
     public void testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow() throws Exception {
-        // Reproduces issue #6090: certs issued by Windows CA contain a UPN otherName SAN entry
-        // (OID 1.3.6.1.4.1.311.20.2.3). Java surfaces such entries as a List with size > 2, where
-        // the third element is the OID String. The previous iterator-based parser tried to cast
-        // the OID String to int on the next loop iteration, throwing ClassCastException.
         X509Certificate cert = mock(X509Certificate.class);
         List<List<?>> sanList = new ArrayList<>();
-        // otherName SAN: [typeId=0, value (parsed), oid (String)]
         sanList.add(Arrays.asList(0, "user@example.com", "1.3.6.1.4.1.311.20.2.3"));
         when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
 
@@ -63,7 +58,6 @@ public class DefaultInterClusterRequestEvaluatorTest {
     public void testIsInterClusterRequest_oidSanMatchesNodeOid_returnsTrue() throws Exception {
         X509Certificate cert = mock(X509Certificate.class);
         List<List<?>> sanList = new ArrayList<>();
-        // registeredID SAN (typeId=8) — value is the OID as String
         sanList.add(Arrays.asList(8, NODE_OID));
         when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
 
@@ -80,7 +74,6 @@ public class DefaultInterClusterRequestEvaluatorTest {
 
     @Test
     public void testIsInterClusterRequest_oidSanAlongsideUpn_returnsTrue() throws Exception {
-        // Mixed SAN list: UPN otherName + matching node OID. Must not throw and must still match.
         X509Certificate cert = mock(X509Certificate.class);
         List<List<?>> sanList = new ArrayList<>();
         sanList.add(Arrays.asList(0, "user@example.com", "1.3.6.1.4.1.311.20.2.3"));

--- a/src/test/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluatorTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.transport;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.transport.TransportRequest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DefaultInterClusterRequestEvaluatorTest {
+
+    private static final String NODE_OID = "1.2.3.4.5.5";
+
+    private DefaultInterClusterRequestEvaluator newEvaluator() {
+        Settings settings = Settings.builder().put(ConfigConstants.SECURITY_CERT_OID, NODE_OID).build();
+        return new DefaultInterClusterRequestEvaluator(settings);
+    }
+
+    @Test
+    public void testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow() throws Exception {
+        // Reproduces issue #6090: certs issued by Windows CA contain a UPN otherName SAN entry
+        // (OID 1.3.6.1.4.1.311.20.2.3). Java surfaces such entries as a List with size > 2, where
+        // the third element is the OID String. The previous iterator-based parser tried to cast
+        // the OID String to int on the next loop iteration, throwing ClassCastException.
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        // otherName SAN: [typeId=0, value (parsed), oid (String)]
+        sanList.add(Arrays.asList(0, "user@example.com", "1.3.6.1.4.1.311.20.2.3"));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        DefaultInterClusterRequestEvaluator evaluator = newEvaluator();
+        boolean result = evaluator.isInterClusterRequest(
+            mock(TransportRequest.class),
+            new X509Certificate[] { cert },
+            new X509Certificate[] { cert },
+            "CN=foo"
+        );
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testIsInterClusterRequest_oidSanMatchesNodeOid_returnsTrue() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        // registeredID SAN (typeId=8) — value is the OID as String
+        sanList.add(Arrays.asList(8, NODE_OID));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        DefaultInterClusterRequestEvaluator evaluator = newEvaluator();
+        boolean result = evaluator.isInterClusterRequest(
+            mock(TransportRequest.class),
+            new X509Certificate[] { cert },
+            new X509Certificate[] { cert },
+            "CN=foo"
+        );
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsInterClusterRequest_oidSanAlongsideUpn_returnsTrue() throws Exception {
+        // Mixed SAN list: UPN otherName + matching node OID. Must not throw and must still match.
+        X509Certificate cert = mock(X509Certificate.class);
+        List<List<?>> sanList = new ArrayList<>();
+        sanList.add(Arrays.asList(0, "user@example.com", "1.3.6.1.4.1.311.20.2.3"));
+        sanList.add(Arrays.asList(2, "node1.example.com"));
+        sanList.add(Arrays.asList(8, NODE_OID));
+        when(cert.getSubjectAlternativeNames()).thenReturn(sanList);
+
+        DefaultInterClusterRequestEvaluator evaluator = newEvaluator();
+        boolean result = evaluator.isInterClusterRequest(
+            mock(TransportRequest.class),
+            new X509Certificate[] { cert },
+            new X509Certificate[] { cert },
+            "CN=foo"
+        );
+
+        assertTrue(result);
+    }
+
+    @Test
+    public void testIsInterClusterRequest_nullSan_returnsFalse() throws Exception {
+        X509Certificate cert = mock(X509Certificate.class);
+        when(cert.getSubjectAlternativeNames()).thenReturn(null);
+
+        DefaultInterClusterRequestEvaluator evaluator = newEvaluator();
+        boolean result = evaluator.isInterClusterRequest(
+            mock(TransportRequest.class),
+            new X509Certificate[] { cert },
+            new X509Certificate[] { cert },
+            "CN=foo"
+        );
+
+        assertFalse(result);
+    }
+}


### PR DESCRIPTION
### Description

Bug fix. `DefaultInterClusterRequestEvaluator#isInterClusterRequest` threw `ClassCastException` during the transport handshake whenever a peer's certificate contained an `otherName` SAN (e.g. UPN, OID `1.3.6.1.4.1.311.20.2.3`, common on Windows-CA-issued certs), preventing affected nodes from joining the cluster. The parser walked each inner SAN list with an `Iterator` and cast every even-indexed element to `int`, which works for two-element entries but breaks on `otherName` entries that return three or more elements with an OID String at index 2. The fix reads each entry as a single `[typeId, value]` pair via `ian.get(0)` / `ian.get(1)` with an `instanceof Integer` guard, matching the Java API contract and the existing pattern in `SPIFFEPrincipalExtractor`.

### Before

`DefaultInterClusterRequestEvaluatorTest#testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow` constructs an `X509Certificate` whose SAN list contains a UPN-shaped `otherName` entry: `[0, "user@example.com", "1.3.6.1.4.1.311.20.2.3"]`. With the parser reverted to its pre-fix state, the test reproduces the exact exception from the bug report:

```bash
20260507143419:sasheto@seshstop920:security:sashetov/609...$ git checkout HEAD~1 -- src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
20260507143420:sasheto@seshstop920:security:sashetov/609...$ fg
vim /tmp/pr-6090-description.md

[1]+  Stopped                 vim /tmp/pr-6090-description.md
20260507143425:sasheto@seshstop920:security:sashetov/609...$ ./gradlew :test --tests "org.opensearch.security.transport.DefaultInterClusterRequestEvaluatorTest.testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow"
=======================================
OpenSearch Build Hamster says Hello!
...
DefaultInterClusterRequestEvaluatorTest > testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow FAILED
...
DefaultInterClusterRequestEvaluatorTest > testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow FAILED
...
DefaultInterClusterRequestEvaluatorTest > testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow FAILED
...
DefaultInterClusterRequestEvaluatorTest > testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow FAILED
...
BUILD FAILED in 24s
12 actionable tasks: 3 executed, 9 up-to-date
```

The exception message and class are identical to the one originally reported in #6090.

### After

Restore the fix and re-run the full test class:

```bash
20260507143321:sasheto@seshstop920:security:sashetov/609...$ git checkout HEAD -- src/main/java/org/opensearch/security/transport/DefaultInterClusterRequestEvaluator.java
20260507143329:sasheto@seshstop920:security:sashetov/609...$ ./gradlew :test --tests "org.opensearch.security.transport.DefaultInterClusterRequestEvaluatorTest"
=======================================
OpenSearch Build Hamster says Hello!
...
BUILD SUCCESSFUL in 7s
12 actionable tasks: 2 executed, 10 up-to-date
```

All four cases pass

Checkstyle is also clean:

```bash
20260507143148:sasheto@seshstop920:security:sashetov/609...$ ./gradlew checkstyleMain checkstyleTest
=======================================
OpenSearch Build Hamster says Hello!
...
BUILD SUCCESSFUL in 15s
23 actionable tasks: 6 executed, 17 up-to-date
```

### Issues Resolved

Closes #6090

This is not a backport.

These changes do not introduce new permissions and require no companion PR in the security dashboards plugin.

### Testing

Adds a new unit test class `DefaultInterClusterRequestEvaluatorTest` (Mockito-based, mirroring the pattern in `SPIFFEPrincipalExtractorTest`) with four cases:

- `testIsInterClusterRequest_upnOtherNameInSan_doesNotThrow` — direct repro of #6090; SAN list contains a 3-element `otherName` entry. Previously threw `ClassCastException`; now returns `false` cleanly.
- `testIsInterClusterRequest_oidSanMatchesNodeOid_returnsTrue` — sanity: a `registeredID` (typeId 8) SAN with the configured node OID still returns `true`.
- `testIsInterClusterRequest_oidSanAlongsideUpn_returnsTrue` — mixed list (UPN otherName + DNS + matching OID) still resolves correctly without throwing.
- `testIsInterClusterRequest_nullSan_returnsFalse` — null SAN list is handled gracefully.

No integration or manual testing was performed; the bug surface is fully covered by the unit-level repro because `getSubjectAlternativeNames()` is the only entry point.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented (no public API change; behavior change documented in PR description)
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR — n/a
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md) — n/a, no API change
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
