### PR TITLE
Allow audit config PUT when document does not exist

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -267,10 +267,22 @@ public class AuditApiAction extends AbstractApiAction {
             .onChangeRequest(RestRequest.Method.PATCH, request -> withEnabledAuditApi(request).map(this::processPatchRequest))
             .onChangeRequest(
                 RestRequest.Method.PUT,
-                request -> withEnabledAuditApi(request).map(ignore -> processPutRequest("config", request))
+                request -> withCreateOrUpdateAuditApi(request).map(ignore -> processPutRequest("config", request))
             )
             .override(RestRequest.Method.POST, methodNotImplementedHandler)
             .override(RestRequest.Method.DELETE, methodNotImplementedHandler);
+    }
+
+    /**
+     * Allows PUT to bootstrap the audit config when the document does not exist,
+     * or to update it through normal validation when it does.
+     */
+    ValidationResult<RestRequest> withCreateOrUpdateAuditApi(final RestRequest request) {
+        if (!securityApiDependencies.configurationRepository().isAuditHotReloadingEnabled()) {
+            // Document does not exist — allow PUT to bootstrap the audit config
+            return ValidationResult.success(request);
+        }
+        return withEnabledAuditApi(request);
     }
 
     ValidationResult<RestRequest> withEnabledAuditApi(final RestRequest request) {

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
@@ -12,11 +12,13 @@
 package org.opensearch.security.dlic.rest.api;
 
 import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
 import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
@@ -40,6 +42,30 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
             assertFalse(result.isValid());
             assertThat(result.status(), is(RestStatus.NOT_IMPLEMENTED));
         }
+    }
+
+    @Test
+    public void putAllowedWhenAuditConfigDocDoesNotExist() {
+        final var auditApiAction = new AuditApiAction(clusterService, threadPool, securityApiDependencies);
+        when(configurationRepository.isAuditHotReloadingEnabled()).thenReturn(false);
+
+        // PUT is allowed when the audit config document does not exist (bootstrap case)
+        final var result = auditApiAction.withCreateOrUpdateAuditApi(
+            FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()
+        );
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    public void putAllowedWhenAuditConfigDocExists() {
+        final var auditApiAction = new AuditApiAction(clusterService, threadPool, securityApiDependencies);
+        when(configurationRepository.isAuditHotReloadingEnabled()).thenReturn(true);
+
+        // PUT is also allowed when the audit config document exists (update case)
+        final var result = auditApiAction.withCreateOrUpdateAuditApi(
+            FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()
+        );
+        assertTrue(result.isValid());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionValidationTest.java
@@ -12,7 +12,6 @@
 package org.opensearch.security.dlic.rest.api;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.Test;
 
@@ -50,9 +49,7 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
         when(configurationRepository.isAuditHotReloadingEnabled()).thenReturn(false);
 
         // PUT is allowed when the audit config document does not exist (bootstrap case)
-        final var result = auditApiAction.withCreateOrUpdateAuditApi(
-            FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()
-        );
+        final var result = auditApiAction.withCreateOrUpdateAuditApi(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build());
         assertTrue(result.isValid());
     }
 
@@ -62,9 +59,7 @@ public class AuditApiActionValidationTest extends AbstractApiActionValidationTes
         when(configurationRepository.isAuditHotReloadingEnabled()).thenReturn(true);
 
         // PUT is also allowed when the audit config document exists (update case)
-        final var result = auditApiAction.withCreateOrUpdateAuditApi(
-            FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build()
-        );
+        final var result = auditApiAction.withCreateOrUpdateAuditApi(FakeRestRequest.builder().withMethod(RestRequest.Method.PUT).build());
         assertTrue(result.isValid());
     }
 


### PR DESCRIPTION
### Description

* Category (Bug fix)
* Why these changes are required?

Previously, all Audit Log REST API operations (GET, PUT, PATCH) were blocked when no audit.yml was deployed at initial cluster creation. This created a chicken-and-egg problem where operators could not bootstrap the audit configuration via the API.
 
PUT now uses a new withCreateOrUpdateAuditApi() validation that allows bootstrapping when the document is absent and normal updates when it exists. GET and PATCH remain gated behind the existing check.

* What is the old behavior before changes and new behavior after changes?

If audit.yml is not deployed at initial cluster creation then none of the Audit Log REST API calls (GET,PUT,PATCH) will work.

### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/5862

### Testing
New supporting tests added.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
