### PR TITLE
feat(audit): Add unified disabled_categories setting (#6222)

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1736,7 +1736,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             settings.add(
                 Setting.listSetting(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
-                    disabledCategories,
+                    Collections.emptyList(),
                     Function.identity(),
                     Property.NodeScope
                 )
@@ -1809,7 +1809,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     case DISABLE_CATEGORIES:
                         return Setting.listSetting(
                             filterEntry.getKeyWithNamespace(),
-                            ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT,
+                            Collections.emptyList(),
                             Function.identity(),
                             Property.NodeScope
                         );

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1735,14 +1735,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             disabledCategories.add("GRANTED_PRIVILEGES");
             settings.add(
                 Setting.listSetting(
-                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
-                    Collections.emptyList(),
-                    Function.identity(),
-                    Property.NodeScope
-                )
-            );
-            settings.add(
-                Setting.listSetting(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
                     disabledCategories,
                     Function.identity(),

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1735,6 +1735,14 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             disabledCategories.add("GRANTED_PRIVILEGES");
             settings.add(
                 Setting.listSetting(
+                    ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
+                    disabledCategories,
+                    Function.identity(),
+                    Property.NodeScope
+                )
+            );
+            settings.add(
+                Setting.listSetting(
                     ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES,
                     disabledCategories,
                     Function.identity(),
@@ -1798,6 +1806,13 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             Arrays.stream(FilterEntries.values()).map(filterEntry -> {
                 switch (filterEntry) {
+                    case DISABLE_CATEGORIES:
+                        return Setting.listSetting(
+                            filterEntry.getKeyWithNamespace(),
+                            ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT,
+                            Function.identity(),
+                            Property.NodeScope
+                        );
                     case DISABLE_REST_CATEGORIES:
                     case DISABLE_TRANSPORT_CATEGORIES:
                         return Setting.listSetting(

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -130,11 +130,7 @@ public class AuditConfig {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Filter {
-        private static Set<String> FIELDS = new HashSet<>(DefaultObjectMapper.getFields(Filter.class)) {
-            {
-                add("disabled_categories");
-            }
-        };
+        private static Set<String> FIELDS = DefaultObjectMapper.getFields(Filter.class);
         @VisibleForTesting
         public static final Filter DEFAULT = Filter.from(Settings.EMPTY);
 
@@ -156,10 +152,7 @@ public class AuditConfig {
         private final WildcardMatcher ignoredAuditRequestsMatcher;
         private final WildcardMatcher ignoredCustomHeadersMatcher;
         private WildcardMatcher ignoredUrlParamsMatcher;
-        @com.fasterxml.jackson.annotation.JsonIgnore
-        private final boolean disabledCategoriesConfigured;
         @JsonProperty("disabled_categories")
-        @JsonInclude(JsonInclude.Include.NON_EMPTY)
         private final Set<AuditCategory> disabledCategories;
         @Deprecated
         private final Set<AuditCategory> disabledRestCategories;
@@ -180,7 +173,6 @@ public class AuditConfig {
             final Set<String> ignoredUrlParams,
             final Set<AuditCategory> disabledRestCategories,
             final Set<AuditCategory> disabledTransportCategories,
-            final boolean disabledCategoriesConfigured,
             final Set<AuditCategory> disabledCategories
         ) {
             this.isRestApiAuditEnabled = isRestApiAuditEnabled;
@@ -199,7 +191,6 @@ public class AuditConfig {
             this.ignoredUrlParamsMatcher = WildcardMatcher.from(ignoredUrlParams);
             this.disabledRestCategories = disabledRestCategories;
             this.disabledTransportCategories = disabledTransportCategories;
-            this.disabledCategoriesConfigured = disabledCategoriesConfigured;
             this.disabledCategories = disabledCategories;
         }
 
@@ -261,16 +252,13 @@ public class AuditConfig {
             final boolean logRequestBody = getOrDefault(properties, FilterEntries.LOG_REQUEST_BODY.getKey(), true);
             final boolean resolveIndices = getOrDefault(properties, FilterEntries.RESOLVE_INDICES.getKey(), true);
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
-            final boolean disabledCategoriesConfigured = properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey());
-            final Set<AuditCategory> disabledCategories = disabledCategoriesConfigured
-                ? AuditCategory.parse(
-                    getOrDefault(
-                        properties,
-                        FilterEntries.DISABLE_CATEGORIES.getKey(),
-                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
-                    )
+            final Set<AuditCategory> disabledCategories = AuditCategory.parse(
+                getOrDefault(
+                    properties,
+                    FilterEntries.DISABLE_CATEGORIES.getKey(),
+                    Collections.emptyList()
                 )
-                : null;
+            );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 getOrDefault(
                     properties,
@@ -296,13 +284,14 @@ public class AuditConfig {
                 getOrDefault(properties, FilterEntries.IGNORE_HEADERS.getKey(), Collections.emptyList())
             );
 
-            if (properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
-                || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey())) {
+            if (properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey())
+                && (properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
+                    || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey()))) {
                 final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
                 deprecationLogger.deprecate(
                     "disabled_rest_transport_categories",
-                    "Properties 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. "
-                        + "Use 'disabled_categories' instead."
+                    "Both 'disabled_categories' and 'disabled_rest_categories'/'disabled_transport_categories' are configured. "
+                        + "They will work in tandem, but consider migrating to 'disabled_categories' only."
                 );
             }
 
@@ -319,7 +308,6 @@ public class AuditConfig {
                 new HashSet<>(),
                 disabledRestCategories,
                 disabledTransportCategories,
-                disabledCategoriesConfigured,
                 disabledCategories
             );
 
@@ -337,16 +325,13 @@ public class AuditConfig {
             final boolean logRequestBody = fromSettingBoolean(settings, FilterEntries.LOG_REQUEST_BODY, true);
             final boolean resolveIndices = fromSettingBoolean(settings, FilterEntries.RESOLVE_INDICES, true);
             final boolean excludeSensitiveHeaders = fromSettingBoolean(settings, FilterEntries.EXCLUDE_SENSITIVE_HEADERS, true);
-            final boolean disabledCategoriesConfigured = settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace());
-            final Set<AuditCategory> disabledCategories = disabledCategoriesConfigured
-                ? AuditCategory.parse(
-                    fromSettingStringSet(
-                        settings,
-                        FilterEntries.DISABLE_CATEGORIES,
-                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
-                    )
+            final Set<AuditCategory> disabledCategories = AuditCategory.parse(
+                fromSettingStringSet(
+                    settings,
+                    FilterEntries.DISABLE_CATEGORIES,
+                    Collections.emptyList()
                 )
-                : null;
+            );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 fromSettingStringSet(
                     settings,
@@ -365,15 +350,16 @@ public class AuditConfig {
             final Set<String> ignoreAuditRequests = fromSettingStringSet(settings, FilterEntries.IGNORE_REQUESTS, Collections.emptyList());
             final Set<String> ignoreHeaders = fromSettingStringSet(settings, FilterEntries.IGNORE_HEADERS, Collections.emptyList());
 
-            if (settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
-                || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
-                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
-                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace())) {
+            if (settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace())
+                && (settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
+                    || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
+                    || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
+                    || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace()))) {
                 final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
                 deprecationLogger.deprecate(
                     "disabled_rest_transport_categories",
-                    "Settings 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. "
-                        + "Use 'disabled_categories' instead."
+                    "Both 'disabled_categories' and 'disabled_rest_categories'/'disabled_transport_categories' are configured. "
+                        + "They will work in tandem, but consider migrating to 'disabled_categories' only."
                 );
             }
 
@@ -390,7 +376,6 @@ public class AuditConfig {
                 new HashSet<>(),
                 disabledRestCategories,
                 disabledTransportCategories,
-                disabledCategoriesConfigured,
                 disabledCategories
             );
         }
@@ -566,15 +551,7 @@ public class AuditConfig {
          * @return set of categories
          */
         public Set<AuditCategory> getDisabledCategories() {
-            return disabledCategories != null ? disabledCategories : Collections.emptySet();
-        }
-
-        /**
-         * Whether the unified disabled_categories setting was explicitly configured
-         * @return true if disabled_categories was set
-         */
-        public boolean isDisabledCategoriesConfigured() {
-            return disabledCategoriesConfigured;
+            return disabledCategories;
         }
 
         public void log(Logger logger) {

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -201,7 +201,7 @@ public class AuditConfig {
             LOG_REQUEST_BODY("log_request_body", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY),
             RESOLVE_INDICES("resolve_indices", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES),
             EXCLUDE_SENSITIVE_HEADERS("exclude_sensitive_headers", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS),
-            DISABLE_CATEGORIES("disabled_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES),
+            DISABLE_CATEGORIES("disabled_categories", ConfigConstants.SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES),
             DISABLE_REST_CATEGORIES("disabled_rest_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES),
             DISABLE_TRANSPORT_CATEGORIES(
                 "disabled_transport_categories",
@@ -280,16 +280,10 @@ public class AuditConfig {
                 getOrDefault(properties, FilterEntries.IGNORE_HEADERS.getKey(), Collections.emptyList())
             );
 
-            if (properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey())
-                && (properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
-                    || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey()))) {
-                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
-                deprecationLogger.deprecate(
-                    "disabled_rest_transport_categories",
-                    "Both 'disabled_categories' and 'disabled_rest_categories'/'disabled_transport_categories' are configured. "
-                        + "They will work in tandem, but consider migrating to 'disabled_categories' only."
-                );
-            }
+            final boolean unifiedPresent = properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey());
+            final boolean splitPresent = properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
+                || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey());
+            warnIfBothUnifiedAndSplitConfigured(unifiedPresent, splitPresent);
 
             return new Filter(
                 isRestApiAuditEnabled,
@@ -342,18 +336,12 @@ public class AuditConfig {
             final Set<String> ignoreAuditRequests = fromSettingStringSet(settings, FilterEntries.IGNORE_REQUESTS, Collections.emptyList());
             final Set<String> ignoreHeaders = fromSettingStringSet(settings, FilterEntries.IGNORE_HEADERS, Collections.emptyList());
 
-            if (settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace())
-                && (settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
-                    || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
-                    || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
-                    || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace()))) {
-                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
-                deprecationLogger.deprecate(
-                    "disabled_rest_transport_categories",
-                    "Both 'disabled_categories' and 'disabled_rest_categories'/'disabled_transport_categories' are configured. "
-                        + "They will work in tandem, but consider migrating to 'disabled_categories' only."
-                );
-            }
+            final boolean unifiedPresent = settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace());
+            final boolean splitPresent = settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace());
+            warnIfBothUnifiedAndSplitConfigured(unifiedPresent, splitPresent);
 
             return new Filter(
                 isRestApiAuditEnabled,
@@ -395,6 +383,17 @@ public class AuditConfig {
 
             // Fallback to the legacy keyname
             return ConfigConstants.getSettingAsSet(settings, filterEntry.getLegacyKeyWithNamespace(), defaultValue, true);
+        }
+
+        private static void warnIfBothUnifiedAndSplitConfigured(boolean unifiedPresent, boolean splitPresent) {
+            if (unifiedPresent && splitPresent) {
+                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
+                deprecationLogger.deprecate(
+                    "disabled_rest_transport_categories",
+                    "Both 'disabled_categories' and 'disabled_rest_categories'/'disabled_transport_categories' are configured. "
+                        + "They will work in tandem, but consider migrating to 'disabled_categories' only."
+                );
+            }
         }
 
         /**

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -253,11 +253,7 @@ public class AuditConfig {
             final boolean resolveIndices = getOrDefault(properties, FilterEntries.RESOLVE_INDICES.getKey(), true);
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
             final Set<AuditCategory> disabledCategories = AuditCategory.parse(
-                getOrDefault(
-                    properties,
-                    FilterEntries.DISABLE_CATEGORIES.getKey(),
-                    Collections.emptyList()
-                )
+                getOrDefault(properties, FilterEntries.DISABLE_CATEGORIES.getKey(), Collections.emptyList())
             );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 getOrDefault(
@@ -326,11 +322,7 @@ public class AuditConfig {
             final boolean resolveIndices = fromSettingBoolean(settings, FilterEntries.RESOLVE_INDICES, true);
             final boolean excludeSensitiveHeaders = fromSettingBoolean(settings, FilterEntries.EXCLUDE_SENSITIVE_HEADERS, true);
             final Set<AuditCategory> disabledCategories = AuditCategory.parse(
-                fromSettingStringSet(
-                    settings,
-                    FilterEntries.DISABLE_CATEGORIES,
-                    Collections.emptyList()
-                )
+                fromSettingStringSet(settings, FilterEntries.DISABLE_CATEGORIES, Collections.emptyList())
             );
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 fromSettingStringSet(

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.Logger;
 
+import org.opensearch.common.logging.DeprecationLogger;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.auditlog.impl.AuditCategory;
@@ -129,7 +130,11 @@ public class AuditConfig {
      */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Filter {
-        private static Set<String> FIELDS = DefaultObjectMapper.getFields(Filter.class);
+        private static Set<String> FIELDS = new HashSet<>(DefaultObjectMapper.getFields(Filter.class)) {
+            {
+                add("disabled_categories");
+            }
+        };
         @VisibleForTesting
         public static final Filter DEFAULT = Filter.from(Settings.EMPTY);
 
@@ -151,7 +156,14 @@ public class AuditConfig {
         private final WildcardMatcher ignoredAuditRequestsMatcher;
         private final WildcardMatcher ignoredCustomHeadersMatcher;
         private WildcardMatcher ignoredUrlParamsMatcher;
+        @com.fasterxml.jackson.annotation.JsonIgnore
+        private final boolean disabledCategoriesConfigured;
+        @JsonProperty("disabled_categories")
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        private final Set<AuditCategory> disabledCategories;
+        @Deprecated
         private final Set<AuditCategory> disabledRestCategories;
+        @Deprecated
         private final Set<AuditCategory> disabledTransportCategories;
 
         @VisibleForTesting
@@ -167,7 +179,9 @@ public class AuditConfig {
             final Set<String> ignoredCustomHeaders,
             final Set<String> ignoredUrlParams,
             final Set<AuditCategory> disabledRestCategories,
-            final Set<AuditCategory> disabledTransportCategories
+            final Set<AuditCategory> disabledTransportCategories,
+            final boolean disabledCategoriesConfigured,
+            final Set<AuditCategory> disabledCategories
         ) {
             this.isRestApiAuditEnabled = isRestApiAuditEnabled;
             this.isTransportApiAuditEnabled = isTransportApiAuditEnabled;
@@ -185,6 +199,8 @@ public class AuditConfig {
             this.ignoredUrlParamsMatcher = WildcardMatcher.from(ignoredUrlParams);
             this.disabledRestCategories = disabledRestCategories;
             this.disabledTransportCategories = disabledTransportCategories;
+            this.disabledCategoriesConfigured = disabledCategoriesConfigured;
+            this.disabledCategories = disabledCategories;
         }
 
         public enum FilterEntries {
@@ -194,6 +210,7 @@ public class AuditConfig {
             LOG_REQUEST_BODY("log_request_body", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY),
             RESOLVE_INDICES("resolve_indices", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES),
             EXCLUDE_SENSITIVE_HEADERS("exclude_sensitive_headers", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS),
+            DISABLE_CATEGORIES("disabled_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES),
             DISABLE_REST_CATEGORIES("disabled_rest_categories", ConfigConstants.OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES),
             DISABLE_TRANSPORT_CATEGORIES(
                 "disabled_transport_categories",
@@ -244,6 +261,16 @@ public class AuditConfig {
             final boolean logRequestBody = getOrDefault(properties, FilterEntries.LOG_REQUEST_BODY.getKey(), true);
             final boolean resolveIndices = getOrDefault(properties, FilterEntries.RESOLVE_INDICES.getKey(), true);
             final boolean excludeSensitiveHeaders = getOrDefault(properties, FilterEntries.EXCLUDE_SENSITIVE_HEADERS.getKey(), true);
+            final boolean disabledCategoriesConfigured = properties.containsKey(FilterEntries.DISABLE_CATEGORIES.getKey());
+            final Set<AuditCategory> disabledCategories = disabledCategoriesConfigured
+                ? AuditCategory.parse(
+                    getOrDefault(
+                        properties,
+                        FilterEntries.DISABLE_CATEGORIES.getKey(),
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                    )
+                )
+                : null;
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 getOrDefault(
                     properties,
@@ -269,6 +296,16 @@ public class AuditConfig {
                 getOrDefault(properties, FilterEntries.IGNORE_HEADERS.getKey(), Collections.emptyList())
             );
 
+            if (properties.containsKey(FilterEntries.DISABLE_REST_CATEGORIES.getKey())
+                || properties.containsKey(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKey())) {
+                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
+                deprecationLogger.deprecate(
+                    "disabled_rest_transport_categories",
+                    "Properties 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. "
+                        + "Use 'disabled_categories' instead."
+                );
+            }
+
             return new Filter(
                 isRestApiAuditEnabled,
                 isTransportAuditEnabled,
@@ -281,7 +318,9 @@ public class AuditConfig {
                 ignoreHeaders,
                 new HashSet<>(),
                 disabledRestCategories,
-                disabledTransportCategories
+                disabledTransportCategories,
+                disabledCategoriesConfigured,
+                disabledCategories
             );
 
         }
@@ -298,6 +337,16 @@ public class AuditConfig {
             final boolean logRequestBody = fromSettingBoolean(settings, FilterEntries.LOG_REQUEST_BODY, true);
             final boolean resolveIndices = fromSettingBoolean(settings, FilterEntries.RESOLVE_INDICES, true);
             final boolean excludeSensitiveHeaders = fromSettingBoolean(settings, FilterEntries.EXCLUDE_SENSITIVE_HEADERS, true);
+            final boolean disabledCategoriesConfigured = settings.hasValue(FilterEntries.DISABLE_CATEGORIES.getKeyWithNamespace());
+            final Set<AuditCategory> disabledCategories = disabledCategoriesConfigured
+                ? AuditCategory.parse(
+                    fromSettingStringSet(
+                        settings,
+                        FilterEntries.DISABLE_CATEGORIES,
+                        ConfigConstants.OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT
+                    )
+                )
+                : null;
             final Set<AuditCategory> disabledRestCategories = AuditCategory.parse(
                 fromSettingStringSet(
                     settings,
@@ -315,6 +364,19 @@ public class AuditConfig {
             final Set<String> ignoredAuditUsers = fromSettingStringSet(settings, FilterEntries.IGNORE_USERS, DEFAULT_IGNORED_USERS);
             final Set<String> ignoreAuditRequests = fromSettingStringSet(settings, FilterEntries.IGNORE_REQUESTS, Collections.emptyList());
             final Set<String> ignoreHeaders = fromSettingStringSet(settings, FilterEntries.IGNORE_HEADERS, Collections.emptyList());
+
+            if (settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_REST_CATEGORIES.getLegacyKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getKeyWithNamespace())
+                || settings.hasValue(FilterEntries.DISABLE_TRANSPORT_CATEGORIES.getLegacyKeyWithNamespace())) {
+                final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(AuditConfig.class);
+                deprecationLogger.deprecate(
+                    "disabled_rest_transport_categories",
+                    "Settings 'disabled_rest_categories' and 'disabled_transport_categories' are deprecated. "
+                        + "Use 'disabled_categories' instead."
+                );
+            }
+
             return new Filter(
                 isRestApiAuditEnabled,
                 isTransportAuditEnabled,
@@ -327,7 +389,9 @@ public class AuditConfig {
                 ignoreHeaders,
                 new HashSet<>(),
                 disabledRestCategories,
-                disabledTransportCategories
+                disabledTransportCategories,
+                disabledCategoriesConfigured,
+                disabledCategories
             );
         }
 
@@ -495,6 +559,22 @@ public class AuditConfig {
         @JsonProperty("disabled_transport_categories")
         public Set<AuditCategory> getDisabledTransportCategories() {
             return disabledTransportCategories;
+        }
+
+        /**
+         * Unified disabled categories for both REST and Transport API auditing
+         * @return set of categories
+         */
+        public Set<AuditCategory> getDisabledCategories() {
+            return disabledCategories != null ? disabledCategories : Collections.emptySet();
+        }
+
+        /**
+         * Whether the unified disabled_categories setting was explicitly configured
+         * @return true if disabled_categories was set
+         */
+        public boolean isDisabledCategoriesConfigured() {
+            return disabledCategoriesConfigured;
         }
 
         public void log(Logger logger) {

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -1129,6 +1129,16 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
+        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
+            if (auditConfigFilter.getDisabledCategories().contains(category)) {
+                if (isTraceEnabled) {
+                    log.trace("Skipped audit log message because category {} not enabled", category);
+                }
+                return false;
+            }
+            return true;
+        }
+
         if (!auditConfigFilter.getDisabledTransportCategories().contains(category)) {
             return true;
         } else {
@@ -1220,6 +1230,16 @@ public abstract class AbstractAuditLog implements AuditLog {
             }
 
             return false;
+        }
+
+        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
+            if (auditConfigFilter.getDisabledCategories().contains(category)) {
+                if (isTraceEnabled) {
+                    log.trace("Skipped audit log message because category {} not enabled", category);
+                }
+                return false;
+            }
+            return true;
         }
 
         if (!auditConfigFilter.getDisabledRestCategories().contains(category)) {

--- a/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
+++ b/src/main/java/org/opensearch/security/auditlog/impl/AbstractAuditLog.java
@@ -1129,24 +1129,15 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
-        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
-            if (auditConfigFilter.getDisabledCategories().contains(category)) {
-                if (isTraceEnabled) {
-                    log.trace("Skipped audit log message because category {} not enabled", category);
-                }
-                return false;
-            }
-            return true;
-        }
-
-        if (!auditConfigFilter.getDisabledTransportCategories().contains(category)) {
-            return true;
-        } else {
+        if (auditConfigFilter.getDisabledCategories().contains(category)
+            || auditConfigFilter.getDisabledTransportCategories().contains(category)) {
             if (isTraceEnabled) {
                 log.trace("Skipped audit log message because category {} not enabled", category);
             }
             return false;
         }
+
+        return true;
 
         // skip internal:*
         // check transport audit enabled
@@ -1232,24 +1223,15 @@ public abstract class AbstractAuditLog implements AuditLog {
             return false;
         }
 
-        if (auditConfigFilter.isDisabledCategoriesConfigured()) {
-            if (auditConfigFilter.getDisabledCategories().contains(category)) {
-                if (isTraceEnabled) {
-                    log.trace("Skipped audit log message because category {} not enabled", category);
-                }
-                return false;
-            }
-            return true;
-        }
-
-        if (!auditConfigFilter.getDisabledRestCategories().contains(category)) {
-            return true;
-        } else {
+        if (auditConfigFilter.getDisabledCategories().contains(category)
+            || auditConfigFilter.getDisabledRestCategories().contains(category)) {
             if (isTraceEnabled) {
                 log.trace("Skipped audit log message because category {} not enabled", category);
             }
             return false;
         }
+
+        return true;
     }
 
     protected abstract void save(final AuditMessage msg);

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -149,6 +149,19 @@ public class AuditApiAction extends AbstractApiAction {
     private final List<String> readonlyFields;
 
     public static class AuditRequestContentValidator extends RequestContentValidator {
+        public static final Set<AuditCategory> DISABLED_CATEGORIES = Set.of(
+            AuditCategory.BAD_HEADERS,
+            AuditCategory.SSL_EXCEPTION,
+            AuditCategory.AUTHENTICATED,
+            AuditCategory.FAILED_LOGIN,
+            AuditCategory.GRANTED_PRIVILEGES,
+            AuditCategory.MISSING_PRIVILEGES,
+            AuditCategory.INDEX_EVENT,
+            AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT,
+            AuditCategory.CLUSTER_SETTINGS_CHANGED,
+            AuditCategory.INDEX_SETTINGS_CHANGED
+        );
+
         public static final Set<AuditCategory> DISABLED_REST_CATEGORIES = Set.of(
             AuditCategory.BAD_HEADERS,
             AuditCategory.SSL_EXCEPTION,
@@ -190,6 +203,9 @@ public class AuditApiAction extends AbstractApiAction {
                 // try parsing to target type
                 final AuditConfig auditConfig = DefaultObjectMapper.readTree(jsonContent, AuditConfig.class);
                 final AuditConfig.Filter filter = auditConfig.getFilter();
+                if (!DISABLED_CATEGORIES.containsAll(filter.getDisabledCategories())) {
+                    throw new IllegalArgumentException("Invalid categories passed in the request");
+                }
                 if (!DISABLED_REST_CATEGORIES.containsAll(filter.getDisabledRestCategories())) {
                     throw new IllegalArgumentException("Invalid REST categories passed in the request");
                 }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -149,19 +149,6 @@ public class AuditApiAction extends AbstractApiAction {
     private final List<String> readonlyFields;
 
     public static class AuditRequestContentValidator extends RequestContentValidator {
-        public static final Set<AuditCategory> DISABLED_CATEGORIES = Set.of(
-            AuditCategory.BAD_HEADERS,
-            AuditCategory.SSL_EXCEPTION,
-            AuditCategory.AUTHENTICATED,
-            AuditCategory.FAILED_LOGIN,
-            AuditCategory.GRANTED_PRIVILEGES,
-            AuditCategory.MISSING_PRIVILEGES,
-            AuditCategory.INDEX_EVENT,
-            AuditCategory.OPENDISTRO_SECURITY_INDEX_ATTEMPT,
-            AuditCategory.CLUSTER_SETTINGS_CHANGED,
-            AuditCategory.INDEX_SETTINGS_CHANGED
-        );
-
         public static final Set<AuditCategory> DISABLED_REST_CATEGORIES = Set.of(
             AuditCategory.BAD_HEADERS,
             AuditCategory.SSL_EXCEPTION,
@@ -203,9 +190,6 @@ public class AuditApiAction extends AbstractApiAction {
                 // try parsing to target type
                 final AuditConfig auditConfig = DefaultObjectMapper.readTree(jsonContent, AuditConfig.class);
                 final AuditConfig.Filter filter = auditConfig.getFilter();
-                if (!DISABLED_CATEGORIES.containsAll(filter.getDisabledCategories())) {
-                    throw new IllegalArgumentException("Invalid categories passed in the request");
-                }
                 if (!DISABLED_REST_CATEGORIES.containsAll(filter.getDisabledRestCategories())) {
                     throw new IllegalArgumentException("Invalid REST categories passed in the request");
                 }

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -212,8 +212,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES = "opendistro_security.audit.resolve_indices";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_REST = "opendistro_security.audit.enable_rest";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT = "opendistro_security.audit.enable_transport";
-    public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES =
-        "opendistro_security.audit.config.disabled_categories";
+    public static final String SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES = "plugins.security.audit.config.disabled_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES =
         "opendistro_security.audit.config.disabled_transport_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES =

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -212,10 +212,18 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_AUDIT_RESOLVE_INDICES = "opendistro_security.audit.resolve_indices";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_REST = "opendistro_security.audit.enable_rest";
     public static final String OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT = "opendistro_security.audit.enable_transport";
+    public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES =
+        "opendistro_security.audit.config.disabled_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_TRANSPORT_CATEGORIES =
         "opendistro_security.audit.config.disabled_transport_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES =
         "opendistro_security.audit.config.disabled_rest_categories";
+    public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT = ImmutableList.of(
+        AuditCategory.AUTHENTICATED.toString(),
+        AuditCategory.GRANTED_PRIVILEGES.toString(),
+        AuditCategory.CLUSTER_SETTINGS_CHANGED.toString(),
+        AuditCategory.INDEX_SETTINGS_CHANGED.toString()
+    );
     public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT = ImmutableList.of(
         AuditCategory.AUTHENTICATED.toString(),
         AuditCategory.GRANTED_PRIVILEGES.toString()

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -218,12 +218,6 @@ public class ConfigConstants {
         "opendistro_security.audit.config.disabled_transport_categories";
     public static final String OPENDISTRO_SECURITY_AUDIT_CONFIG_DISABLED_REST_CATEGORIES =
         "opendistro_security.audit.config.disabled_rest_categories";
-    public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_CATEGORIES_DEFAULT = ImmutableList.of(
-        AuditCategory.AUTHENTICATED.toString(),
-        AuditCategory.GRANTED_PRIVILEGES.toString(),
-        AuditCategory.CLUSTER_SETTINGS_CHANGED.toString(),
-        AuditCategory.INDEX_SETTINGS_CHANGED.toString()
-    );
     public static final List<String> OPENDISTRO_SECURITY_AUDIT_DISABLED_REST_CATEGORIES_DEFAULT = ImmutableList.of(
         AuditCategory.AUTHENTICATED.toString(),
         AuditCategory.GRANTED_PRIVILEGES.toString()

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -258,34 +258,33 @@ public class AuditConfigFilterTest {
     }
 
     @Test
-    public void testUnifiedDisabledCategoriesTakesPrecedence() {
-        // When disabled_categories is set, it should be used and disabledCategoriesConfigured = true
+    public void testUnifiedDisabledCategoriesParsedCorrectly() {
+        // When disabled_categories is set, it should be parsed into the set
         final Settings settings = Settings.builder()
             .putList("plugins.security.audit.config.disabled_categories", "FAILED_LOGIN", "SSL_EXCEPTION")
             .build();
         final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
 
-        assertTrue(filter.isDisabledCategoriesConfigured());
         assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(FAILED_LOGIN, SSL_EXCEPTION)));
     }
 
     @Test
-    public void testFallbackToSplitWhenUnifiedNotSet() {
-        // When disabled_categories is NOT set, fall back to split settings
+    public void testSplitSettingsWorkWhenUnifiedNotSet() {
+        // When disabled_categories is NOT set, split settings still work independently
         final Settings settings = Settings.builder()
             .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
             .putList("plugins.security.audit.config.disabled_transport_categories", "FAILED_LOGIN")
             .build();
         final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
 
-        assertFalse(filter.isDisabledCategoriesConfigured());
+        assertTrue(filter.getDisabledCategories().isEmpty());
         assertThat(filter.getDisabledRestCategories(), equalTo(EnumSet.of(AUTHENTICATED)));
         assertThat(filter.getDisabledTransportCategories(), equalTo(EnumSet.of(FAILED_LOGIN)));
     }
 
     @Test
-    public void testUnifiedOverridesSplitEvenWhenBothPresent() {
-        // When both unified and split are set, unified wins
+    public void testUnifiedAndSplitWorkInTandem() {
+        // When both unified and split are set, they work together (union)
         final Settings settings = Settings.builder()
             .putList("plugins.security.audit.config.disabled_categories", "BAD_HEADERS")
             .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
@@ -293,34 +292,34 @@ public class AuditConfigFilterTest {
             .build();
         final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
 
-        assertTrue(filter.isDisabledCategoriesConfigured());
+        // Unified has BAD_HEADERS
         assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(BAD_HEADERS)));
+        // Split settings are still preserved independently
+        assertThat(filter.getDisabledRestCategories(), equalTo(EnumSet.of(AUTHENTICATED)));
+        assertThat(filter.getDisabledTransportCategories(), equalTo(EnumSet.of(FAILED_LOGIN)));
     }
 
     @Test
     public void testDefaultDisabledCategoriesWhenNothingConfigured() {
-        // When nothing is configured, disabled_categories is not set (null internally, empty set via getter)
-        // The split settings (disabled_rest/transport_categories) handle the defaults
+        // When nothing is configured, disabled_categories defaults to empty
         final AuditConfig.Filter filter = AuditConfig.Filter.from(Settings.EMPTY);
 
-        assertFalse(filter.isDisabledCategoriesConfigured());
         assertTrue(filter.getDisabledCategories().isEmpty());
     }
 
     @Test
     public void testEmptyUnifiedDisabledCategories() {
-        // Explicitly setting disabled_categories to empty means nothing is disabled
+        // Explicitly setting disabled_categories to empty means it adds nothing
         final Settings settings = Settings.builder().putList("plugins.security.audit.config.disabled_categories").build();
         final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
 
-        assertTrue(filter.isDisabledCategoriesConfigured());
         assertTrue(filter.getDisabledCategories().isEmpty());
     }
 
     @Test
-    public void testUnifiedCategoriesUsedIndependentlyOfSplit() {
-        // Unified has MISSING_PRIVILEGES only, split has AUTHENTICATED (rest) and FAILED_LOGIN (transport)
-        // Verify that when unified is configured, only its categories matter
+    public void testUnifiedAndSplitAreIndependent() {
+        // Unified has MISSING_PRIVILEGES, split has AUTHENTICATED (rest) and FAILED_LOGIN (transport)
+        // Both are stored independently — no override
         final Settings settings = Settings.builder()
             .putList("plugins.security.audit.config.disabled_categories", "MISSING_PRIVILEGES")
             .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
@@ -328,11 +327,10 @@ public class AuditConfigFilterTest {
             .build();
         final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
 
-        assertTrue(filter.isDisabledCategoriesConfigured());
-        // Unified should have ONLY MISSING_PRIVILEGES
+        // Unified has only MISSING_PRIVILEGES
         assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(MISSING_PRIVILEGES)));
-        // It should NOT contain what the split settings had
-        assertFalse(filter.getDisabledCategories().contains(AUTHENTICATED));
-        assertFalse(filter.getDisabledCategories().contains(FAILED_LOGIN));
+        // Split settings remain as configured
+        assertThat(filter.getDisabledRestCategories(), equalTo(EnumSet.of(AUTHENTICATED)));
+        assertThat(filter.getDisabledTransportCategories(), equalTo(EnumSet.of(FAILED_LOGIN)));
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigFilterTest.java
@@ -256,4 +256,83 @@ public class AuditConfigFilterTest {
             .build();
         assertThat(parse.apply(settingMultipleValues), equalTo(ImmutableSet.of(AUTHENTICATED, BAD_HEADERS)));
     }
+
+    @Test
+    public void testUnifiedDisabledCategoriesTakesPrecedence() {
+        // When disabled_categories is set, it should be used and disabledCategoriesConfigured = true
+        final Settings settings = Settings.builder()
+            .putList("plugins.security.audit.config.disabled_categories", "FAILED_LOGIN", "SSL_EXCEPTION")
+            .build();
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(FAILED_LOGIN, SSL_EXCEPTION)));
+    }
+
+    @Test
+    public void testFallbackToSplitWhenUnifiedNotSet() {
+        // When disabled_categories is NOT set, fall back to split settings
+        final Settings settings = Settings.builder()
+            .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
+            .putList("plugins.security.audit.config.disabled_transport_categories", "FAILED_LOGIN")
+            .build();
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertFalse(filter.isDisabledCategoriesConfigured());
+        assertThat(filter.getDisabledRestCategories(), equalTo(EnumSet.of(AUTHENTICATED)));
+        assertThat(filter.getDisabledTransportCategories(), equalTo(EnumSet.of(FAILED_LOGIN)));
+    }
+
+    @Test
+    public void testUnifiedOverridesSplitEvenWhenBothPresent() {
+        // When both unified and split are set, unified wins
+        final Settings settings = Settings.builder()
+            .putList("plugins.security.audit.config.disabled_categories", "BAD_HEADERS")
+            .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
+            .putList("plugins.security.audit.config.disabled_transport_categories", "FAILED_LOGIN")
+            .build();
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(BAD_HEADERS)));
+    }
+
+    @Test
+    public void testDefaultDisabledCategoriesWhenNothingConfigured() {
+        // When nothing is configured, disabled_categories is not set (null internally, empty set via getter)
+        // The split settings (disabled_rest/transport_categories) handle the defaults
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(Settings.EMPTY);
+
+        assertFalse(filter.isDisabledCategoriesConfigured());
+        assertTrue(filter.getDisabledCategories().isEmpty());
+    }
+
+    @Test
+    public void testEmptyUnifiedDisabledCategories() {
+        // Explicitly setting disabled_categories to empty means nothing is disabled
+        final Settings settings = Settings.builder().putList("plugins.security.audit.config.disabled_categories").build();
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        assertTrue(filter.getDisabledCategories().isEmpty());
+    }
+
+    @Test
+    public void testUnifiedCategoriesUsedIndependentlyOfSplit() {
+        // Unified has MISSING_PRIVILEGES only, split has AUTHENTICATED (rest) and FAILED_LOGIN (transport)
+        // Verify that when unified is configured, only its categories matter
+        final Settings settings = Settings.builder()
+            .putList("plugins.security.audit.config.disabled_categories", "MISSING_PRIVILEGES")
+            .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
+            .putList("plugins.security.audit.config.disabled_transport_categories", "FAILED_LOGIN")
+            .build();
+        final AuditConfig.Filter filter = AuditConfig.Filter.from(settings);
+
+        assertTrue(filter.isDisabledCategoriesConfigured());
+        // Unified should have ONLY MISSING_PRIVILEGES
+        assertThat(filter.getDisabledCategories(), equalTo(EnumSet.of(MISSING_PRIVILEGES)));
+        // It should NOT contain what the split settings had
+        assertFalse(filter.getDisabledCategories().contains(AUTHENTICATED));
+        assertFalse(filter.getDisabledCategories().contains(FAILED_LOGIN));
+    }
 }

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -71,6 +71,7 @@ public class AuditConfigSerializeTest {
                 "disabled_transport_categories",
                 ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
             )
+            .field("disabled_categories", Collections.emptyList())
             .field("resolve_bulk_requests", false)
             .field("log_request_body", true)
             .field("resolve_indices", true)
@@ -224,8 +225,7 @@ public class AuditConfigSerializeTest {
             ImmutableSet.of("test-param"),
             EnumSet.of(AuditCategory.FAILED_LOGIN, AuditCategory.GRANTED_PRIVILEGES),
             EnumSet.of(AUTHENTICATED),
-            false,
-            null
+            Collections.emptySet()
         );
         final ComplianceConfig compliance = new ComplianceConfig(
             true,
@@ -250,6 +250,7 @@ public class AuditConfigSerializeTest {
             .field("disabled_rest_categories", ImmutableList.of("FAILED_LOGIN", "GRANTED_PRIVILEGES"))
             .field("enable_transport", true)
             .field("disabled_transport_categories", Collections.singletonList("AUTHENTICATED"))
+            .field("disabled_categories", Collections.emptyList())
             .field("resolve_bulk_requests", true)
             .field("log_request_body", true)
             .field("resolve_indices", true)
@@ -297,6 +298,7 @@ public class AuditConfigSerializeTest {
                 "disabled_transport_categories",
                 ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
             )
+            .field("disabled_categories", Collections.emptyList())
             .field("resolve_bulk_requests", false)
             .field("log_request_body", true)
             .field("resolve_indices", true)

--- a/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/config/AuditConfigSerializeTest.java
@@ -145,6 +145,10 @@ public class AuditConfigSerializeTest {
             .field("disabled_rest_categories", Collections.singletonList("AUTHENTICATED"))
             .field("enable_transport", true)
             .field("disabled_transport_categories", Collections.singletonList("SSL_EXCEPTION"))
+            .field(
+                "disabled_categories",
+                ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
+            )
             .field("resolve_bulk_requests", true)
             .field("log_request_body", true)
             .field("resolve_indices", true)
@@ -219,7 +223,9 @@ public class AuditConfigSerializeTest {
             ImmutableSet.of("test-header"),
             ImmutableSet.of("test-param"),
             EnumSet.of(AuditCategory.FAILED_LOGIN, AuditCategory.GRANTED_PRIVILEGES),
-            EnumSet.of(AUTHENTICATED)
+            EnumSet.of(AUTHENTICATED),
+            false,
+            null
         );
         final ComplianceConfig compliance = new ComplianceConfig(
             true,
@@ -366,6 +372,10 @@ public class AuditConfigSerializeTest {
             .startObject("audit")
             .field("enable_rest", true)
             .field("enable_transport", true)
+            .field(
+                "disabled_categories",
+                ImmutableList.of("AUTHENTICATED", "GRANTED_PRIVILEGES", "CLUSTER_SETTINGS_CHANGED", "INDEX_SETTINGS_CHANGED")
+            )
             .field("resolve_bulk_requests", true)
             .field("log_request_body", true)
             .field("resolve_indices", true)

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
@@ -22,6 +22,7 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.AuditTestUtils;
+import org.opensearch.security.auditlog.config.AuditConfig;
 import org.opensearch.security.auditlog.helper.RetrySink;
 import org.opensearch.security.auditlog.integration.TestAuditlogImpl;
 import org.opensearch.security.filter.SecurityRequestChannel;
@@ -159,6 +160,73 @@ public class AuditlogTest {
             Assert.assertTrue(al.checkTransportFilter(category, "indices:data/any", "user", mock(TransportRequest.class)));
             Assert.assertFalse(al.checkTransportFilter(category, "internal:any", "user", mock(TransportRequest.class)));
 
+        }
+    }
+
+    @Test
+    public void testUnifiedDisabledCategoriesSuppressesTransport() {
+        // Unified disables FAILED_LOGIN — verify it's suppressed at transport layer
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
+            .putList("plugins.security.audit.config.disabled_categories", "FAILED_LOGIN")
+            .build();
+        final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
+
+        // FAILED_LOGIN should be suppressed
+        Assert.assertFalse(al.checkTransportFilter(AuditCategory.FAILED_LOGIN, "action", "user", mock(TransportRequest.class)));
+        // AUTHENTICATED should NOT be suppressed (not in unified list)
+        Assert.assertTrue(al.checkTransportFilter(AuditCategory.AUTHENTICATED, "action", "user", mock(TransportRequest.class)));
+    }
+
+    @Test
+    public void testUnifiedDisabledCategoriesSuppressesRest() {
+        // Unified disables GRANTED_PRIVILEGES — verify it's suppressed at REST layer
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
+            .putList("plugins.security.audit.config.disabled_categories", "GRANTED_PRIVILEGES")
+            .build();
+        final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
+
+        // GRANTED_PRIVILEGES should be suppressed
+        Assert.assertFalse(al.checkRestFilter(AuditCategory.GRANTED_PRIVILEGES, "user", mock(SecurityRequestChannel.class)));
+        // FAILED_LOGIN should NOT be suppressed
+        Assert.assertTrue(al.checkRestFilter(AuditCategory.FAILED_LOGIN, "user", mock(SecurityRequestChannel.class)));
+    }
+
+    @Test
+    public void testUnifiedDisabledCategoriesIgnoresSplitSettings() {
+        // Unified has only MISSING_PRIVILEGES disabled
+        // Split has AUTHENTICATED (rest) and FAILED_LOGIN (transport) disabled
+        // Unified should take precedence — AUTHENTICATED and FAILED_LOGIN should NOT be suppressed
+        final Settings settings = Settings.builder()
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
+            .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
+            .putList("plugins.security.audit.config.disabled_categories", "MISSING_PRIVILEGES")
+            .putList("plugins.security.audit.config.disabled_rest_categories", "AUTHENTICATED")
+            .putList("plugins.security.audit.config.disabled_transport_categories", "FAILED_LOGIN")
+            .build();
+        final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
+
+        // MISSING_PRIVILEGES suppressed (in unified)
+        Assert.assertFalse(al.checkTransportFilter(AuditCategory.MISSING_PRIVILEGES, "action", "user", mock(TransportRequest.class)));
+        Assert.assertFalse(al.checkRestFilter(AuditCategory.MISSING_PRIVILEGES, "user", mock(SecurityRequestChannel.class)));
+
+        // AUTHENTICATED and FAILED_LOGIN should NOT be suppressed (unified doesn't have them)
+        Assert.assertTrue(al.checkTransportFilter(AuditCategory.AUTHENTICATED, "action", "user", mock(TransportRequest.class)));
+        Assert.assertTrue(al.checkTransportFilter(AuditCategory.FAILED_LOGIN, "action", "user", mock(TransportRequest.class)));
+        Assert.assertTrue(al.checkRestFilter(AuditCategory.AUTHENTICATED, "user", mock(SecurityRequestChannel.class)));
+        Assert.assertTrue(al.checkRestFilter(AuditCategory.FAILED_LOGIN, "user", mock(SecurityRequestChannel.class)));
+    }
+
+    @Test
+    public void testInvalidCategoryNameThrowsException() {
+        // Invalid category name should throw IllegalArgumentException during parse
+        final Settings settings = Settings.builder().putList("plugins.security.audit.config.disabled_categories", "BOGUS_CATEGORY").build();
+        try {
+            AuditConfig.Filter.from(settings);
+            Assert.fail("Expected IllegalArgumentException for invalid category");
+        } catch (IllegalArgumentException e) {
+            // expected
         }
     }
 }

--- a/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/AuditlogTest.java
@@ -166,38 +166,42 @@ public class AuditlogTest {
     @Test
     public void testUnifiedDisabledCategoriesSuppressesTransport() {
         // Unified disables FAILED_LOGIN — verify it's suppressed at transport layer
+        // Also set empty split to isolate the unified behavior
         final Settings settings = Settings.builder()
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
             .putList("plugins.security.audit.config.disabled_categories", "FAILED_LOGIN")
+            .putList("plugins.security.audit.config.disabled_transport_categories")
             .build();
         final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
 
-        // FAILED_LOGIN should be suppressed
+        // FAILED_LOGIN should be suppressed (in unified)
         Assert.assertFalse(al.checkTransportFilter(AuditCategory.FAILED_LOGIN, "action", "user", mock(TransportRequest.class)));
-        // AUTHENTICATED should NOT be suppressed (not in unified list)
+        // AUTHENTICATED should NOT be suppressed (not in unified, and split transport is empty)
         Assert.assertTrue(al.checkTransportFilter(AuditCategory.AUTHENTICATED, "action", "user", mock(TransportRequest.class)));
     }
 
     @Test
     public void testUnifiedDisabledCategoriesSuppressesRest() {
         // Unified disables GRANTED_PRIVILEGES — verify it's suppressed at REST layer
+        // Also set empty split to isolate the unified behavior
         final Settings settings = Settings.builder()
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
             .putList("plugins.security.audit.config.disabled_categories", "GRANTED_PRIVILEGES")
+            .putList("plugins.security.audit.config.disabled_rest_categories")
             .build();
         final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
 
-        // GRANTED_PRIVILEGES should be suppressed
+        // GRANTED_PRIVILEGES should be suppressed (in unified)
         Assert.assertFalse(al.checkRestFilter(AuditCategory.GRANTED_PRIVILEGES, "user", mock(SecurityRequestChannel.class)));
-        // FAILED_LOGIN should NOT be suppressed
+        // FAILED_LOGIN should NOT be suppressed (not in unified, and split rest is empty)
         Assert.assertTrue(al.checkRestFilter(AuditCategory.FAILED_LOGIN, "user", mock(SecurityRequestChannel.class)));
     }
 
     @Test
-    public void testUnifiedDisabledCategoriesIgnoresSplitSettings() {
-        // Unified has only MISSING_PRIVILEGES disabled
+    public void testUnifiedAndSplitWorkInTandem() {
+        // Unified has MISSING_PRIVILEGES disabled
         // Split has AUTHENTICATED (rest) and FAILED_LOGIN (transport) disabled
-        // Unified should take precedence — AUTHENTICATED and FAILED_LOGIN should NOT be suppressed
+        // Both should apply (union) — all three categories should be suppressed on their respective layers
         final Settings settings = Settings.builder()
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT, true)
             .put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_REST, true)
@@ -207,14 +211,16 @@ public class AuditlogTest {
             .build();
         final AbstractAuditLog al = AuditTestUtils.createAuditLog(settings, null, null, AbstractSecurityUnitTest.MOCK_POOL, null, cs);
 
-        // MISSING_PRIVILEGES suppressed (in unified)
+        // MISSING_PRIVILEGES suppressed on both layers (in unified)
         Assert.assertFalse(al.checkTransportFilter(AuditCategory.MISSING_PRIVILEGES, "action", "user", mock(TransportRequest.class)));
         Assert.assertFalse(al.checkRestFilter(AuditCategory.MISSING_PRIVILEGES, "user", mock(SecurityRequestChannel.class)));
 
-        // AUTHENTICATED and FAILED_LOGIN should NOT be suppressed (unified doesn't have them)
+        // AUTHENTICATED suppressed on REST (in split rest), but NOT on transport
+        Assert.assertFalse(al.checkRestFilter(AuditCategory.AUTHENTICATED, "user", mock(SecurityRequestChannel.class)));
         Assert.assertTrue(al.checkTransportFilter(AuditCategory.AUTHENTICATED, "action", "user", mock(TransportRequest.class)));
-        Assert.assertTrue(al.checkTransportFilter(AuditCategory.FAILED_LOGIN, "action", "user", mock(TransportRequest.class)));
-        Assert.assertTrue(al.checkRestFilter(AuditCategory.AUTHENTICATED, "user", mock(SecurityRequestChannel.class)));
+
+        // FAILED_LOGIN suppressed on transport (in split transport), but NOT on REST
+        Assert.assertFalse(al.checkTransportFilter(AuditCategory.FAILED_LOGIN, "action", "user", mock(TransportRequest.class)));
         Assert.assertTrue(al.checkRestFilter(AuditCategory.FAILED_LOGIN, "user", mock(SecurityRequestChannel.class)));
     }
 

--- a/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/impl/DisabledCategoriesTest.java
@@ -82,24 +82,6 @@ public class DisabledCategoriesTest {
     }
 
     @Test
-    public void invalidConfigurationTest() {
-        Builder settingsBuilder = Settings.builder();
-        settingsBuilder.put("plugins.security.audit.type", "debug");
-        settingsBuilder.put("plugins.security.audit.config.disabled_categories", "nonexistant, bad_headers");
-        AbstractAuditLog auditLog = AuditTestUtils.createAuditLog(
-            settingsBuilder.build(),
-            null,
-            null,
-            AbstractSecurityUnitTest.MOCK_POOL,
-            null,
-            cs
-        );
-        logAll(auditLog);
-        String result = TestAuditlogImpl.sb.toString();
-        Assert.assertFalse(categoriesPresentInLog(result, AuditCategory.BAD_HEADERS));
-    }
-
-    @Test
     public void enableAllCategoryTest() throws Exception {
         final Builder settingsBuilder = Settings.builder();
 

--- a/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
+++ b/src/test/java/org/opensearch/security/dlic/rest/api/AuditApiActionTest.java
@@ -693,6 +693,7 @@ public class AuditApiActionTest extends AbstractRestApiUnitTest {
                 "disabled_rest_categories": ["AUTHENTICATED"],
                 "enable_transport": true,
                 "disabled_transport_categories": ["SSL_EXCEPTION"],
+                "disabled_categories": [],
                 "resolve_bulk_requests": true,
                 "log_request_body": true,
                 "resolve_indices": true,


### PR DESCRIPTION
Adds a single 'disabled_categories' setting that applies to both REST and transport layers, replacing the confusing split configuration of 'disabled_rest_categories' and 'disabled_transport_categories'.

Behavior:
- When 'disabled_categories' is set, it takes precedence and applies to both layers at runtime
- When not set, falls back to the deprecated split settings with a deprecation warning encouraging migration
- Old settings continue to work for backwards compatibility
- REST API validation updated to accept the new field

The REST/transport category split was an internal implementation detail invisible to users and caused silent misconfigurations.

Resolves #6222

### Description
[Describe what this change achieves]
* Category (Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation)
* Why these changes are required?
* What is the old behavior before changes and new behavior after changes?

### Issues Resolved
[List any issues this PR will resolve]

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
