### PR TITLE
improve the error message if unresolved user attrs are in DLS

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
@@ -67,6 +67,7 @@ import org.opensearch.test.framework.TestSecurityConfig;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensearch.security.util.MockIndexMetadataBuilder.dataStreams;
 import static org.opensearch.security.util.MockIndexMetadataBuilder.indices;
 import static org.junit.Assert.assertEquals;
@@ -386,6 +387,10 @@ public class DocumentPrivilegesTest {
                 if (index == index_a1) {
                     if (userSpec.roles.contains("dls_role_1") && userSpec.roles.contains("dls_role_2")) {
                         assertNotNull(exception);
+                        assertThat(
+                            exception.getMessage(),
+                            equalTo("DLS query references undefined user attributes: [attr.attr_a]. Available attributes are: [none]")
+                        );
                     }
                 }
             } else if (userSpec.roles.contains("non_dls_role") && dfmEmptyOverridesAll) {

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DocumentPrivileges.java
@@ -168,12 +168,17 @@ public class DocumentPrivileges extends AbstractRuleBasedPrivileges<DocumentPriv
                 if (UserAttributes.needsAttributeSubstitution(effectiveQueryString)) {
                     List<String> unresolved = UserAttributes.findUnresolvedAttributes(effectiveQueryString);
                     Set<String> available = context.getUser().getCustomAttributesMap().keySet();
-                    String availableStr = available.size() > MAX_ATTRIBUTES_IN_ERROR_MESSAGE
-                        ? available.stream().limit(MAX_ATTRIBUTES_IN_ERROR_MESSAGE).collect(Collectors.joining(", "))
+                    String availableStr;
+                    if (available.size() > MAX_ATTRIBUTES_IN_ERROR_MESSAGE) {
+                        availableStr = available.stream().limit(MAX_ATTRIBUTES_IN_ERROR_MESSAGE).collect(Collectors.joining(", "))
                             + " ... and "
                             + (available.size() - MAX_ATTRIBUTES_IN_ERROR_MESSAGE)
-                            + " more"
-                        : String.join(", ", available);
+                            + " more";
+                    } else if (!available.isEmpty()) {
+                        availableStr = String.join(", ", available);
+                    } else {
+                        availableStr = "[none]";
+                    }
                     throw new PrivilegesEvaluationException(
                         "DLS query references undefined user attributes: " + unresolved + ". Available attributes are: " + availableStr,
                         new OpenSearchSecurityException("User attribute substitution failed")


### PR DESCRIPTION
### Description
if no user attributes are present then the error message looked weird, as it just didn't list anything and it wasn't clear whether that was a bug or if there really were no custom attributes available.

this now enhances it to explicitly show "[none]" if no user attributes are available.

### Issues Resolved
n/a

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
unit test

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
