### PR TITLE
fix(spi): Add @Nullable to assignResourceSharingClient parameter

### DIFF
--- a/spi/src/main/java/org/opensearch/security/spi/resources/ResourceSharingExtension.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/ResourceSharingExtension.java
@@ -10,6 +10,7 @@ package org.opensearch.security.spi.resources;
 
 import java.util.Set;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.security.spi.SecurityConfigExtension;
 import org.opensearch.security.spi.resources.client.ResourceSharingClient;
 
@@ -32,7 +33,8 @@ public interface ResourceSharingExtension extends SecurityConfigExtension {
 
     /**
      * Assigns the ResourceSharingClient to the resource plugin. Plugins can then utilize this to call the methods for access control.
-     * @param client the ResourceSharingClient instance
+     * When the resource-sharing feature is disabled, this method is called with {@code null} to clear the client reference.
+     * @param client the ResourceSharingClient instance, or {@code null} when the feature is disabled
      */
-    void assignResourceSharingClient(ResourceSharingClient client);
+    void assignResourceSharingClient(@Nullable ResourceSharingClient client);
 }


### PR DESCRIPTION
The security plugin passes null to assignResourceSharingClient() when the resource-sharing feature flag is disabled via cluster settings. Kotlin consumers interpret a non-annotated Java parameter as non-null, causing an NPE that crashes ClusterApplierService and triggers an infinite master election loop.

Add @Nullable annotation to make the null contract explicit for all language consumers. Update javadoc to document the disable behavior.


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
