### PR TITLE
Skip result scrubbing for ReadableSystemIndexDescriptor indices

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexTests.java
+++ b/src/integrationTest/java/org/opensearch/security/systemindex/SystemIndexTests.java
@@ -128,4 +128,36 @@ public class SystemIndexTests {
             assertThat(response1.getBody(), response1.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"));
         }
     }
+
+    @Test
+    public void regularUserShouldBeAbleToSearchReadableSystemIndex() {
+        // Create a task entry in .tasks by running update_by_query with wait_for_completion=false
+        try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+            // Create a test index with a document
+            client.putJson("test-ubq-index/_doc/1?refresh=true", "{\"field\":\"value\"}");
+
+            // Run update_by_query with wait_for_completion=false to create a .tasks entry
+            HttpResponse ubqResponse = client.postJson(
+                "test-ubq-index/_update_by_query?wait_for_completion=false&refresh=true",
+                "{\"script\":{\"source\":\"ctx._source.field='updated'\",\"lang\":\"painless\"}}"
+            );
+            assertThat(ubqResponse.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+
+            // Wait briefly for the task to be persisted
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+
+            // Search .tasks - should return results since it's a ReadableSystemIndexDescriptor
+            HttpResponse searchResponse = client.get(".tasks/_search");
+            assertThat(searchResponse.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
+            assertThat(
+                "Expected non-empty results from .tasks search",
+                searchResponse.getBody().contains("\"hits\":{\"total\":{\"value\":0,\"relation\":\"eq\"}"),
+                equalTo(false)
+            );
+        }
+    }
 }

--- a/src/main/java/org/opensearch/security/configuration/SystemIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/configuration/SystemIndexSearcherWrapper.java
@@ -40,6 +40,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.index.Index;
 import org.opensearch.index.IndexService;
+import org.opensearch.indices.SystemIndexDescriptor;
 import org.opensearch.indices.SystemIndexRegistry;
 import org.opensearch.security.privileges.PrivilegesConfiguration;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
@@ -153,6 +154,12 @@ public class SystemIndexSearcherWrapper implements CheckedFunction<DirectoryRead
         boolean matchesSystemIndexRegisteredWithCore = !SystemIndexRegistry.matchesSystemIndexPattern(Set.of(index.getName())).isEmpty();
         boolean isSystemIndex = systemIndexMatcher.test(index.getName()) || matchesSystemIndexRegisteredWithCore;
         if (!isSystemIndex) {
+            return false;
+        }
+
+        // Don't block readable system indices - they are explicitly marked to allow search/get
+        Set<SystemIndexDescriptor> matchingDescriptors = SystemIndexRegistry.matchesSystemIndexDescriptor(Set.of(index.getName()));
+        if (matchingDescriptors.stream().anyMatch(SystemIndexDescriptor::isReadable)) {
             return false;
         }
 


### PR DESCRIPTION
### Description

System indices marked as `ReadableSystemIndexDescriptor` should allow search/get operations to return results instead of being scrubbed to empty. This enables indices like `.tasks` to be searchable by regular users while still protecting sensitive system indices (like `.opendistro_security`).

Currently, the security plugin scrubs all search results on system indices by returning an `EmptyDirectoryReader`. With this change, if a system index is registered as a `ReadableSystemIndexDescriptor` in core, the security plugin will let the search results pass through as intended.

### Use Case

The `.tasks` index stores task results when requests are run with `?wait_for_completion=false`. Users need to be able to search this index to find their task IDs and results, but currently get empty results due to the blanket scrubbing of system index searches.

### Companion PR

This PR depends on https://github.com/opensearch-project/OpenSearch/pull/17296 which introduces `ReadableSystemIndexDescriptor` as a subclass of `SystemIndexDescriptor` in core.

### Changes

- `SystemIndexSearcherWrapper.java`: Skip blocking for indices that match a `ReadableSystemIndexDescriptor`
- `SystemIndexTests.java`: Added integration test that verifies `.tasks` returns non-empty results when searched by a regular user

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).