### PR TITLE
Fix Argon2PasswordHasher locale-sensitive toUpperCase bug

### DIFF
--- a/src/main/java/org/opensearch/security/hasher/Argon2PasswordHasher.java
+++ b/src/main/java/org/opensearch/security/hasher/Argon2PasswordHasher.java
@@ -83,7 +83,7 @@ class Argon2PasswordHasher extends AbstractPasswordHasher {
         if (type == null) {
             throw new IllegalArgumentException("Argon2 type can't be null");
         }
-        switch (type.toUpperCase()) {
+        switch (type.toUpperCase(java.util.Locale.ROOT)) {
             case "ARGON2ID":
                 return Argon2.ID;
             case "ARGON2I":


### PR DESCRIPTION
### Description

Saw this test failing on the 3.8 version increment PR: https://github.com/opensearch-project/security/pull/6207#issuecomment-4672123562

Fixes `Argon2PasswordHasher.parseType()` failing with `IllegalArgumentException: Unknown Argon2 type: argon2id` when JVM runs with Turkish/Azerbaijani locale.

### Root Cause

`String.toUpperCase()` is locale-sensitive. In Turkish/Azerbaijani locales, `"i".toUpperCase()` produces `"İ"` (capital I with dot above) instead of `"I"`. This causes `"argon2id".toUpperCase()` → `"ARGON2İD"` which doesn't match the switch case `"ARGON2ID"`.

### Fix

Use `Locale.ROOT` for the case conversion: `type.toUpperCase(Locale.ROOT)`.

### Testing

Verified with `./gradlew test --tests "*.Argon2PasswordHasherTests" -Dtests.locale=az` — passes with fix, fails without.