### PR TITLE
[Bugfix] Implement skipsDeserialization() in RestoringTransportResponseHandler

### DIFF
--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -379,12 +379,14 @@ public class SecurityInterceptor {
     // based on
     // org.opensearch.transport.TransportService.ContextRestoreResponseHandler<T>
     // which is private scoped
-    private class RestoringTransportResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
+    // Visible for testing
+    class RestoringTransportResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
 
         private final Supplier<ThreadContext.StoredContext> contextToRestore;
         private final TransportResponseHandler<T> innerHandler;
 
-        private RestoringTransportResponseHandler(
+        // Visible for testing
+        RestoringTransportResponseHandler(
             TransportResponseHandler<T> innerHandler,
             Supplier<ThreadContext.StoredContext> contextToRestore
         ) {
@@ -395,6 +397,11 @@ public class SecurityInterceptor {
         @Override
         public T read(StreamInput in) throws IOException {
             return innerHandler.read(in);
+        }
+
+        @Override
+        public boolean skipsDeserialization() {
+            return innerHandler.skipsDeserialization();
         }
 
         @Override

--- a/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
@@ -21,8 +21,6 @@ import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.stream.StreamTransportResponse;
 
-import org.jspecify.annotations.NonNull;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 

--- a/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
@@ -11,7 +11,6 @@ package org.opensearch.security.transport;
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import org.jspecify.annotations.NonNull;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -21,6 +20,8 @@ import org.opensearch.core.transport.TransportResponse;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportResponseHandler;
 import org.opensearch.transport.stream.StreamTransportResponse;
+
+import org.jspecify.annotations.NonNull;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -44,38 +45,37 @@ public class RestoringTransportResponseHandlerTests {
         );
 
         // Verify executor is forwarded
-        assertEquals(
-            "executor must match inner handler",
-            innerHandler.executor(),
-            wrappedHandler.executor()
-        );
+        assertEquals("executor must match inner handler", innerHandler.executor(), wrappedHandler.executor());
 
         // Verify read() forwards the StreamInput and returns the same response
         byte[] payload = new byte[] { 0x01, 0x42, (byte) 0xFF, 0x00, 0x7E, (byte) 0xAB };
         StreamInput streamInput = StreamInput.wrap(payload);
         TransportResponse readResult = wrappedHandler.read(streamInput);
 
-        assertSame(
-            "read() must forward the exact StreamInput to inner handler",
-            streamInput,
-            innerHandler.lastReadInput
-        );
-        assertSame(
-            "read() must return the inner handler's response",
-            innerHandler.readResponse,
-            readResult
-        );
+        assertSame("read() must forward the exact StreamInput to inner handler", streamInput, innerHandler.lastReadInput);
+        assertSame("read() must return the inner handler's response", innerHandler.readResponse, readResult);
     }
 
-    private static @NonNull TransportResponseHandler<TransportResponse> getRestorableTransportResponseTransportResponseHandler(TestTransportResponseHandler innerHandler) {
+    private static TransportResponseHandler<TransportResponse> getRestorableTransportResponseTransportResponseHandler(
+        TestTransportResponseHandler innerHandler
+    ) {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         Supplier<ThreadContext.StoredContext> restorableContext = threadContext.newRestorableContext(true);
         SecurityInterceptor interceptor = new SecurityInterceptor(
-            null, null, null, null, null, null, null, null, null, null, () -> false, null
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            () -> false,
+            null
         );
-        TransportResponseHandler<TransportResponse> wrappedHandler =
-            interceptor.new RestoringTransportResponseHandler<>(innerHandler, restorableContext);
-        return wrappedHandler;
+        return interceptor.new RestoringTransportResponseHandler<>(innerHandler, restorableContext);
     }
 
     private static class TestTransportResponseHandler implements TransportResponseHandler<TransportResponse> {

--- a/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
+++ b/src/test/java/org/opensearch/security/transport/RestoringTransportResponseHandlerTests.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.transport;
+
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.NonNull;
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.transport.TransportResponse;
+import org.opensearch.transport.TransportException;
+import org.opensearch.transport.TransportResponseHandler;
+import org.opensearch.transport.stream.StreamTransportResponse;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+/**
+ * Verifies that RestoringTransportResponseHandler delegates all interface methods
+ * identically to the inner handler.
+ */
+public class RestoringTransportResponseHandlerTests {
+
+    @Test
+    public void testWrappedHandlerBehavesIdenticallyToInnerHandler() throws IOException {
+        TestTransportResponseHandler innerHandler = new TestTransportResponseHandler(true, "search_worker");
+        TransportResponseHandler<TransportResponse> wrappedHandler = getRestorableTransportResponseTransportResponseHandler(innerHandler);
+
+        // Verify skipsDeserialization is forwarded (critical for Arrow Flight zero-copy)
+        assertEquals(
+            "skipsDeserialization must match inner handler",
+            innerHandler.skipsDeserialization(),
+            wrappedHandler.skipsDeserialization()
+        );
+
+        // Verify executor is forwarded
+        assertEquals(
+            "executor must match inner handler",
+            innerHandler.executor(),
+            wrappedHandler.executor()
+        );
+
+        // Verify read() forwards the StreamInput and returns the same response
+        byte[] payload = new byte[] { 0x01, 0x42, (byte) 0xFF, 0x00, 0x7E, (byte) 0xAB };
+        StreamInput streamInput = StreamInput.wrap(payload);
+        TransportResponse readResult = wrappedHandler.read(streamInput);
+
+        assertSame(
+            "read() must forward the exact StreamInput to inner handler",
+            streamInput,
+            innerHandler.lastReadInput
+        );
+        assertSame(
+            "read() must return the inner handler's response",
+            innerHandler.readResponse,
+            readResult
+        );
+    }
+
+    private static @NonNull TransportResponseHandler<TransportResponse> getRestorableTransportResponseTransportResponseHandler(TestTransportResponseHandler innerHandler) {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        Supplier<ThreadContext.StoredContext> restorableContext = threadContext.newRestorableContext(true);
+        SecurityInterceptor interceptor = new SecurityInterceptor(
+            null, null, null, null, null, null, null, null, null, null, () -> false, null
+        );
+        TransportResponseHandler<TransportResponse> wrappedHandler =
+            interceptor.new RestoringTransportResponseHandler<>(innerHandler, restorableContext);
+        return wrappedHandler;
+    }
+
+    private static class TestTransportResponseHandler implements TransportResponseHandler<TransportResponse> {
+        private final boolean skipsDeserialization;
+        private final String executor;
+        final TransportResponse readResponse = new TransportResponse.Empty();
+        StreamInput lastReadInput;
+
+        TestTransportResponseHandler(boolean skipsDeserialization, String executor) {
+            this.skipsDeserialization = skipsDeserialization;
+            this.executor = executor;
+        }
+
+        @Override
+        public TransportResponse read(StreamInput in) throws IOException {
+            lastReadInput = in;
+            return readResponse;
+        }
+
+        @Override
+        public boolean skipsDeserialization() {
+            return skipsDeserialization;
+        }
+
+        @Override
+        public void handleResponse(TransportResponse response) {}
+
+        @Override
+        public void handleStreamResponse(StreamTransportResponse<TransportResponse> response) {}
+
+        @Override
+        public void handleException(TransportException exp) {}
+
+        @Override
+        public String executor() {
+            return executor;
+        }
+    }
+}


### PR DESCRIPTION
### Description

The security interceptor's RestoringTransportResponseHandler wraps the inner transport response handler but does not forward the `skipsDeserialization()` method which was added in a recent [upstream core change](https://github.com/opensearch-project/OpenSearch/commit/00a0ea78dc1d64678757a9c5cf2645b9ffa3b716#diff-5a32ed85ebe74787aabfd31cd6116dc4e653788c5f2c2c7926d68e013c25e607R105-R114).

This results in a mismatch between the client and server configurations, the client sending payloads over the stream has `skipsDeserialization() = true` while the response handling side sees `skipsDeserialization() = false` due to the default value in the `RestoringTransportResponseHandler` interface, and unknowingly [opens the `VectorStreamInput.forByteSerialized` stream input to handle the response.](https://github.com/opensearch-project/OpenSearch/blob/main/plugins/arrow-flight-rpc/src/main/java/org/opensearch/arrow/flight/transport/FlightTransportResponse.java#L149-L153)


This causes the Arrow Flight stream transport responses to throw the following exception:


```
[2026-05-20T05:42:17,029][INFO ][o.o.a.e.QueryScheduler   ][4778b9b750ef6b705f2b6beedbfde8a9] [QueryScheduler] ExecutionGraph built:
ExecutionGraph[queryId=48f9634d-76b6-4075-9794-4f2faac14225, stages=1, leaves=1]
  Stage 0 [ShardFragmentStageExecution] state=CREATED

[2026-05-20T05:42:17,034][ERROR][o.o.a.f.t.FlightClientChannel][4778b9b750ef6b705f2b6beedbfde8a9] Exception while handling stream response
org.opensearch.transport.stream.StreamException: no such index [test-composite]
        at org.opensearch.arrow.flight.transport.FlightErrorMapper.fromFlightException(FlightErrorMapper.java:65)
        at org.opensearch.arrow.flight.transport.FlightTransportResponse.lambda$openAndPrefetchAsync$0(FlightTransportResponse.java:104)
        at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
[2026-05-20T05:42:17,034][ERROR][o.o.s.p.r.RestPPLQueryAction][4778b9b750ef6b705f2b6beedbfde8a9] Error happened during query handling (status INTERNAL_SERVER_ERROR)
java.lang.RuntimeException: Stage 0 failed
        at org.opensearch.analytics.exec.stage.ShardFragmentStageExecution$1.onFailure(ShardFragmentStageExecution.java:134)
        at org.opensearch.analytics.exec.AnalyticsSearchTransportService$1.handleException(AnalyticsSearchTransportService.java:174)
        at org.opensearch.transport.TransportService$9.handleException(TransportService.java:1831)
        at org.opensearch.security.transport.SecurityInterceptor$RestoringTransportResponseHandler.handleException(SecurityInterceptor.java:450)
        at org.opensearch.transport.TransportService$ContextRestoreResponseHandler.handleException(TransportService.java:1607)
        at org.opensearch.arrow.flight.transport.MetricsTrackingResponseHandler.handleException(MetricsTrackingResponseHandler.java:55)
        at org.opensearch.arrow.flight.transport.FlightClientChannel.safeHandleException(FlightClientChannel.java:344)
        at org.opensearch.arrow.flight.transport.FlightClientChannel.notifyHandlerOfException(FlightClientChannel.java:336)
        at org.opensearch.arrow.flight.transport.FlightClientChannel.handleStreamException(FlightClientChannel.java:311)
        at org.opensearch.arrow.flight.transport.FlightClientChannel.lambda$openStreamAndInvokeHandler$1(FlightClientChannel.java:273)
        at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:884)
        at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:862)
        at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:531)
        at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2221)
        at org.opensearch.arrow.flight.transport.FlightTransportResponse.lambda$openAndPrefetchAsync$0(FlightTransportResponse.java:104)
        at java.base/java.lang.VirtualThread.run(VirtualThread.java:456)
Caused by: org.opensearch.transport.stream.StreamException: no such index [test-composite]
        at org.opensearch.arrow.flight.transport.FlightErrorMapper.fromFlightException(FlightErrorMapper.java:65)
        ... 2 more
```

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
