### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/audit/AuditLogsRule.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/audit/AuditLogsRule.java
@@ -124,7 +124,7 @@ public class AuditLogsRule implements TestRule {
         List<AuditMessage> copy = new ArrayList<>(currentTestAuditMessages);
         String auditMessages = auditMessagesToString(copy);
         log.error(
-            "Timeout occured due to insufficient number ('{}') of captured audit messages during test '{}'\n{}",
+            "Timeout occurred due to insufficient number ('{}') of captured audit messages during test '{}'\n{}",
             copy.size(),
             methodName,
             auditMessages

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/TestRestClient.java
@@ -277,7 +277,7 @@ public class TestRestClient implements AutoCloseable {
 
             return new HttpResponse(httpClient.execute(uriRequest));
         } catch (IOException e) {
-            throw new RestClientException("Error occured during HTTP request execution", e);
+            throw new RestClientException("Error occurred during HTTP request execution", e);
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainsDocumentMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainsDocumentMatcher.java
@@ -44,7 +44,7 @@ class ClusterContainsDocumentMatcher extends TypeSafeDiagnosingMatcher<Client> {
             }
         } catch (InterruptedException | ExecutionException e) {
             log.error("Cannot verify if cluster contains document '{}' in index '{}'.", documentId, indexName, e);
-            mismatchDescription.appendText("Exception occured during verification if cluster contain document").appendValue(e);
+            mismatchDescription.appendText("Exception occurred during verification if cluster contain document").appendValue(e);
             return false;
         }
         return true;

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainsDocumentWithFieldValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/ClusterContainsDocumentWithFieldValueMatcher.java
@@ -65,7 +65,7 @@ class ClusterContainsDocumentWithFieldValueMatcher extends TypeSafeDiagnosingMat
             }
         } catch (InterruptedException | ExecutionException e) {
             log.error("Cannot verify if cluster contains document '{}' in index '{}'.", documentId, indexName, e);
-            mismatchDescription.appendText("Exception occured during verification if cluster contain document").appendValue(e);
+            mismatchDescription.appendText("Exception occurred during verification if cluster contain document").appendValue(e);
             return false;
         }
         return true;

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -173,7 +173,7 @@ public class SecurityAdmin {
                 System.exit(-1);
             }
 
-            System.out.println("ERR: An unexpected " + e.getClass().getSimpleName() + " occured: " + e.getMessage());
+            System.out.println("ERR: An unexpected " + e.getClass().getSimpleName() + " occurred: " + e.getMessage());
             System.out.println("Trace:");
             System.out.println(ExceptionsHelper.stackTrace(e));
             System.out.println();


### PR DESCRIPTION
Fixes the misspelling "occured" -> "occurred" in five log/error messages across `SecurityAdmin` and the integration-test framework.