### PR TITLE
Fix spurious MISSING_PRIVILEGES audits in SSL exception handler

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java
+++ b/src/main/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandler.java
@@ -26,6 +26,9 @@
 
 package org.opensearch.security.auditlog;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import org.opensearch.OpenSearchException;
 import org.opensearch.security.filter.SecurityRequestChannel;
 import org.opensearch.security.ssl.SslExceptionHandler;
@@ -33,6 +36,8 @@ import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportRequest;
 
 public class AuditLogSslExceptionHandler implements SslExceptionHandler {
+
+    private static final Logger log = LogManager.getLogger(AuditLogSslExceptionHandler.class);
 
     private final AuditLog auditLog;
 
@@ -69,7 +74,12 @@ public class AuditLogSslExceptionHandler implements SslExceptionHandler {
         switch (type) {
             case 0:
                 if (t instanceof OpenSearchException) {
-                    auditLog.logMissingPrivileges(action, request, task);
+                    log.debug(
+                        "Exception caught at SSL request handler (action={}, class={}); not audited.",
+                        action,
+                        t.getClass().getName(),
+                        t
+                    );
                 } else {
                     auditLog.logSSLException(request, t, action, task);
                 }

--- a/src/test/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AuditLogSslExceptionHandlerTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.auditlog;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.OpenSearchException;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportRequest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link AuditLogSslExceptionHandler#logError(Throwable, TransportRequest, String, Task, int)}.
+ *
+ * The {@code type=0} branch funnels exceptions caught by the generic
+ * {@code catch (Exception e)} in {@code SecuritySSLRequestHandler.messageReceived}. Privilege
+ * denials are audited at their decision point (e.g. {@code SecurityFilter.handleUnauthorized})
+ * before the {@link OpenSearchException} is thrown or delivered. The catch-site no longer emits a
+ * {@code MISSING_PRIVILEGES} audit; it debug-logs for diagnostic visibility instead.
+ */
+public class AuditLogSslExceptionHandlerTest {
+
+    private AuditLog auditLog;
+    private AuditLogSslExceptionHandler handler;
+    private TransportRequest request;
+    private Task task;
+    private static final String ACTION = "indices:data/read/search[can_match][n]";
+
+    @Before
+    public void setUp() {
+        auditLog = mock(AuditLog.class);
+        handler = new AuditLogSslExceptionHandler(auditLog);
+        request = mock(TransportRequest.class);
+        task = mock(Task.class);
+    }
+
+    @Test
+    public void shouldNotEmitMissingPrivilegesForOpenSearchException() {
+        Throwable t = new OpenSearchException("any opensearch exception reaching the catch site");
+
+        handler.logError(t, request, ACTION, task, 0);
+
+        verify(auditLog, never()).logMissingPrivileges(anyString(), any(TransportRequest.class), any(Task.class));
+    }
+}


### PR DESCRIPTION
### Description

Fix spurious `MISSING_PRIVILEGES` audits emitted by `AuditLogSslExceptionHandler.logError(type=0)` for non-security exceptions reaching the generic catch in `SecuritySSLRequestHandler.messageReceived`. Surfaces during ISM rollovers when transient cluster-state exceptions (`ShardNotFoundException`, `IllegalIndexShardStateException`, etc.) bubble up and are misclassified as privilege denials.

* Category: **Bug fix**
* Why these changes are required?

The `instanceof OpenSearchException` check is over-broad. `OpenSearchException` is the base class of essentially every domain exception in the project, only a small subset of which represent permission denials. Privilege denials are audited at their [decision point](https://github.com/opensearch-project/security/blob/9e62714db8b8df1918a6cc70e6e0e1f639c01e11/src/main/java/org/opensearch/security/filter/SecurityFilter.java#L402-L414) before the exception is thrown or delivered via `listener.onFailure`. The catch-site emission was at best redundant, at worst spurious.

* What is the old behavior before changes and new behavior after changes?

**Old:** Any `OpenSearchException` reaching the catch triggers a `MISSING_PRIVILEGES` audit, regardless of whether it represents a permission failure. Transient runtime exceptions during normal cluster operations (ISM rollovers, shard recoveries, retention-lease cleanup, etc.) produce phantom audits attributed to whichever user happens to be issuing requests at the time.

**New:** The `MISSING_PRIVILEGES` branch is removed. `OpenSearchException` instances reaching this catch are debug-logged with the action and exception class for diagnostic visibility. The non-`OpenSearchException` branch (SSL handling) is unchanged. Real privilege denials continue to be audited at their decision points.


### Issues Resolved
Resolves #6150

Is this a backport? No.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? No

### Testing
New `AuditLogSslExceptionHandlerTest.shouldNotEmitMissingPrivilegesForOpenSearchException` asserts `logMissingPrivileges` is never invoked when an `OpenSearchException` reaches `logError(type=0)`. Fails on `main` (Mockito reports the spurious invocation from `AuditLogSslExceptionHandler.java:72`); passes after the fix.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
