### PR TITLE
Lower JWKS static-key fallback logs from WARN to INFO

### DIFF
--- a/src/main/java/org/opensearch/security/auth/http/jwt/keybyjwks/HTTPJwtKeyByJWKSAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/keybyjwks/HTTPJwtKeyByJWKSAuthenticator.java
@@ -72,7 +72,7 @@ public class HTTPJwtKeyByJWKSAuthenticator extends AbstractHTTPJwtAuthenticator 
 
         // Initialize static JWT authenticator as fallback if jwks_uri is not configured
         if (!useJwks) {
-            log.warn("jwks_uri is not configured, falling back to static JWT authentication");
+            log.info("jwks_uri is not configured, using static JWT authentication with the configured signing_key");
             this.staticJwtAuthenticator = new HTTPJwtAuthenticator(settings, configPath);
         } else {
             this.staticJwtAuthenticator = null;
@@ -85,7 +85,7 @@ public class HTTPJwtKeyByJWKSAuthenticator extends AbstractHTTPJwtAuthenticator 
 
         // If jwks_uri is not configured, return null (will use static JWT fallback)
         if (jwksUri == null || jwksUri.isBlank()) {
-            log.warn("jwks_uri is not configured, will use static JWT authentication fallback");
+            log.info("jwks_uri is not configured, using static JWT authentication with the configured signing_key");
             return null;
         }
 

--- a/src/main/java/org/opensearch/security/auth/http/jwt/keybyjwks/HTTPJwtKeyByJWKSAuthenticator.java
+++ b/src/main/java/org/opensearch/security/auth/http/jwt/keybyjwks/HTTPJwtKeyByJWKSAuthenticator.java
@@ -85,7 +85,7 @@ public class HTTPJwtKeyByJWKSAuthenticator extends AbstractHTTPJwtAuthenticator 
 
         // If jwks_uri is not configured, return null (will use static JWT fallback)
         if (jwksUri == null || jwksUri.isBlank()) {
-            log.info("jwks_uri is not configured, using static JWT authentication with the configured signing_key");
+            log.info("jwks_uri is not configured, skipping JWKS key provider initialization");
             return null;
         }
 

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
@@ -15,20 +15,20 @@ import java.util.HashMap;
 import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auth.http.jwt.keybyjwks.HTTPJwtKeyByJWKSAuthenticator;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.core.Appender;
-import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
+import org.mockito.ArgumentCaptor;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
+++ b/src/test/java/org/opensearch/security/auth/http/jwt/keybyoidc/HTTPJwtKeyByJWKSAuthenticatorTest.java
@@ -12,18 +12,29 @@
 package org.opensearch.security.auth.http.jwt.keybyoidc;
 
 import java.util.HashMap;
+import java.util.List;
 
 import com.google.common.collect.ImmutableMap;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auth.http.jwt.keybyjwks.HTTPJwtKeyByJWKSAuthenticator;
 import org.opensearch.security.user.AuthCredentials;
 import org.opensearch.security.util.FakeRestRequest;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class HTTPJwtKeyByJWKSAuthenticatorTest {
 
@@ -241,6 +252,42 @@ public class HTTPJwtKeyByJWKSAuthenticatorTest {
 
         Assert.assertNotNull(jwtAuth);
         assertThat(jwtAuth.getType(), is("jwt"));
+    }
+
+    @Test
+    public void testStaticFallbackIsLoggedAtInfoNotWarn() {
+        Appender mockAppender = mock(Appender.class);
+        ArgumentCaptor<LogEvent> logEventCaptor = ArgumentCaptor.forClass(LogEvent.class);
+        when(mockAppender.getName()).thenReturn("MockAppender");
+        when(mockAppender.isStarted()).thenReturn(true);
+
+        Logger logger = (Logger) LogManager.getLogger(HTTPJwtKeyByJWKSAuthenticator.class);
+        logger.addAppender(mockAppender);
+        logger.setLevel(Level.INFO);
+
+        try {
+            Settings settings = Settings.builder()
+                .put("signing_key", "dGVzdC1zaWduaW5nLWtleS10aGF0LWlzLWxvbmctZW5vdWdoLWZvci1obWFjLXNoYTI1Ng==")
+                .build();
+
+            new HTTPJwtKeyByJWKSAuthenticator(settings, null);
+
+            org.mockito.Mockito.verify(mockAppender, atLeastOnce()).append(logEventCaptor.capture());
+
+            List<LogEvent> events = logEventCaptor.getAllValues();
+            boolean sawStaticInfoMessage = false;
+            for (LogEvent event : events) {
+                String message = event.getMessage().getFormattedMessage();
+                if (message.contains("jwks_uri is not configured")) {
+                    // The static-key path is a supported configuration, so it must not warn.
+                    assertThat(event.getLevel(), is(Level.INFO));
+                    sawStaticInfoMessage = true;
+                }
+            }
+            Assert.assertTrue("Expected an INFO log about static JWT authentication", sawStaticInfoMessage);
+        } finally {
+            logger.removeAppender(mockAppender);
+        }
     }
 
     @Test


### PR DESCRIPTION
### Description
* Category: Bug fix
* Why these changes are required?

When a JWT auth domain is configured with a static `signing_key` instead of a `jwks_uri`, `HTTPJwtKeyByJWKSAuthenticator` logged two WARN messages on every startup ("jwks_uri is not configured, falling back to static JWT authentication" and "jwks_uri is not configured, will use static JWT authentication fallback"). Static-key JWT is a fully supported, intentional configuration, so warning-level logging is noisy and misleading. As confirmed on the issue, these should be INFO-level messages.

* What is the old behavior before changes and new behavior after changes?

Old behavior: the two static-key messages were logged at WARN in `HTTPJwtKeyByJWKSAuthenticator` (the constructor and `initKeyProvider`). New behavior: both are logged at INFO. No control flow or authentication behavior is changed.

### Issues Resolved
Fixes #6104

### Testing
Added `testStaticFallbackIsLoggedAtInfoNotWarn` in `HTTPJwtKeyByJWKSAuthenticatorTest`, which attaches a mock appender to the authenticator's logger, constructs the authenticator with a static `signing_key` and no `jwks_uri`, and asserts the "jwks_uri is not configured" message is emitted at INFO. The existing JWKS and static-fallback tests continue to cover authentication behavior. The targeted Gradle test could not be run locally because no Java runtime is available in this environment.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
