### PR TITLE
Fix API token count results

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenTest.java
@@ -274,6 +274,36 @@ public class ApiTokenTest {
     }
 
     @Test
+    public void testApiTokenWithReadActionGroup_canCountAllowedDocuments() {
+        try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
+            adminClient.putJson("test-index-count/_doc/1?refresh=true", "{\"field\":\"value\"}").assertStatusCode(HttpStatus.SC_CREATED);
+        }
+
+        String payload = """
+            {
+              "name": "test-token-count",
+              "cluster_permissions": [],
+              "index_permissions": [{
+                "index_pattern": ["test-index-count"],
+                "allowed_actions": ["read"]
+              }],
+              "duration_seconds": 3600
+            }
+            """;
+        String apiToken = generateApiToken(payload);
+        Header authHeader = new BasicHeader("Authorization", "ApiKey " + apiToken);
+
+        try (TestRestClient client = cluster.getRestClient(authHeader)) {
+            TestRestClient.HttpResponse countResponse = client.get("test-index-count/_count");
+            countResponse.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(countResponse.getTextFromJsonBody("/count"), equalTo("1"));
+
+            TestRestClient.HttpResponse forbiddenResponse = client.get("other-index/_count");
+            assertThat(forbiddenResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        }
+    }
+
+    @Test
     public void testApiTokenWithOnlyIndexPermissions_noClusterPermissionsField() {
         try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
             adminClient.putJson("test-index-nocluster", "{\"settings\":{\"number_of_shards\":1}}").assertStatusCode(HttpStatus.SC_OK);

--- a/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenTest.java
@@ -304,6 +304,96 @@ public class ApiTokenTest {
     }
 
     @Test
+    public void testApiTokenWithReadActionGroup_canSearchAndReturnHits() {
+        try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
+            adminClient.putJson("test-index-search/_doc/1?refresh=true", "{\"msg\":\"hello\"}").assertStatusCode(HttpStatus.SC_CREATED);
+        }
+
+        String payload = """
+            {
+              "name": "test-token-search",
+              "cluster_permissions": [],
+              "index_permissions": [{
+                "index_pattern": ["test-index-search"],
+                "allowed_actions": ["read"]
+              }],
+              "duration_seconds": 3600
+            }
+            """;
+        String apiToken = generateApiToken(payload);
+        Header authHeader = new BasicHeader("Authorization", "ApiKey " + apiToken);
+
+        try (TestRestClient client = cluster.getRestClient(authHeader)) {
+            TestRestClient.HttpResponse searchResponse = client.get("test-index-search/_search");
+            searchResponse.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(searchResponse.getTextFromJsonBody("/hits/total/value"), equalTo("1"));
+        }
+    }
+
+    @Test
+    public void testApiTokenWithReadActionGroup_canGetDocumentById() {
+        try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
+            adminClient.putJson("test-index-get/_doc/doc1?refresh=true", "{\"msg\":\"found\"}").assertStatusCode(HttpStatus.SC_CREATED);
+        }
+
+        String payload = """
+            {
+              "name": "test-token-get",
+              "cluster_permissions": [],
+              "index_permissions": [{
+                "index_pattern": ["test-index-get"],
+                "allowed_actions": ["read"]
+              }],
+              "duration_seconds": 3600
+            }
+            """;
+        String apiToken = generateApiToken(payload);
+        Header authHeader = new BasicHeader("Authorization", "ApiKey " + apiToken);
+
+        try (TestRestClient client = cluster.getRestClient(authHeader)) {
+            TestRestClient.HttpResponse getResponse = client.get("test-index-get/_doc/doc1");
+            getResponse.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(getResponse.getTextFromJsonBody("/_source/msg"), equalTo("found"));
+
+            TestRestClient.HttpResponse forbiddenResponse = client.get("other-index/_doc/doc1");
+            assertThat(forbiddenResponse.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void testApiTokenWithReadActionGroup_canCountAndSearchMultipleDocuments() {
+        try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
+            adminClient.putJson("test-index-multi/_doc/1?refresh=false", "{\"n\":1}").assertStatusCode(HttpStatus.SC_CREATED);
+            adminClient.putJson("test-index-multi/_doc/2?refresh=false", "{\"n\":2}").assertStatusCode(HttpStatus.SC_CREATED);
+            adminClient.putJson("test-index-multi/_doc/3?refresh=true", "{\"n\":3}").assertStatusCode(HttpStatus.SC_CREATED);
+        }
+
+        String payload = """
+            {
+              "name": "test-token-multi",
+              "cluster_permissions": [],
+              "index_permissions": [{
+                "index_pattern": ["test-index-multi"],
+                "allowed_actions": ["read"]
+              }],
+              "duration_seconds": 3600
+            }
+            """;
+        String apiToken = generateApiToken(payload);
+        Header authHeader = new BasicHeader("Authorization", "ApiKey " + apiToken);
+
+        try (TestRestClient client = cluster.getRestClient(authHeader)) {
+            TestRestClient.HttpResponse countResponse = client.get("test-index-multi/_count");
+            countResponse.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(countResponse.getTextFromJsonBody("/count"), equalTo("3"));
+
+            TestRestClient.HttpResponse searchResponse = client.get("test-index-multi/_search");
+            searchResponse.assertStatusCode(HttpStatus.SC_OK);
+            assertThat(searchResponse.getTextFromJsonBody("/hits/total/value"), equalTo("3"));
+        }
+    }
+
+    @Test
     public void testApiTokenWithOnlyIndexPermissions_noClusterPermissionsField() {
         try (TestRestClient adminClient = cluster.getRestClient(ADMIN_USER)) {
             adminClient.putJson("test-index-nocluster", "{\"settings\":{\"number_of_shards\":1}}").assertStatusCode(HttpStatus.SC_OK);

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -46,6 +46,14 @@ public class DlsFlsBaseContext {
             return null;
         }
 
+        if (user.isApiTokenRequest()) {
+            // API token permissions are currently limited to action/index permissions and cannot express DLS, FLS, or
+            // field masking rules. Without this branch, the role-based DLS/FLS layer sees no mapped roles for token
+            // users and applies a match-none restriction after the token-specific privilege evaluator has allowed the
+            // request. TODO: replace this with token-aware DLS/FLS/FM restrictions if those are added to API tokens.
+            return null;
+        }
+
         PrivilegesEvaluationContext ctx = this.privilegesConfiguration.privilegesEvaluator().createContext(user, null);
         threadContext.putTransient("tmp_dls_fls_ctx", ctx);
         return ctx;


### PR DESCRIPTION
## Description

Fixes API key reads returning empty `_count` results for an index that the API key is allowed to read.

An API key is authorized through token-specific index permissions, but the DLS/FLS/field masking layer is role based. API key users currently do not carry mapped roles with DLS/FLS/field masking metadata, so the DLS/FLS layer can apply a match-none restriction after the API key privilege evaluator has already allowed the request.

This change adds an explicit API-token branch in DLS/FLS context setup. API tokens currently support action/index permissions, but do not support DLS, FLS, or field masking restrictions. The branch is intentionally separate from the internal/plugin/admin bypass and includes a TODO to replace it with token-aware DLS/FLS/FM restrictions if those are added to API tokens.

Fixes #6217

Forum report: https://forum.opensearch.org/t/no-results-when-using-api-keys/28134

## Test Coverage

Added an integration test that verifies:

- an API key with `read` on `test-index-count` receives `_count == 1` for that index
- the same API key still receives `403` when counting `other-index`

Validation run:

```bash
./gradlew :integrationTest --tests org.opensearch.security.privileges.ApiTokenTest.testApiTokenWithReadActionGroup_canCountAllowedDocuments -Dtests.security.manager=false
```

Result: `BUILD SUCCESSFUL`