### PR TITLE
Add support of ./gradlew run task to allow running the plugin locally

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -7,7 +7,8 @@ So you want to contribute code to OpenSearch Security? Excellent! We're glad you
     - [Native platforms](#native-platforms)
   - [Building](#building)
   - [Using IntelliJ IDEA](#using-intellij-idea)
-  - [Running integration tests](#running-integration-tests)
+  - [Running locally](#running-locally)
+  - [Running tests in the integrationTest package](#running-integration-tests)
     - [Bulk test runs](#bulk-test-runs)
     - [Checkstyle Violations](#checkstyle-violations)
   - [Authorization in REST Layer](#authorization-in-rest-layer)
@@ -265,6 +266,26 @@ public RepeatRule repeatRule = new RepeatRule();
 public void testMethod() {
     ...
 }
+```
+
+## Running locally
+
+It is often quite handy to be able to run the OpenSearch distribution with the locally modified plugin bundle. To do that, you could use the following command:
+
+```
+./gradlew run  -Pcrypto.standard=any-supported
+```
+
+If you need the ability to attach the debugger to the running OpenSearch process, use the following command instead:
+
+```
+./gradlew run  -Pcrypto.standard=any-supported --debug-server-jvm
+```
+
+By default, the cluster will be accessible using `admin` / `admin` credentials, for example:
+
+```
+curl 'https://localhost:9200/' -k -u admin:admin
 ```
 
 ## Running tests in the integrationTest package

--- a/build.gradle
+++ b/build.gradle
@@ -990,3 +990,62 @@ tasks.register("updateVersion") {
         ant.replaceregexp(file: 'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags: 'g', byline: true)
     }
 }
+
+run {
+    useCluster project.testClusters.integTest
+    testClusters.integTest.plugin(project.tasks.bundlePlugin.archiveFile)
+
+    // Set JVM arguments for memory
+    testClusters.integTest.nodes.each { node ->
+        node.jvmArgs(
+                '-Xms2g',  // Initial heap size
+                '-Xmx2g',   // Maximum heap size
+        )
+    }
+
+    // Configure security for run task
+    afterEvaluate {
+      testClusters.integTest.nodes.each  { node ->
+        // Add certificate files
+        node.extraConfigFile("kirk.pem", file("bwc-test/src/test/resources/security/kirk.pem"))
+        node.extraConfigFile("kirk-key.pem", file("bwc-test/src/test/resources/security/kirk-key.pem"))
+        node.extraConfigFile("esnode.pem", file("bwc-test/src/test/resources/security/esnode.pem"))
+        node.extraConfigFile("esnode-key.pem", file("bwc-test/src/test/resources/security/esnode-key.pem"))
+        node.extraConfigFile("root-ca.pem", file("bwc-test/src/test/resources/security/root-ca.pem"))
+
+        // Security settings
+        node.setting("plugins.security.ssl.transport.pemcert_filepath", "esnode.pem")
+        node.setting("plugins.security.ssl.transport.pemkey_filepath", "esnode-key.pem")
+        node.setting("plugins.security.ssl.transport.pemtrustedcas_filepath", "root-ca.pem")
+        node.setting("plugins.security.ssl.transport.enforce_hostname_verification", "false")
+        node.setting("plugins.security.ssl.http.enabled", "true")
+        node.setting("plugins.security.ssl.http.pemcert_filepath", "esnode.pem")
+        node.setting("plugins.security.ssl.http.pemkey_filepath", "esnode-key.pem")
+        node.setting("plugins.security.ssl.http.pemtrustedcas_filepath", "root-ca.pem")
+        node.setting("plugins.security.allow_unsafe_democertificates", "true")
+        node.setting("plugins.security.allow_default_init_securityindex", "true")
+        node.setting("plugins.security.authcz.admin_dn", "\n - CN=kirk,OU=client,O=client,L=test,C=de")
+        node.setting("plugins.security.audit.type", "internal_opensearch")
+        node.setting("plugins.security.enable_snapshot_restore_privilege", "true")
+        node.setting("plugins.security.check_snapshot_restore_write_privileges", "true")
+        node.setting("plugins.security.restapi.roles_enabled", "[\"all_access\", \"security_rest_api_access\"]")
+        node.setting("plugins.security.system_indices.enabled", "true")
+
+        var creds = node.getCredentials()
+        if (creds.isEmpty()) {
+            creds.add(Map.of('username', 'admin', 'password', 'admin'))
+        } else {
+            creds.get(0).putAll(Map.of('username', 'admin', 'password', 'admin'))
+        }
+      }
+    }
+
+    doFirst {
+        // There seems to be an issue when running multi node run or integ tasks with unicast_hosts
+        // not being written, the waitForAllConditions ensures it's written
+        getClusters().forEach { cluster ->
+            cluster.setSecure(true)
+            cluster.waitForAllConditions()
+        }
+    }
+}


### PR DESCRIPTION
### Description
Add support of `./gradlew run` task to allow running the plugin locally. Most of the plugins support this feature in order to low the effort required to verify the plugin with OpenSearch distribution. It is also possible to run the plugin with debugger.

### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/6306

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
All the Gradle commands have been tested locally

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
