### PR TITLE
Adapt more unit tests for testing conventions

### DIFF
--- a/src/test/java/org/opensearch/security/hasher/AbstractPasswordHasherTests.java
+++ b/src/test/java/org/opensearch/security/hasher/AbstractPasswordHasherTests.java
@@ -13,6 +13,7 @@ package org.opensearch.security.hasher;
 
 import java.nio.CharBuffer;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
@@ -22,7 +23,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThrows;
 
-public abstract class AbstractPasswordHasherTests {
+public abstract class AbstractPasswordHasherTests extends LuceneTestCase {
 
     PasswordHasher passwordHasher;
 

--- a/src/test/java/org/opensearch/security/hasher/PasswordHasherFactoryTests.java
+++ b/src/test/java/org/opensearch/security/hasher/PasswordHasherFactoryTests.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.security.hasher;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import org.opensearch.common.settings.Settings;
@@ -20,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
-public class PasswordHasherFactoryTests {
+public class PasswordHasherFactoryTests extends LuceneTestCase {
 
     @Test
     public void shouldReturnBCryptByDefault() {

--- a/src/test/java/org/opensearch/security/support/Base64HelperTest.java
+++ b/src/test/java/org/opensearch/security/support/Base64HelperTest.java
@@ -19,6 +19,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.stream.IntStream;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchException;
@@ -30,7 +31,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 
-public class Base64HelperTest {
+public class Base64HelperTest extends LuceneTestCase {
 
     private static final class NotSafeSerializable implements Serializable {
         private static final long serialVersionUID = 5135559266828470092L;

--- a/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
+++ b/src/test/java/org/opensearch/security/support/ConfigReaderTest.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,7 +28,7 @@ import static org.opensearch.security.configuration.ConfigurationRepository.DEFA
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-public class ConfigReaderTest {
+public class ConfigReaderTest extends LuceneTestCase {
 
     @ClassRule
     public static TemporaryFolder folder = new TemporaryFolder();

--- a/src/test/java/org/opensearch/security/support/GuardedSearchOperationWrapperTest.java
+++ b/src/test/java/org/opensearch/security/support/GuardedSearchOperationWrapperTest.java
@@ -12,6 +12,7 @@ package org.opensearch.security.support;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import org.opensearch.index.shard.SearchOperationListener;
@@ -26,7 +27,8 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-public class GuardedSearchOperationWrapperTest {
+@LuceneTestCase.SuppressSysoutChecks(bugUrl = "Test intentionally exercises exception paths that log stack traces")
+public class GuardedSearchOperationWrapperTest extends LuceneTestCase {
 
     @Test
     public void onNewReaderContextCanThrowException() {

--- a/src/test/java/org/opensearch/security/support/HostAndCidrMatcherTest.java
+++ b/src/test/java/org/opensearch/security/support/HostAndCidrMatcherTest.java
@@ -15,12 +15,13 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.Collections;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class HostAndCidrMatcherTest {
+public class HostAndCidrMatcherTest extends LuceneTestCase {
 
     private static final String OPENSEARCH_DOMAIN = "*.opensearch.org";
     private static final String OPENSEARCH_WWW = "www.opensearch.org";

--- a/src/test/java/org/opensearch/security/support/HostResolverModeTest.java
+++ b/src/test/java/org/opensearch/security/support/HostResolverModeTest.java
@@ -11,12 +11,13 @@
 
 package org.opensearch.security.support;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-public class HostResolverModeTest {
+public class HostResolverModeTest extends LuceneTestCase {
 
     @Test
     public void testIpHostnameValue() {

--- a/src/test/java/org/opensearch/security/support/JsonFlattenerTest.java
+++ b/src/test/java/org/opensearch/security/support/JsonFlattenerTest.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +23,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-public class JsonFlattenerTest {
+public class JsonFlattenerTest extends LuceneTestCase {
     @Test
     public void testFlattenAsMapBasic() {
         Map<String, Object> flattenedMap1 = JsonFlattener.flattenAsMap("{\"key\": {\"nested\": 1}, \"another.key\": [\"one\", \"two\"] }");

--- a/src/test/java/org/opensearch/security/support/PemKeyReaderDetectStoreTypeTest.java
+++ b/src/test/java/org/opensearch/security/support/PemKeyReaderDetectStoreTypeTest.java
@@ -17,6 +17,7 @@ import java.io.UncheckedIOException;
 import java.security.KeyStore;
 import java.security.Security;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -30,7 +31,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assume.assumeFalse;
 
-public class PemKeyReaderDetectStoreTypeTest {
+public class PemKeyReaderDetectStoreTypeTest extends LuceneTestCase {
 
     static {
         if (Security.getProvider("BCFIPS") == null) {

--- a/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
+++ b/src/test/java/org/opensearch/security/support/SafeSerializationUtilsTest.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.After;
 import org.junit.Test;
 
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-public class SafeSerializationUtilsTest {
+public class SafeSerializationUtilsTest extends LuceneTestCase {
 
     @After
     public void clearCache() {

--- a/src/test/java/org/opensearch/security/support/SecurityUtilsTest.java
+++ b/src/test/java/org/opensearch/security/support/SecurityUtilsTest.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,7 +23,7 @@ import static org.opensearch.security.support.SecurityUtils.ENVBASE64_PATTERN;
 import static org.opensearch.security.support.SecurityUtils.ENVBC_PATTERN;
 import static org.opensearch.security.support.SecurityUtils.ENV_PATTERN;
 
-public class SecurityUtilsTest {
+public class SecurityUtilsTest extends LuceneTestCase {
 
     private final Collection<String> interestingEnvKeyNames = List.of(
         "=ExitCode",


### PR DESCRIPTION
## Summary

Adapts additional Security unit tests so they extend the expected OpenSearch/Lucene randomized test base used by the testing conventions check.

This covers the hasher tests and the straightforward support package tests. `GuardedSearchOperationWrapperTest` also gets a targeted `LuceneTestCase.SuppressSysoutChecks` annotation because it intentionally exercises exception paths that log stack traces.

## Verification

Ran the affected test packages:

```bash
./gradlew test --tests 'org.opensearch.security.hasher.*'
./gradlew test --tests 'org.opensearch.security.support.*'
./gradlew spotlessApply
```

Also temporarily enabled/configured `testingConventions` locally and ran:

```bash
./gradlew testingConventions
```

The convention check still fails because many unrelated tests remain to be adapted, but the classes changed in this PR no longer appear in the base-class convention violation output. The remaining support-package offender is `org.opensearch.security.support.SecurityIndexHandlerTest`, as expected.
