### PR TITLE
Add tests demonstrating _data_stream/** failure with securitytenant header [3.7]

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -299,7 +299,9 @@ public class DashboardMultiTenancyIntTests {
     static final TestSecurityConfig.User WILDCARD_TENANT_USER = new TestSecurityConfig.User("wildcard_tenant_user").description("r/w to *")
         .roles(
             TestSecurityConfig.Role.KIBANA_USER,
-            new TestSecurityConfig.Role("wildcard_tenant_role").clusterPermissions("cluster_composite_ops")
+            new TestSecurityConfig.Role("wildcard_tenant_role").clusterPermissions("cluster_composite_ops", "cluster_monitor")
+                .indexPermissions("indices:monitor/*", "indices:admin/data_stream/get")
+                .on("*")
                 .tenantPermissions("kibana_all_write")
                 .on("*")
         )
@@ -967,6 +969,53 @@ public class DashboardMultiTenancyIntTests {
                     throw new RuntimeException("Error while deleting " + path + "\n" + response.getBody());
                 }
             }
+        }
+    }
+
+    /**
+     * Verifies that _cat/indices with a broad pattern and securitytenant header is NOT denied.
+     */
+    @Test
+    public void catIndices_withTenantHeader_shouldNotBeDenied() {
+        if (!user.equals(WILDCARD_TENANT_USER)) {
+            return;
+        }
+
+        if (clusterConfig.systemIndexPrivilegeEnabled) {
+            return;
+        }
+
+        try (TestRestClient restClient = cluster.getRestClient(WILDCARD_TENANT_USER)) {
+            TestRestClient.HttpResponse response = restClient.get(
+                "_cat/indices/.kib*?format=json",
+                new BasicHeader("securitytenant", "human_resources")
+            );
+
+            assertThat(response, isOk());
+        }
+    }
+
+    /**
+     * Verifies that _data_stream/** with a securitytenant header is NOT denied.
+     * ISM Dashboards sends this on the Data Streams page load.
+     */
+    @Test
+    public void dataStream_withTenantHeader_shouldNotBeDenied() {
+        if (!user.equals(WILDCARD_TENANT_USER)) {
+            return;
+        }
+
+        if (clusterConfig.systemIndexPrivilegeEnabled) {
+            return;
+        }
+
+        try (TestRestClient restClient = cluster.getRestClient(WILDCARD_TENANT_USER)) {
+            TestRestClient.HttpResponse response = restClient.get(
+                "_data_stream/**",
+                new BasicHeader("securitytenant", "human_resources")
+            );
+
+            assertThat(response, isOk());
         }
     }
 }


### PR DESCRIPTION
## Purpose

This PR adds tests that demonstrate the issue where `_data_stream/**` and `_cat/indices/.kib*` requests fail with 403 when the `securitytenant` header is present on non-global tenants.

**These tests are expected to FAIL on 3.7**, proving the issue exists.

The fix is in #6284 (targeting main).

### Tests Added

1. `catIndices_withTenantHeader_shouldNotBeDenied` — `_cat/indices/.kib*` with `securitytenant` header
2. `dataStream_withTenantHeader_shouldNotBeDenied` — `_data_stream/**` with `securitytenant` header (matches what ISM Dashboards sends on page load)

### Root Cause

The `PrivilegesInterceptor.replaceDashboardsIndex()` uses `getAllIndices()` (fully resolved set) which includes `.kibana_*` tenant indices. The `**` pattern from `_data_stream/**` does not trigger `isLocalAll` (because `**` ≠ `*`), so the request enters the cross-tenant check block and gets denied.