### PR TITLE
misc changes in libs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -818,10 +818,6 @@ dependencies {
 
     testRuntimeOnly 'org.scala-lang:scala-library:2.13.18'
     testRuntimeOnly 'com.typesafe.scala-logging:scala-logging_3:3.9.6'
-    testRuntimeOnly('org.apache.zookeeper:zookeeper:3.9.4') {
-        exclude(group: 'ch.qos.logback', module: 'logback-classic')
-        exclude(group: 'ch.qos.logback', module: 'logback-core')
-    }
     testRuntimeOnly 'com.yammer.metrics:metrics-core:2.2.0'
     testRuntimeOnly "org.apache.kafka:kafka-metadata:${kafka_version}"
     testRuntimeOnly "org.apache.kafka:kafka-storage:${kafka_version}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-open_saml           = "5.2.1"
-open_saml_shib      = "9.2.1"
+open_saml           = "5.2.2"
+open_saml_shib      = "9.2.2"
 one_login_saml      = "2.9.0"
 dropwizard_metrics  = "4.2.38"
 jjwt                = "0.13.0"


### PR DESCRIPTION
### Description
Changes
 - Bump `OpenSAML` to version `5.2.2`
 - Removed `ZooKeeper` from the test dependencies, since starting with version 4, Kafka switched to KRaft instead of ZooKeeper.

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
