### PR TITLE
Add Rishav Kumar (gh: Rishav9852Kumar) as a co-maintainer of the Security repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @derek-ho @finnegancarroll @nibix @RyanL1997 @reta @shikharj05 @willyborankin
+* @cwperks @DarshitChanpura @derek-ho @finnegancarroll @nibix @Rishav9852Kumar @RyanL1997 @reta @shikharj05 @willyborankin

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
+| Rishav Kumar     | [Rishav9852Kumar](https://github.com/Rishav9852Kumar) | Amazon      |
 | Shikhar Jain     | [shikharj05](https://github.com/shikharj05)           | Independent |
 | Finnegan Carroll | [finnegancarroll](https://github.com/finnegancarroll) | Amazon      |
 | Andriy Redko     | [reta](https://github.com/reta)                       | Independent |


### PR DESCRIPTION
### Description

I have nominated and maintainers have agreed to add @Rishav9852Kumar as a co-maintainer of the security repo.

Rishav has made strong and sustained contributions to the repo over the past year, spanning JWT authentication, audit logging, caching infrastructure, and CI/CD improvements. His contributions demonstrate both deep technical insight and a willingness to take on complex, multi-faceted features from design through implementation.

### Highlighted Contributions

**Cluster and Index Settings Audit Logging ([#6113](https://github.com/opensearch-project/security/pull/6113))** — A substantial new feature adding `CLUSTER_SETTINGS_CHANGED` and `INDEX_SETTINGS_CHANGED` audit log categories. This implementation demonstrates exceptional attention to detail: structured per-setting audit entries with old/new values, operation types (set/removed), scope classification (persistent/transient/index), automatic redaction of sensitive settings via SecureSetting detection, and wildcard index resolution. The PR includes 27 unit tests and integration tests covering redaction, category disabling, and cluster state unavailability edge cases.

**JWKS support for JWT without OpenID Connect ([#5578](https://github.com/opensearch-project/security/pull/5578))** — A feature that required exceptional architectural insight. Rishav identified and resolved the unnecessary coupling between JWT authentication and OIDC infrastructure by implementing a new `HTTPJwtKeyByJWKSAuthenticator` that enables direct JWKS endpoint access via `jwks_uri` in JWT config — without requiring OIDC discovery. This clean separation was a long-requested enhancement ([#4974](https://github.com/opensearch-project/security/issues/4974)) that he both proposed and implemented.

### Notable Code Contributions

- Audit logging for DELETE operations: [#5914](https://github.com/opensearch-project/security/pull/5914) — Enabled compliance audit logging to capture deleted document contents, providing parity with CREATE/UPDATE operations
- JWT nested claim subject support: [#5467](https://github.com/opensearch-project/security/pull/5467) — Extended JWT authentication to handle subject keys in nested claims, addressing real-world JWT structures from enterprise identity providers
- Selective user cache invalidation: [#5337](https://github.com/opensearch-project/security/pull/5337) — New REST endpoint for per-user cache invalidation, solving a long-standing efficiency issue ([#2829](https://github.com/opensearch-project/security/issues/2829)) where LDAP user updates forced full cache flushes
- Changelog verification workflow: [#5318](https://github.com/opensearch-project/security/pull/5318) — Added automated changelog enforcement to the repo's CI
- Dependabot workflow fix: [#5331](https://github.com/opensearch-project/security/pull/5331) — Fixed broken Dependabot PR workflow by migrating from `pull_request` to `pull_request_target` for secret access

### Issues and Design Work

- [FEATURE] Usage of JWKS with JWT (without OpenID Connect): [#4974](https://github.com/opensearch-project/security/issues/4974)
- [FEATURE] Support subject key in nested claim within JWT: [#5430](https://github.com/opensearch-project/security/issues/5430)

His contribution history shows sustained engagement over 13+ months, with 7 merged PRs spanning security-critical areas including authentication (JWT/JWKS), audit logging (compliance and settings changes), caching, and CI infrastructure. He consistently provides thorough testing (unit, integration, and manual) and well-documented PR descriptions.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).