### PR TITLE
Add CodeQL workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,6 +365,10 @@ jobs:
 
   code-ql:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5


### PR DESCRIPTION
## What changed

Adds explicit permissions to the `code-ql` job in `.github/workflows/ci.yml`:

- `actions: read`
- `contents: read`
- `security-events: write`

## Why

The CodeQL job can build and analyze successfully, but result upload fails with:

```text
Resource not accessible by integration
This run of the CodeQL Action does not have permission to access the CodeQL Action API endpoints.
CodeQL job status was configuration error.
```

The failing run showed the job token only had `contents`, `metadata`, and `packages` read permissions. CodeQL needs `security-events: write` to upload code scanning results.

Failing job: https://github.com/opensearch-project/security/actions/runs/26438643407/job/77827325750

## Validation

- Inspected the failing CodeQL job log and confirmed the failure happens during SARIF/code scanning result upload, not during Gradle build or CodeQL query execution.
- Ran `git diff --check`.