### PR TITLE
fix(config)!: remove own_index default roles mapping

### DIFF
--- a/config/roles_mapping.yml
+++ b/config/roles_mapping.yml
@@ -16,12 +16,6 @@ all_access:
   - "admin"
   description: "Maps admin to all_access"
 
-own_index:
-  reserved: false
-  users:
-  - "*"
-  description: "Allow full access to an index named like the username"
-
 logstash:
   reserved: false
   backend_roles:


### PR DESCRIPTION
### Description
Remove the `own_index` default roles mapping from `config/roles_mapping.yml`.

* Category: Maintenance
* Why these changes are required? The `own_index` roles mapping maps all users (`*`) to a role that grants full access to an index named like the username. This is an overly permissive default that weakens the security posture out of the box.
* Old behavior: All users automatically received full access to an index matching their username via the default roles mapping. New behavior: No default mapping for `own_index` exists; administrators must explicitly configure this mapping if needed.

We want to use the [opensearch-k8s-operator](https://github.com/opensearch-project/opensearch-k8s-operator) to setup our clusters. The overall defaults (`roles` and `roles_mapping`) are very good (and we want to keep them). But with additional authentication backends (like OIDC / SAML / LDAP) this would allow *any* authenticated user to potentially create an index with their name (which is not what we want in a production cluster).

Still...the old behaviour can be enabled again by providing this roles mapping manually again (if this is needed). As I do not know, if truly users exist, that rely on this roles mapping....this could be a BREAKING CHANGE.

This `own_index` roles mapping makes perfectly sense for some "demo / gym / playground" cluster to "play around".

### Issues Resolved
N/A

### Testing
No new testing required — this is a configuration-only change removing a default mapping. Existing tests pass.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).