### PR TITLE
Narrow kibana_user role to only the dashboards index alias

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -41,6 +41,8 @@ import static org.opensearch.test.framework.matcher.RestMatchers.isCreated;
 import static org.opensearch.test.framework.matcher.RestMatchers.isForbidden;
 import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * An integration test matrix for Dashboards multi-tenancy. Verifies both read and write operations
@@ -957,6 +959,85 @@ public class DashboardMultiTenancyIntTests {
         this.user = user;
         this.cluster = clusterInstances.get(clusterConfig);
         this.clusterConfig = clusterConfig;
+    }
+
+    /**
+     * Verifies that a user with kibana_user role cannot directly read another user's concrete
+     * tenant index via _mget without the securitytenant header. The kibana_user role should not
+     * grant index-level access to .kibana_* indices.
+     */
+    @Test
+    public void mget_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        if (user.reference(READ).covers(dashboards_index_human_resources)) {
+            return;
+        }
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            String docId = dashboards_index_human_resources.anyDocument().id();
+
+            TestRestClient.HttpResponse response = restClient.postJson("_mget/?pretty", """
+                {
+                  "docs": [
+                    {
+                      "_index": "%s",
+                      "_id": "%s"
+                    }
+                  ]
+                }
+                """.formatted(dashboards_index_human_resources.name(), docId));
+
+            // _mget returns 200 at top level but each doc has an error
+            if (response.getStatusCode() == 200) {
+                String body = response.getBody();
+                assertTrue("Expected security_exception in mget doc response but got: " + body, body.contains("security_exception"));
+                assertFalse("Expected no found documents but got: " + body, body.contains("\"found\" : true"));
+            } else {
+                assertThat(response, isForbidden());
+            }
+        }
+    }
+
+    /**
+     * Verifies that a user with kibana_user role cannot directly search another user's concrete
+     * tenant index without the securitytenant header.
+     */
+    @Test
+    public void search_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        if (user.reference(READ).covers(dashboards_index_human_resources)) {
+            return;
+        }
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = restClient.get(dashboards_index_human_resources.name() + "/_search?size=10");
+
+            assertThat(response, isForbidden());
+        }
+    }
+
+    /**
+     * Verifies that a user with kibana_user role cannot directly write to another user's concrete
+     * tenant index via _bulk without the securitytenant header.
+     */
+    @Test
+    public void bulk_concreteIndexWithoutTenantHeader_shouldBeDenied() {
+        if (user.reference(WRITE).covers(dashboards_index_human_resources)) {
+            return;
+        }
+        try (TestRestClient restClient = cluster.getRestClient(user)) {
+            TestRestClient.HttpResponse response = restClient.postJson("_bulk", """
+                { "index" : { "_index" : "%s", "_id" : "test_no_header_1" } }
+                { "type": "dashboard", "title": "test" }
+                """.formatted(dashboards_index_human_resources.name()));
+
+            // _bulk returns 200 at top level but each item has a 403 status
+            if (response.getStatusCode() == 200) {
+                String body = response.getBody();
+                assertTrue(
+                    "Expected security_exception in bulk item response but got: " + body,
+                    body.contains("security_exception") || body.contains("\"status\":403")
+                );
+            } else {
+                assertThat(response, isForbidden());
+            }
+        }
     }
 
     private void delete(String... paths) {

--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -31,23 +31,12 @@ kibana_user:
   index_permissions:
     - index_patterns:
         - ".kibana"
-        - ".kibana-6"
-        - ".kibana_*"
         - ".opensearch_dashboards"
-        - ".opensearch_dashboards-6"
-        - ".opensearch_dashboards_*"
       allowed_actions:
         - "delete"
         - "index"
         - "manage"
         - "read"
-    - index_patterns:
-        - ".tasks"
-        - ".management-beats"
-        - "*:.tasks"
-        - "*:.management-beats"
-      allowed_actions:
-        - "indices_all"
 
 own_index:
   reserved: true


### PR DESCRIPTION
### Description

Removes `.kibana_*`, `.opensearch_dashboards_*`, `.kibana-6`, `.opensearch_dashboards-6`, `.tasks`, and `.management-beats` from the `kibana_user` static role's `index_permissions`. This ensures that `tenant_permissions` is the sole mechanism controlling tenant access, rather than broad index-level permissions.

### Background

The `kibana_user` role previously granted `read`, `index`, `delete`, `manage` on `.kibana_*`. This pattern matches every concrete tenant index (e.g., `.kibana_{hash}_{username}`), allowing any user with the role to directly access these indices.

The Security plugin's `PrivilegesInterceptor` (legacy) and `DashboardsMultitenancySystemIndexHandler` (nextgen) already handle tenant access entirely through:
1. Rewriting requests from the `.kibana` alias to the correct concrete tenant index
2. Validating `tenant_permissions` for the requested tenant
3. Stashing a `DocumentAllowList` in the thread context to grant access to the concrete index for downstream shard-level operations

No additional index permissions are needed for the standard Dashboards UI flow, which always sends the `securitytenant` header.

The `.tasks` entry is redundant (`.tasks` is now a system index with its own protection), and `.management-beats` is not used by OpenSearch Dashboards.

### Testing

All 468 existing `DashboardMultiTenancyIntTests` pass (both legacy and nextgen evaluator paths), confirming that Dashboards operations work correctly with `tenant_permissions` alone.

New tests added:
- `mget_concreteIndexWithoutTenantHeader_shouldBeDenied`
- `search_concreteIndexWithoutTenantHeader_shouldBeDenied`
- `bulk_concreteIndexWithoutTenantHeader_shouldBeDenied`

### Breaking change note

Users who rely on direct API access (e.g., curl, Dev Tools) to concrete `.kibana_*` tenant indices **without** the `securitytenant` header will need to either:
- Add the `securitytenant` header to their requests, or
- Create a custom role with explicit `.kibana_*` index permissions

The standard Dashboards UI workflow is unaffected.

### Related issues

- [#6206 - kibana_user role is too permissive](https://github.com/opensearch-project/security/issues/6206)
- [#5349 - What's the status of the kibana_user role](https://github.com/opensearch-project/security/issues/5349)
- [#379 - Shouldn't tenant_permissions add implicit permissions](https://github.com/opensearch-project/security/issues/379)

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.