### PR TITLE
Add unified disabled_categories audit log setting

### DIFF
--- a/config/audit.yml
+++ b/config/audit.yml
@@ -10,6 +10,10 @@ config:
     # Enable/disable REST API auditing
     enable_rest: true
 
+    disabled_categories:
+      - AUTHENTICATED
+      - GRANTED_PRIVILEGES
+
     # Categories to exclude from REST API auditing
     disabled_rest_categories:
       - AUTHENTICATED

--- a/src/integrationTest/java/org/opensearch/test/framework/AuditFilters.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/AuditFilters.java
@@ -37,8 +37,12 @@ public class AuditFilters implements ToXContentObject {
     private List<String> ignoreHeaders;
     private List<String> ignoreUrlParams;
 
+    private List<String> disabledCategories;
+
+    @Deprecated
     private List<String> disabledRestCategories;
 
+    @Deprecated
     private List<String> disabledTransportCategories;
 
     public AuditFilters() {
@@ -108,6 +112,11 @@ public class AuditFilters implements ToXContentObject {
         return this;
     }
 
+    public AuditFilters disabledCategories(List<String> disabledCategories) {
+        this.disabledCategories = disabledCategories;
+        return this;
+    }
+
     public AuditFilters disabledRestCategories(List<String> disabledRestCategories) {
         this.disabledRestCategories = disabledRestCategories;
         return this;
@@ -131,6 +140,7 @@ public class AuditFilters implements ToXContentObject {
         xContentBuilder.field("ignore_requests", ignoreRequests);
         xContentBuilder.field("ignore_headers", ignoreHeaders);
         xContentBuilder.field("ignore_url_params", ignoreUrlParams);
+        xContentBuilder.field("disabled_categories", disabledCategories);
         xContentBuilder.field("disabled_rest_categories", disabledRestCategories);
         xContentBuilder.field("disabled_transport_categories", disabledTransportCategories);
         xContentBuilder.endObject();

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1735,6 +1735,14 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             disabledCategories.add("GRANTED_PRIVILEGES");
             settings.add(
                 Setting.listSetting(
+                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
+                    disabledCategories,
+                    Function.identity(),
+                    Property.NodeScope
+                )
+            );
+            settings.add(
+                Setting.listSetting(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
                     disabledCategories,
                     Function.identity(),
@@ -1798,6 +1806,13 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             Arrays.stream(FilterEntries.values()).map(filterEntry -> {
                 switch (filterEntry) {
+                    case DISABLE_CATEGORIES:
+                        return Setting.listSetting(
+                            filterEntry.getKeyWithNamespace(),
+                            ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT,
+                            Function.identity(),
+                            Property.NodeScope
+                        );
                     case DISABLE_REST_CATEGORIES:
                     case DISABLE_TRANSPORT_CATEGORIES:
                         return Setting.listSetting(

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.impl.AuditCategory;
@@ -151,8 +152,12 @@ public class AuditConfig {
         private final WildcardMatcher ignoredAuditRequestsMatcher;
         private final WildcardMatcher ignoredCustomHeadersMatcher;
         private WildcardMatcher ignoredUrlParamsMatcher;
+        @Deprecated
         private final Set<AuditCategory> disabledRestCategories;
+        @Deprecated
         private final Set<AuditCategory> disabledTransportCategories;
+        private final boolean disabledCategoriesConfigured;
+        private final Set<AuditCategory> disabledCategories;
 
         @VisibleForTesting
         Filter(
@@ -167,7 +172,9 @@ public class AuditConfig {
             final Set<String> ignoredCustomHeaders,
             final Set<String> ignoredUrlParams,
             final Set<AuditCategory> disabledRestCategories,
-            final Set<AuditCategory> disabledTransportCategories
+            final Set<AuditCategory> disabledTransportCategories,
+            final boolean disabledCategoriesConfigured,
+            final Set<AuditCategory> disabledCategories
         ) {
             this.isRestApiAuditEnabled = isRestApiAuditEnabled;
             this.isTransportApiAuditEnabled = isTransportApiAuditEnabled;
@@ -185,6 +192,8 @@ public class AuditConfig {
             this.ignoredUrlParamsMatcher = WildcardMatcher.from(ignoredUrlParams);
             this.disabledRestCategories = disabledRestCategories;
             this.disabledTransportCategories = disabledTransportCategories;
+            this.disabledCategoriesConfigured = disabledCategoriesConfigured;
+            this.disabledCategories = disabledCategories;
         }
 
         public enum FilterEntries {
@@ -194,6 +203,7 @@ public class AuditConfig {
             LOG_REQUEST_BODY("log_request_body", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY),
             RESOLVE_INDICES("resolve_indices", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES),
             EXCLUDE_SENSITIVE_HEADERS("exclude_sensitive_headers", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS),
+            DISABLE_CATEGORIES("disabled_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES),
             DISABLE_REST_CATEGORIES("disabled_rest_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES),
             DISABLE_TRANSPORT_CATEGORIES(
                 "disabled_transport_categories",
@@ -244,6 +254,17 @@ public class AuditConfig {
             final boolean logRequestBody = getOrDefault(properties, FilterEntries.LOG_REQUEST_BODY.getKey(), true);
             final boolean resolveIndices = getOrDefault(properties, FilterEntries.RESOLVE_INDICES.getKey(), true);
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
+            final boolean disabledCategoriesConfigured = properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey());
+
+
+            // Defaults for disabledCategories are not applied; fallback is to REST/transport split settings.
+            final Set<AuditCategory> disabledCategories = AuditCategory.parse(
+                getOrDefault(
+                    properties,
+                    FilterEntries.DISABLE_CATEGORIES.getKey(),
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                )
+            );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 getOrDefault(
                     properties,
@@ -269,6 +290,15 @@ public class AuditConfig {
                 getOrDefault(properties, FilterEntries.IGNORE_HEADERS.getKey(), Collections.emptyList())
             );
 
+            if (properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
+                || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey())) {
+                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
+                deprecationLogger.deprecate(
+                    "disabled_rest_transport_categories",
+                    "Properties 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. Use 'disabled_categories' instead."
+                );
+            }
+
             return new Filter(
                 isRestApiAuditEnabled,
                 isTransportAuditEnabled,
@@ -281,7 +311,9 @@ public class AuditConfig {
                 ignoreHeaders,
                 new HashSet<>(),
                 disabledRestCategories,
-                disabledTransportCategories
+                disabledTransportCategories,
+                disabledCategoriesConfigured,
+                disabledCategories
             );
 
         }
@@ -298,6 +330,16 @@ public class AuditConfig {
             final boolean logRequestBody = fromSettingBoolean(settings, FilterEntries.LOG_REQUEST_BODY, true);
             final boolean resolveIndices = fromSettingBoolean(settings, FilterEntries.RESOLVE_INDICES, true);
             final boolean excludeSensitiveHeaders = fromSettingBoolean(settings, FilterEntries.EXCLUDE_SENSITIVE_HEADERS, true);
+            final boolean disabledCategoriesConfigured = settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace());
+
+            // Defaults for disabledCategories are not applied; fallback is to REST/transport split settings.
+            final Set<AuditCategory> disabledCategories = AuditCategory.parse(
+                fromSettingStringSet(
+                    settings,
+                    FilterEntries.DISABLE_CATEGORIES,
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                )
+            );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 fromSettingStringSet(
                     settings,
@@ -315,6 +357,18 @@ public class AuditConfig {
             final Set<String> ignoredAuditUsers = fromSettingStringSet(settings, FilterEntries.IGNORE_USERS, DEFAULT_IGNORED_USERS);
             final Set<String> ignoreAuditRequests = fromSettingStringSet(settings, FilterEntries.IGNORE_REQUESTS, Collections.emptyList());
             final Set<String> ignoreHeaders = fromSettingStringSet(settings, FilterEntries.IGNORE_HEADERS, Collections.emptyList());
+
+            if (settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace())) {
+                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
+                deprecationLogger.deprecate(
+                    "disabled_rest_transport_categories",
+                    "Settingssssss 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. Use 'disabled_categories' instead."
+                );
+            }
+
             return new Filter(
                 isRestApiAuditEnabled,
                 isTransportAuditEnabled,
@@ -327,8 +381,9 @@ public class AuditConfig {
                 ignoreHeaders,
                 new HashSet<>(),
                 disabledRestCategories,
-                disabledTransportCategories
-            );
+                disabledTransportCategories,
+                disabledCategoriesConfigured,
+                disabledCategories);
         }
 
         static boolean fromSettingBoolean(final Settings settings, FilterEntries filterEntry, final boolean defaultValue) {
@@ -480,6 +535,23 @@ public class AuditConfig {
         }
 
         /**
+         * Disabled categories for API auditing
+         * @return set of categories
+         */
+        @JsonProperty("disabled_categories")
+        public Set<AuditCategory> getDisabledCategories() {
+            return disabledCategories;
+        }
+
+        /**
+         * Whether the unified disabled_categories setting is present
+         * @return true if disabled_categories was explicitly set
+         */
+        public boolean isDisabledCategoriesConfigured() {
+            return disabledCategoriesConfigured;
+        }
+
+        /**
          * Disabled categories for REST API auditing
          * @return set of categories
          */
@@ -499,9 +571,17 @@ public class AuditConfig {
 
         public void log(Logger logger) {
             logger.info("Auditing on REST API is {}.", isRestApiAuditEnabled ? "enabled" : "disabled");
-            logger.info("{} are excluded from REST API auditing.", disabledRestCategories);
             logger.info("Auditing on Transport API is {}.", isTransportApiAuditEnabled ? "enabled" : "disabled");
-            logger.info("{} are excluded from Transport API auditing.", disabledTransportCategories);
+            if (disabledCategoriesConfigured) {
+                if (disabledCategories.isEmpty()) {
+                    logger.info("No audit categories are excluded from REST or Transport API auditing.");
+                } else {
+                    logger.info("{} are excluded from REST and Transport API auditing.", disabledCategories);
+                }
+            } else {
+                logger.info("{} are excluded from REST API auditing.", disabledRestCategories);
+                logger.info("{} are excluded from Transport API auditing.", disabledTransportCategories);
+            }
             logger.info("Auditing of request body is {}.", logRequestBody ? "enabled" : "disabled");
             logger.info("Bulk requests resolution is {} during request auditing.", resolveBulkRequests ? "enabled" : "disabled");
             logger.info("Index resolution is {} during request auditing.", resolveIndices ? "enabled" : "disabled");
@@ -516,10 +596,14 @@ public class AuditConfig {
             return "Filter{"
                 + "isRestApiAuditEnabled="
                 + isRestApiAuditEnabled
-                + ", disabledRestCategories="
-                + disabledRestCategories
                 + ", isTransportApiAuditEnabled="
                 + isTransportApiAuditEnabled
+                + ", disabledCategoriesConfigured="
+                + disabledCategoriesConfigured
+                + ", disabledCategories="
+                + disabledCategories
+                + ", disabledRestCategories="
+                + disabledRestCategories
                 + ", disabledTransportCategories="
                 + disabledTransportCategories
                 + ", resolveBulkRequests="

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -257,13 +257,12 @@ public class AuditConfig {
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
             final boolean disabledCategoriesConfigured = properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey());
 
-
             // Defaults for disabledCategories are not applied; fallback is to REST/transport split settings.
             final Set<AuditCategory> disabledCategories = AuditCategory.parse(
                 getOrDefault(
                     properties,
                     FilterEntries.DISABLE_CATEGORIES.getKey(),
-                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
                 )
             );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
@@ -338,7 +337,7 @@ public class AuditConfig {
                 fromSettingStringSet(
                     settings,
                     FilterEntries.DISABLE_CATEGORIES,
-                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
                 )
             );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
@@ -384,7 +383,8 @@ public class AuditConfig {
                 disabledRestCategories,
                 disabledTransportCategories,
                 disabledCategoriesConfigured,
-                disabledCategories);
+                disabledCategories
+            );
         }
 
         static boolean fromSettingBoolean(final Settings settings, FilterEntries filterEntry, final boolean defaultValue) {

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.Logger;
@@ -547,6 +548,7 @@ public class AuditConfig {
          * Whether the unified disabled_categories setting is present
          * @return true if disabled_categories was explicitly set
          */
+        @JsonIgnore
         public boolean isDisabledCategoriesConfigured() {
             return disabledCategoriesConfigured;
         }

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -365,7 +365,7 @@ public class AuditConfig {
                 final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
                 deprecationLogger.deprecate(
                     "disabled_rest_transport_categories",
-                    "Settingssssss 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. Use 'disabled_categories' instead."
+                    "Settings 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. Use 'disabled_categories' instead."
                 );
             }
 

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -1129,6 +1129,16 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
+        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
+            if (auditConfigFilter.getDisabledCategories().contains(category)) {
+                if (isTraceEnabled) {
+                    log.trace("Skipped audit log message because category {} not enabled", category);
+                }
+                return false;
+            }
+            return true;
+        }
+
         if (!auditConfigFilter.getDisabledTransportCategories().contains(category)) {
             return true;
         } else {
@@ -1220,6 +1230,16 @@ public abstract class AbstractAuditLog implements AuditLog {
             }
 
             return false;
+        }
+
+        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
+            if (auditConfigFilter.getDisabledCategories().contains(category)) {
+                if (isTraceEnabled) {
+                    log.trace("Skipped audit log message because category {} not enabled", category);
+                }
+                return false;
+            }
+            return true;
         }
 
         if (!auditConfigFilter.getDisabledRestCategories().contains(category)) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -149,6 +149,20 @@ public class AuditApiAction extends AbstractApiAction {
     private final List<String> readonlyFields;
 
     public static class AuditRequestContentValidator extends RequestContentValidator {
+
+        public static final Set<AuditCategory> DISABLED_CATEGORIES = Set.of(
+            AuditCategory.BAD_HEADERS,
+            AuditCategory.SSL_EXCEPTION,
+            AuditCategory.AUTHENTICATED,
+            AuditCategory.FAILED_LOGIN,
+            AuditCategory.GRANTED_PRIVILEGES,
+            AuditCategory.MISSING_PRIVILEGES,
+            AuditCategory.INDEX_EVENT,
+            AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT,
+            AuditCategory.CLUSTER_SETTINGS_CHANGED,
+            AuditCategory.INDEX_SETTINGS_CHANGED
+        );
+
         public static final Set<AuditCategory> DISABLED_REST_CATEGORIES = Set.of(
             AuditCategory.BAD_HEADERS,
             AuditCategory.SSL_EXCEPTION,
@@ -190,6 +204,9 @@ public class AuditApiAction extends AbstractApiAction {
                 // try parsing to target type
                 final AuditConfig auditConfig = DefaultObjectMapper.readTree(jsonContent, AuditConfig.class);
                 final AuditConfig.Filter filter = auditConfig.getFilter();
+                if (!DISABLED_CATEGORIES.containsAll(filter.getDisabledCategories())) {
+                    throw new IllegalArgumentException("Invalid REST/Transport categories passed in the request");
+                }
                 if (!DISABLED_REST_CATEGORIES.containsAll(filter.getDisabledRestCategories())) {
                     throw new IllegalArgumentException("Invalid REST categories passed in the request");
                 }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -212,10 +212,18 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES = "opendistro_security.audit.resolve_indices";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_REST = "opendistro_security.audit.enable_rest";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT = "opendistro_security.audit.enable_transport";
+    public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES =
+        "opendistro_security.audit.config.disabled_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES =
         "opendistro_security.audit.config.disabled_transport_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES =
         "opendistro_security.audit.config.disabled_rest_categories";
+    public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT = ImmutableList.of(
+        AuditCategory.AUTHENTICATED.toString(),
+        AuditCategory.GRANTED_PRIVILEGES.toString(),
+        AuditCategory.CLUSTER_SETTINGS_CHANGED.toString(),
+        AuditCategory.INDEX_SETTINGS_CHANGED.toString()
+    );
     public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT = ImmutableList.of(
         AuditCategory.AUTHENTICATED.toString(),
         AuditCategory.GRANTED_PRIVILEGES.toString()

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -270,9 +270,7 @@ public class AuditConfigFilterTest {
         assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES)));
 
         // Test via map
-        final Map<String, Object> properties = Map.of(
-            FilterEntries.DISABLE_CATEGORIES.getKey(), List.of("FAILED_LOGIN", "SSL_EXCEPTION")
-        );
+        final Map<String, Object> properties = Map.of(FilterEntries.DISABLE_CATEGORIES.getKey(), List.of("FAILED_LOGIN", "SSL_EXCEPTION"));
 
         final AuditConfig.Filter filterFromMap = AuditConfig.Filter.from(properties);
 

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -256,4 +256,43 @@ public class AuditConfigFilterTest {
             .build();
         assertThat(parse.apply(settingMultipleValues), equalTo(ImmutableSet.of(AUTHENTICATED, BAD_HEADERS)));
     }
+
+    @Test
+    public void testDisabledCategoriesConfigured() {
+        // Test via the primary (plugins.security.*) key
+        final Settings settings = Settings.builder()
+            .putList(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace(), "AUTHENTICATED", "GRANTED_PRIVILEGES")
+            .build();
+
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES)));
+
+        // Test via map
+        final Map<String, Object> properties = Map.of(
+            FilterEntries.DISABLE_CATEGORIES.getKey(), List.of("FAILED_LOGIN", "SSL_EXCEPTION")
+        );
+
+        final AuditConfig.Filter filterFromMap = AuditConfig.Filter.from(properties);
+
+        assertTrue(filterFromMap.isDisabledCategoriesConfigured());
+        assertThat(filterFromMap.getDisabledCategories(), equalTo(EnumSet.of(FAILED_LOGIN, SSL_EXCEPTION)));
+    }
+
+    @Test
+    public void testDisabledCategoriesPrecedence() {
+        final Settings settings = Settings.builder()
+            .putList(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace(), "SSL_EXCEPTION")
+            .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES, "AUTHENTICATED")
+            .putList(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES, "FAILED_LOGIN")
+            .build();
+
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(SSL_EXCEPTION)));
+        assertThat(filter.getDisabledRestCategories(), equalTo(EnumSet.of(AUTHENTICATED)));
+        assertThat(filter.getDisabledTransportCategories(), equalTo(EnumSet.of(FAILED_LOGIN)));
+    }
 }

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -65,6 +65,7 @@ public class AuditConfigSerializeTest {
             .field("enabled", true)
             .startObject("audit")
             .field("enable_rest", true)
+            .field("disabled_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED"))
             .field("disabled_rest_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field(
@@ -105,6 +106,18 @@ public class AuditConfigSerializeTest {
         final ComplianceConfig compliance = auditConfig.getCompliance();
         // assert
         assertTrue(audit.isRestApiAuditEnabled());
+        assertFalse(audit.isDisabledCategoriesConfigured());
+        assertThat(
+            audit.getDisabledCategories(),
+            is(
+                EnumSet.of(
+                    AuditCategory.AUTHENTICATED,
+                    AuditCategory.GRANTED_PRIVILEGES,
+                    AuditCategory.CLUSTER_SETTINGS_CHANGED,
+                    AuditCategory.INDEX_SETTINGS_CHANGED
+                )
+            )
+        );
         assertThat(audit.getDisabledRestCategories(), is(EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES)));
         assertTrue(audit.isTransportApiAuditEnabled());
         assertThat(
@@ -175,6 +188,18 @@ public class AuditConfigSerializeTest {
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
         // assert
         assertTrue(audit.isRestApiAuditEnabled());
+        assertFalse(audit.isDisabledCategoriesConfigured());
+        assertThat(
+            audit.getDisabledCategories(),
+            is(
+                EnumSet.of(
+                    AuditCategory.AUTHENTICATED,
+                    AuditCategory.GRANTED_PRIVILEGES,
+                    AuditCategory.CLUSTER_SETTINGS_CHANGED,
+                    AuditCategory.INDEX_SETTINGS_CHANGED
+                )
+            )
+        );
         assertThat(EnumSet.of(AuditCategory.AUTHENTICATED), is(audit.getDisabledRestCategories()));
         assertTrue(audit.isTransportApiAuditEnabled());
         assertThat(EnumSet.of(AuditCategory.SSL_EXCEPTION), is(audit.getDisabledTransportCategories()));
@@ -219,7 +244,9 @@ public class AuditConfigSerializeTest {
             ImmutableSet.of("test-header"),
             ImmutableSet.of("test-param"),
             EnumSet.of(AuditCategory.FAILED_LOGIN, AuditCategory.GRANTED_PRIVILEGES),
-            EnumSet.of(AUTHENTICATED)
+            EnumSet.of(AUTHENTICATED),
+            false,
+            Collections.emptySet()
         );
         final ComplianceConfig compliance = new ComplianceConfig(
             true,
@@ -244,6 +271,7 @@ public class AuditConfigSerializeTest {
             .field("disabled_rest_categories", ImmutableList.of("FAILED_LOGIN", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field("disabled_transport_categories", Collections.singletonList("AUTHENTICATED"))
+            .field("disabled_categories", Collections.emptyList())
             .field("resolve_bulk_requests", true)
             .field("log_request_body", true)
             .field("resolve_indices", true)
@@ -285,6 +313,7 @@ public class AuditConfigSerializeTest {
             .field("enabled", true)
             .startObject("audit")
             .field("enable_rest", true)
+            .field("disabled_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED"))
             .field("disabled_rest_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field(
@@ -331,6 +360,18 @@ public class AuditConfigSerializeTest {
         // assert
         final AuditConfig.Filter audit = auditConfig.getFilter();
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
+        assertFalse(audit.isDisabledCategoriesConfigured());
+        assertThat(
+            audit.getDisabledCategories(),
+            is(
+                EnumSet.of(
+                    AUTHENTICATED,
+                    GRANTED_PRIVILEGES,
+                    AuditCategory.CLUSTER_SETTINGS_CHANGED,
+                    AuditCategory.INDEX_SETTINGS_CHANGED
+                )
+            )
+        );
         assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledRestCategories()));
         assertThat(
             EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES, AuditCategory.CLUSTER_SETTINGS_CHANGED, AuditCategory.INDEX_SETTINGS_CHANGED),
@@ -388,6 +429,7 @@ public class AuditConfigSerializeTest {
         // assert
         final AuditConfig.Filter audit = auditConfig.getFilter();
         final ComplianceConfig configCompliance = auditConfig.getCompliance();
+        assertFalse(audit.isDisabledCategoriesConfigured());
         assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledRestCategories()));
         assertThat(
             EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES, AuditCategory.CLUSTER_SETTINGS_CHANGED, AuditCategory.INDEX_SETTINGS_CHANGED),
@@ -403,9 +445,114 @@ public class AuditConfigSerializeTest {
         assertThat(configCompliance.getAuditLogIndex(), is("test-auditlog-index"));
     }
 
+    @Test
+    public void testSerializeWithDisabledCategories() throws IOException {
+        // arrange
+        final AuditConfig.Filter audit = new AuditConfig.Filter(
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            ImmutableSet.of("ignore-user-1"),
+            ImmutableSet.of("ignore-request-1"),
+            ImmutableSet.of("test-header"),
+            ImmutableSet.of("test-param"),
+            EnumSet.of(AuditCategory.FAILED_LOGIN),
+            EnumSet.of(AUTHENTICATED),
+            true,
+            EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES)
+        );
+        final ComplianceConfig compliance = ComplianceConfig.DEFAULT;
+        final AuditConfig auditConfig = new AuditConfig(true, audit, compliance);
+        final XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("enabled", true)
+            .startObject("audit")
+            .field("enable_rest", true)
+            .field("disabled_rest_categories", Collections.singletonList("FAILED_LOGIN"))
+            .field("enable_transport", true)
+            .field("disabled_transport_categories", Collections.singletonList("AUTHENTICATED"))
+            .field("disabled_categories", ImmutableList.of("GRANTED_PRIVILEGES", "AUTHENTICATED"))
+            .field("resolve_bulk_requests", true)
+            .field("log_request_body", true)
+            .field("resolve_indices", true)
+            .field("exclude_sensitive_headers", true)
+            .field("ignore_users", Collections.singletonList("ignore-user-1"))
+            .field("ignore_requests", Collections.singletonList("ignore-request-1"))
+            .field("ignore_headers", Collections.singletonList("test-header"))
+            .field("ignore_url_params", Collections.singletonList("test-param"))
+            .endObject()
+            .startObject("compliance")
+            .field("enabled", true)
+            .field("external_config", false)
+            .field("internal_config", false)
+            .field("read_metadata_only", false)
+            .field("read_watched_fields", Collections.emptyMap())
+            .field("read_ignore_users", Collections.singletonList("kibanaserver"))
+            .field("write_metadata_only", false)
+            .field("write_log_diffs", false)
+            .field("write_watched_indices", Collections.emptyList())
+            .field("write_ignore_users", Collections.singletonList("kibanaserver"))
+            .endObject()
+            .endObject();
+
+        // act
+        final String json = objectMapper.writeValueAsString(auditConfig);
+        // assert
+        assertTrue(compareJson(jsonBuilder.toString(), json));
+    }
+
+    @Test
+    public void testDeserializeWithDisabledCategories() throws IOException {
+        // arrange
+        final XContentBuilder jsonBuilder = XContentFactory.jsonBuilder()
+            .startObject()
+            .field("enabled", true)
+            .startObject("audit")
+            .field("enable_rest", true)
+            .field("disabled_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES"))
+            .field("enable_transport", true)
+            .field("resolve_bulk_requests", true)
+            .field("log_request_body", true)
+            .field("resolve_indices", true)
+            .field("exclude_sensitive_headers", true)
+            .field("ignore_users", Collections.singletonList("test-user-1"))
+            .field("ignore_requests", Collections.singletonList("test-request"))
+            .field("ignore_headers", Collections.singletonList("test-headers"))
+            .field("ignore_url_params", Collections.singletonList("test-param"))
+            .endObject()
+            .startObject("compliance")
+            .field("enabled", true)
+            .field("external_config", false)
+            .endObject()
+            .endObject();
+        final String json = jsonBuilder.toString();
+
+        // act
+        final AuditConfig auditConfig = objectMapper.readValue(json, AuditConfig.class);
+        final AuditConfig.Filter audit = auditConfig.getFilter();
+        // assert
+        assertTrue(audit.isRestApiAuditEnabled());
+        assertTrue(audit.isDisabledCategoriesConfigured());
+        assertThat(EnumSet.of(AuditCategory.AUTHENTICATED, AuditCategory.GRANTED_PRIVILEGES), is(audit.getDisabledCategories()));
+    }
+
     private boolean compareJson(final String json1, final String json2) {
-        ObjectNode objectNode1 = objectMapper.readValue(json1, ObjectNode.class);
-        ObjectNode objectNode2 = objectMapper.readValue(json2, ObjectNode.class);
-        return objectNode1.equals(objectNode2);
+        try {
+            ObjectNode objectNode1 = objectMapper.readValue(json1, ObjectNode.class);
+            ObjectNode objectNode2 = objectMapper.readValue(json2, ObjectNode.class);
+            if (!objectNode1.equals(objectNode2)) {
+                System.err.println("JSON MISMATCH!");
+                System.err.println("EXPECTED: " + json1);
+                System.err.println("ACTUAL:   " + json2);
+                return false;
+            }
+            return true;
+        } catch (Exception e) {
+            System.err.println("Exception in compareJson: " + e.getMessage());
+            return false;
+        }
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -65,7 +65,10 @@ public class AuditConfigSerializeTest {
             .field("enabled", true)
             .startObject("audit")
             .field("enable_rest", true)
-            .field("disabled_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED"))
+            .field(
+                "disabled_categories",
+                ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
+            )
             .field("disabled_rest_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field(
@@ -313,7 +316,10 @@ public class AuditConfigSerializeTest {
             .field("enabled", true)
             .startObject("audit")
             .field("enable_rest", true)
-            .field("disabled_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED"))
+            .field(
+                "disabled_categories",
+                ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
+            )
             .field("disabled_rest_categories", ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field(
@@ -363,14 +369,7 @@ public class AuditConfigSerializeTest {
         assertFalse(audit.isDisabledCategoriesConfigured());
         assertThat(
             audit.getDisabledCategories(),
-            is(
-                EnumSet.of(
-                    AUTHENTICATED,
-                    GRANTED_PRIVILEGES,
-                    AuditCategory.CLUSTER_SETTINGS_CHANGED,
-                    AuditCategory.INDEX_SETTINGS_CHANGED
-                )
-            )
+            is(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES, AuditCategory.CLUSTER_SETTINGS_CHANGED, AuditCategory.INDEX_SETTINGS_CHANGED))
         );
         assertThat(EnumSet.of(AUTHENTICATED, GRANTED_PRIVILEGES), is(audit.getDisabledRestCategories()));
         assertThat(

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
@@ -113,9 +113,11 @@ public class AuditApiActionRequestContentValidatorTest extends AbstractApiAction
             .createEndpointValidator()
             .createRequestContentValidator();
 
-        final var validCategories = Stream.of(AuditCategory.AUTHENTICATED, AuditCategory.CLUSTER_SETTINGS_CHANGED, AuditCategory.BAD_HEADERS)
-            .map(Enum::name)
-            .collect(Collectors.toList());
+        final var validCategories = Stream.of(
+            AuditCategory.AUTHENTICATED,
+            AuditCategory.CLUSTER_SETTINGS_CHANGED,
+            AuditCategory.BAD_HEADERS
+        ).map(Enum::name).collect(Collectors.toList());
         final var auditConfig = new AuditConfig(
             true,
             AuditConfig.Filter.from(Map.of("disabled_categories", validCategories)),

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionRequestContentValidatorTest.java
@@ -80,4 +80,49 @@ public class AuditApiActionRequestContentValidatorTest extends AbstractApiAction
         assertFalse(result.isValid());
         assertThat(result.status(), is(RestStatus.BAD_REQUEST));
     }
+
+    @Test
+    public void validateAuditDisabledCategoriesInvalid() throws IOException {
+        InjectableValues.Std injectableValues = new InjectableValues.Std();
+        injectableValues.addValue(Settings.class, Settings.EMPTY);
+        DefaultObjectMapper.inject(injectableValues);
+        final var auditApiActionRequestContentValidator = new AuditApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+
+        final var invalidCategories = Stream.of(AuditCategory.COMPLIANCE_DOC_WRITE, AuditCategory.COMPLIANCE_DOC_READ)
+            .map(Enum::name)
+            .toList();
+        final var auditConfig = new AuditConfig(
+            true,
+            AuditConfig.Filter.from(Map.of("disabled_categories", invalidCategories)),
+            ComplianceConfig.DEFAULT
+        );
+        final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
+        var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
+        assertFalse(result.isValid());
+        assertThat(result.status(), is(RestStatus.BAD_REQUEST));
+    }
+
+    @Test
+    public void validateAuditDisabledCategoriesValid() throws IOException {
+        InjectableValues.Std injectableValues = new InjectableValues.Std();
+        injectableValues.addValue(Settings.class, Settings.EMPTY);
+        DefaultObjectMapper.inject(injectableValues);
+        final var auditApiActionRequestContentValidator = new AuditApiAction(clusterService, threadPool, securityApiDependencies)
+            .createEndpointValidator()
+            .createRequestContentValidator();
+
+        final var validCategories = Stream.of(AuditCategory.AUTHENTICATED, AuditCategory.CLUSTER_SETTINGS_CHANGED, AuditCategory.BAD_HEADERS)
+            .map(Enum::name)
+            .collect(Collectors.toList());
+        final var auditConfig = new AuditConfig(
+            true,
+            AuditConfig.Filter.from(Map.of("disabled_categories", validCategories)),
+            ComplianceConfig.DEFAULT
+        );
+        final var content = DefaultObjectMapper.writeValueAsString(objectMapper.valueToTree(auditConfig), false);
+        var result = auditApiActionRequestContentValidator.validate(FakeRestRequest.builder().withContent(new BytesArray(content)).build());
+        org.junit.Assert.assertTrue(result.isValid());
+    }
 }


### PR DESCRIPTION
### Description

Introduces a new unified `disabled_categories` setting for audit logging that applies to both the REST and transport layers, simplifying configuration. The existing `disabled_rest_categories` and `disabled_transport_categories` settings are deprecated but remain supported for backward compatibility.

* Category: New feature

* Why these changes are required?

Previously, users had to configure separate settings for REST and transport audit categories, requiring knowledge of which layer each category belonged to. This often led to misconfigurations, especially with transport-only categories such as `CLUSTER_SETTINGS_CHANGED` and `INDEX_SETTINGS_CHANGED`.

* What is the old behavior before changes and new behavior after changes?

Before: Users configured disabled_rest_categories and disabled_transport_categories independently.

After: Users can configure a single setting:
`
config:
  audit:
    disabled_categories:
      - AUTHENTICATED
      - GRANTED_PRIVILEGES`

Precedence:

disabled_categories takes precedence when configured.
If absent, the existing split settings continue to work unchanged.
Using the deprecated split settings emits a deprecation warning.


### Issues Resolved
https://github.com/opensearch-project/security/issues/6222

Is this a backport? No.

### Testing
Unit tests and manual testing

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.