### PR TITLE
read cert from header when trusted proxy sets it

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/http/CertificateAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/CertificateAuthenticationTest.java
@@ -9,13 +9,17 @@
 */
 package org.opensearch.security.http;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.opensearch.security.ssl.util.SSLConfigConstants;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain;
 import org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.HttpAuthenticator;
@@ -66,7 +70,14 @@ public class CertificateAuthenticationTest {
 
     @ClassRule
     public static final LocalCluster cluster = new LocalCluster.Builder().nodeSettings(
-        Map.of("plugins.security.ssl.http.clientauth_mode", "OPTIONAL")
+        Map.of(
+            "plugins.security.ssl.http.clientauth_mode",
+            "OPTIONAL",
+            SSLConfigConstants.SECURITY_SSL_HTTP_USE_HEADER_CERT,
+            "true",
+            SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_ALLOWED_PROXY_PRINCIPLE,
+            "DC=de,L=test,O=users,OU=bridge,CN=spock"
+        )
     )
         .clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
         .anonymousAuth(false)
@@ -161,6 +172,32 @@ public class CertificateAuthenticationTest {
             List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
             assertThat(roles, hasSize(1));
             assertThat(roles, containsInAnyOrder(ROLE_ALL_INDEX_SEARCH.getName()));
+        }
+    }
+
+    @Test
+    /**
+     * The test will result in resolving to user kirk associated role because header cert will get priority.
+     * In a external load balancer where TLS handshake is done at load balancer, opensearch will only get load balancer certificate
+     * in handshake. To pass original client cert to opensearch, it can be passed as header. OpenSearch can use this header to resolve
+     *  the role of original client instead of using load balancer certificate. This is specially useful in kubernetes environment
+     *  where load balancer is the only way to connect to the cluster in many cases.
+     */
+    public void shouldRetrieveBackendRoleFromCertificate_positiveRoleCaptain_fromheader() {
+        CertificateData userKirkCertificate = TEST_CERTIFICATES.issueUserCertificate(BACKEND_ROLE_CAPTAIN, USER_KIRK);
+        CertificateData userSpockCertificate = TEST_CERTIFICATES.issueUserCertificate(BACKEND_ROLE_BRIDGE, USER_SPOCK);
+
+        String encodedKirkCert = URLEncoder.encode(userKirkCertificate.certificateInPemFormat(), StandardCharsets.UTF_8);
+        try (TestRestClient client = cluster.getRestClient(userSpockCertificate, new BasicHeader("x-client-cert", encodedKirkCert))) {
+
+            HttpResponse response = client.getAuthInfo();
+
+            response.assertStatusCode(200);
+            List<String> backendRoles = response.getTextArrayFromJsonBody(POINTER_BACKEND_ROLES);
+            assertThat(backendRoles, hasSize(1));
+            assertThat(backendRoles, containsInAnyOrder(BACKEND_ROLE_CAPTAIN));
+            List<String> roles = response.getTextArrayFromJsonBody(POINTER_ROLES);
+            assertThat(roles, hasSize(0));
         }
     }
 

--- a/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
+++ b/src/main/java/org/opensearch/security/ssl/OpenSearchSecuritySSLPlugin.java
@@ -569,6 +569,15 @@ public class OpenSearchSecuritySSLPlugin extends Plugin implements SystemIndexPl
         settings.add(
             Setting.simpleString(SSLConfigConstants.SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH, Property.NodeScope, Property.Filtered)
         );
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_HTTP_USE_HEADER_CERT, Property.NodeScope, Property.Filtered));
+        settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_NAME, Property.NodeScope, Property.Filtered));
+        settings.add(
+            Setting.simpleString(
+                SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_ALLOWED_PROXY_PRINCIPLE,
+                Property.NodeScope,
+                Property.Filtered
+            )
+        );
 
         settings.add(Setting.simpleString(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_FILE, Property.NodeScope, Property.Filtered));
         settings.add(Setting.boolSetting(SSLConfigConstants.SECURITY_SSL_HTTP_CRL_VALIDATE, false, Property.NodeScope, Property.Filtered));

--- a/src/main/java/org/opensearch/security/ssl/util/HeaderClientCertResolver.java
+++ b/src/main/java/org/opensearch/security/ssl/util/HeaderClientCertResolver.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.ssl.util;
+
+import java.io.ByteArrayInputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.filter.SecurityRequest;
+import org.opensearch.security.ssl.transport.PrincipalExtractor;
+import org.opensearch.security.support.WildcardMatcher;
+
+public class HeaderClientCertResolver {
+    private static final Logger log = LogManager.getLogger(HeaderClientCertResolver.class);
+
+    public static SSLRequestHelper.SSLInfo maybeOverride(
+        Settings settings,
+        SecurityRequest request,
+        X509Certificate[] x509Certs,
+        String principal,
+        PrincipalExtractor principalExtractor,
+        String protocol,
+        String cipher,
+        X509Certificate[] localCerts
+    ) {
+        final String clientCertHeaderName = settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_NAME, "x-client-cert");
+        // SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_ALLOWED_PROXY_PRINCIPLE configuration used to specify which principle can switch
+        // user to header cert so its limited to external load balancer proxy , not all clients
+        final WildcardMatcher allowedPrinciplesToAssumeHeaderCert = WildcardMatcher.from(
+            settings.getAsList(SSLConfigConstants.SECURITY_SSL_HTTP_HEADER_CERT_ALLOWED_PROXY_PRINCIPLE)
+        );
+
+        final boolean allowRoleFromHeaderCert = Boolean.parseBoolean(
+            settings.get(SSLConfigConstants.SECURITY_SSL_HTTP_USE_HEADER_CERT, "false")
+        );
+
+        String clientCert = request.header(clientCertHeaderName);
+        // we want to make x509Certs is not null and has already been validated through handshake ,
+        // only then we allow header based cert role assumption
+        if (clientCert != null && allowRoleFromHeaderCert && x509Certs != null) {
+            if (allowedPrinciplesToAssumeHeaderCert.test(principal)) {
+                log.trace("Client Cert Encoded : {} ", clientCert);
+                clientCert = URLDecoder.decode(clientCert, StandardCharsets.UTF_8);
+                log.trace("Client Cert From Header : {} ", clientCert);
+
+                byte[] decodedClientCert = clientCert.getBytes(StandardCharsets.UTF_8);
+
+                CertificateFactory factory = null;
+                try {
+                    factory = CertificateFactory.getInstance("X.509");
+                    X509Certificate[] x509HeaderCerts = new X509Certificate[1];
+                    x509HeaderCerts[0] = (X509Certificate) factory.generateCertificate(new ByteArrayInputStream(decodedClientCert));
+                    principal = principalExtractor == null
+                        ? null
+                        : principalExtractor.extractPrincipal(x509HeaderCerts[0], PrincipalExtractor.Type.HTTP);
+                    // At this point if no exception in parsing, then replace original certs that were used in handshake validation to
+                    // header
+                    // cert
+                    x509Certs = x509HeaderCerts;
+                } catch (CertificateException e) {
+                    log.error("Failed to parse  certificate from header", e);
+                }
+            }
+        }
+        return new SSLRequestHelper.SSLInfo(x509Certs, principal, protocol, cipher, localCerts);
+    }
+}

--- a/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLConfigConstants.java
@@ -100,6 +100,15 @@ public final class SSLConfigConstants {
         + ENFORCE_CERT_RELOAD_DN_VERIFICATION;
     public static final String SECURITY_SSL_HTTP_PEMTRUSTEDCAS_FILEPATH = SSL_HTTP_PREFIX + PEM_TRUSTED_CAS_FILEPATH;
 
+    // header cert resolve
+    public static final String USE_HEADER_CERT = "clientauth_use_header_cert";
+    public static final String HEADER_CERT_NAME = "clientauth_header_cert_name";
+    public static final String ALLOWED_PROXY_PRINCIPLE_TO_USE_HEADER_CERT = "clientauth_header_cert_allowed_for_principle";
+    public static final String SECURITY_SSL_HTTP_USE_HEADER_CERT = SSL_HTTP_PREFIX + USE_HEADER_CERT;
+    public static final String SECURITY_SSL_HTTP_HEADER_CERT_NAME = SSL_HTTP_PREFIX + HEADER_CERT_NAME;
+    public static final String SECURITY_SSL_HTTP_HEADER_CERT_ALLOWED_PROXY_PRINCIPLE = SSL_HTTP_PREFIX
+        + ALLOWED_PROXY_PRINCIPLE_TO_USE_HEADER_CERT;
+
     // http cert revocation list settings
     public static final String SECURITY_SSL_HTTP_CRL_FILE = SSL_HTTP_CRL_PREFIX + "file_path";
     public static final String SECURITY_SSL_HTTP_CRL_VALIDATE = SSL_HTTP_CRL_PREFIX + "validate";

--- a/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
+++ b/src/main/java/org/opensearch/security/ssl/util/SSLRequestHelper.java
@@ -156,8 +156,16 @@ public class SSLRequestHelper {
         if (session.getLocalCertificates() != null) {
             localCerts = Arrays.stream(session.getLocalCertificates()).map(X509Certificate.class::cast).toArray(X509Certificate[]::new);
         }
-
-        return new SSLInfo(x509Certs, principal, protocol, cipher, localCerts);
+        return HeaderClientCertResolver.maybeOverride(
+            settings,
+            request,
+            x509Certs,
+            principal,
+            principalExtractor,
+            protocol,
+            cipher,
+            localCerts
+        );
     }
 
     private static void validatePeerCerts(final X509Certificate[] x509Certs, final Settings settings, final Path configPath)


### PR DESCRIPTION
### Description
Where there a external load balancer/proxy that itself does mTLS authentication, it forwards the request to opensearch where client to opensearch is load balancer and original client cert is no longer performing client cert authentication with OpenSearch , it is the load balancer that is performing client authentication with opensearch cluster.

What solution would you like?
To preserve identity of the original client, we can have first opensearch do client authentication validation with external load balancer /proxy , during TLS handshake and then external load balancer/proxy can store the original client certificate in header as URL encoded value in header field x-client-cert (This is  configurable by setting  "plugins.security.ssl.http.clientauth_header_cert_name"). The external load balancer/proxy will connect to opensearch cluster and forward the request with original client cert in header so that opensearch cluster can assign original client's principle which is correct identity of the original client. The load balancer has to be trusted by the opensearch so that it can trust its header so load balancer certificate will be validated at every request by opensearch using its standard certficate based authentication and then will validate if the external load balancer certificate principle matches setting plugins.security.ssl.http.clientauth_header_cert_allowed_for_principle list of regex.

The feature  will be controlled by flag settings  "clientauth_header_cert_allowed_for_principle" where by default this feature will be disabled.

* Category (Enhancement)

* Why these changes are required?
Some of the general purpose load balancers are allowing the actual cert to be placed in header, but those load balancers are not setting x-forwarded-for field with the principle as its dedicated for IP. So allowing opensearch to extract its desired field from the certificate allows both opensearch and load balancer to work with their own requirements and configuration but still work together. In this scenerio,load balancer will validate original client and but it does not have the role mapping or correct principle extraction logic, so it will just pass the cert as is, Opensearch then will know the request is from proxy from proxy(external load balancer) by validating   client cert authentication of the load balancer/proxy,  so it will trust the request , but it should assume the actual client associated user that belongs to original client and not the load balancer , so it will then use certificate from header  to switch to that principle .

* What is the old behavior before changes and new behavior after changes?
By default the flag to read from header cert is false, so it does not change default behaviour. 
If user sets this flag plugins.security.ssl.http.clientauth_use_header_cert to true, then a header cert will be checked when plugins.security.ssl.http.clientauth_header_cert_allowed_for_principle setting has the principle regex list that matches proxy server (external load balancer) client cert principle matching .

### Issues Resolved
[ #6268 ] 

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.
- Not a backport
Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here
-No new permission
### Testing
[unit testing added]

### Check List
- [x ] New functionality includes testing
- [ x] New functionality has been documented - if approved, I will add a documentation PR
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
