### PR TITLE
Convert multi-line strings to text blocks in BasicAuditlogTest

### DIFF
--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -401,14 +401,12 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
 
     public void testMsearch() throws Exception {
 
-        String msearch = "{\"index\":\"sf\", \"ignore_unavailable\": true}"
-            + System.lineSeparator()
-            + "{\"size\":0,\"query\":{\"match_all\":{}}}"
-            + System.lineSeparator()
-            + "{\"index\":\"sf\", \"ignore_unavailable\": true}"
-            + System.lineSeparator()
-            + "{\"size\":0,\"query\":{\"match_all\":{}}}"
-            + System.lineSeparator();
+        String msearch = """
+            {"index":"sf", "ignore_unavailable": true}
+            {"size":0,"query":{"match_all":{}}}
+            {"index":"sf", "ignore_unavailable": true}
+            {"size":0,"query":{"match_all":{}}}
+            """;
 
         // msaerch
         HttpResponse response = rh.executePostRequest("_msearch?pretty", msearch, encodeBasicHeader("admin", "admin"));
@@ -426,26 +424,17 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
     public void testBulkAuth() throws Exception {
 
         // testBulkAuth
-        String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"field1\" : \"value1\" }"
-            + System.lineSeparator()
-            + "{ \"index\" : { \"_index\" : \"worf\", \"_id\" : \"2\" } }"
-            + System.lineSeparator()
-            + "{ \"field2\" : \"value2\" }"
-            + System.lineSeparator()
-            +
-
-            "{ \"update\" : {\"_id\" : \"1\", \"_index\" : \"test\"} }"
-            + System.lineSeparator()
-            + "{ \"doc\" : {\"field\" : \"valuex\"} }"
-            + System.lineSeparator()
-            + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"create\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"field1\" : \"value3x\" }"
-            + System.lineSeparator();
+        String bulkBody = """
+            { "index" : { "_index" : "test", "_id" : "1" } }
+            { "field1" : "value1" }
+            { "index" : { "_index" : "worf", "_id" : "2" } }
+            { "field2" : "value2" }
+            { "update" : {"_id" : "1", "_index" : "test"} }
+            { "doc" : {"field" : "valuex"} }
+            { "delete" : { "_index" : "test", "_id" : "1" } }
+            { "create" : { "_index" : "test", "_id" : "1" } }
+            { "field1" : "value3x" }
+            """;
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("admin", "admin"));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_OK));
@@ -464,26 +453,17 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
 
     public void testBulkNonAuth() throws Exception {
 
-        String bulkBody = "{ \"index\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"field1\" : \"value1\" }"
-            + System.lineSeparator()
-            + "{ \"index\" : { \"_index\" : \"worf\", \"_id\" : \"2\" } }"
-            + System.lineSeparator()
-            + "{ \"field2\" : \"value2\" }"
-            + System.lineSeparator()
-            +
-
-            "{ \"update\" : {\"_id\" : \"1\", \"_index\" : \"test\"} }"
-            + System.lineSeparator()
-            + "{ \"doc\" : {\"field\" : \"valuex\"} }"
-            + System.lineSeparator()
-            + "{ \"delete\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"create\" : { \"_index\" : \"test\", \"_id\" : \"1\" } }"
-            + System.lineSeparator()
-            + "{ \"field1\" : \"value3x\" }"
-            + System.lineSeparator();
+        String bulkBody = """
+            { "index" : { "_index" : "test", "_id" : "1" } }
+            { "field1" : "value1" }
+            { "index" : { "_index" : "worf", "_id" : "2" } }
+            { "field2" : "value2" }
+            { "update" : {"_id" : "1", "_index" : "test"} }
+            { "doc" : {"field" : "valuex"} }
+            { "delete" : { "_index" : "test", "_id" : "1" } }
+            { "create" : { "_index" : "test", "_id" : "1" } }
+            { "field1" : "value3x" }
+            """;
 
         HttpResponse response = rh.executePostRequest("_bulk", bulkBody, encodeBasicHeader("worf", "worf"));
 
@@ -502,14 +482,8 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
 
     public void testUpdateSettings() throws Exception {
 
-        String json = "{"
-            + "\"persistent\" : {"
-            + "\"indices.recovery.*\" : null"
-            + "},"
-            + "\"transient\" : {"
-            + "\"indices.recovery.*\" : null"
-            + "}"
-            + "}";
+        String json = """
+            {"persistent" : {"indices.recovery.*" : null},"transient" : {"indices.recovery.*" : null}}""";
 
         String expectedRequestBodyLog =
             "{\\\"persistent_settings\\\":{\\\"indices\\\":{\\\"recovery\\\":{\\\"*\\\":null}}},\\\"transient_settings\\\":{\\\"indices\\\":{\\\"recovery\\\":{\\\"*\\\":null}}}}";


### PR DESCRIPTION
### Description

Convert multi-line string concatenations using `System.lineSeparator()` to Java text blocks in `BasicAuditlogTest` for improved readability.

* Category: Refactoring
* Why these changes are required: Text blocks (Java 15+) are cleaner and easier to read than multi-line string concatenation with `System.lineSeparator()`. The project already targets JDK 21.
* Old behavior: Bulk/msearch/settings request bodies built via `+` concatenation across 10-20 lines
* New behavior: Same strings expressed as text blocks — functionally identical output

### Issues Resolved

N/A — code style improvement only

### Testing

Existing unit tests (`BasicAuditlogTest`) cover the changed code. No behavioral changes introduced. All 20 tests in the class pass.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
