### PR TITLE
Enable bootstrap.serial_filter in integration tests

### DIFF
--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -91,6 +91,23 @@ public class LocalOpenSearchCluster {
 
     static {
         System.setProperty("opensearch.enforce.bootstrap.checks", "true");
+        initializeSerialFilter();
+    }
+
+    /**
+     * Installs a process-wide ObjectInputFilter that rejects all deserialization by default,
+     * mirroring what OpenSearch bootstrap does when bootstrap.serial_filter is enabled.
+     * Code that legitimately needs deserialization must set a filter on their ObjectInputStream.
+     */
+    private static void initializeSerialFilter() {
+        try {
+            java.io.ObjectInputFilter rejectAllFilter = filterInfo -> filterInfo.serialClass() == null
+                ? java.io.ObjectInputFilter.Status.UNDECIDED
+                : java.io.ObjectInputFilter.Status.REJECTED;
+            java.io.ObjectInputFilter.Config.setSerialFilter(rejectAllFilter);
+        } catch (IllegalStateException e) {
+            // Filter already set
+        }
     }
 
     private static final Logger log = LogManager.getLogger(LocalOpenSearchCluster.class);
@@ -611,6 +628,7 @@ public class LocalOpenSearchCluster {
                 .put("discovery.probe.handshake_timeout", "10s")
                 .put("http.cors.enabled", true)
                 .put("gateway.auto_import_dangling_indices", "true")
+                .put("bootstrap.serial_filter", true)
                 .build();
         }
 

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/LocalOpenSearchCluster.java
@@ -91,23 +91,6 @@ public class LocalOpenSearchCluster {
 
     static {
         System.setProperty("opensearch.enforce.bootstrap.checks", "true");
-        initializeSerialFilter();
-    }
-
-    /**
-     * Installs a process-wide ObjectInputFilter that rejects all deserialization by default,
-     * mirroring what OpenSearch bootstrap does when bootstrap.serial_filter is enabled.
-     * Code that legitimately needs deserialization must set a filter on their ObjectInputStream.
-     */
-    private static void initializeSerialFilter() {
-        try {
-            java.io.ObjectInputFilter rejectAllFilter = filterInfo -> filterInfo.serialClass() == null
-                ? java.io.ObjectInputFilter.Status.UNDECIDED
-                : java.io.ObjectInputFilter.Status.REJECTED;
-            java.io.ObjectInputFilter.Config.setSerialFilter(rejectAllFilter);
-        } catch (IllegalStateException e) {
-            // Filter already set
-        }
     }
 
     private static final Logger log = LogManager.getLogger(LocalOpenSearchCluster.class);

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
+import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
@@ -103,7 +104,7 @@ public class Base64Helper {
     private final static class SafeObjectInputStream extends ObjectInputStream {
         public SafeObjectInputStream(InputStream in) throws IOException {
             super(in);
-            // setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=10"));
+            setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=10"));
         }
 
         @Override

--- a/src/main/java/org/opensearch/security/support/Base64Helper.java
+++ b/src/main/java/org/opensearch/security/support/Base64Helper.java
@@ -31,7 +31,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InvalidClassException;
-import java.io.ObjectInputFilter;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
@@ -104,7 +103,7 @@ public class Base64Helper {
     private final static class SafeObjectInputStream extends ObjectInputStream {
         public SafeObjectInputStream(InputStream in) throws IOException {
             super(in);
-            setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=10"));
+            // setObjectInputFilter(ObjectInputFilter.Config.createFilter("maxdepth=10"));
         }
 
         @Override

--- a/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/cluster/ClusterHelper.java
@@ -481,7 +481,8 @@ public final class ClusterHelper {
             .put("transport.tcp.port", tcpPort)
             .put("http.port", httpPort)
             .put("http.cors.enabled", true)
-            .put("path.home", "./target");
+            .put("path.home", "./target")
+            .put("bootstrap.serial_filter", true);
     }
 
     private enum ClusterState {


### PR DESCRIPTION
## Description

Enables the `bootstrap.serial_filter` setting (introduced in https://github.com/opensearch-project/OpenSearch/pull/22073) in the security plugin's integration test clusters.

This setting installs a process-wide `ObjectInputFilter` that rejects all Java deserialization by default. Running the security plugin's integration tests with this filter enabled ensures the plugin works correctly with this runtime enforcement active.

## Testing

- `./gradlew integrationTest`
- `./gradlew test`