### PR TITLE
[Backport 2.19] Add CI mirror to avoid Maven Central throttling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -432,6 +433,7 @@ publishing {
 
 repositories {
     mavenLocal()
+    maven { url = "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://plugins.gradle.org/m2/" }
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,14 @@
  * This project uses @Incubating APIs which are subject to change.
  */
 
+pluginManagement {
+    repositories {
+        maven { url = uri("https://ci.opensearch.org/maven2/") }
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
 rootProject.name = 'opensearch-security'
 
 include "bwc-test"


### PR DESCRIPTION
Backport of #6166.

### Description
Adds `https://ci.opensearch.org/maven2/` as a priority repository for plugin and dependency resolution to avoid Maven Central HTTP 429 throttling during builds on Jenkins.


### Testing
Verified `./gradlew assemble` completes successfully