### PR TITLE
Restore CI after setup-gradle v6 upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Build and Test
         run: ./gradlew ${{ matrix.gradle_task }} -Dbuild.snapshot=false
+        shell: bash
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -105,11 +106,7 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-disabled: true
-
+      # The CI container runs JavaScript actions with Node 20, but setup-gradle v6 requires Node 24.
       - name: Build and Test
         run: ./gradlew ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
@@ -166,6 +163,7 @@ jobs:
 
       - name: Run Integration Tests
         run: ./gradlew :integrationTest -Dbuild.snapshot=false
+        shell: bash
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -203,11 +201,7 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-disabled: true
-
+      # The CI container runs JavaScript actions with Node 20, but setup-gradle v6 requires Node 24.
       - name: Build and Test
         run: ./gradlew :integrationTest -Dbuild.snapshot=false
 
@@ -247,9 +241,7 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-
+      # The CI container runs JavaScript actions with Node 20, but setup-gradle v6 requires Node 24.
       - name: Run SampleResourcePlugin Integration Tests
         run: ./gradlew :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
 
@@ -284,6 +276,7 @@ jobs:
 
       - name: Run SampleResourcePlugin Integration Tests
         run: ./gradlew :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
+        shell: bash
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Build and Test
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |
@@ -105,7 +105,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Build and Test
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |
@@ -158,7 +158,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Run Integration Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |
@@ -201,7 +201,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Build and Test
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |
@@ -244,7 +244,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Run SampleResourcePlugin Integration Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           arguments: |
             :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
@@ -276,7 +276,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Run SampleResourcePlugin Integration Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           arguments: |
             :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
@@ -309,7 +309,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Run Resource Tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |
@@ -327,7 +327,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Build BWC tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,12 +61,13 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            ${{ matrix.gradle_task }} -Dbuild.snapshot=false
+
+      - name: Build and Test
+        run: ./gradlew ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -104,12 +105,13 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            ${{ matrix.gradle_task }} -Dbuild.snapshot=false
+
+      - name: Build and Test
+        run: ./gradlew ${{ matrix.gradle_task }} -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -157,12 +159,13 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Run Integration Tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            :integrationTest -Dbuild.snapshot=false
+
+      - name: Run Integration Tests
+        run: ./gradlew :integrationTest -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -200,12 +203,13 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Build and Test
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            :integrationTest -Dbuild.snapshot=false
+
+      - name: Build and Test
+        run: ./gradlew :integrationTest -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -243,11 +247,11 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Run SampleResourcePlugin Integration Tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          arguments: |
-            :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
+
+      - name: Run SampleResourcePlugin Integration Tests
+        run: ./gradlew :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -275,11 +279,11 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Run SampleResourcePlugin Integration Tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          arguments: |
-            :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
+
+      - name: Run SampleResourcePlugin Integration Tests
+        run: ./gradlew :opensearch-sample-resource-plugin:integrationTest -Dbuild.snapshot=false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -308,12 +312,13 @@ jobs:
       - name: Checkout security
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Run Resource Tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            :integrationTest -Dbuild.snapshot=false --tests org.opensearch.security.ResourceFocusedTests
+
+      - name: Run Resource Tests
+        run: ./gradlew :integrationTest -Dbuild.snapshot=false --tests org.opensearch.security.ResourceFocusedTests
 
   backward-compatibility-build:
     runs-on: ubuntu-latest
@@ -326,12 +331,13 @@ jobs:
       - name: Checkout Security Repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Build BWC tests
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: |
-            -p bwc-test build -x test -x integTest
+
+      - name: Build BWC tests
+        run: ./gradlew -p bwc-test build -x test -x integTest
 
   backward-compatibility:
     strategy:

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: spotlessCheck
+
+      - run: ./gradlew spotlessCheck
 
   checkstyle:
     runs-on: ubuntu-latest
@@ -43,7 +44,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: checkstyleMain checkstyleTest checkstyleIntegrationTest
+
+      - run: ./gradlew checkstyleMain checkstyleTest checkstyleIntegrationTest
 
   spotbugs:
     runs-on: ubuntu-latest
@@ -59,7 +61,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: spotbugsMain
+
+      - run: ./gradlew spotbugsMain
 
   check-permissions-order:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-hygiene.yml
+++ b/.github/workflows/code-hygiene.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: spotlessCheck
@@ -40,7 +40,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: checkstyleMain checkstyleTest checkstyleIntegrationTest
@@ -56,7 +56,7 @@ jobs:
           distribution: temurin # Temurin is a distribution of adoptium
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: spotbugsMain

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Assemble target plugin
         run: ./gradlew assemble
+        shell: bash
 
       # Move and rename the plugin for installation
       - name: Move and rename the plugin for installation
@@ -67,4 +68,7 @@ jobs:
           jdk-version: 21
 
       - name: Run sanity tests
-        run: ./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.generate-password.outputs.password }} -i
+        run: ./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin "-Dpassword=${SECURITY_PASSWORD}" -i
+        shell: bash
+        env:
+          SECURITY_PASSWORD: ${{ steps.generate-password.outputs.password }}

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - name: Assemble target plugin
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: assemble
@@ -65,7 +65,7 @@ jobs:
           jdk-version: 21
 
       - name: Run sanity tests
-        uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
           arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.generate-password.outputs.password }} -i

--- a/.github/workflows/plugin_install.yml
+++ b/.github/workflows/plugin_install.yml
@@ -33,11 +33,13 @@ jobs:
       - name: Checkout Branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
-      - name: Assemble target plugin
+      - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
           cache-disabled: true
-          arguments: assemble
+
+      - name: Assemble target plugin
+        run: ./gradlew assemble
 
       # Move and rename the plugin for installation
       - name: Move and rename the plugin for installation
@@ -65,7 +67,4 @@ jobs:
           jdk-version: 21
 
       - name: Run sanity tests
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-disabled: true
-          arguments: integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.generate-password.outputs.password }} -i
+        run: ./gradlew integTestRemote -Dtests.rest.cluster=localhost:9200 -Dtests.cluster=localhost:9200 -Dtests.clustername="opensearch" -Dhttps=true -Duser=admin -Dpassword=${{ steps.generate-password.outputs.password }} -i


### PR DESCRIPTION
## Summary

- bump `gradle/actions/setup-gradle` from 3.5.0 to 6.2.0
- split Gradle setup from task execution in CI, code hygiene, and plugin installation workflows
- execute the existing tasks and flags through the project Gradle wrapper
- configure Gradle once in the plugin installation job and reuse it for both builds
- run Gradle commands through Bash on Windows so `-D` system properties are preserved
- invoke the wrapper directly in container jobs that cannot run the Node 24 action

## Root cause

`setup-gradle` v6 removed the deprecated `arguments` input. The original
Dependabot update in #6293 retained that input, causing every affected job to
fail during action setup before Gradle could execute.

Two runner-specific issues also surfaced after the initial migration:

- the OpenSearch CI container invokes JavaScript actions with Node 20.18, while
  `setup-gradle` v6 declares Node 24 and ships an ESM bundle
- PowerShell altered Gradle `-D` arguments when invoking `gradlew`, causing
  values such as `.snapshot=false` to be interpreted as task names

Container jobs already disabled Gradle caching, so they now invoke the wrapper
directly. Windows jobs retain `setup-gradle` and execute the wrapper through
Bash. The plugin installation password is passed through the environment to
avoid shell reinterpretation.

This PR supersedes #6293 by including both the version update and the required
workflow migration.

## Validation

- parsed all three modified workflow files as YAML
- `./gradlew spotlessCheck checkstyleMain checkstyleTest checkstyleIntegrationTest spotbugsMain`
