### PR TITLE
Standalone audit loggin

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTest.java
@@ -1,0 +1,100 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
+package org.opensearch.security;
+
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+/**
+ * Integration tests for standalone audit logging in SSL-only mode.
+ * Verifies that REQUEST_AUDIT events are produced with correct fields
+ * when no authentication/authorization layer is active.
+ */
+public class StandaloneAuditLoggingTest {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_SSL_ONLY, true,
+                "plugins.security.audit.type", TestRuleAuditLogSink.class.getName()
+            )
+        )
+        .sslOnly(true)
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    @Test
+    public void shouldProduceRequestAuditEventForSearch() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            client.get("test-index/_search");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) ->
+            msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && "SearchRequest".equals(msg.getRequestType())
+        );
+    }
+
+    @Test
+    public void shouldProduceRequestAuditEventForIndexOperation() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            client.putJson("test-index/_doc/1", "{\"field\": \"value\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) ->
+            msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("indices:data/write")
+        );
+    }
+
+    @Test
+    public void shouldProduceRequestAuditEventForClusterHealth() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            client.get("_cluster/health");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) ->
+            msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("cluster:monitor/health")
+        );
+    }
+
+    @Test
+    public void shouldNotProduceAuthRelatedEvents() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            client.get("_cat/indices");
+        }
+
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) ->
+            msg.getCategory() == AuditCategory.AUTHENTICATED
+                || msg.getCategory() == AuditCategory.GRANTED_PRIVILEGES
+                || msg.getCategory() == AuditCategory.FAILED_LOGIN
+        );
+    }
+}

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -146,7 +146,9 @@ import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
 import org.opensearch.security.auditlog.AuditLogSslExceptionHandler;
 import org.opensearch.security.auditlog.NullAuditLog;
+import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.auditlog.config.AuditConfig.Filter.FilterEntries;
+import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.auditlog.impl.AuditLogImpl;
 import org.opensearch.security.auth.BackendRegistry;
 import org.opensearch.security.auth.RolesInjector;
@@ -354,9 +356,23 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver(threadPool.getThreadContext());
         final String auditType = settings.get(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, null);
         if (auditType != null) {
-            auditLog = new AuditLogImpl(settings, configPath, localClient, threadPool, resolver, clusterService, environment, new UserFactory.Simple());
+            AuditLogImpl auditLogImpl = new AuditLogImpl(settings, configPath, localClient, threadPool, resolver, clusterService, environment, new UserFactory.Simple());
+            auditLogImpl.setConfig(AuditConfig.from(settings));
+            auditLog = auditLogImpl;
+            warnIfAuthCategoriesEnabled(settings);
         } else {
             auditLog = new NullAuditLog();
+        }
+    }
+
+    private void warnIfAuthCategoriesEnabled(Settings settings) {
+        AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+        Set<AuditCategory> enabledAuthOnly = new HashSet<>(AuditCategory.AUTH_ONLY_CATEGORIES);
+        enabledAuthOnly.removeAll(filter.getDisabledRestCategories());
+        enabledAuthOnly.removeAll(filter.getDisabledTransportCategories());
+        if (!enabledAuthOnly.isEmpty()) {
+            log.warn("Auth-related audit categories {} are enabled but will not produce events "
+                + "as no authentication layer is active.", enabledAuthOnly);
         }
     }
 
@@ -985,8 +1001,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         List<ActionFilter> filters = new ArrayList<>(1);
         if (!client && !disabled && !SSLConfig.isSslOnlyMode()) {
             filters.add(Objects.requireNonNull(sf));
-        } else if (!client && auditLog != null && !(auditLog instanceof NullAuditLog)) {
-            filters.add(new AuditActionFilter(auditLog));
+        
+        // !(auditLog instanceof NullAuditLog) prevents registering AuditActionFilter when there's no real sink to send events to. No point intercepting every request just to discard the message.
+        } else if (!client && auditLog != null && !(auditLog instanceof NullAuditLog)) {  
+            filters.add(new AuditActionFilter(auditLog, cs));
         }
         return filters;
     }
@@ -1645,6 +1663,408 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             )
         );
 
+        // Security - Audit (registered outside sslOnlyMode gate for standalone audit logging)
+        settings.add(Setting.simpleString(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ROUTES + ".", Property.NodeScope));
+        settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + ".", Property.NodeScope));
+        settings.add(Setting.intSetting(ConfigConstants.SECURITY_AUDIT_THREADPOOL_SIZE, 10, Property.NodeScope, Property.Filtered));
+        settings.add(
+            Setting.intSetting(
+                ConfigConstants.SECURITY_AUDIT_THREADPOOL_MAX_QUEUE_LEN,
+                100 * 1000,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY, true, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+            Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES, true, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+            Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true, Property.NodeScope, Property.Filtered)
+        );
+        settings.add(
+            Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true, Property.NodeScope, Property.Filtered)
+        );
+        final List<String> disabledCategories = new ArrayList<String>(2);
+        disabledCategories.add("AUTHENTICATED");
+        disabledCategories.add("GRANTED_PRIVILEGES");
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                disabledCategories,
+                Function.identity(),
+                Property.NodeScope
+            )
+        ); // not filtered here
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                disabledCategories,
+                Function.identity(),
+                Property.NodeScope
+            )
+        ); // not filtered here
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        final List<String> ignoredUsers = new ArrayList<String>(2);
+        ignoredUsers.add("kibanaserver");
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS,
+                ignoredUsers,
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        ); // not filtered here
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.SECURITY_AUDIT_IGNORE_HEADERS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_BULK_REQUESTS,
+                false,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS,
+                true,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+
+        final BiFunction<String, Boolean, Setting<Boolean>> boolSettingNodeScopeFiltered = (
+            String keyWithNamespace,
+            Boolean value) -> Setting.boolSetting(keyWithNamespace, value, Property.NodeScope, Property.Filtered);
+
+        Arrays.stream(FilterEntries.values()).map(filterEntry -> {
+            switch (filterEntry) {
+                case DISABLE_REST_CATEGORIES:
+                case DISABLE_TRANSPORT_CATEGORIES:
+                    return Setting.listSetting(
+                        filterEntry.getKeyWithNamespace(),
+                        disabledCategories,
+                        Function.identity(),
+                        Property.NodeScope
+                    );
+                case DISABLE_CATEGORIES:
+                    return Setting.listSetting(
+                        filterEntry.getKeyWithNamespace(),
+                        Collections.emptyList(),
+                        Function.identity(),
+                        Property.NodeScope
+                    );
+                case IGNORE_REQUESTS:
+                case IGNORE_HEADERS:
+                    return Setting.listSetting(
+                        filterEntry.getKeyWithNamespace(),
+                        Collections.emptyList(),
+                        Function.identity(),
+                        Property.NodeScope
+                    );
+                case IGNORE_USERS:
+                    return Setting.listSetting(
+                        filterEntry.getKeyWithNamespace(),
+                        ignoredUsers,
+                        Function.identity(),
+                        Property.NodeScope
+                    );
+                // All boolean settings with default of true
+                case ENABLE_REST:
+                case ENABLE_TRANSPORT:
+                case EXCLUDE_SENSITIVE_HEADERS:
+                case LOG_REQUEST_BODY:
+                case RESOLVE_INDICES:
+                    return boolSettingNodeScopeFiltered.apply(filterEntry.getKeyWithNamespace(), true);
+                case RESOLVE_BULK_REQUESTS:
+                    return boolSettingNodeScopeFiltered.apply(filterEntry.getKeyWithNamespace(), false);
+                default:
+                    throw new RuntimeException("Please add support for new FilterEntries value '" + filterEntry.name() + "'");
+            }
+        }).forEach(settings::add);
+
+        // Security - Audit - Sink
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_INDEX,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_TYPE,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+
+        // Internal OpenSearch DataStream
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_NAME,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_MANAGE,
+                true,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NAME,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.intSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NUMBER_OF_SHARDS,
+                1,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.intSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NUMBER_OF_REPLICAS,
+                0,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+
+        // External OpenSearch
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_HTTP_ENDPOINTS,
+                Lists.newArrayList("localhost:9200"),
+                Function.identity(),
+                Property.NodeScope
+            )
+        ); // not filtered here
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_USERNAME,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_PASSWORD,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLE_SSL,
+                false,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_VERIFY_HOSTNAMES,
+                true,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLE_SSL_CLIENT_AUTH,
+                false,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMCERT_CONTENT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMCERT_FILEPATH,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_CONTENT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_FILEPATH,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_PASSWORD,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMTRUSTEDCAS_CONTENT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMTRUSTEDCAS_FILEPATH,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_JKS_CERT_ALIAS,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_CIPHERS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );// not filtered here
+        settings.add(
+            Setting.listSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_PROTOCOLS,
+                Collections.emptyList(),
+                Function.identity(),
+                Property.NodeScope
+            )
+        );// not filtered here
+
+        // Webhooks
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_URL,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_FORMAT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.boolSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_SSL_VERIFY,
+                true,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_FILEPATH,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_CONTENT,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+
+        // Log4j
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_LOG4J_LOGGER_NAME,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.simpleString(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_LOG4J_LEVEL,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+        settings.add(
+            Setting.intSetting(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
+                    + ConfigConstants.SECURITY_AUDIT_LOG4J_MAXIMUM_INDEX_CHARACTERS_PER_MESSAGE,
+                Integer.MAX_VALUE,
+                255,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
+
         if (!SSLConfig.isSslOnlyMode()) {
             settings.add(
                 Setting.listSetting(
@@ -1724,394 +2144,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 Setting.boolSetting(ConfigConstants.SECURITY_DISABLE_ENVVAR_REPLACEMENT, false, Property.NodeScope, Property.Filtered)
             );
 
-            // Security - Audit
-            settings.add(Setting.simpleString(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, Property.NodeScope, Property.Filtered));
-            settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ROUTES + ".", Property.NodeScope));
-            settings.add(Setting.groupSetting(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + ".", Property.NodeScope));
-            settings.add(Setting.intSetting(ConfigConstants.SECURITY_AUDIT_THREADPOOL_SIZE, 10, Property.NodeScope, Property.Filtered));
-            settings.add(
-                Setting.intSetting(
-                    ConfigConstants.SECURITY_AUDIT_THREADPOOL_MAX_QUEUE_LEN,
-                    100 * 1000,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY, true, Property.NodeScope, Property.Filtered)
-            );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES, true, Property.NodeScope, Property.Filtered)
-            );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true, Property.NodeScope, Property.Filtered)
-            );
-            settings.add(
-                Setting.boolSetting(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true, Property.NodeScope, Property.Filtered)
-            );
             settings.add(
                 Setting.simpleString(ConfigConstants.SECURITY_MASKED_FIELDS_ALGORITHM_DEFAULT, Property.NodeScope, Property.Filtered)
-            );
-            final List<String> disabledCategories = new ArrayList<String>(2);
-            disabledCategories.add("AUTHENTICATED");
-            disabledCategories.add("GRANTED_PRIVILEGES");
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
-                    disabledCategories,
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
-                    disabledCategories,
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
-            final List<String> ignoredUsers = new ArrayList<String>(2);
-            ignoredUsers.add("kibanaserver");
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS,
-                    ignoredUsers,
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            );
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,
-                    Collections.emptyList(),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.SECURITY_AUDIT_IGNORE_HEADERS,
-                    Collections.emptyList(),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_BULK_REQUESTS,
-                    false,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS,
-                    true,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-
-            final BiFunction<String, Boolean, Setting<Boolean>> boolSettingNodeScopeFiltered = (
-                String keyWithNamespace,
-                Boolean value) -> Setting.boolSetting(keyWithNamespace, value, Property.NodeScope, Property.Filtered);
-
-            Arrays.stream(FilterEntries.values()).map(filterEntry -> {
-                switch (filterEntry) {
-                    case DISABLE_REST_CATEGORIES:
-                    case DISABLE_TRANSPORT_CATEGORIES:
-                        return Setting.listSetting(
-                            filterEntry.getKeyWithNamespace(),
-                            disabledCategories,
-                            Function.identity(),
-                            Property.NodeScope
-                        );
-                    case IGNORE_REQUESTS:
-                    case IGNORE_HEADERS:
-                        return Setting.listSetting(
-                            filterEntry.getKeyWithNamespace(),
-                            Collections.emptyList(),
-                            Function.identity(),
-                            Property.NodeScope
-                        );
-                    case IGNORE_USERS:
-                        return Setting.listSetting(
-                            filterEntry.getKeyWithNamespace(),
-                            ignoredUsers,
-                            Function.identity(),
-                            Property.NodeScope
-                        );
-                    // All boolean settings with default of true
-                    case ENABLE_REST:
-                    case ENABLE_TRANSPORT:
-                    case EXCLUDE_SENSITIVE_HEADERS:
-                    case LOG_REQUEST_BODY:
-                    case RESOLVE_INDICES:
-                        return boolSettingNodeScopeFiltered.apply(filterEntry.getKeyWithNamespace(), true);
-                    case RESOLVE_BULK_REQUESTS:
-                        return boolSettingNodeScopeFiltered.apply(filterEntry.getKeyWithNamespace(), false);
-                    default:
-                        throw new RuntimeException("Please add support for new FilterEntries value '" + filterEntry.name() + "'");
-                }
-            }).forEach(settings::add);
-
-            // Security - Audit - Sink
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_INDEX,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_TYPE,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-
-            // Internal OpenSearch DataStream
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_NAME,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_MANAGE,
-                    true,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NAME,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.intSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NUMBER_OF_SHARDS,
-                    1,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.intSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_DATASTREAM_TEMPLATE_NUMBER_OF_REPLICAS,
-                    0,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-
-            // External OpenSearch
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_HTTP_ENDPOINTS,
-                    Lists.newArrayList("localhost:9200"),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            ); // not filtered here
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_USERNAME,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_PASSWORD,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLE_SSL,
-                    false,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_VERIFY_HOSTNAMES,
-                    true,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLE_SSL_CLIENT_AUTH,
-                    false,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMCERT_CONTENT,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMCERT_FILEPATH,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_CONTENT,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_FILEPATH,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMKEY_PASSWORD,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMTRUSTEDCAS_CONTENT,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_PEMTRUSTEDCAS_FILEPATH,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_JKS_CERT_ALIAS,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_CIPHERS,
-                    Collections.emptyList(),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            );// not filtered here
-            settings.add(
-                Setting.listSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_PROTOCOLS,
-                    Collections.emptyList(),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            );// not filtered here
-
-            // Webhooks
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_URL,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_FORMAT,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.boolSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_SSL_VERIFY,
-                    true,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_FILEPATH,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_PEMTRUSTEDCAS_CONTENT,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-
-            // Log4j
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_LOG4J_LOGGER_NAME,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.simpleString(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_LOG4J_LEVEL,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
-            );
-            settings.add(
-                Setting.intSetting(
-                    ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
-                        + ConfigConstants.SECURITY_AUDIT_LOG4J_MAXIMUM_INDEX_CHARACTERS_PER_MESSAGE,
-                    Integer.MAX_VALUE,
-                    255,
-                    Property.NodeScope,
-                    Property.Filtered
-                )
             );
 
             // Kerberos

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -165,6 +165,7 @@ import org.opensearch.security.dlic.rest.api.SecurityRestApiActions;
 import org.opensearch.security.dlic.rest.api.ssl.CertificatesActionType;
 import org.opensearch.security.dlic.rest.api.ssl.TransportCertificatesInfoNodesAction;
 import org.opensearch.security.dlic.rest.validation.PasswordValidator;
+import org.opensearch.security.filter.AuditActionFilter;
 import org.opensearch.security.filter.SecurityFilter;
 import org.opensearch.security.filter.SecurityRestFilter;
 import org.opensearch.security.hasher.PasswordHasher;
@@ -339,6 +340,24 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         }
 
         return Objects.requireNonNull(sslExceptionHandler);
+    }
+
+    /**
+     * Initializes audit logging for SSL-only or disabled modes where the full security
+     * stack is not bootstrapped. If audit type is configured, creates a real AuditLogImpl;
+     * otherwise uses NullAuditLog.
+     */
+    private void initStandaloneAuditIfEnabled(Client localClient, ThreadPool threadPool, ClusterService clusterService, Environment environment) {
+        this.threadPool = threadPool;
+        this.cs = clusterService;
+        this.localClient = localClient;
+        final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver(threadPool.getThreadContext());
+        final String auditType = settings.get(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, null);
+        if (auditType != null) {
+            auditLog = new AuditLogImpl(settings, configPath, localClient, threadPool, resolver, clusterService, environment, new UserFactory.Simple());
+        } else {
+            auditLog = new NullAuditLog();
+        }
     }
 
     private static boolean isDisabled(final Settings settings) {
@@ -966,6 +985,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         List<ActionFilter> filters = new ArrayList<>(1);
         if (!client && !disabled && !SSLConfig.isSslOnlyMode()) {
             filters.add(Objects.requireNonNull(sf));
+        } else if (!client && auditLog != null && !(auditLog instanceof NullAuditLog)) {
+            filters.add(new AuditActionFilter(auditLog));
         }
         return filters;
     }
@@ -1179,6 +1200,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
     ) {
         SSLConfig.registerClusterSettingsChangeListener(clusterService.getClusterSettings());
         if (SSLConfig.isSslOnlyMode()) {
+            initStandaloneAuditIfEnabled(localClient, threadPool, clusterService, environment);
             return super.createComponents(
                 localClient,
                 clusterService,

--- a/src/main/java/org/opensearch/security/auditlog/AuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/AuditLog.java
@@ -36,6 +36,7 @@ import org.opensearch.index.engine.Engine.Index;
 import org.opensearch.index.engine.Engine.IndexResult;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.security.auditlog.config.AuditConfig;
+import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.tasks.Task;
@@ -59,6 +60,9 @@ public interface AuditLog extends Closeable {
 
     // index event requests
     void logIndexEvent(String privilege, TransportRequest request, Task task);
+
+    // standalone audit (non-FGAC modes)
+    void logRequestAudit(AuditMessage msg);
 
     // settings change events
     void logSettingsChange(String action, TransportRequest request, Task task);

--- a/src/main/java/org/opensearch/security/auditlog/NullAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/NullAuditLog.java
@@ -36,6 +36,7 @@ import org.opensearch.index.engine.Engine.Index;
 import org.opensearch.index.engine.Engine.IndexResult;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.security.auditlog.config.AuditConfig;
+import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.security.compliance.ComplianceConfig;
 import org.opensearch.security.filter.SecurityRequest;
 import org.opensearch.tasks.Task;
@@ -70,6 +71,11 @@ public class NullAuditLog implements AuditLog {
 
     @Override
     public void logIndexEvent(String privilege, TransportRequest request, Task task) {
+        // noop, intentionally left empty
+    }
+
+    @Override
+    public void logRequestAudit(AuditMessage msg) {
         // noop, intentionally left empty
     }
 

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.common.settings.Settings;
@@ -129,7 +130,12 @@ public class AuditConfig {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Filter {
-        private static Set<String> FIELDS = DefaultObjectMapper.getFields(Filter.class);
+        private static final Logger log = LogManager.getLogger(Filter.class);
+        private static Set<String> FIELDS = new HashSet<>(DefaultObjectMapper.getFields(Filter.class)) {
+            {
+                add("disabled_categories");
+            }
+        };
         @VisibleForTesting
         public static final Filter DEFAULT = Filter.from(Settings.EMPTY);
 
@@ -199,6 +205,7 @@ public class AuditConfig {
                 "disabled_transport_categories",
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES
             ),
+            DISABLE_CATEGORIES("disabled_categories", ConfigConstants.SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES),
             IGNORE_USERS("ignore_users", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS),
             IGNORE_REQUESTS("ignore_requests", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS),
             IGNORE_HEADERS("ignore_headers", ConfigConstants.SECURITY_AUDIT_IGNORE_HEADERS);
@@ -244,20 +251,33 @@ public class AuditConfig {
             final boolean logRequestBody = getOrDefault(properties, FilterEntries.LOG_REQUEST_BODY.getKey(), true);
             final boolean resolveIndices = getOrDefault(properties, FilterEntries.RESOLVE_INDICES.getKey(), true);
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
-            final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
-                getOrDefault(
-                    properties,
-                    FilterEntries.DISABLE_REST_CATEGORIES.getKey(),
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT
-                )
+            final List<String> unifiedCategories = getOrDefault(
+                properties,
+                FilterEntries.DISABLE_CATEGORIES.getKey(),
+                Collections.emptyList()
             );
-            final Set<AuditCategory> disabledTransportCategories = AuditCategory.parse(
-                getOrDefault(
-                    properties,
-                    FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey(),
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_TRANSPORT_CATEGORIES_DEFAULT
-                )
-            );
+            final Set<AuditCategory> disabledRestCategories;
+            final Set<AuditCategory> disabledTransportCategories;
+            if (!unifiedCategories.isEmpty()) {
+                Set<AuditCategory> parsed = AuditCategory.parse(unifiedCategories);
+                disabledRestCategories = parsed;
+                disabledTransportCategories = parsed;
+            } else {
+                disabledRestCategories = AuditCategory.parse(
+                    getOrDefault(
+                        properties,
+                        FilterEntries.DISABLE_REST_CATEGORIES.getKey(),
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT
+                    )
+                );
+                disabledTransportCategories = AuditCategory.parse(
+                    getOrDefault(
+                        properties,
+                        FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey(),
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_TRANSPORT_CATEGORIES_DEFAULT
+                    )
+                );
+            }
             final List<String> rawIgnoredUsers = getOrDefault(properties, FilterEntries.IGNORE_USERS.getKey(), DEFAULT_IGNORED_USERS);
             final Set<String> ignoredAuditUsers = rawIgnoredUsers.size() == 1 && "NONE".equalsIgnoreCase(rawIgnoredUsers.get(0))
                 ? Collections.emptySet()
@@ -298,20 +318,37 @@ public class AuditConfig {
             final boolean logRequestBody = fromSettingBoolean(settings, FilterEntries.LOG_REQUEST_BODY, true);
             final boolean resolveIndices = fromSettingBoolean(settings, FilterEntries.RESOLVE_INDICES, true);
             final boolean excludeSensitiveHeaders = fromSettingBoolean(settings, FilterEntries.EXCLUDE_SENSITIVE_HEADERS, true);
-            final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
-                fromSettingStringSet(
-                    settings,
-                    FilterEntries.DISABLE_REST_CATEGORIES,
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT
-                )
+            final Set<String> unifiedCategories = fromSettingStringSet(
+                settings,
+                FilterEntries.DISABLE_CATEGORIES,
+                Collections.emptyList()
             );
-            final Set<AuditCategory> disabledTransportCategories = AuditCategory.parse(
-                fromSettingStringSet(
-                    settings,
-                    FilterEntries.DISABLE_TRANSPORT_CATEGORIES,
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_TRANSPORT_CATEGORIES_DEFAULT
-                )
-            );
+            final Set<AuditCategory> disabledRestCategories;
+            final Set<AuditCategory> disabledTransportCategories;
+            if (!unifiedCategories.isEmpty()) {
+                // Unified setting takes precedence
+                Set<AuditCategory> parsed = AuditCategory.parse(unifiedCategories);
+                disabledRestCategories = parsed;
+                disabledTransportCategories = parsed;
+            } else {
+                // Fall back to deprecated split settings
+                log.warn("'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. "
+                    + "Use 'disabled_categories' instead to apply to both layers.");
+                disabledRestCategories = AuditCategory.parse(
+                    fromSettingStringSet(
+                        settings,
+                        FilterEntries.DISABLE_REST_CATEGORIES,
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT
+                    )
+                );
+                disabledTransportCategories = AuditCategory.parse(
+                    fromSettingStringSet(
+                        settings,
+                        FilterEntries.DISABLE_TRANSPORT_CATEGORIES,
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_TRANSPORT_CATEGORIES_DEFAULT
+                    )
+                );
+            }
             final Set<String> ignoredAuditUsers = fromSettingStringSet(settings, FilterEntries.IGNORE_USERS, DEFAULT_IGNORED_USERS);
             final Set<String> ignoreAuditRequests = fromSettingStringSet(settings, FilterEntries.IGNORE_REQUESTS, Collections.emptyList());
             final Set<String> ignoreHeaders = fromSettingStringSet(settings, FilterEntries.IGNORE_HEADERS, Collections.emptyList());

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -337,6 +337,11 @@ public abstract class AbstractAuditLog implements AuditLog {
         msgs.forEach(this::save);
     }
 
+    @Override
+    public void logRequestAudit(AuditMessage msg) {
+        save(msg);  // sends to AuditMessageRouter → configured sinks (async)
+    }
+
     // Routes settings change audit to the appropriate handler
     @Override
     public void logSettingsChange(String action, TransportRequest request, Task task) {

--- a/src/main/java/org/opensearch/security/auditlog/impl/AuditCategory.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AuditCategory.java
@@ -33,7 +33,21 @@ public enum AuditCategory {
     COMPLIANCE_INTERNAL_CONFIG_WRITE,
     CLUSTER_SETTINGS_CHANGED,
     INDEX_SETTINGS_CHANGED,
-    API_TOKEN_WRITE;
+    API_TOKEN_WRITE,
+    REQUEST_AUDIT;
+
+    /**
+     * Categories that require an authentication/authorization layer to produce events.
+     * These will never fire in SSL-only or disabled modes.
+     */
+    public static final Set<AuditCategory> AUTH_ONLY_CATEGORIES = ImmutableSet.of(
+        AUTHENTICATED,
+        FAILED_LOGIN,
+        GRANTED_PRIVILEGES,
+        MISSING_PRIVILEGES,
+        OPENDISTRO_SECURITY_INDEX_ATTEMPT,
+        API_TOKEN_WRITE
+    );
 
     public static Set<AuditCategory> parse(final Collection<String> categories) {
         if (categories.isEmpty()) return Collections.emptySet();

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -9,25 +9,36 @@
 package org.opensearch.security.filter;
 
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.IndicesRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.auditlog.AuditLog.Origin;
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
 import org.opensearch.tasks.Task;
 
 /**
  * A lightweight action filter that logs audit events without performing
  * authentication or authorization. Used in SSL-only and disabled modes
  * where the full SecurityFilter is not registered.
+ *
+ * Builds REQUEST_AUDIT events directly with the data available in non-FGAC modes:
+ * source IP, action name, target indices, request type, node info, timestamp.
  */
 public class AuditActionFilter implements ActionFilter {
 
     private final AuditLog auditLog;
+    private final ClusterService clusterService;
 
-    public AuditActionFilter(AuditLog auditLog) {
+    public AuditActionFilter(AuditLog auditLog, ClusterService clusterService) {
         this.auditLog = auditLog;
+        this.clusterService = clusterService;
     }
 
     @Override
@@ -44,8 +55,36 @@ public class AuditActionFilter implements ActionFilter {
         ActionListener<Response> listener,
         ActionFilterChain<Request, Response> chain
     ) {
-        auditLog.logGrantedPrivileges(action, request, task);
-        auditLog.logIndexEvent(action, request, task);
-        chain.proceed(task, action, request, listener);
+        // Build the audit event with fields available in non-FGAC modes
+        AuditMessage msg = new AuditMessage(AuditCategory.REQUEST_AUDIT, clusterService, Origin.REST, Origin.TRANSPORT);
+
+        // Source IP — from the request directly 
+        TransportAddress remoteAddress = request.remoteAddress();
+        msg.addRemoteAddress(remoteAddress);
+
+        // Action name — the transport action string (e.g., "indices:data/write/index")
+        msg.addPrivilege(action);
+
+        // Request type — the class name (e.g., "IndexRequest", "SearchRequest")
+        msg.addRequestType(request.getClass().getSimpleName());
+
+        // Target indices — if the request is index-scoped
+        if (request instanceof IndicesRequest) {
+            msg.addIndices(((IndicesRequest) request).indices());
+        }
+
+        // Task ID — for correlating related operations
+        if (task != null) {
+            msg.addTaskId(task.getId());
+            if (task.getParentTaskId() != null && task.getParentTaskId().isSet()) {
+                msg.addTaskParentId(task.getParentTaskId().toString());
+            }
+        }
+
+        // TODO: request body (Phase 2 — needs configurable sensitive header exclusion)
+        // TODO: user identity from client cert CN/SAN in SSL-only mode
+
+        auditLog.logRequestAudit(msg); // routes to configured sink (log4j, index, etc)
+        chain.proceed(task, action, request, listener); //  passes the request to the next filter in the chain, or if there are no more filters, executes the actual action (index the doc, run the search, etc.).
     }
 }

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.filter;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.support.ActionFilter;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.tasks.Task;
+
+/**
+ * A lightweight action filter that logs audit events without performing
+ * authentication or authorization. Used in SSL-only and disabled modes
+ * where the full SecurityFilter is not registered.
+ */
+public class AuditActionFilter implements ActionFilter {
+
+    private final AuditLog auditLog;
+
+    public AuditActionFilter(AuditLog auditLog) {
+        this.auditLog = auditLog;
+    }
+
+    @Override
+    public int order() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task,
+        String action,
+        Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        auditLog.logGrantedPrivileges(action, request, task);
+        auditLog.logIndexEvent(action, request, task);
+        chain.proceed(task, action, request, listener);
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -216,6 +216,8 @@ public class ConfigConstants {
         "opendistro_security.audit.config.disabled_transport_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES =
         "opendistro_security.audit.config.disabled_rest_categories";
+    public static final String SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES = SECURITY_SETTINGS_PREFIX
+        + "audit.config.disabled_categories";
     public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT = ImmutableList.of(
         AuditCategory.AUTHENTICATED.toString(),
         AuditCategory.GRANTED_PRIVILEGES.toString()

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -256,4 +256,66 @@ public class AuditConfigFilterTest {
             .build();
         assertThat(parse.apply(settingMultipleValues), equalTo(ImmutableSet.of(AUTHENTICATED, BAD_HEADERS)));
     }
+
+    @Test
+    public void testUnifiedDisabledCategoriesTakesPrecedence() {
+        // When disabled_categories is set, it should be used for both REST and transport
+        final Settings settings = Settings.builder()
+            .putList(
+                ConfigConstants.SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
+                BAD_HEADERS.toString(),
+                FAILED_LOGIN.toString()
+            )
+            .putList(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                SSL_EXCEPTION.toString()
+            )
+            .putList(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                MISSING_PRIVILEGES.toString()
+            )
+            .build();
+
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        // Unified setting wins — split settings are ignored
+        assertThat(filter.getDisabledRestCategories(), is(ImmutableSet.of(BAD_HEADERS, FAILED_LOGIN)));
+        assertThat(filter.getDisabledTransportCategories(), is(ImmutableSet.of(BAD_HEADERS, FAILED_LOGIN)));
+    }
+
+    @Test
+    public void testFallsBackToSplitSettingsWhenUnifiedAbsent() {
+        // When disabled_categories is NOT set, fall back to split settings
+        final Settings settings = Settings.builder()
+            .putList(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES,
+                BAD_HEADERS.toString(),
+                SSL_EXCEPTION.toString()
+            )
+            .putList(
+                ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
+                FAILED_LOGIN.toString(),
+                MISSING_PRIVILEGES.toString()
+            )
+            .build();
+
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertThat(filter.getDisabledRestCategories(), is(ImmutableSet.of(BAD_HEADERS, SSL_EXCEPTION)));
+        assertThat(filter.getDisabledTransportCategories(), is(ImmutableSet.of(FAILED_LOGIN, MISSING_PRIVILEGES)));
+    }
+
+    @Test
+    public void testUnifiedDisabledCategoriesViaMap() {
+        // Test the JSON/Map path (dynamic config)
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("disabled_categories", List.of(BAD_HEADERS.toString(), FAILED_LOGIN.toString()));
+        properties.put("disabled_rest_categories", List.of(SSL_EXCEPTION.toString()));
+        properties.put("disabled_transport_categories", List.of(MISSING_PRIVILEGES.toString()));
+
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(properties);
+
+        assertThat(filter.getDisabledRestCategories(), is(ImmutableSet.of(BAD_HEADERS, FAILED_LOGIN)));
+        assertThat(filter.getDisabledTransportCategories(), is(ImmutableSet.of(BAD_HEADERS, FAILED_LOGIN)));
+    }
 }

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.filter;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.ActionFilterChain;
+import org.opensearch.action.support.ActionRequestMetadata;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.node.DiscoveryNode;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.security.auditlog.AuditLog;
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.tasks.Task;
+
+import org.mockito.ArgumentCaptor;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AuditActionFilterTest {
+
+    private AuditLog auditLog;
+    private ClusterService clusterService;
+    private AuditActionFilter filter;
+
+    @Before
+    public void setUp() {
+        auditLog = mock(AuditLog.class);
+        clusterService = mock(ClusterService.class);
+
+        DiscoveryNode node = mock(DiscoveryNode.class);
+        when(node.getHostAddress()).thenReturn("127.0.0.1");
+        when(node.getId()).thenReturn("node-1-id");
+        when(node.getHostName()).thenReturn("node-1-host");
+        when(node.getName()).thenReturn("node-1");
+        when(clusterService.localNode()).thenReturn(node);
+        when(clusterService.getClusterName()).thenReturn(new ClusterName("test-cluster"));
+
+        filter = new AuditActionFilter(auditLog, clusterService);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplyLogsCorrectFields() throws Exception {
+        // Setup request with remote address and indices
+        SearchRequest request = new SearchRequest("my-index", "logs-*");
+        request.remoteAddress(new TransportAddress(new InetSocketAddress(InetAddress.getByName("192.168.1.10"), 54321)));
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(42L);
+        when(task.getParentTaskId()).thenReturn(null);
+
+        ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        // Act
+        filter.apply(task, "indices:data/read/search", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Verify audit message was logged
+        ArgumentCaptor<AuditMessage> captor = ArgumentCaptor.forClass(AuditMessage.class);
+        verify(auditLog).logRequestAudit(captor.capture());
+
+        AuditMessage msg = captor.getValue();
+        Map<String, Object> fields = msg.getAsMap();
+
+        // Verify category
+        assertThat(msg.getCategory(), equalTo(AuditCategory.REQUEST_AUDIT));
+
+        // Verify fields from request
+        assertThat(msg.getPrivilege(), equalTo("indices:data/read/search"));
+        assertThat(msg.getRequestType(), equalTo("SearchRequest"));
+        assertThat((String[]) fields.get(AuditMessage.INDICES), arrayContaining("my-index", "logs-*"));
+        assertThat(fields.get(AuditMessage.REMOTE_ADDRESS), notNullValue());
+
+        // Verify node/cluster info from ClusterService
+        assertThat(fields.get(AuditMessage.NODE_NAME), equalTo("node-1"));
+        assertThat(fields.get(AuditMessage.NODE_ID), equalTo("node-1-id"));
+        assertThat(fields.get(AuditMessage.CLUSTER_NAME), equalTo("test-cluster"));
+
+        // Verify task ID (format is nodeId:taskId)
+        assertThat(fields.get(AuditMessage.TASK_ID), equalTo("node-1-id:42"));
+
+        // Verify chain continues
+        verify(chain).proceed(task, "indices:data/read/search", request, listener);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testApplyWithNonIndicesRequest() throws Exception {
+        // A request that doesn't implement IndicesRequest (e.g., cluster health)
+        ClusterHealthRequest request = new ClusterHealthRequest();
+
+        ActionFilterChain<ClusterHealthRequest, ActionResponse> chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        filter.apply(null, "cluster:monitor/health", request, ActionRequestMetadata.empty(), listener, chain);
+
+        ArgumentCaptor<AuditMessage> captor = ArgumentCaptor.forClass(AuditMessage.class);
+        verify(auditLog).logRequestAudit(captor.capture());
+
+        AuditMessage msg = captor.getValue();
+        Map<String, Object> fields = msg.getAsMap();
+
+        assertThat(msg.getCategory(), equalTo(AuditCategory.REQUEST_AUDIT));
+        assertThat(msg.getPrivilege(), equalTo("cluster:monitor/health"));
+        assertThat(msg.getRequestType(), equalTo("ClusterHealthRequest"));
+        // No indices field since it's not an IndicesRequest
+        assertThat(fields.get(AuditMessage.INDICES), equalTo(null));
+        // No task ID since task is null
+        assertThat(fields.get(AuditMessage.TASK_ID), equalTo(null));
+
+        verify(chain).proceed(null, "cluster:monitor/health", request, listener);
+    }
+}


### PR DESCRIPTION
### Description
Standalone Audit Logging — Weeks 1-3 (Days 1-3)
  
  Enables audit logging in SSL-only and disabled modes without depending on auth/authz.
  
  - Added REQUEST_AUDIT category + AuditActionFilter (captures every transport action)
  - Wired standalone audit pipeline: initStandaloneAuditIfEnabled() → setConfig() → sink
  - Ungated all audit settings from sslOnlyMode in getSettings()
  - Auth-only categories validation warning at startup
  - Unified disabled_categories setting with deprecation of split settings (Issue #6222)
  - Unit + integration tests
  
