### PR TITLE
Handle Dashboards multitenancy for m* cluster actions early

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyClusterActionIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyClusterActionIntTests.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.privileges.int_tests;
+
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration test verifying that cluster-level actions (_mget, _msearch, _bulk) are
+ * handled correctly in a multi-tenancy setup, and that the correct tenant is used for authorization and audit logging.
+ */
+public class DashboardMultiTenancyClusterActionIntTests {
+
+    static final TestSecurityConfig.Tenant TENANT_A = new TestSecurityConfig.Tenant("tenant_a").description("Tenant A");
+
+    // user_a has kibana_user role with access to tenant_a only
+    static final TestSecurityConfig.User USER_A = new TestSecurityConfig.User("user_a").roles(
+        TestSecurityConfig.Role.KIBANA_USER,
+        new TestSecurityConfig.Role("user_a_role").clusterPermissions("cluster_composite_ops")
+            .tenantPermissions("kibana_all_write")
+            .on("tenant_a")
+    );
+
+    // user_b owns a separate tenant
+    static final TestSecurityConfig.User USER_B = new TestSecurityConfig.User("user_b").roles(
+        TestSecurityConfig.Role.KIBANA_USER,
+        new TestSecurityConfig.Role("user_b_role").clusterPermissions("cluster_composite_ops")
+    );
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(USER_A, USER_B)
+        .tenants(TENANT_A)
+        .build();
+
+    /**
+     * User A uses _mget targeting .kibana with a tenant they don't have access to.
+     * This should be denied.
+     */
+    @Test
+    public void mget_unauthorizedTenantAccess_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(USER_A)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_mget", """
+                {
+                  "docs": [
+                    {
+                      "_index": ".kibana",
+                      "_id": "some_doc"
+                    }
+                  ]
+                }
+                """, new BasicHeader("securitytenant", "user_b"));
+
+            assertThat(response, isForbidden());
+        }
+    }
+
+    /**
+     * User A uses _msearch targeting .kibana with a tenant they don't have access to.
+     * This should be denied. For _msearch, the denial may appear either as a top-level 403
+     * or as a per-sub-request error within a 200 response (v4 evaluator behavior).
+     */
+    @Test
+    public void msearch_unauthorizedTenantAccess_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(USER_A)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_msearch", """
+                {"index":".kibana"}
+                {"size":10, "query":{"match_all":{}}}
+                """, new BasicHeader("securitytenant", "user_b"));
+
+            if (response.getStatusCode() == 200) {
+                // v4 evaluator: top-level 200 but inner response should contain a 403 error
+                String body = response.getBody();
+                assertTrue(
+                    "Expected security_exception in msearch response but got: " + body,
+                    body.contains("security_exception") || body.contains("\"status\":403")
+                );
+            } else {
+                assertThat(response, isForbidden());
+            }
+        }
+    }
+
+    /**
+     * User A uses _bulk to attempt to write to .kibana in a tenant they don't have access to.
+     * This should be denied.
+     */
+    @Test
+    public void bulk_unauthorizedTenantAccess_shouldBeDenied() {
+        try (TestRestClient restClient = cluster.getRestClient(USER_A)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_bulk", """
+                { "index" : { "_index" : ".kibana", "_id" : "test_doc_1" } }
+                { "type": "dashboard", "title": "test" }
+                """, new BasicHeader("securitytenant", "user_b"));
+
+            assertThat(response, isForbidden());
+        }
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -533,7 +533,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("responses[*].hits.hits[*]._index")
                     .reducedBy(user.reference(READ))
-                    .whenEmpty(isOk())
+                    .whenEmpty(isForbidden())
             );
         }
     }
@@ -575,7 +575,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("docs[?(@.found == true)]._index")
                     .reducedBy(user.reference(READ))
-                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isOk() : isForbidden())
+                    .whenEmpty(isForbidden())
             );
         }
     }
@@ -650,7 +650,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("items[*].index[?(@.result == 'created')]._index")
                     .reducedBy(user.reference(WRITE))
-                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isOk() : isForbidden())
+                    .whenEmpty(isForbidden())
             );
         } finally {
             delete(
@@ -737,7 +737,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_finance).at("items[*].index[?(@.result == 'created')]._index")
                     .reducedBy(user.reference(WRITE))
-                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isOk() : isForbidden())
+                    .whenEmpty(isForbidden())
             );
         } finally {
             delete(".kibana_-853258278_finance_1");
@@ -808,7 +808,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("items[*].delete[?(@.result == 'deleted')]._index")
                     .reducedBy(user.reference(WRITE))
-                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isOk() : isForbidden())
+                    .whenEmpty(isForbidden())
             );
         } finally {
             delete(
@@ -858,9 +858,6 @@ public class DashboardMultiTenancyIntTests {
                         .reducedBy(user.reference(WRITE))
                         .whenEmpty(isOk())
                 );
-            } else if (clusterConfig.legacyPrivilegeEvaluation) {
-                // In the legacy mode, the requests on the items fail
-                assertThat(response, containsExactly().at("items[*].update[?(@.result == 'updated')]._index").whenEmpty(isOk()));
             } else {
                 // In the new privilege evaluation mode, the whole bulk request fails
                 assertThat(response, isForbidden());
@@ -894,7 +891,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("docs[?(@.found == true)]._index")
                     .reducedBy(user.reference(READ))
-                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isOk() : isForbidden())
+                    .whenEmpty(isForbidden())
             );
         }
     }

--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -533,7 +533,7 @@ public class DashboardMultiTenancyIntTests {
                 response,
                 containsExactly(dashboards_index_human_resources).at("responses[*].hits.hits[*]._index")
                     .reducedBy(user.reference(READ))
-                    .whenEmpty(isForbidden())
+                    .whenEmpty(clusterConfig.legacyPrivilegeEvaluation ? isForbidden() : isOk())
             );
         }
     }

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -432,7 +432,7 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
 
                     if (!replaceResult.continueEvaluation) {
                         if (replaceResult.accessDenied) {
-                            auditLog.logMissingPrivileges(action0, request, task);
+                            return PrivilegesEvaluatorResponse.insufficient(action0);
                         } else {
                             return PrivilegesEvaluatorResponse.ok().with(replaceResult.createIndexRequestBuilder);
                         }


### PR DESCRIPTION
### Description

This tightens checks for Dashboards multitenancy on actions like mget, msearch, etc to happen on the root action level instead of the leaf action level.

* Category: Bugfix
* Why these changes are required? 
* What is the old behavior before changes and new behavior after changes?



### Testing

- New integration tests

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
