### PR TITLE
Inline get-opensearch-version in create-bwc-build action

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -46,9 +46,10 @@ runs:
         build-root-directory: ${{ inputs.plugin-branch }}
 
     - id: get-opensearch-version
-      uses: peternied/get-opensearch-version@c13e2946341f9f17befbafe76327dae0d1e0b7a0 # v1
-      with:
-        working-directory: ${{ inputs.plugin-branch }}
+      run: |
+        echo "version=$(./gradlew properties -Dbuild.snapshot=false | grep ^version: | awk '{split($0, a, ": ");print a[2]}')" >> $GITHUB_OUTPUT
+      working-directory: ${{ inputs.plugin-branch }}
+      shell: bash
 
     - name: Copy current distro into the expected folder
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,16 +131,12 @@ jobs:
         run: ls -R
         working-directory: downloaded-artifacts
 
-      - name: Upload Coverage with retry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
+      - name: Upload Coverage
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          action: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
-          with: |
-            token: ${{ secrets.CODECOV_TOKEN }}
-            fail_ci_if_error: true
-            verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          verbose: true
 
   integration-tests-windows:
     name: integration-tests


### PR DESCRIPTION
### Description

Inlines the `peternied/get-opensearch-version` external action in the `create-bwc-build` composite action. The external action simply runs `./gradlew properties -Dbuild.snapshot=false` and extracts the version — no need for an external dependency for a one-liner.

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.