### PR TITLE
Unify allowedKeys and allowedKeysWithConfig into single method

### DIFF
--- a/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AccountApiAction.java
@@ -30,6 +30,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
@@ -221,8 +222,15 @@ public class AccountApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        return ImmutableMap.of("hash", DataType.STRING, "password", DataType.STRING, "current_password", DataType.STRING);
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        return ImmutableMap.of(
+                            "hash",
+                            FieldConfiguration.of(DataType.STRING),
+                            "password",
+                            FieldConfiguration.of(DataType.STRING),
+                            "current_password",
+                            FieldConfiguration.of(DataType.STRING)
+                        );
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ActionGroupsApiAction.java
@@ -32,6 +32,7 @@ import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
@@ -229,15 +230,15 @@ public class ActionGroupsApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
                         if (isCurrentUserAdmin()) {
-                            allowedKeys.put("hidden", DataType.BOOLEAN);
-                            allowedKeys.put("reserved", DataType.BOOLEAN);
+                            allowedKeys.put("hidden", FieldConfiguration.of(DataType.BOOLEAN));
+                            allowedKeys.put("reserved", FieldConfiguration.of(DataType.BOOLEAN));
                         }
-                        allowedKeys.put("allowed_actions", DataType.ARRAY);
-                        allowedKeys.put("description", DataType.STRING);
-                        allowedKeys.put("type", DataType.STRING);
+                        allowedKeys.put("allowed_actions", FieldConfiguration.of(DataType.ARRAY));
+                        allowedKeys.put("description", FieldConfiguration.of(DataType.STRING));
+                        allowedKeys.put("type", FieldConfiguration.of(DataType.STRING));
                         return allowedKeys.build();
                     }
 

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AllowlistApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AllowlistApiAction.java
@@ -24,6 +24,7 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.tools.SecurityAdmin;
@@ -138,8 +139,13 @@ public class AllowlistApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        return ImmutableMap.of("enabled", DataType.BOOLEAN, "requests", DataType.OBJECT);
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        return ImmutableMap.of(
+                            "enabled",
+                            FieldConfiguration.of(DataType.BOOLEAN),
+                            "requests",
+                            FieldConfiguration.of(DataType.OBJECT)
+                        );
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -32,6 +32,7 @@ import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
@@ -326,8 +327,15 @@ public class AuditApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        return ImmutableMap.of("enabled", DataType.BOOLEAN, "audit", DataType.OBJECT, "compliance", DataType.OBJECT);
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        return ImmutableMap.of(
+                            "enabled",
+                            FieldConfiguration.of(DataType.BOOLEAN),
+                            "audit",
+                            FieldConfiguration.of(DataType.OBJECT),
+                            "compliance",
+                            FieldConfiguration.of(DataType.OBJECT)
+                        );
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/ConfigUpgradeApiAction.java
@@ -45,6 +45,7 @@ import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
@@ -399,8 +400,13 @@ public class ConfigUpgradeApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        return Map.of(REQUEST_PARAM_CONFIGS_KEY, DataType.ARRAY, REQUEST_PARAM_ENTITIES_KEY, DataType.ARRAY);
+                    public Map<String, FieldConfiguration> allowedKeys() {
+                        return Map.of(
+                            REQUEST_PARAM_CONFIGS_KEY,
+                            FieldConfiguration.of(DataType.ARRAY),
+                            REQUEST_PARAM_ENTITIES_KEY,
+                            FieldConfiguration.of(DataType.ARRAY)
+                        );
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -29,6 +29,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.securityconf.Hashed;
@@ -327,18 +328,18 @@ public class InternalUsersApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
                         if (isCurrentUserAdmin()) {
-                            allowedKeys.put("hidden", DataType.BOOLEAN);
-                            allowedKeys.put("reserved", DataType.BOOLEAN);
+                            allowedKeys.put("hidden", FieldConfiguration.of(DataType.BOOLEAN));
+                            allowedKeys.put("reserved", FieldConfiguration.of(DataType.BOOLEAN));
                         }
-                        return allowedKeys.put("backend_roles", DataType.ARRAY)
-                            .put("attributes", DataType.OBJECT)
-                            .put("description", DataType.STRING)
-                            .put("opendistro_security_roles", DataType.ARRAY)
-                            .put("hash", DataType.STRING)
-                            .put("password", DataType.STRING)
+                        return allowedKeys.put("backend_roles", FieldConfiguration.of(DataType.ARRAY))
+                            .put("attributes", FieldConfiguration.of(DataType.OBJECT))
+                            .put("description", FieldConfiguration.of(DataType.STRING))
+                            .put("opendistro_security_roles", FieldConfiguration.of(DataType.ARRAY))
+                            .put("hash", FieldConfiguration.of(DataType.STRING))
+                            .put("password", FieldConfiguration.of(DataType.STRING))
                             .build();
                     }
                 });

--- a/src/main/java/org/opensearch/security/dlic/rest/api/MultiTenancyConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/MultiTenancyConfigApiAction.java
@@ -138,24 +138,7 @@ public class MultiTenancyConfigApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        // Provide basic type information for backward compatibility
-                        return ImmutableMap.of(
-                            DEFAULT_TENANT_JSON_PROPERTY,
-                            DataType.STRING,
-                            PRIVATE_TENANT_ENABLED_JSON_PROPERTY,
-                            DataType.BOOLEAN,
-                            MULTITENANCY_ENABLED_JSON_PROPERTY,
-                            DataType.BOOLEAN,
-                            SIGN_IN_OPTIONS,
-                            DataType.ARRAY,
-                            PREFERRED_TENANTS,
-                            DataType.ARRAY
-                        );
-                    }
-
-                    @Override
-                    public Map<String, FieldConfiguration> allowedKeysWithConfig() {
+                    public Map<String, FieldConfiguration> allowedKeys() {
                         return ImmutableMap.<String, FieldConfiguration>builder()
                             .put(
                                 DEFAULT_TENANT_JSON_PROPERTY,

--- a/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/NodesDnApiAction.java
@@ -30,6 +30,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.NodesDn;
@@ -187,8 +188,8 @@ public class NodesDnApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        return ImmutableMap.of("nodes_dn", DataType.ARRAY);
+                    public Map<String, FieldConfiguration> allowedKeys() {
+                        return ImmutableMap.of("nodes_dn", FieldConfiguration.of(DataType.ARRAY));
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RateLimitersApiAction.java
@@ -29,6 +29,7 @@ import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.v7.ConfigV7;
@@ -140,17 +141,17 @@ public class RateLimitersApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
 
-                        return allowedKeys.put(TYPE_JSON_PROPERTY, DataType.STRING)
-                            .put(IGNORE_HOSTS_JSON_PROPERTY, DataType.ARRAY)
-                            .put(AUTHENTICATION_BACKEND_JSON_PROPERTY, DataType.STRING)
-                            .put(ALLOWED_TRIES_JSON_PROPERTY, DataType.INTEGER)
-                            .put(TIME_WINDOW_SECONDS_JSON_PROPERTY, DataType.INTEGER)
-                            .put(BLOCK_EXPIRY_JSON_PROPERTY, DataType.INTEGER)
-                            .put(MAX_BLOCKED_CLIENTS_JSON_PROPERTY, DataType.INTEGER)
-                            .put(MAX_TRACKED_CLIENTS_JSON_PROPERTY, DataType.INTEGER)
+                        return allowedKeys.put(TYPE_JSON_PROPERTY, FieldConfiguration.of(DataType.STRING))
+                            .put(IGNORE_HOSTS_JSON_PROPERTY, FieldConfiguration.of(DataType.ARRAY))
+                            .put(AUTHENTICATION_BACKEND_JSON_PROPERTY, FieldConfiguration.of(DataType.STRING))
+                            .put(ALLOWED_TRIES_JSON_PROPERTY, FieldConfiguration.of(DataType.INTEGER))
+                            .put(TIME_WINDOW_SECONDS_JSON_PROPERTY, FieldConfiguration.of(DataType.INTEGER))
+                            .put(BLOCK_EXPIRY_JSON_PROPERTY, FieldConfiguration.of(DataType.INTEGER))
+                            .put(MAX_BLOCKED_CLIENTS_JSON_PROPERTY, FieldConfiguration.of(DataType.INTEGER))
+                            .put(MAX_TRACKED_CLIENTS_JSON_PROPERTY, FieldConfiguration.of(DataType.INTEGER))
                             .build();
                     }
                 });

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -31,6 +31,7 @@ import org.opensearch.security.configuration.Salt;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.securityconf.impl.CType;
@@ -179,16 +180,16 @@ public class RolesApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
                         if (isCurrentUserAdmin()) {
-                            allowedKeys.put("hidden", DataType.BOOLEAN);
-                            allowedKeys.put("reserved", DataType.BOOLEAN);
+                            allowedKeys.put("hidden", FieldConfiguration.of(DataType.BOOLEAN));
+                            allowedKeys.put("reserved", FieldConfiguration.of(DataType.BOOLEAN));
                         }
-                        return allowedKeys.put("cluster_permissions", DataType.ARRAY)
-                            .put("tenant_permissions", DataType.ARRAY)
-                            .put("index_permissions", DataType.ARRAY)
-                            .put("description", DataType.STRING)
+                        return allowedKeys.put("cluster_permissions", FieldConfiguration.of(DataType.ARRAY))
+                            .put("tenant_permissions", FieldConfiguration.of(DataType.ARRAY))
+                            .put("index_permissions", FieldConfiguration.of(DataType.ARRAY))
+                            .put("description", FieldConfiguration.of(DataType.STRING))
                             .build();
                     }
                 });

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -27,6 +27,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
@@ -150,17 +151,17 @@ public class RolesMappingApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
                         if (isCurrentUserAdmin()) {
-                            allowedKeys.put("hidden", DataType.BOOLEAN);
-                            allowedKeys.put("reserved", DataType.BOOLEAN);
+                            allowedKeys.put("hidden", FieldConfiguration.of(DataType.BOOLEAN));
+                            allowedKeys.put("reserved", FieldConfiguration.of(DataType.BOOLEAN));
                         }
-                        return allowedKeys.put("backend_roles", DataType.ARRAY)
-                            .put("and_backend_roles", DataType.ARRAY)
-                            .put("hosts", DataType.ARRAY)
-                            .put("users", DataType.ARRAY)
-                            .put("description", DataType.STRING)
+                        return allowedKeys.put("backend_roles", FieldConfiguration.of(DataType.ARRAY))
+                            .put("and_backend_roles", FieldConfiguration.of(DataType.ARRAY))
+                            .put("hosts", FieldConfiguration.of(DataType.ARRAY))
+                            .put("users", FieldConfiguration.of(DataType.ARRAY))
+                            .put("description", FieldConfiguration.of(DataType.STRING))
                             .build();
                     }
                 });

--- a/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/SecurityConfigApiAction.java
@@ -25,6 +25,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.threadpool.ThreadPool;
@@ -142,8 +143,8 @@ public class SecurityConfigApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        return ImmutableMap.of("dynamic", DataType.OBJECT);
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        return ImmutableMap.of("dynamic", FieldConfiguration.of(DataType.OBJECT));
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -40,6 +40,7 @@ import org.opensearch.rest.RestRequest.Method;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -123,13 +124,13 @@ public class TenantsApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        final ImmutableMap.Builder<String, DataType> allowedKeys = ImmutableMap.builder();
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
+                        final ImmutableMap.Builder<String, FieldConfiguration> allowedKeys = ImmutableMap.builder();
                         if (isCurrentUserAdmin()) {
-                            allowedKeys.put("hidden", DataType.BOOLEAN);
-                            allowedKeys.put("reserved", DataType.BOOLEAN);
+                            allowedKeys.put("hidden", FieldConfiguration.of(DataType.BOOLEAN));
+                            allowedKeys.put("reserved", FieldConfiguration.of(DataType.BOOLEAN));
                         }
-                        return allowedKeys.put("description", DataType.STRING).build();
+                        return allowedKeys.put("description", FieldConfiguration.of(DataType.STRING)).build();
                     }
                 });
             }

--- a/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/validation/RequestContentValidator.java
@@ -56,7 +56,7 @@ public class RequestContentValidator implements ToXContent {
         }
 
         @Override
-        public Map<String, DataType> allowedKeys() {
+        public Map<String, FieldConfiguration> allowedKeys() {
             return Collections.emptyMap();
         }
     }) {
@@ -178,16 +178,7 @@ public class RequestContentValidator implements ToXContent {
 
         Settings settings();
 
-        Map<String, DataType> allowedKeys();
-
-        /**
-         * Optional: Returns field configurations with validation rules.
-         * If not overridden, returns null and the validator will use allowedKeys() instead.
-         * This is an opt-in enhancement for more flexible validation.
-         */
-        default Map<String, FieldConfiguration> allowedKeysWithConfig() {
-            return null;
-        }
+        Map<String, FieldConfiguration> allowedKeys();
 
     }
 
@@ -273,14 +264,7 @@ public class RequestContentValidator implements ToXContent {
         mandatory.removeAll(requestedKeys);
         missingMandatoryKeys.addAll(mandatory);
 
-        // Use allowedKeysWithConfig if provided, otherwise fall back to allowedKeys
-        final Map<String, FieldConfiguration> fieldConfigs = validationContext.allowedKeysWithConfig();
-        final Set<String> allowed;
-        if (fieldConfigs != null) {
-            allowed = new HashSet<>(fieldConfigs.keySet());
-        } else {
-            allowed = new HashSet<>(validationContext.allowedKeys().keySet());
-        }
+        final Set<String> allowed = new HashSet<>(validationContext.allowedKeys().keySet());
         requestedKeys.removeAll(allowed);
         invalidKeys.addAll(requestedKeys);
 
@@ -292,9 +276,7 @@ public class RequestContentValidator implements ToXContent {
     }
 
     private ValidationResult<JsonNode> validateDataType(final JsonNode jsonContent) {
-        // Check if enhanced validation is available
-        final Map<String, FieldConfiguration> fieldConfigs = validationContext.allowedKeysWithConfig();
-        final boolean useEnhancedValidation = (fieldConfigs != null);
+        final Map<String, FieldConfiguration> fieldConfigs = validationContext.allowedKeys();
 
         try (final JsonParser parser = DefaultObjectMapper.objectMapper().treeAsTokens(jsonContent)) {
             JsonToken token;
@@ -302,17 +284,8 @@ public class RequestContentValidator implements ToXContent {
                 if (token.equals(JsonToken.PROPERTY_NAME)) {
                     String currentName = parser.currentName();
 
-                    // Get data type from either FieldConfiguration or simple DataType map
-                    final DataType dataType;
-                    final FieldConfiguration fieldConfig;
-
-                    if (useEnhancedValidation && fieldConfigs != null) {
-                        fieldConfig = fieldConfigs.get(currentName);
-                        dataType = (fieldConfig != null) ? fieldConfig.getDataType() : null;
-                    } else {
-                        fieldConfig = null;
-                        dataType = validationContext.allowedKeys().get(currentName);
-                    }
+                    final FieldConfiguration fieldConfig = fieldConfigs.get(currentName);
+                    final DataType dataType = (fieldConfig != null) ? fieldConfig.getDataType() : null;
 
                     if (dataType != null) {
                         JsonToken valueToken = parser.nextToken();
@@ -393,9 +366,7 @@ public class RequestContentValidator implements ToXContent {
     }
 
     private ValidationResult<JsonNode> nullValuesInArrayValidator(final JsonNode jsonContent) {
-        // Use allowedKeysWithConfig if provided, otherwise fall back to allowedKeys
-        final Map<String, FieldConfiguration> fieldConfigs = validationContext.allowedKeysWithConfig();
-        final Set<String> allowedKeys = (fieldConfigs != null) ? fieldConfigs.keySet() : validationContext.allowedKeys().keySet();
+        final Set<String> allowedKeys = validationContext.allowedKeys().keySet();
 
         for (final String key : allowedKeys) {
             final JsonNode value = jsonContent.get(key);
@@ -504,8 +475,7 @@ public class RequestContentValidator implements ToXContent {
 
             private final Set<String> mandatoryOrKeys = validationContext.mandatoryOrKeys();
 
-            private final Map<String, DataType> allowedKeys = validationContext.allowedKeys();
-            private final Map<String, FieldConfiguration> allowedKeysWithConfig = validationContext.allowedKeysWithConfig();
+            private final Map<String, FieldConfiguration> allowedKeys = validationContext.allowedKeys();
 
             @Override
             public Settings settings() {
@@ -528,13 +498,8 @@ public class RequestContentValidator implements ToXContent {
             }
 
             @Override
-            public Map<String, DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return allowedKeys;
-            }
-
-            @Override
-            public Map<String, FieldConfiguration> allowedKeysWithConfig() {
-                return allowedKeysWithConfig;
             }
         });
     }

--- a/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
@@ -466,19 +466,7 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                     }
 
                     @Override
-                    public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                        // Provide basic type information for backward compatibility
-                        return ImmutableMap.<String, RequestContentValidator.DataType>builder()
-                            .put("source_index", RequestContentValidator.DataType.STRING)
-                            .put("username_path", RequestContentValidator.DataType.STRING)
-                            .put("backend_roles_path", RequestContentValidator.DataType.STRING)
-                            .put("default_owner", RequestContentValidator.DataType.STRING)
-                            .put("default_access_level", RequestContentValidator.DataType.OBJECT)
-                            .build();
-                    }
-
-                    @Override
-                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeysWithConfig() {
+                    public Map<String, RequestContentValidator.FieldConfiguration> allowedKeys() {
                         Set<String> allowedIndices = resourcePluginInfo.getResourceIndicesForProtectedTypes();
                         RequestContentValidator.FieldValidator sourceIndexValidator = (fieldName, value) -> {
                             if (value instanceof String strValue) {

--- a/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/validation/RequestContentValidatorTest.java
@@ -34,6 +34,8 @@ import org.opensearch.http.HttpChannel;
 import org.opensearch.http.HttpRequest;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.DataType;
+import org.opensearch.security.dlic.rest.validation.RequestContentValidator.FieldConfiguration;
 
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -86,7 +88,7 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return Collections.emptyMap();
             }
         });
@@ -110,7 +112,7 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return Collections.emptyMap();
             }
         });
@@ -139,16 +141,16 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return ImmutableMap.of(
                     "a",
-                    RequestContentValidator.DataType.STRING,
+                    FieldConfiguration.of(DataType.STRING),
                     "b",
-                    RequestContentValidator.DataType.OBJECT,
+                    FieldConfiguration.of(DataType.OBJECT),
                     "c",
-                    RequestContentValidator.DataType.ARRAY,
+                    FieldConfiguration.of(DataType.ARRAY),
                     "d",
-                    RequestContentValidator.DataType.INTEGER
+                    FieldConfiguration.of(DataType.INTEGER)
                 );
             }
         });
@@ -191,8 +193,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING, "b", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING), "b", FieldConfiguration.of(DataType.STRING));
             }
         });
 
@@ -225,8 +227,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return ImmutableMap.of("a", RequestContentValidator.DataType.ARRAY);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return ImmutableMap.of("a", FieldConfiguration.of(DataType.ARRAY));
             }
         });
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode().putObject("a");
@@ -250,8 +252,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.ARRAY);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.ARRAY));
             }
         });
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
@@ -280,8 +282,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING, "b", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING), "b", FieldConfiguration.of(DataType.STRING));
             }
         });
         final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value");
@@ -309,14 +311,14 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return Map.of(
                     "a",
-                    RequestContentValidator.DataType.STRING,
+                    FieldConfiguration.of(DataType.STRING),
                     "b",
-                    RequestContentValidator.DataType.STRING,
+                    FieldConfiguration.of(DataType.STRING),
                     "c",
-                    RequestContentValidator.DataType.STRING
+                    FieldConfiguration.of(DataType.STRING)
                 );
             }
         });
@@ -342,13 +344,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING);
-            }
-
-            @Override
-            public Map<String, RequestContentValidator.FieldConfiguration> allowedKeysWithConfig() {
-                return Map.of("a", RequestContentValidator.FieldConfiguration.of(RequestContentValidator.DataType.STRING, 5));
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING, 5));
             }
         });
         final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "toolong");
@@ -373,20 +370,12 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING);
-            }
-
-            @Override
-            public Map<String, RequestContentValidator.FieldConfiguration> allowedKeysWithConfig() {
-                return Map.of(
-                    "a",
-                    RequestContentValidator.FieldConfiguration.of(RequestContentValidator.DataType.STRING, (fieldName, value) -> {
-                        if (value instanceof String && ((String) value).contains("bad")) {
-                            throw new IllegalArgumentException("Value contains 'bad'");
-                        }
-                    })
-                );
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING, (fieldName, value) -> {
+                    if (value instanceof String && ((String) value).contains("bad")) {
+                        throw new IllegalArgumentException("Value contains 'bad'");
+                    }
+                }));
             }
         });
         final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "bad_value");
@@ -411,20 +400,12 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.ARRAY);
-            }
-
-            @Override
-            public Map<String, RequestContentValidator.FieldConfiguration> allowedKeysWithConfig() {
-                return Map.of(
-                    "a",
-                    RequestContentValidator.FieldConfiguration.of(RequestContentValidator.DataType.ARRAY, (fieldName, value) -> {
-                        if (value instanceof JsonNode && ((JsonNode) value).size() > 2) {
-                            throw new IllegalArgumentException("Array too large");
-                        }
-                    })
-                );
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.ARRAY, (fieldName, value) -> {
+                    if (value instanceof JsonNode && ((JsonNode) value).size() > 2) {
+                        throw new IllegalArgumentException("Array too large");
+                    }
+                }));
             }
         });
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
@@ -450,20 +431,12 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.OBJECT);
-            }
-
-            @Override
-            public Map<String, RequestContentValidator.FieldConfiguration> allowedKeysWithConfig() {
-                return Map.of(
-                    "a",
-                    RequestContentValidator.FieldConfiguration.of(RequestContentValidator.DataType.OBJECT, (fieldName, value) -> {
-                        if (value instanceof JsonNode && !((JsonNode) value).has("required")) {
-                            throw new IllegalArgumentException("Missing required field");
-                        }
-                    })
-                );
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.OBJECT, (fieldName, value) -> {
+                    if (value instanceof JsonNode && !((JsonNode) value).has("required")) {
+                        throw new IllegalArgumentException("Missing required field");
+                    }
+                }));
             }
         });
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
@@ -489,8 +462,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING));
             }
         });
         final JsonNode original = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value");
@@ -513,8 +486,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.STRING));
             }
         });
         final JsonNode original = DefaultObjectMapper.objectMapper().createObjectNode().put("a", "value1");
@@ -537,8 +510,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("hash", RequestContentValidator.DataType.STRING, "backend_roles", RequestContentValidator.DataType.ARRAY);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("hash", FieldConfiguration.of(DataType.STRING), "backend_roles", FieldConfiguration.of(DataType.ARRAY));
             }
         });
         // Original has a legacy empty-string in backend_roles
@@ -568,8 +541,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("hash", RequestContentValidator.DataType.STRING, "backend_roles", RequestContentValidator.DataType.ARRAY);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("hash", FieldConfiguration.of(DataType.STRING), "backend_roles", FieldConfiguration.of(DataType.ARRAY));
             }
         });
         final ObjectNode original = DefaultObjectMapper.objectMapper().createObjectNode();
@@ -612,8 +585,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("password", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("password", FieldConfiguration.of(DataType.STRING));
             }
         });
         final JsonNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("password", "");
@@ -636,8 +609,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return Map.of("a", RequestContentValidator.DataType.OBJECT);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return Map.of("a", FieldConfiguration.of(DataType.OBJECT));
             }
         });
         final ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode();
@@ -781,8 +754,8 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
-                return ImmutableMap.of("password", RequestContentValidator.DataType.STRING);
+            public Map<String, FieldConfiguration> allowedKeys() {
+                return ImmutableMap.of("password", FieldConfiguration.of(DataType.STRING));
             }
         });
         ObjectNode payload = DefaultObjectMapper.objectMapper().createObjectNode().put("password", "a");
@@ -810,20 +783,20 @@ public class RequestContentValidatorTest {
             }
 
             @Override
-            public Map<String, RequestContentValidator.DataType> allowedKeys() {
+            public Map<String, FieldConfiguration> allowedKeys() {
                 return ImmutableMap.of(
                     "a",
-                    RequestContentValidator.DataType.ARRAY,
+                    FieldConfiguration.of(DataType.ARRAY),
                     "b",
-                    RequestContentValidator.DataType.BOOLEAN,
+                    FieldConfiguration.of(DataType.BOOLEAN),
                     "c",
-                    RequestContentValidator.DataType.OBJECT,
+                    FieldConfiguration.of(DataType.OBJECT),
                     "d",
-                    RequestContentValidator.DataType.STRING,
+                    FieldConfiguration.of(DataType.STRING),
                     "e",
-                    RequestContentValidator.DataType.BOOLEAN,
+                    FieldConfiguration.of(DataType.BOOLEAN),
                     "f",
-                    RequestContentValidator.DataType.INTEGER
+                    FieldConfiguration.of(DataType.INTEGER)
                 );
             }
         });


### PR DESCRIPTION
## Summary

Simplifies the REST API validation by removing the dual-method pattern where `allowedKeys()` returned a `Map<String, DataType>` and `allowedKeysWithConfig()` returned a `Map<String, FieldConfiguration>`. Now there is only one method: `allowedKeys()` returning `Map<String, FieldConfiguration>`.

## What changed

- `ValidationContext.allowedKeys()` return type changed from `Map<String, DataType>` to `Map<String, FieldConfiguration>`
- `ValidationContext.allowedKeysWithConfig()` removed entirely
- All branching logic in `RequestContentValidator` (`if (fieldConfigs != null) ... else ...`) removed
- All API actions updated to use `FieldConfiguration.of(DataType.X)` for simple type-only validation
- Enhanced validation (maxLength, custom validators) uses the same `allowedKeys()` method with `FieldConfiguration.of(DataType.X, maxLength, validator)`

## Motivation

The two methods represented the same concept (defining valid request body fields) with confusing precedence rules. `allowedKeysWithConfig()` silently overrode `allowedKeys()` when present, and any API action implementing both had dead code in its `allowedKeys()` method. This unification makes the validation path easier to trace and eliminates the cognitive overhead of choosing between two methods.

## Testing

All existing validation tests pass with no behavioral changes.