### PR TITLE
Bump org.ow2.asm:asm from 9.9.1 to 9.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,7 @@ configurations {
             force "org.hamcrest:hamcrest:2.2"
             force "org.mockito:mockito-core:5.23.0"
             force "net.bytebuddy:byte-buddy:1.18.8"
-            force "org.ow2.asm:asm:9.9.1"
+            force "org.ow2.asm:asm:${versions.asm}"
 
             // For org.opensearch.plugin:transport-grpc
             force "com.google.guava:failureaccess:1.0.3"
@@ -730,7 +730,7 @@ dependencies {
     compileOnly "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
     runtimeOnly 'com.sun.istack:istack-commons-runtime:4.2.0'
     runtimeOnly 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.5'
-    runtimeOnly 'org.ow2.asm:asm:9.9.1'
+    runtimeOnly "org.ow2.asm:asm:${versions.asm}"
 
     testImplementation 'org.apache.camel:camel-xmlsecurity:3.22.4'
 


### PR DESCRIPTION
Bumps org.ow2.asm:asm from 9.9.1 to 9.10.1.

---
updated-dependencies:
- dependency-name: org.ow2.asm:asm dependency-version: 9.10.1 dependency-type: direct:production update-type: version-update:semver-minor ...

### Description
Updated https://github.com/opensearch-project/security/pull/6198

### Issues Resolved
N/A

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
