### PR TITLE
switch partially to gradle versions catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,6 @@ buildscript {
         common_utils_version = System.getProperty("common_utils.version", '3.2.0.0')
 
         kafka_version  = '4.2.0'
-        open_saml_version = '5.2.1'
-        open_saml_shib_version = "9.1.4"
-        one_login_java_saml = '2.9.0'
-        jjwt_version = '0.13.0'
-        guava_version = '33.6.0-jre'
-        jaxb_version = '2.3.9'
-        spring_version = '7.0.7'
 
         if (buildVersionQualifier) {
             opensearch_build += "-${buildVersionQualifier}"
@@ -502,9 +495,9 @@ configurations {
             force "io.netty:netty-transport:${versions.netty}"
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
             force "com.github.luben:zstd-jni:${versions.zstd}"
-            force "org.xerial.snappy:snappy-java:1.1.10.8"
-            force "com.google.guava:guava:${guava_version}"
-            force "at.yawk.lz4:lz4-java:1.11.0"
+            force libs.google.guava
+            force libs.lz4.java
+            force libs.snappy.java
 
             // for spotbugs dependency conflict
             force "org.apache.commons:commons-lang3:${versions.commonslang}"
@@ -604,7 +597,7 @@ allprojects {
                 integrationTestImplementation "org.opensearch.plugin:aggs-matrix-stats-client:${opensearch_version}"
                 integrationTestImplementation "org.opensearch.plugin:parent-join-client:${opensearch_version}"
                 integrationTestImplementation "com.password4j:password4j:${versions.password4j}"
-                integrationTestImplementation "com.google.guava:guava:${guava_version}"
+                integrationTestImplementation libs.google.guava
                 integrationTestImplementation "org.apache.commons:commons-lang3:${versions.commonslang}"
                 integrationTestImplementation "tools.jackson.core:jackson-databind:${versions.jackson3_databind}"
                 integrationTestImplementation 'org.greenrobot:eventbus-java:3.3.1'
@@ -687,7 +680,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
-    implementation "com.google.guava:guava:${guava_version}"
+    implementation libs.google.guava
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.11.0'
     // When building with crypto.standard=FIPS-140-3 (set in gradle.properties), bcFips jars are provided by OpenSearch
@@ -714,9 +707,7 @@ dependencies {
     implementation 'com.selectivem.collections:special-collections-complete:1.4.0'
 
     //JWT
-    implementation "io.jsonwebtoken:jjwt-api:${jjwt_version}"
-    implementation "io.jsonwebtoken:jjwt-impl:${jjwt_version}"
-    implementation "io.jsonwebtoken:jjwt-jackson:${jjwt_version}"
+    implementation libs.bundles.jjwt
     implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
 
@@ -743,8 +734,7 @@ dependencies {
     testImplementation 'org.apache.camel:camel-xmlsecurity:3.22.4'
 
     //Onelogin OpenSaml
-    implementation "com.onelogin:java-saml:${one_login_java_saml}"
-    implementation "com.onelogin:java-saml-core:${one_login_java_saml}"
+    implementation libs.bundles.onelogin.saml
     //OpenSAML
     runtimeOnly "io.dropwizard.metrics:metrics-core:4.2.38"
     implementation project(path: ':libs:opensaml', configuration: 'shadow')
@@ -753,14 +743,16 @@ dependencies {
 
     implementation 'org.apache.commons:commons-text:1.15.0'
 
-    runtimeOnly "org.glassfish.jaxb:jaxb-runtime:${jaxb_version}"
     compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
-    runtimeOnly 'at.yawk.lz4:lz4-java:1.11.0'
+
+    runtimeOnly libs.bundles.archivers
+
     runtimeOnly 'org.slf4j:slf4j-api:1.7.36'
+
+    runtimeOnly libs.bundles.jaxb
+
     runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl:${versions.log4j}"
-    runtimeOnly 'org.xerial.snappy:snappy-java:1.1.10.8'
     runtimeOnly 'org.codehaus.woodstox:stax2-api:4.3.0'
-    runtimeOnly "org.glassfish.jaxb:txw2:${jaxb_version}"
     runtimeOnly 'com.fasterxml.woodstox:woodstox-core:6.7.0'
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.2'
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.5'
@@ -770,7 +762,8 @@ dependencies {
     testRuntimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
-    testImplementation "org.opensaml:opensaml-messaging-impl:${open_saml_version}"
+    testImplementation libs.opensaml.messaging.impl
+
     testImplementation "jakarta.servlet:jakarta.servlet-api:6.1.0"
     implementation "org.apache.commons:commons-lang3:${versions.commonslang}"
     testImplementation "org.opensearch:common-utils:${common_utils_version}"
@@ -804,7 +797,6 @@ dependencies {
     testImplementation "org.apache.kafka:kafka-transaction-coordinator:${kafka_version}"
     testImplementation 'commons-validator:commons-validator:1.10.1'
     testImplementation "org.springframework.kafka:spring-kafka-test:4.0.5"
-    testImplementation "org.springframework:spring-beans:${spring_version}"
     testImplementation 'org.junit.jupiter:junit-jupiter:5.14.4'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.14.4'
     testImplementation('org.awaitility:awaitility:4.3.0') {
@@ -817,9 +809,13 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
     // Kafka test execution
     testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.4'
-    testRuntimeOnly ("org.springframework:spring-core:${spring_version}") {
+
+    testImplementation libs.springframework.beans
+
+    testRuntimeOnly (libs.springframework.core) {
         exclude(group:'org.springframework', module: 'spring-jcl' )
     }
+
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.18'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.6'
     testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.4') {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,83 @@
+[versions]
+open_saml           = "5.2.1"
+open_saml_shib      = "9.2.1"
+one_login_saml      = "2.9.0"
+dropwizard_metrics  = "4.2.38"
+jjwt                = "0.13.0"
+jaxb                = "2.3.9"
+lz4_java            = "1.11.0"
+snappy_java         = "1.1.10.8"
+guava               = "33.6.0-jre"
+spring_framework    = "7.0.7"
+
+[libraries]
+#OneLogin saml
+onelogin-java-saml = { group = "com.onelogin", name = "java-saml", version.ref = "one_login_saml" }
+onelogin-java-saml-core = { group = "com.onelogin", name = "java-saml-core", version.ref = "one_login_saml" }
+#OpenSAML
+opensaml-core-api = { group = "org.opensaml", name = "opensaml-core-api", version.ref = "open_saml" }
+opensaml-core-impl = { group = "org.opensaml", name = "opensaml-core-impl", version.ref = "open_saml" }
+opensaml-security-api = { group = "org.opensaml", name = "opensaml-security-api", version.ref = "open_saml" }
+opensaml-security-impl = { group = "org.opensaml", name = "opensaml-security-impl", version.ref = "open_saml" }
+opensaml-xmlsec-api = { group = "org.opensaml", name = "opensaml-xmlsec-api", version.ref = "open_saml" }
+opensaml-xmlsec-impl = { group = "org.opensaml", name = "opensaml-xmlsec-impl", version.ref = "open_saml" }
+opensaml-saml-api = { group = "org.opensaml", name = "opensaml-saml-api", version.ref = "open_saml" }
+opensaml-saml-impl = { group = "org.opensaml", name = "opensaml-saml-impl", version.ref = "open_saml" }
+opensaml-messaging-api = { group = "org.opensaml", name = "opensaml-messaging-api", version.ref = "open_saml" }
+opensaml-messaging-impl = { group = "org.opensaml", name = "opensaml-messaging-impl", version.ref = "open_saml" }
+opensaml-storage-api = { group = "org.opensaml", name = "opensaml-storage-api", version.ref = "open_saml" }
+opensaml-profile-api = { group = "org.opensaml", name = "opensaml-profile-api", version.ref = "open_saml" }
+opensaml-soap-api = { group = "org.opensaml", name = "opensaml-soap-api", version.ref = "open_saml" }
+opensaml-soap-impl = { group = "org.opensaml", name = "opensaml-soap-impl", version.ref = "open_saml" }
+
+shib-support = { group = "net.shibboleth", name = "shib-support", version.ref = "open_saml_shib" }
+shib-security = { group = "net.shibboleth", name = "shib-security", version.ref = "open_saml_shib" }
+shib-networking = { group = "net.shibboleth", name = "shib-networking", version.ref = "open_saml_shib" }
+
+dropwizard-metrics-core = { group = "io.dropwizard.metrics", name = "metrics-core", version.ref = "dropwizard_metrics" }
+
+#JWT
+jjwt-api = { group = "io.jsonwebtoken", name = "jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { group = "io.jsonwebtoken", name="jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { group = "io.jsonwebtoken", name="jjwt-jackson", version.ref = "jjwt" }
+
+#JAXB
+jaxb-runtime = { group = "org.glassfish.jaxb", name = "jaxb-runtime", version.ref = "jaxb" }
+jaxb-txw2 = { group = "org.glassfish.jaxb", name = "txw2", version.ref = "jaxb" }
+
+#archivers
+lz4-java = { group = "at.yawk.lz4", name = "lz4-java", version.ref = "lz4_java" }
+snappy-java = { group = "org.xerial.snappy", name = "snappy-java", version.ref = "snappy_java" }
+
+google-guava = { group = "com.google.guava", name="guava", version.ref = "guava" }
+
+#spring framework
+springframework-core = { group = "org.springframework", name = "spring-core", version.ref = "spring_framework" }
+springframework-beans = { group = "org.springframework", name = "spring-beans", version.ref = "spring_framework" }
+
+[bundles]
+onelogin-saml = ["onelogin-java-saml", "onelogin-java-saml-core"]
+opensaml = [
+    "opensaml-core-api",
+    "opensaml-core-impl",
+    "opensaml-security-api",
+    "opensaml-security-impl",
+    "opensaml-xmlsec-api",
+    "opensaml-xmlsec-impl",
+    "opensaml-saml-api",
+    "opensaml-saml-impl",
+    "opensaml-messaging-api",
+    "opensaml-storage-api",
+    "shib-support",
+    "shib-security",
+    "shib-networking"
+]
+opensaml-runtime = [
+    "opensaml-profile-api",
+    "opensaml-soap-api",
+    "opensaml-soap-impl",
+    "dropwizard-metrics-core"
+]
+jjwt = ["jjwt-api", "jjwt-impl", "jjwt-jackson"]
+jaxb = ["jaxb-runtime", "jaxb-txw2"]
+archivers = ["lz4-java", "snappy-java"]

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -5,24 +5,18 @@ apply plugin: 'jacoco'
 apply plugin: 'maven-publish'
 
 buildscript {
-    ext {
-        open_saml_version = '5.2.1'
-        open_saml_shib_version = "9.2.1"
-    }
-
     repositories {
         mavenLocal()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+        maven { url "https://artifacts.opensearch.org/snapshots/lucene/" }
+        maven { url "https://build.shibboleth.net/nexus/content/groups/public" }
     }
 
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
     }
-}
-
-repositories {
-    maven { url "build.shibboleth.net/maven/releases"}
 }
 
 configurations.all {
@@ -41,29 +35,11 @@ task sourcesJar(type: Jar) {
 }
 
 dependencies {
-    implementation "org.opensaml:opensaml-security-api:${open_saml_version}"
-    implementation "org.opensaml:opensaml-security-impl:${open_saml_version}"
 
-    implementation "net.shibboleth:shib-support:${open_saml_shib_version}"
-    implementation "net.shibboleth:shib-security:${open_saml_shib_version}"
-    implementation "net.shibboleth:shib-networking:${open_saml_shib_version}"
-    implementation "org.opensaml:opensaml-core-api:${open_saml_version}"
-    implementation "org.opensaml:opensaml-core-impl:${open_saml_version}"
-
-
-    implementation "org.opensaml:opensaml-xmlsec-api:${open_saml_version}"
-    implementation "org.opensaml:opensaml-xmlsec-impl:${open_saml_version}"
-
-    implementation "org.opensaml:opensaml-saml-api:${open_saml_version}"
-    implementation ("org.opensaml:opensaml-saml-impl:${open_saml_version}") {
-        exclude(group: 'org.apache.velocity', module: 'velocity')
+    implementation(libs.bundles.opensaml) {
+        exclude(group: "org.apache.velocity", module: "velocity")
     }
-    implementation "org.opensaml:opensaml-messaging-api:${open_saml_version}"
-    implementation "org.opensaml:opensaml-storage-api:${open_saml_version}"
-
-    runtimeOnly "org.opensaml:opensaml-profile-api:${open_saml_version}"
-    runtimeOnly "org.opensaml:opensaml-soap-api:${open_saml_version}"
-    runtimeOnly "org.opensaml:opensaml-soap-impl:${open_saml_version}"
+    runtimeOnly libs.bundles.opensaml.runtime
 
     runtimeOnly "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
     runtimeOnly "org.apache.httpcomponents.client5:httpclient5-cache:${versions.httpclient5}"

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -79,7 +79,7 @@ configurations {
             // Force versions present in security plugin
             force "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
             force "com.google.protobuf:protobuf-java:${versions.protobuf}"
-            force "com.google.guava:guava:${guava_version}"
+            force libs.google.guava
             force "com.google.guava:failureaccess:1.0.3"
             force "io.projectreactor:reactor-core:3.8.5"
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,13 @@
 plugins {
     id("com.autonomousapps.build-health") version "3.10.0"
 }
-
+dependencyResolutionManagement {
+    versionCatalogs {
+        libraries {
+            from(files("gradle/libs.versions.toml"))
+        }
+    }
+}
 rootProject.name = 'opensearch-security'
 
 include "spi"
@@ -18,4 +24,6 @@ project(":sample-resource-plugin").name = "opensearch-sample-resource-plugin"
 
 include "bwc-test"
 project(":bwc-test").name = rootProject.name + "-bwc-test"
+
+
 include 'libs:opensaml'


### PR DESCRIPTION
### Description

Switched partially to the Gradle Version Catalog instead of defining versions directly in the build.gradle file except kafka version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
