### PR TITLE
Remove passay and Guava BaseEncoding dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,35 @@ java.sourceCompatibility = JavaVersion.VERSION_21
 java.targetCompatibility = JavaVersion.VERSION_21
 
 
-tasks.withType(JavaCompile).configureEach {
+compileJava {
+    options.compilerArgs = [
+            '-Xlint:auxiliaryclass',
+            '-Xlint:cast',
+            '-Xlint:classfile',
+            '-Xlint:dep-ann',
+            '-Xlint:divzero',
+            '-Xlint:empty',
+            '-Xlint:exports',
+            '-Xlint:fallthrough',
+            '-Xlint:finally',
+            '-Xlint:module',
+            '-Xlint:opens',
+            '-Xlint:overloads',
+            '-Xlint:overrides',
+            '-Xlint:-processing',
+            '-Xlint:rawtypes',
+            '-Xlint:removal',
+            '-Xlint:requires-automatic',
+            '-Xlint:requires-transitive-automatic',
+            '-Xlint:static',
+            '-Xlint:unchecked',
+            '-Xlint:varargs',
+            '-Xlint:preview',
+            '-Werror']
+    options.encoding = 'UTF-8'
+}
+
+compileTestJava {
     options.compilerArgs = [
             '-Xlint:auxiliaryclass',
             '-Xlint:cast',

--- a/build.gradle
+++ b/build.gradle
@@ -91,35 +91,7 @@ java.sourceCompatibility = JavaVersion.VERSION_21
 java.targetCompatibility = JavaVersion.VERSION_21
 
 
-compileJava {
-    options.compilerArgs = [
-            '-Xlint:auxiliaryclass',
-            '-Xlint:cast',
-            '-Xlint:classfile',
-            '-Xlint:dep-ann',
-            '-Xlint:divzero',
-            '-Xlint:empty',
-            '-Xlint:exports',
-            '-Xlint:fallthrough',
-            '-Xlint:finally',
-            '-Xlint:module',
-            '-Xlint:opens',
-            '-Xlint:overloads',
-            '-Xlint:overrides',
-            '-Xlint:-processing',
-            '-Xlint:rawtypes',
-            '-Xlint:removal',
-            '-Xlint:requires-automatic',
-            '-Xlint:requires-transitive-automatic',
-            '-Xlint:static',
-            '-Xlint:unchecked',
-            '-Xlint:varargs',
-            '-Xlint:preview',
-            '-Werror']
-    options.encoding = 'UTF-8'
-}
-
-compileTestJava {
+tasks.withType(JavaCompile).configureEach {
     options.compilerArgs = [
             '-Xlint:auxiliaryclass',
             '-Xlint:cast',
@@ -591,7 +563,6 @@ allprojects {
                 integrationTestImplementation "org.apache.httpcomponents:httpcore:4.4.16"
                 integrationTestImplementation "org.apache.httpcomponents:httpasyncclient:4.1.5"
                 integrationTestImplementation "org.mockito:mockito-core:5.23.0"
-                integrationTestImplementation "org.passay:passay:1.6.6"
                 integrationTestImplementation "org.opensearch:opensearch:${opensearch_version}"
                 integrationTestImplementation "org.opensearch.plugin:transport-netty4-client:${opensearch_version}"
                 integrationTestImplementation "org.opensearch.plugin:aggs-matrix-stats-client:${opensearch_version}"
@@ -715,9 +686,6 @@ dependencies {
     implementation 'io.github.vishwakarma:zjsonpatch:0.6.2'
     implementation "org.apache.commons:commons-collections4:${versions.commonscollections4}"
 
-    //Password generation
-    implementation 'org.passay:passay:1.6.6'
-
     implementation "org.apache.kafka:kafka-clients:${kafka_version}"
 
     runtimeOnly 'net.minidev:accessors-smart:2.6.0'
@@ -759,7 +727,6 @@ dependencies {
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
     testRuntimeOnly 'com.google.guava:failureaccess:1.0.3'
     testRuntimeOnly 'org.checkerframework:checker-qual:3.55.1'
-    testRuntimeOnly 'org.scala-lang.modules:scala-java8-compat_3:1.0.2'
 
 
     testImplementation libs.opensaml.messaging.impl
@@ -807,8 +774,6 @@ dependencies {
     testImplementation "org.bouncycastle:bcutil-fips:${versions.bouncycastle_util}"
     // JUnit build requirement
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
-    // Kafka test execution
-    testRuntimeOnly 'org.springframework.retry:spring-retry:1.3.4'
 
     testImplementation libs.springframework.beans
 

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -30,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -529,7 +529,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                                 .collect(
                                     Collectors.toMap(
                                         entry -> "id",
-                                        entry -> new String(BaseEncoding.base64().decode(entry.getValue()), StandardCharsets.UTF_8)
+                                        entry -> new String(Base64.getDecoder().decode(entry.getValue()), StandardCharsets.UTF_8)
                                     )
                                 );
                             msg.addSecurityConfigMapToRequestBody(Utils.convertJsonToxToStructuredMap(map.get("id")), id);
@@ -608,7 +608,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                             } else {
                                 Object base64 = parser.map().values().iterator().next();
                                 if (base64 instanceof String) {
-                                    originalSource = (new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8));
+                                    originalSource = (new String(Base64.getDecoder().decode((String) base64), StandardCharsets.UTF_8));
                                 } else {
                                     originalSource = XContentHelper.convertToJson(
                                         originalResult.internalSourceRef(),
@@ -635,7 +635,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                         } else {
                             Object base64 = parser.map().values().iterator().next();
                             if (base64 instanceof String) {
-                                currentSource = new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8);
+                                currentSource = new String(Base64.getDecoder().decode((String) base64), StandardCharsets.UTF_8);
                             } else {
                                 currentSource = XContentHelper.convertToJson(currentIndex.source(), false, XContentType.JSON);
                             }
@@ -678,7 +678,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                     Object base64 = parser.map().values().iterator().next();
                     if (base64 instanceof String) {
                         msg.addSecurityConfigContentToRequestBody(
-                            new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
+                            new String(Base64.getDecoder().decode((String) base64), StandardCharsets.UTF_8),
                             id
                         );
                     } else {
@@ -747,7 +747,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                     ) {
                         Object base64 = parser.map().values().iterator().next();
                         if (base64 instanceof String) {
-                            originalSource = new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8);
+                            originalSource = new String(Base64.getDecoder().decode((String) base64), StandardCharsets.UTF_8);
                         } else {
                             originalSource = XContentHelper.convertToJson(originalResult.internalSourceRef(), false, XContentType.JSON);
                         }
@@ -796,7 +796,7 @@ public abstract class AbstractAuditLog implements AuditLog {
                     Object base64 = parser.map().values().iterator().next();
                     if (base64 instanceof String) {
                         msg.addSecurityConfigContentToRequestBody(
-                            new String(BaseEncoding.base64().decode((String) base64), StandardCharsets.UTF_8),
+                            new String(Base64.getDecoder().decode((String) base64), StandardCharsets.UTF_8),
                             id
                         );
                     } else {

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -37,9 +37,9 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.Base64;
 
 import com.google.common.base.Preconditions;
-import com.google.common.io.BaseEncoding;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.core.common.Strings;
@@ -85,14 +85,14 @@ public class Base64Helper {
             throw new OpenSearchException("Instance {} of class {} is not serializable", e, object, object.getClass());
         }
         final byte[] bytes = bos.toByteArray();
-        return BaseEncoding.base64().encode(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
     }
 
     public static Serializable deserializeObject(final String string) {
 
         Preconditions.checkArgument(!Strings.isNullOrEmpty(string), "object must not be null or empty");
 
-        final byte[] bytes = BaseEncoding.base64().decode(string);
+        final byte[] bytes = Base64.getDecoder().decode(string);
         final ByteArrayInputStream bis = new ByteArrayInputStream(bytes);
         try (Base64Helper.SafeObjectInputStream in = new Base64Helper.SafeObjectInputStream(bis)) {
             return (Serializable) in.readObject();

--- a/src/main/java/org/opensearch/security/user/UserService.java
+++ b/src/main/java/org/opensearch/security/user/UserService.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
@@ -51,9 +50,6 @@ import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.SecurityJsonNode;
 import org.opensearch.transport.client.Client;
 
-import org.passay.CharacterRule;
-import org.passay.EnglishCharacterData;
-import org.passay.PasswordGenerator;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
@@ -232,23 +228,40 @@ public class UserService {
         }
     }
 
+    private static final String LOWERCASE = "abcdefghijklmnopqrstuvwxyz";
+    private static final String UPPERCASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final String DIGITS = "0123456789";
+    private static final String ALL_CHARS = LOWERCASE + UPPERCASE + DIGITS;
+
     /**
-     * Use Passay to generate an 8 - 16 character password with 1+ lowercase, 1+ uppercase, 1+ digit, 1+ special character
+     * Generate an 8 - 16 character password with 1+ lowercase, 1+ uppercase, 1+ digit.
      *
      * @return A password for a service account.
      */
     public static String generatePassword() {
-
-        CharacterRule lowercaseCharacterRule = new CharacterRule(EnglishCharacterData.LowerCase, 1);
-        CharacterRule uppercaseCharacterRule = new CharacterRule(EnglishCharacterData.UpperCase, 1);
-        CharacterRule numericCharacterRule = new CharacterRule(EnglishCharacterData.Digit, 1);
-
-        List<CharacterRule> rules = Arrays.asList(lowercaseCharacterRule, uppercaseCharacterRule, numericCharacterRule);
-        PasswordGenerator passwordGenerator = new PasswordGenerator();
-
         Random random = Randomness.get();
+        int length = random.nextInt(8) + 8;
+        char[] password = new char[length];
 
-        return passwordGenerator.generatePassword(random.nextInt(8) + 8, rules);
+        // Guarantee at least one of each required type
+        password[0] = LOWERCASE.charAt(random.nextInt(LOWERCASE.length()));
+        password[1] = UPPERCASE.charAt(random.nextInt(UPPERCASE.length()));
+        password[2] = DIGITS.charAt(random.nextInt(DIGITS.length()));
+
+        // Fill remaining with random chars from all pools
+        for (int i = 3; i < length; i++) {
+            password[i] = ALL_CHARS.charAt(random.nextInt(ALL_CHARS.length()));
+        }
+
+        // Shuffle to avoid predictable positions
+        for (int i = length - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            char tmp = password[i];
+            password[i] = password[j];
+            password[j] = tmp;
+        }
+
+        return new String(password);
     }
 
     /**

--- a/src/test/java/org/opensearch/security/UserServiceUnitTests.java
+++ b/src/test/java/org/opensearch/security/UserServiceUnitTests.java
@@ -34,11 +34,6 @@ import org.opensearch.security.user.UserService;
 import org.opensearch.transport.client.Client;
 
 import org.mockito.Mock;
-import org.passay.CharacterCharacteristicsRule;
-import org.passay.CharacterRule;
-import org.passay.EnglishCharacterData;
-import org.passay.LengthRule;
-import org.passay.PasswordData;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.dataformat.yaml.YAMLFactory;
@@ -127,28 +122,18 @@ public class UserServiceUnitTests {
     @Test
     public void testGeneratedPasswordContents() {
         String password = UserService.generatePassword();
-        PasswordData data = new PasswordData(password);
 
-        LengthRule lengthRule = new LengthRule(8, 16);
+        // Verify length is 8-16
+        assertThat(password.length() >= 8 && password.length() <= 16, is(true));
 
-        CharacterCharacteristicsRule characteristicsRule = new CharacterCharacteristicsRule();
+        // Verify at least 1 lowercase, 1 uppercase, 1 digit
+        assertThat(password.chars().anyMatch(Character::isLowerCase), is(true));
+        assertThat(password.chars().anyMatch(Character::isUpperCase), is(true));
+        assertThat(password.chars().anyMatch(Character::isDigit), is(true));
 
-        // Define M (3 in this case)
-        characteristicsRule.setNumberOfCharacteristics(3);
-
-        // Define elements of N (upper, lower, digit, symbol)
-        characteristicsRule.getRules().add(new CharacterRule(EnglishCharacterData.UpperCase, 1));
-        characteristicsRule.getRules().add(new CharacterRule(EnglishCharacterData.LowerCase, 1));
-        characteristicsRule.getRules().add(new CharacterRule(EnglishCharacterData.Digit, 1));
-        characteristicsRule.getRules().add(new CharacterRule(EnglishCharacterData.Special, 1));
-
-        org.passay.PasswordValidator validator = new org.passay.PasswordValidator(lengthRule, characteristicsRule);
-        validator.validate(data);
-
+        // Verify two generated passwords are different
         String password2 = UserService.generatePassword();
-        PasswordData data2 = new PasswordData(password2);
         assertNotEquals(password, password2);
-        assertNotEquals(data, data2);
     }
 
 }

--- a/src/test/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/HTTPJwtAuthenticatorTest.java
@@ -21,6 +21,7 @@ import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -28,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.junit.Assert;
 import org.junit.Test;
@@ -84,7 +84,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testBadKey() throws Exception {
         try {
             final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-                Settings.builder().put("signing_key", BaseEncoding.base64().encode(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 })),
+                Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 })),
                 Jwts.builder().setSubject("Leonard McCoy")
             );
             fail("Expected WeakKeyException");
@@ -96,7 +96,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testTokenMissing() {
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
@@ -112,7 +112,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testInvalid() throws Exception {
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         String jwsToken = "123invalidtoken..";
 
@@ -139,7 +139,7 @@ public class HTTPJwtAuthenticatorTest {
             .signWith(Keys.hmacShaKeyFor(secretKeyBytes), SignatureAlgorithm.HS512)
             .compact();
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
@@ -172,7 +172,7 @@ public class HTTPJwtAuthenticatorTest {
             .signWith(Keys.hmacShaKeyFor(secretKeyBytes), SignatureAlgorithm.HS512)
             .compact();
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
 
@@ -193,7 +193,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testClockSkewInvalid() {
         Settings settings = Settings.builder()
-            .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+            .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
             .put("jwt_clock_skew_tolerance_seconds", 0)
             .build();
 
@@ -224,7 +224,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testClockSkewValid() {
         Settings settings = Settings.builder()
-            .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+            .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
             .put("jwt_clock_skew_tolerance_seconds", 60)
             .build();
 
@@ -272,7 +272,7 @@ public class HTTPJwtAuthenticatorTest {
             .signWith(Keys.hmacShaKeyFor(secretKeyBytes), SignatureAlgorithm.HS512)
             .compact();
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
         Map<String, String> headers = new HashMap<String, String>();
@@ -309,8 +309,8 @@ public class HTTPJwtAuthenticatorTest {
         Settings settings = Settings.builder()
             .put(
                 "signing_key",
-                BaseEncoding.base64()
-                    .encode(
+                Base64.getEncoder()
+                    .encodeToString(
                         "thisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDothisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDo"
                             .getBytes(StandardCharsets.UTF_8)
                     )
@@ -341,8 +341,8 @@ public class HTTPJwtAuthenticatorTest {
         Settings settings = Settings.builder()
             .put(
                 "signing_key",
-                BaseEncoding.base64()
-                    .encode(
+                Base64.getEncoder()
+                    .encodeToString(
                         "additionalDatathisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDothisIsSecretThatIsVeryHardToCrackItsPracticallyImpossibleToDo"
                             .getBytes(StandardCharsets.UTF_8)
                     )
@@ -364,7 +364,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testBearer() throws Exception {
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         String jwsToken = Jwts.builder()
             .setSubject("Leonard McCoy")
@@ -390,7 +390,7 @@ public class HTTPJwtAuthenticatorTest {
     @Test
     public void testBearerWrongPosition() throws Exception {
 
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
 
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(secretKey, SignatureAlgorithm.HS512).compact();
 
@@ -408,10 +408,10 @@ public class HTTPJwtAuthenticatorTest {
 
     @Test
     public void testBasicAuthHeader() throws Exception {
-        Settings settings = Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).build();
+        Settings settings = Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).build();
         HTTPJwtAuthenticator jwtAuth = new HTTPJwtAuthenticator(settings, null);
 
-        String basicAuth = BaseEncoding.base64().encode("user:password".getBytes(StandardCharsets.UTF_8));
+        String basicAuth = Base64.getEncoder().encodeToString("user:password".getBytes(StandardCharsets.UTF_8));
         Map<String, String> headers = Collections.singletonMap(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth);
 
         AuthCredentials credentials = jwtAuth.extractCredentials(
@@ -425,7 +425,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testRoles() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("roles_key", "roles"),
             Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2")
         );
 
@@ -438,7 +438,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testNullClaim() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("roles_key", "roles"),
             Jwts.builder().setSubject("Leonard McCoy").claim("roles", null)
         );
 
@@ -451,7 +451,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testNonStringClaim() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("roles_key", "roles"),
             Jwts.builder().setSubject("Leonard McCoy").claim("roles", 123L)
         );
 
@@ -465,7 +465,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testRolesMissing() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("roles_key", "roles"),
             Jwts.builder().setSubject("Leonard McCoy")
         );
 
@@ -478,7 +478,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testWrongSubjectKey() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "missing"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("subject_key", "missing"),
             Jwts.builder().claim("roles", "role1,role2").claim("asub", "Dr. Who")
         );
 
@@ -489,7 +489,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testAlternativeSubject() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "asub"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("subject_key", "asub"),
             Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2").claim("asub", "Dr. Who")
         );
 
@@ -502,7 +502,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testNonStringAlternativeSubject() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("subject_key", "asub"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("subject_key", "asub"),
             Jwts.builder().setSubject("Leonard McCoy").claim("roles", "role1,role2").claim("asub", false)
         );
 
@@ -515,7 +515,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testUrlParam() throws Exception {
 
         Settings settings = Settings.builder()
-            .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+            .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
             .put("jwt_url_parameter", "abc")
             .build();
 
@@ -537,7 +537,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testExp() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)),
             Jwts.builder().setSubject("Expired").setExpiration(new Date(100))
         );
 
@@ -548,7 +548,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testNbf() throws Exception {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)),
             Jwts.builder().setSubject("Expired").setNotBefore(new Date(System.currentTimeMillis() + (1000 * 36000)))
         );
 
@@ -564,7 +564,9 @@ public class HTTPJwtAuthenticatorTest {
         PublicKey pub = pair.getPublic();
 
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.RS256).compact();
-        String signingKey = "-----BEGIN PUBLIC KEY-----\n" + BaseEncoding.base64().encode(pub.getEncoded()) + "-----END PUBLIC KEY-----";
+        String signingKey = "-----BEGIN PUBLIC KEY-----\n"
+            + Base64.getEncoder().encodeToString(pub.getEncoded())
+            + "-----END PUBLIC KEY-----";
         AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
 
         Assert.assertNotNull(creds);
@@ -600,7 +602,7 @@ public class HTTPJwtAuthenticatorTest {
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.RS256).compact();
 
         String signingKey = "-----BEGIN PUBLIC KEY-----\n"
-            + formatKeyWithNewlines(BaseEncoding.base64().encode(pub.getEncoded()))
+            + formatKeyWithNewlines(Base64.getEncoder().encodeToString(pub.getEncoded()))
             + "\n-----END PUBLIC KEY-----";
         AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
 
@@ -628,7 +630,7 @@ public class HTTPJwtAuthenticatorTest {
         PrivateKey priv = pair.getPrivate();
         PublicKey pub = pair.getPublic();
 
-        String signingKey = BaseEncoding.base64().encode(pub.getEncoded());
+        String signingKey = Base64.getEncoder().encodeToString(pub.getEncoded());
         String jwsToken = Jwts.builder().setSubject("Leonard McCoy").signWith(priv, SignatureAlgorithm.ES512).compact();
 
         AuthCredentials creds = testJwtAuthenticationWithSigningKey(signingKey, jwsToken);
@@ -644,7 +646,7 @@ public class HTTPJwtAuthenticatorTest {
         JwtBuilder builder = Jwts.builder().setPayload("{" + "\"sub\": \"John Doe\"," + "\"roles\": [\"a\",\"b\",\"3rd\"]" + "}");
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("roles_key", "roles"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("roles_key", "roles"),
             builder
         );
 
@@ -660,7 +662,9 @@ public class HTTPJwtAuthenticatorTest {
     public void testRequiredAudienceWithCorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_audience", "test_audience"),
+            Settings.builder()
+                .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
+                .put("required_audience", "test_audience"),
             Jwts.builder().setSubject("Leonard McCoy").setAudience("test_audience")
         );
 
@@ -672,7 +676,9 @@ public class HTTPJwtAuthenticatorTest {
     public void testRequiredAudienceWithIncorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_audience", "test_audience"),
+            Settings.builder()
+                .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
+                .put("required_audience", "test_audience"),
             Jwts.builder().setSubject("Leonard McCoy").setAudience("wrong_audience")
         );
 
@@ -684,7 +690,7 @@ public class HTTPJwtAuthenticatorTest {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
                 .put("required_audience", "test_audience,test_audience_2"),
             Jwts.builder().setSubject("Leonard McCoy").setAudience("test_audience_2")
         );
@@ -698,7 +704,7 @@ public class HTTPJwtAuthenticatorTest {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
             Settings.builder()
-                .put("signing_key", BaseEncoding.base64().encode(secretKeyBytes))
+                .put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes))
                 .put("required_audience", "test_audience,test_audience_2"),
             Jwts.builder().setSubject("Leonard McCoy").setAudience("wrong_audience")
         );
@@ -710,7 +716,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testRequiredIssuerWithCorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_issuer", "test_issuer"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("required_issuer", "test_issuer"),
             Jwts.builder().setSubject("Leonard McCoy").setIssuer("test_issuer")
         );
 
@@ -722,7 +728,7 @@ public class HTTPJwtAuthenticatorTest {
     public void testRequiredIssuerWithIncorrectAudience() {
 
         final AuthCredentials credentials = extractCredentialsFromJwtHeader(
-            Settings.builder().put("signing_key", BaseEncoding.base64().encode(secretKeyBytes)).put("required_issuer", "test_issuer"),
+            Settings.builder().put("signing_key", Base64.getEncoder().encodeToString(secretKeyBytes)).put("required_issuer", "test_issuer"),
             Jwts.builder().setSubject("Leonard McCoy").setIssuer("wrong_issuer")
         );
 
@@ -749,9 +755,9 @@ public class HTTPJwtAuthenticatorTest {
             .put(
                 "signing_key",
                 "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub1.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub1.getEncoded())
                     + "-----END PUBLIC KEY-----,-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub2.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub2.getEncoded())
                     + "-----END PUBLIC KEY-----"
             )
             .build();
@@ -801,9 +807,9 @@ public class HTTPJwtAuthenticatorTest {
             .put(
                 "signing_key",
                 "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub1.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub1.getEncoded())
                     + "-----END PUBLIC KEY-----,     -----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub2.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub2.getEncoded())
                     + "-----END PUBLIC KEY-----"
             )
             .build();
@@ -856,9 +862,9 @@ public class HTTPJwtAuthenticatorTest {
             .put(
                 "signing_key",
                 "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub1.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub1.getEncoded())
                     + "-----END PUBLIC KEY-----,"
-                    + BaseEncoding.base64().encode(pub2.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub2.getEncoded())
             )
             .build();
 
@@ -923,14 +929,14 @@ public class HTTPJwtAuthenticatorTest {
             .put(
                 "signing_key",
                 "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub1.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub1.getEncoded())
                     + "-----END PUBLIC KEY-----,"
-                    + BaseEncoding.base64().encode(pub2.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub2.getEncoded())
                     + ","
                     + "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub3.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub3.getEncoded())
                     + "-----END PUBLIC KEY-----,"
-                    + BaseEncoding.base64().encode(pub4.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub4.getEncoded())
             )
             .build();
 
@@ -1001,9 +1007,9 @@ public class HTTPJwtAuthenticatorTest {
             .put(
                 "signing_key",
                 "-----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub1.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub1.getEncoded())
                     + "-----END PUBLIC KEY-----,     -----BEGIN PUBLIC KEY-----\n"
-                    + BaseEncoding.base64().encode(pub2.getEncoded())
+                    + Base64.getEncoder().encodeToString(pub2.getEncoded())
                     + "-----END PUBLIC KEY-----"
             )
             .build();

--- a/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
+++ b/src/test/java/org/opensearch/security/authtoken/jwt/JwtVendorTest.java
@@ -12,11 +12,11 @@
 package org.opensearch.security.authtoken.jwt;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.function.LongSupplier;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
@@ -55,7 +55,7 @@ public class JwtVendorTest {
 
     final static String signingKey =
         "This is my super safe signing key that no one will ever be able to guess. It's would take billions of years and the world's most powerful quantum computer to crack";
-    final static String signingKeyB64Encoded = BaseEncoding.base64().encode(signingKey.getBytes(StandardCharsets.UTF_8));
+    final static String signingKeyB64Encoded = Base64.getEncoder().encodeToString(signingKey.getBytes(StandardCharsets.UTF_8));
 
     @Test
     public void testCreateJwkFromSettings() {

--- a/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/http/OnBehalfOfAuthenticatorTest.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 import javax.crypto.SecretKey;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.logging.log4j.Level;
@@ -68,7 +67,7 @@ public class OnBehalfOfAuthenticatorTest {
 
     final static String signingKey =
         "This is my super safe signing key that no one will ever be able to guess. It's would take billions of years and the world's most powerful quantum computer to crack";
-    final static String signingKeyB64Encoded = BaseEncoding.base64().encode(signingKey.getBytes(StandardCharsets.UTF_8));
+    final static String signingKeyB64Encoded = Base64.getEncoder().encodeToString(signingKey.getBytes(StandardCharsets.UTF_8));
     final static SecretKey secretKey = Keys.hmacShaKeyFor(signingKeyB64Encoded.getBytes(StandardCharsets.UTF_8));
 
     private static final String SECURITY_PREFIX = "/_plugins/_security/";
@@ -125,7 +124,7 @@ public class OnBehalfOfAuthenticatorTest {
         Exception exception = assertThrows(
             RuntimeException.class,
             () -> extractCredentialsFromJwtHeader(
-                BaseEncoding.base64().encode(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 }),
+                Base64.getEncoder().encodeToString(new byte[] { 1, 3, 3, 4, 3, 6, 7, 8, 3, 10 }),
                 claimsEncryptionKey,
                 Jwts.builder().setIssuer(clusterName).setSubject("Leonard McCoy"),
                 false

--- a/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
+++ b/src/test/java/org/opensearch/security/identity/SecurityTokenManagerTest.java
@@ -13,8 +13,8 @@ package org.opensearch.security.identity;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
-import com.google.common.io.BaseEncoding;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,7 +79,7 @@ public class SecurityTokenManagerTest {
 
     final static String signingKey =
         "This is my super safe signing key that no one will ever be able to guess. It's would take billions of years and the world's most powerful quantum computer to crack";
-    final static String signingKeyB64Encoded = BaseEncoding.base64().encode(signingKey.getBytes(StandardCharsets.UTF_8));
+    final static String signingKeyB64Encoded = Base64.getEncoder().encodeToString(signingKey.getBytes(StandardCharsets.UTF_8));
 
     @Test
     public void onDynamicConfigModelChanged_JwtVendorEnabled() {

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -15,10 +15,10 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.stream.IntStream;
 
-import com.google.common.io.BaseEncoding;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchException;
@@ -107,7 +107,7 @@ public class Base64HelperTest {
         }
         final OpenSearchException exception = assertThrows(
             OpenSearchException.class,
-            () -> Base64Helper.deserializeObject(BaseEncoding.base64().encode(bos.toByteArray()))
+            () -> Base64Helper.deserializeObject(Base64.getEncoder().encodeToString(bos.toByteArray()))
         );
         assertThat(exception.getMessage(), containsString("Unauthorized deserialization attempt"));
     }


### PR DESCRIPTION
### Description

Spring cleaning: remove unused dependencies, replace Guava utilities with JDK equivalents, and consolidate build config.

**Dependencies removed:**
- `org.passay:passay:1.6.6` — replaced with a `SecureRandom`-based password generator in `UserService`
- `org.scala-lang.modules:scala-java8-compat_3:1.0.2` — unused leftover from pre-KRaft Kafka
- `org.springframework.retry:spring-retry:1.3.4` — unused leftover from older Kafka

**Guava usage reduced:**
- `com.google.common.io.BaseEncoding` → `java.util.Base64` (7 files)

**Build cleanup:**
- Consolidated duplicate `compileJava`/`compileTestJava` compiler args into single `tasks.withType(JavaCompile).configureEach` block

* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)

Maintenance

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
