### PR TITLE
Grant indices:admin/get to kibana_server role

### DIFF
--- a/src/main/resources/static_config/static_roles.yml
+++ b/src/main/resources/static_config/static_roles.yml
@@ -116,6 +116,7 @@ kibana_server:
         - "*"
       allowed_actions:
         - "indices:admin/aliases*"
+        - "indices:admin/get"
 
 logstash:
   reserved: true


### PR DESCRIPTION
## Summary

- Add `indices:admin/get` to the `kibana_server` static role catch-all (`*`) index pattern so OpenSearch Dashboards can probe `.kibana` before saved-objects bootstrap on a fresh cluster.


Fixes #6103


