### PR TITLE
Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -553,6 +554,7 @@ subprojects {
 allprojects {
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,14 @@
  * This project uses @Incubating APIs which are subject to change.
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 plugins {
     id("com.autonomousapps.build-health") version "3.10.0"
 }


### PR DESCRIPTION
### Description

Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins, such as integration tests run against release candidates (RCs) during the release process.

### Changes
- `settings.gradle` — Add `pluginManagement` block with CI mirror before gradlePluginPortal and mavenCentral
- `build.gradle` — Add CI mirror before mavenCentral in both buildscript and allprojects repositories

### Testing
- Verified `./gradlew assemble` completes successfully