### PR TITLE
support attributes from request headers in DLS

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/dlsfls/HeaderAttrInDlsGrpcIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/dlsfls/HeaderAttrInDlsGrpcIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlsfls;
+
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.security.grpc.GrpcHelpers;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.opensearch.security.dlsfls.HeaderAttrInDlsIntegrationTest.DLS_INDEX;
+import static org.opensearch.security.dlsfls.HeaderAttrInDlsIntegrationTest.SINGLE_VALUE_DLS_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
+import static org.opensearch.security.grpc.GrpcHelpers.createChannelWithBasicAuthorization;
+import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
+import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
+import static org.opensearch.security.grpc.GrpcHelpers.secureChannel;
+
+/**
+ * due to a bug the gRPC tests are currently flaky when run with a multi-node cluster. thus we temporarily have to use a single-node cluster for this test.
+ * as we have to avoid having other nodes running in the same JVM we have to split this into a separate test class from the HTTP tests in {@link HeaderAttrInDlsIntegrationTest}.
+ * TODO: remove & use a single cluster for HTTP + gRPC tests once this ticket is fixed: https://github.com/opensearch-project/security/issues/6431
+ */
+public class HeaderAttrInDlsGrpcIntegrationTest {
+    @ClassRule
+    public static final LocalCluster cluster = HeaderAttrInDlsIntegrationTest.clusterBuilder.clusterManager(ClusterManager.SINGLENODE)
+        .nodeSettings(GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
+        .nodeSettings(GrpcHelpers.CLIENT_AUTH_REQUIRE)
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        HeaderAttrInDlsIntegrationTest.createTestData(cluster);
+    }
+
+    @Test
+    public void testGrpcChannel() throws Exception {
+        final var channel = secureChannel(getSecureGrpcEndpoint(cluster));
+        try {
+            final var channelWithAuth = createChannelWithBasicAuthorization(
+                channel,
+                SINGLE_VALUE_DLS_USER.getName(),
+                SINGLE_VALUE_DLS_USER.getPassword()
+            );
+            final var authInterceptor = createHeaderInterceptor(Map.of("X-Example-Header", "foobar"));
+            final var channelWithHeader = io.grpc.ClientInterceptors.intercept(channelWithAuth, authInterceptor);
+
+            final var searchResp = GrpcHelpers.doMatchAll(channelWithHeader, DLS_INDEX, 10);
+            assertThat(searchResp, notNullValue());
+            assertThat(searchResp.getHits().getTotal().getTotalHits().getValue(), is(1L));
+        } finally {
+            channel.shutdown();
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/dlsfls/HeaderAttrInDlsIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/dlsfls/HeaderAttrInDlsIntegrationTest.java
@@ -1,0 +1,178 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.dlsfls;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.RestMatchers.isBadRequest;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+public class HeaderAttrInDlsIntegrationTest {
+    static final String DLS_INDEX = "testindex";
+
+    private static final String DLS_INDEX_SETTINGS = """
+        {
+          "mappings": {
+            "properties": {
+              "testfield": {
+                "type": "text"
+              }
+            }
+          }
+        }""";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    static final TestSecurityConfig.User SINGLE_VALUE_DLS_USER = new TestSecurityConfig.User("sv_dls_user").roles(
+        new TestSecurityConfig.Role("sv_dls_role").clusterPermissions("*")
+            .indexPermissions("*")
+            .dls("{ \"term\": { \"testfield\": \"${attr.header.x-example-header}\" } }")
+            .on(DLS_INDEX)
+    );
+
+    static final TestSecurityConfig.User MULTI_VALUE_DLS_USER = new TestSecurityConfig.User("mv_dls_user").roles(
+        new TestSecurityConfig.Role("mv_dls_role").clusterPermissions("*")
+            .indexPermissions("*")
+            .dls("{ \"terms\": { \"testfield\": [${attr.header.x-example-header-mv}] } }")
+            .on(DLS_INDEX)
+    );
+
+    static final TestSecurityConfig.User SHORT_VALUE_DLS_USER = new TestSecurityConfig.User("short_dls_user").roles(
+        new TestSecurityConfig.Role("short_dls_role").clusterPermissions("*")
+            .indexPermissions("*")
+            .dls("{ \"term\": { \"testfield\": \"${attr.header.x-short-header}\" } }")
+            .on(DLS_INDEX)
+    );
+
+    public static final LocalCluster.Builder clusterBuilder = new LocalCluster.Builder().authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, SINGLE_VALUE_DLS_USER, MULTI_VALUE_DLS_USER, SHORT_VALUE_DLS_USER)
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header.name", "X-Example-Header")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header.isMultiValue", "false")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header.validationRegex", "[a-z\\-]+")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header-mv.name", "X-Example-Header-MV")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header-mv.isMultiValue", "true")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-example-header-mv.validationRegex", "[a-z\\-]+")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-invalid-header.name", "X-Invalid-Header")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-short-header.name", "X-Short-Header")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-short-header.validationRegex", "[a-z\\-]+")
+        .nodeSetting("plugins.security.unsupported.dls.allowed_request_headers.x-short-header.maxValueLength", "3");
+
+    @ClassRule
+    public static final LocalCluster cluster = clusterBuilder.clusterManager(ClusterManager.DEFAULT).build();
+
+    @BeforeClass
+    public static void createTestData() {
+        createTestData(cluster);
+    }
+
+    public static void createTestData(final LocalCluster cluster) {
+        try (final var client = cluster.getRestClient(ADMIN_USER)) {
+            client.putJson(DLS_INDEX, DLS_INDEX_SETTINGS);
+            client.postJson(DLS_INDEX + "/_doc?refresh=true", "{\"testfield\": \"foobar\"}");
+            client.postJson(DLS_INDEX + "/_doc?refresh=true", "{\"testfield\": \"foo\"}");
+            client.postJson(DLS_INDEX + "/_doc?refresh=true", "{\"testfield\": \"baz\"}");
+        }
+    }
+
+    @Test
+    public void testQueryWithSingleValueHeaderMatches() {
+        assertThat(runSearchAndGetTotalHitsForSingleValueHeader("foobar"), is(1));
+        assertThat(runSearchAndGetTotalHitsForSingleValueHeader("does-not-exist"), is(0));
+    }
+
+    @Test
+    public void testQueryWithMultiValueHeaderMatches() {
+        assertThat(runSearchAndGetTotalHitsForMultiValueHeader("foobar"), is(1));
+        assertThat(runSearchAndGetTotalHitsForMultiValueHeader("does-not-exist"), is(0));
+        assertThat(runSearchAndGetTotalHitsForMultiValueHeader("foobar", "foo"), is(2));
+    }
+
+    @Test
+    public void testFailureOnValueNotMatchingRegex() {
+        try (final var client = cluster.getRestClient(SINGLE_VALUE_DLS_USER)) {
+            final var response = client.get(DLS_INDEX + "/_search", new BasicHeader("X-Example-Header", "UPPERCASE-IS-INVALID"));
+            assertThat(response, isBadRequest());
+        }
+    }
+
+    @Test
+    public void testFailureOnUndefinedRegex() {
+        try (final var client = cluster.getRestClient(SINGLE_VALUE_DLS_USER)) {
+            final var response = client.get(DLS_INDEX + "/_search", new BasicHeader("X-Invalid-Header", "nothing matches here"));
+            assertThat(response, isBadRequest());
+        }
+    }
+
+    @Test
+    public void testLengthLimit() {
+        // short works
+        runSearchAndGetTotalHits(SHORT_VALUE_DLS_USER, new BasicHeader("X-Short-Header", "foo"));
+        // exceeding the limit fails it
+        try (final var client = cluster.getRestClient(SHORT_VALUE_DLS_USER)) {
+            final var response = client.get(DLS_INDEX + "/_search", new BasicHeader("X-Short-Header", "foobar"));
+            assertThat(response, isBadRequest());
+        }
+    }
+
+    @Test
+    public void testFailureOnMultipleValuesOnSingleValueConfig() {
+        try (final var client = cluster.getRestClient(SINGLE_VALUE_DLS_USER)) {
+            final var response = client.get(
+                DLS_INDEX + "/_search",
+                new BasicHeader("X-Example-Header", "a"),
+                new BasicHeader("X-Example-Header", "b")
+            );
+            assertThat(response, isBadRequest());
+        }
+    }
+
+    @Test
+    public void testFailureOnTooManyHeadersOverall() {
+        try (final var client = cluster.getRestClient(MULTI_VALUE_DLS_USER)) {
+            final var headers = Stream.iterate(new BasicHeader("X-Example-Header-MV", "a"), h -> h).limit(257).toArray(Header[]::new);
+            final var response = client.get(DLS_INDEX + "/_search", headers);
+            assertThat(response, isBadRequest());
+        }
+    }
+
+    int runSearchAndGetTotalHitsForSingleValueHeader(final String headerValue) {
+        return runSearchAndGetTotalHits(SINGLE_VALUE_DLS_USER, new BasicHeader("X-Example-Header", headerValue));
+    }
+
+    int runSearchAndGetTotalHitsForMultiValueHeader(final String... headerValues) {
+        final var headers = Arrays.stream(headerValues).map(s -> new BasicHeader("X-Example-Header-MV", s)).toArray(Header[]::new);
+        return runSearchAndGetTotalHits(MULTI_VALUE_DLS_USER, headers);
+    }
+
+    int runSearchAndGetTotalHits(final TestSecurityConfig.User user, final Header... headers) {
+        try (final var client = cluster.getRestClient(user)) {
+            final var response = client.get(DLS_INDEX + "/_search", headers);
+            assertThat(response, isOk());
+            return response.getIntFromJsonBody("/hits/total/value");
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/grpc/BasicAuthGrpcTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/BasicAuthGrpcTest.java
@@ -11,22 +11,14 @@
 
 package org.opensearch.security.grpc;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.Version;
-import org.opensearch.plugins.PluginInfo;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -36,8 +28,11 @@ import io.grpc.StatusRuntimeException;
 
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_ROLE;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
 import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
 import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
+import static org.opensearch.security.grpc.GrpcHelpers.createBasicAuthHeader;
+import static org.opensearch.security.grpc.GrpcHelpers.createChannelWithBasicAuthorization;
 import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
 import static org.opensearch.security.grpc.GrpcHelpers.doBulk;
 import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
@@ -63,55 +58,19 @@ public class BasicAuthGrpcTest {
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
-        .plugin(
-            new PluginInfo(
-                GrpcPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                GrpcPlugin.class.getName(),
-                null,
-                Collections.emptyList(),
-                false
-            )
-        )
-        .plugin(
-            new PluginInfo(
-                OpenSearchSecurityPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                OpenSearchSecurityPlugin.class.getName(),
-                null,
-                List.of("org.opensearch.transport.grpc.GrpcPlugin"),
-                false
-            )
-        )
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
         .users(GRPC_INDEX_USER)
         .roles(GRPC_INDEX_ROLE)
         .rolesMapping(new TestSecurityConfig.RoleMapping(GRPC_INDEX_ROLE.getName()).users(GRPC_INDEX_USER.getName()))
         .authc(BASIC_AUTH_DOMAIN)
         .build();
 
-    /**
-     * Creates a Basic Auth header value: "Basic base64(username:password)"
-     */
-    private String createBasicAuthHeader(String username, String password) {
-        String credentials = username + ":" + password;
-        String base64Credentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
-        return "Basic " + base64Credentials;
-    }
-
     @Test
     public void testBasicAuthenticationWrongPassword() throws Exception {
-        String authHeader = createBasicAuthHeader(GRPC_INDEX_USER.getName(), "wrong-password");
-        ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
+        final var channel = secureChannel(getSecureGrpcEndpoint(cluster));
 
         try {
-            ClientInterceptor authInterceptor = createHeaderInterceptor(Map.of("Authorization", authHeader));
-            Channel channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            final var channelWithAuth = createChannelWithBasicAuthorization(channel, GRPC_INDEX_USER.getName(), "wrong-password");
 
             try {
                 doBulk(channelWithAuth, "test-grpc-basic-wrong-pass", 2);
@@ -127,12 +86,10 @@ public class BasicAuthGrpcTest {
 
     @Test
     public void testBasicAuthenticationUnknownUser() throws Exception {
-        String authHeader = createBasicAuthHeader("nonexistent-user", "any-password");
-        ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
+        final var channel = secureChannel(getSecureGrpcEndpoint(cluster));
 
         try {
-            ClientInterceptor authInterceptor = createHeaderInterceptor(Map.of("Authorization", authHeader));
-            Channel channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            final var channelWithAuth = createChannelWithBasicAuthorization(channel, "nonexistent-user", "any-password");
 
             try {
                 doBulk(channelWithAuth, "test-grpc-basic-unknown-user", 2);
@@ -148,12 +105,14 @@ public class BasicAuthGrpcTest {
 
     @Test
     public void testBasicAuthenticationSuccess() throws Exception {
-        String authHeader = createBasicAuthHeader(GRPC_INDEX_USER.getName(), GRPC_INDEX_USER.getPassword());
-        ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
+        final var channel = secureChannel(getSecureGrpcEndpoint(cluster));
 
         try {
-            ClientInterceptor authInterceptor = createHeaderInterceptor(Map.of("Authorization", authHeader));
-            Channel channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+            final var channelWithAuth = createChannelWithBasicAuthorization(
+                channel,
+                GRPC_INDEX_USER.getName(),
+                GRPC_INDEX_USER.getPassword()
+            );
             var bulkResp = doBulk(channelWithAuth, "test-grpc-basic-auth", 2);
             assertNotNull(bulkResp);
             assertFalse("Bulk request should succeed with valid Basic Auth", bulkResp.getErrors());

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcAnonymousAuthTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcAnonymousAuthTest.java
@@ -12,30 +12,23 @@
 package org.opensearch.security.grpc;
 
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.Version;
-import org.opensearch.plugins.PluginInfo;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
-import io.grpc.Channel;
-import io.grpc.ClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
 import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
 import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
-import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
+import static org.opensearch.security.grpc.GrpcHelpers.createChannelWithAuthorization;
 import static org.opensearch.security.grpc.GrpcHelpers.doBulk;
 import static org.opensearch.security.grpc.GrpcHelpers.getSecureGrpcEndpoint;
 import static org.opensearch.security.grpc.GrpcHelpers.secureChannel;
@@ -54,32 +47,7 @@ public class GrpcAnonymousAuthTest {
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
         .nodeSettings(Map.of("plugins.security.authcz.admin_dn", Arrays.asList(TEST_CERTIFICATES.getAdminDNs())))
-        .plugin(
-            new PluginInfo(
-                GrpcPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                GrpcPlugin.class.getName(),
-                null,
-                Collections.emptyList(),
-                false
-            )
-        )
-        .plugin(
-            new PluginInfo(
-                OpenSearchSecurityPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                OpenSearchSecurityPlugin.class.getName(),
-                null,
-                List.of("org.opensearch.transport.grpc.GrpcPlugin"),
-                false
-            )
-        )
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
         .anonymousAuth(true)
         .roles(ANONYMOUS_BULK_ROLE)
         .rolesMapping(new TestSecurityConfig.RoleMapping(ANONYMOUS_BULK_ROLE.getName()).users("*"))
@@ -103,10 +71,9 @@ public class GrpcAnonymousAuthTest {
 
     @Test
     public void testInvalidAuthHeaderRejected() throws Exception {
-        ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
+        final var channel = secureChannel(getSecureGrpcEndpoint(cluster));
         try {
-            ClientInterceptor mockAuthInterceptor = createHeaderInterceptor(Map.of("Authorization", "mock-auth-header"));
-            Channel channelWithAuth = io.grpc.ClientInterceptors.intercept(channel, mockAuthInterceptor);
+            final var channelWithAuth = createChannelWithAuthorization(channel, "mock-auth-header");
 
             try {
                 doBulk(channelWithAuth, "test-invalid-auth", 2);

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -10,15 +10,19 @@
 package org.opensearch.security.grpc;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
 import org.opensearch.common.transport.PortsRange;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.plugins.PluginInfo;
 import org.opensearch.protobufs.BulkRequest;
 import org.opensearch.protobufs.BulkRequestBody;
 import org.opensearch.protobufs.BulkResponse;
@@ -32,11 +36,13 @@ import org.opensearch.protobufs.SearchRequestBody;
 import org.opensearch.protobufs.SearchResponse;
 import org.opensearch.protobufs.services.DocumentServiceGrpc;
 import org.opensearch.protobufs.services.SearchServiceGrpc;
+import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
+import org.opensearch.transport.grpc.GrpcPlugin;
 import org.opensearch.transport.grpc.spi.GrpcInterceptorProvider;
 import org.opensearch.transport.grpc.ssl.SecureNetty4GrpcServerTransport;
 
@@ -59,6 +65,30 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import static io.grpc.internal.GrpcUtil.NOOP_PROXY_DETECTOR;
 
 public class GrpcHelpers {
+    public static final PluginInfo[] SECURITY_WITH_GRPC_PLUGIN = {
+        new PluginInfo(
+            GrpcPlugin.class.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "21",
+            GrpcPlugin.class.getName(),
+            null,
+            Collections.emptyList(),
+            false
+        ),
+        new PluginInfo(
+            OpenSearchSecurityPlugin.class.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "21",
+            OpenSearchSecurityPlugin.class.getName(),
+            null,
+            List.of("org.opensearch.transport.grpc.GrpcPlugin"),
+            false
+        ) };
+
     protected static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
     protected static final TestCertificates UN_TRUSTED_TEST_CERTIFICATES = new TestCertificates();
 
@@ -107,6 +137,24 @@ public class GrpcHelpers {
                 };
             }
         };
+    }
+
+    /**
+     * Creates a Basic Auth header value: "Basic base64(username:password)"
+     */
+    public static String createBasicAuthHeader(String username, String password) {
+        String credentials = username + ":" + password;
+        String base64Credentials = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + base64Credentials;
+    }
+
+    public static Channel createChannelWithAuthorization(final ManagedChannel channel, final String authorizationHeader) {
+        final var authInterceptor = createHeaderInterceptor(Map.of("Authorization", authorizationHeader));
+        return io.grpc.ClientInterceptors.intercept(channel, authInterceptor);
+    }
+
+    public static Channel createChannelWithBasicAuthorization(final ManagedChannel channel, final String username, final String password) {
+        return createChannelWithAuthorization(channel, createBasicAuthHeader(username, password));
     }
 
     protected static final Map<String, Object> CLIENT_AUTH_NONE = Map.of(

--- a/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/GrpcHelpers.java
@@ -157,17 +157,17 @@ public class GrpcHelpers {
         return createChannelWithAuthorization(channel, createBasicAuthHeader(username, password));
     }
 
-    protected static final Map<String, Object> CLIENT_AUTH_NONE = Map.of(
+    public static final Map<String, Object> CLIENT_AUTH_NONE = Map.of(
         "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "NONE"
     );
 
-    protected static final Map<String, Object> CLIENT_AUTH_OPT = Map.of(
+    public static final Map<String, Object> CLIENT_AUTH_OPT = Map.of(
         "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "OPTIONAL"
     );
 
-    protected static final Map<String, Object> CLIENT_AUTH_REQUIRE = Map.of(
+    public static final Map<String, Object> CLIENT_AUTH_REQUIRE = Map.of(
         "plugins.security.ssl.aux.secure-transport-grpc.clientauth_mode",
         "REQUIRE"
     );

--- a/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDefaultAuthHeaderTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDefaultAuthHeaderTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.grpc;
 
 import java.security.KeyPair;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -21,14 +20,10 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.Version;
-import org.opensearch.plugins.PluginInfo;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.test.framework.JwtConfigBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -40,6 +35,7 @@ import io.jsonwebtoken.security.Keys;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_ROLE;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
 import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
 import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
 import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
@@ -79,32 +75,7 @@ public class JWTGrpcDefaultAuthHeaderTest {
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
-        .plugin(
-            new PluginInfo(
-                GrpcPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                GrpcPlugin.class.getName(),
-                null,
-                Collections.emptyList(),
-                false
-            )
-        )
-        .plugin(
-            new PluginInfo(
-                OpenSearchSecurityPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                OpenSearchSecurityPlugin.class.getName(),
-                null,
-                List.of("org.opensearch.transport.grpc.GrpcPlugin"),
-                false
-            )
-        )
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
         .users(GRPC_INDEX_USER)
         .roles(GRPC_INDEX_ROLE)
         .rolesMapping(new TestSecurityConfig.RoleMapping(GRPC_INDEX_ROLE.getName()).backendRoles("grpc_index_role"))

--- a/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDisabledAuthDomainTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcDisabledAuthDomainTest.java
@@ -13,7 +13,6 @@ package org.opensearch.security.grpc;
 
 import java.security.KeyPair;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -21,14 +20,10 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.Version;
-import org.opensearch.plugins.PluginInfo;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.test.framework.JwtConfigBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -42,6 +37,7 @@ import io.jsonwebtoken.security.Keys;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_ROLE;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
 import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
 import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
 import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
@@ -90,32 +86,7 @@ public class JWTGrpcDisabledAuthDomainTest {
     public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .certificates(TEST_CERTIFICATES)
         .nodeSettings(SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS)
-        .plugin(
-            new PluginInfo(
-                GrpcPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                GrpcPlugin.class.getName(),
-                null,
-                Collections.emptyList(),
-                false
-            )
-        )
-        .plugin(
-            new PluginInfo(
-                OpenSearchSecurityPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                OpenSearchSecurityPlugin.class.getName(),
-                null,
-                List.of("org.opensearch.transport.grpc.GrpcPlugin"),
-                false
-            )
-        )
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
         .users(GRPC_INDEX_USER)
         .roles(GRPC_INDEX_ROLE)
         .rolesMapping(new TestSecurityConfig.RoleMapping(GRPC_INDEX_ROLE.getName()).backendRoles("grpc_index_role"))

--- a/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcInterceptorTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcInterceptorTest.java
@@ -14,7 +14,6 @@ package org.opensearch.security.grpc;
 import java.security.KeyPair;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -22,15 +21,11 @@ import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.Version;
-import org.opensearch.plugins.PluginInfo;
 import org.opensearch.protobufs.BulkResponse;
-import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.test.framework.JwtConfigBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.transport.grpc.GrpcPlugin;
 
 import io.grpc.Channel;
 import io.grpc.ClientInterceptor;
@@ -48,6 +43,7 @@ import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_INDEX_USER_NO_MAPPING;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_SEARCH_ROLE;
 import static org.opensearch.security.grpc.GrpcHelpers.GRPC_SEARCH_USER;
+import static org.opensearch.security.grpc.GrpcHelpers.SECURITY_WITH_GRPC_PLUGIN;
 import static org.opensearch.security.grpc.GrpcHelpers.SINGLE_NODE_SECURE_AUTH_GRPC_TRANSPORT_SETTINGS;
 import static org.opensearch.security.grpc.GrpcHelpers.TEST_CERTIFICATES;
 import static org.opensearch.security.grpc.GrpcHelpers.createHeaderInterceptor;
@@ -136,34 +132,7 @@ public class JWTGrpcInterceptorTest {
                 Arrays.asList("grpc_search_user", "grpc_user")
             )
         )
-        .plugin(
-            // Add GrpcPlugin
-            new PluginInfo(
-                GrpcPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                GrpcPlugin.class.getName(),
-                null,
-                Collections.emptyList(),
-                false
-            )
-        )
-        .plugin(
-            // Override the default security plugin with one that declares extension relationship
-            new PluginInfo(
-                OpenSearchSecurityPlugin.class.getName(),
-                "classpath plugin",
-                "NA",
-                Version.CURRENT,
-                "21",
-                OpenSearchSecurityPlugin.class.getName(),
-                null,
-                List.of("org.opensearch.transport.grpc.GrpcPlugin"), // Extends GrpcPlugin
-                false
-            )
-        )
+        .plugin(SECURITY_WITH_GRPC_PLUGIN)
         .anonymousAuth(false)
         .users(GRPC_INDEX_USER, GRPC_INDEX_USER_NO_MAPPING, GRPC_SEARCH_USER, GRPC_IMPERSONATING_USER)
         .roles(GRPC_INDEX_ROLE, GRPC_INDEX_ROLE_NO_MAPPING, GRPC_SEARCH_ROLE)

--- a/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcInterceptorTest.java
+++ b/src/integrationTest/java/org/opensearch/security/grpc/JWTGrpcInterceptorTest.java
@@ -286,11 +286,10 @@ public class JWTGrpcInterceptorTest {
         }
     }
 
-    @Test
-    public void testBadSecurityHeaderInMetadata() throws Exception {
+    private void testBadSecurityHeaderInMetadata(final String headerName) throws Exception {
         ManagedChannel channel = secureChannel(getSecureGrpcEndpoint(cluster));
         try {
-            ClientInterceptor badHeaderInterceptor = createHeaderInterceptor(Map.of("_opendistro_security_user", "malicious_user"));
+            ClientInterceptor badHeaderInterceptor = createHeaderInterceptor(Map.of(headerName, "malicious_user"));
             Channel channelWithBadHeader = io.grpc.ClientInterceptors.intercept(channel, badHeaderInterceptor);
 
             try {
@@ -303,6 +302,16 @@ public class JWTGrpcInterceptorTest {
         } finally {
             channel.shutdown();
         }
+    }
+
+    @Test
+    public void testBadOpenDistroSecurityHeaderInMetadata() throws Exception {
+        testBadSecurityHeaderInMetadata("_opendistro_security_user");
+    }
+
+    @Test
+    public void testBadOpenSearchSecurityHeaderInMetadata() throws Exception {
+        testBadSecurityHeaderInMetadata("_opensearch_security_user");
     }
 
     @Test

--- a/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/nextgen/DashboardsMultitenancySystemIndexHandlerTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/actionlevel/nextgen/DashboardsMultitenancySystemIndexHandlerTest.java
@@ -10,6 +10,8 @@
  */
 package org.opensearch.security.privileges.actionlevel.nextgen;
 
+import java.util.List;
+
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
@@ -78,7 +80,8 @@ public class DashboardsMultitenancySystemIndexHandlerTest {
             resolver,
             new IndicesRequestResolver(resolver),
             () -> clusterState,
-            ActionPrivileges.EMPTY
+            ActionPrivileges.EMPTY,
+            List.of()
         );
 
         assertNull(subject.handle(searchRequest, "indices:data/read/search", user, ctx));
@@ -118,7 +121,8 @@ public class DashboardsMultitenancySystemIndexHandlerTest {
             resolver,
             new IndicesRequestResolver(resolver),
             () -> clusterState,
-            ActionPrivileges.EMPTY
+            ActionPrivileges.EMPTY,
+            List.of()
         );
 
         PrivilegesEvaluatorResponse result = subject.handle(searchRequest, "indices:data/read/search", user, ctx);
@@ -158,7 +162,8 @@ public class DashboardsMultitenancySystemIndexHandlerTest {
             resolver,
             new IndicesRequestResolver(resolver),
             () -> clusterState,
-            ActionPrivileges.EMPTY
+            ActionPrivileges.EMPTY,
+            List.of()
         );
 
         PrivilegesEvaluatorResponse result = subject.handle(searchRequest, "indices:data/read/search", user, ctx);
@@ -222,7 +227,8 @@ public class DashboardsMultitenancySystemIndexHandlerTest {
             resolver,
             new IndicesRequestResolver(resolver),
             () -> clusterState,
-            ActionPrivileges.EMPTY
+            ActionPrivileges.EMPTY,
+            List.of()
         );
 
         PrivilegesEvaluatorResponse result = subject.handle(unsupportedRequest, "indices:data/read/search", user, ctx);

--- a/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/dlsfls/DocumentPrivilegesTest.java
@@ -541,7 +541,8 @@ public class DocumentPrivilegesTest {
                 null,
                 null,
                 () -> CLUSTER_STATE,
-                ActionPrivileges.EMPTY
+                ActionPrivileges.EMPTY,
+                List.of()
             );
             this.statefulness = statefulness;
             this.dfmEmptyOverridesAll = dfmEmptyOverridesAll == DfmEmptyOverridesAll.DFM_EMPTY_OVERRIDES_ALL_TRUE;
@@ -844,7 +845,8 @@ public class DocumentPrivilegesTest {
                 INDEX_NAME_EXPRESSION_RESOLVER,
                 null,
                 () -> CLUSTER_STATE,
-                ActionPrivileges.EMPTY
+                ActionPrivileges.EMPTY,
+                List.of()
             );
             this.statefulness = statefulness;
             this.dfmEmptyOverridesAll = dfmEmptyOverridesAll == DfmEmptyOverridesAll.DFM_EMPTY_OVERRIDES_ALL_TRUE;
@@ -1146,7 +1148,8 @@ public class DocumentPrivilegesTest {
                 null,
                 () -> CLUSTER_STATE,
 
-                ActionPrivileges.EMPTY
+                ActionPrivileges.EMPTY,
+                List.of()
             );
             this.statefulness = statefulness;
             this.dfmEmptyOverridesAll = dfmEmptyOverridesAll == DfmEmptyOverridesAll.DFM_EMPTY_OVERRIDES_ALL_TRUE;

--- a/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
+++ b/src/integrationTest/java/org/opensearch/security/rest/WhoAmITests.java
@@ -50,6 +50,7 @@ import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.grantedPrivilege;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.privilegePredicateRESTLayer;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.userAuthenticatedPredicate;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class WhoAmITests {
@@ -203,6 +204,8 @@ public class WhoAmITests {
                 transportSet.add(auditMessage);
             }
         }
+        assertFalse(restSet.isEmpty());
+        assertFalse(transportSet.isEmpty());
         // We pass 1 message from each layer to check for similarity
         checkForStructuralSimilarity(restSet.get(0), transportSet.get(0));
     }

--- a/src/integrationTest/java/org/opensearch/security/util/MockPrivilegeEvaluationContextBuilder.java
+++ b/src/integrationTest/java/org/opensearch/security/util/MockPrivilegeEvaluationContextBuilder.java
@@ -14,6 +14,7 @@ package org.opensearch.security.util;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -100,7 +101,8 @@ public class MockPrivilegeEvaluationContextBuilder {
             indexNameExpressionResolver,
             new IndicesRequestResolver(indexNameExpressionResolver),
             () -> clusterState,
-            this.actionPrivileges
+            this.actionPrivileges,
+            List.of()
         );
     }
 }

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2739,6 +2739,11 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(SecuritySettings.USER_ATTRIBUTE_SERIALIZATION_ENABLED_SETTING);
             settings.add(SecuritySettings.DLS_WRITE_BLOCKED);
+
+            settings.add(Setting.groupSetting(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS_CONFIG + ".", Property.NodeScope
+            // do not make this Property.Dynamic - as a security measure,
+            // this can only be changed with access to the config file.
+            ));
         }
 
         return settings;

--- a/src/main/java/org/opensearch/security/filter/SecurityGrpcFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityGrpcFilter.java
@@ -21,6 +21,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auth.BackendRegistry;
+import org.opensearch.security.privileges.dlsfls.DlsRequestHeadersUtil;
 import org.opensearch.security.ssl.OpenSearchSecuritySSLPlugin;
 import org.opensearch.security.ssl.util.SSLRequestHelper;
 import org.opensearch.security.support.ConfigConstants;
@@ -77,7 +78,8 @@ public class SecurityGrpcFilter implements GrpcInterceptorProvider {
                 return new AuthNGrpcInterceptor(
                     threadContext,
                     OpenSearchSecurityPlugin.GuiceHolder.getBackendRegistry(),
-                    OpenSearchSecurityPlugin.GuiceHolder.getAuditLog()
+                    OpenSearchSecurityPlugin.GuiceHolder.getAuditLog(),
+                    settings
                 );
             }
         });
@@ -92,11 +94,13 @@ public class SecurityGrpcFilter implements GrpcInterceptorProvider {
         private final ThreadContext threadContext;
         private final BackendRegistry backendRegistry;
         private final AuditLog auditLog;
+        private final Settings settings;
 
-        public AuthNGrpcInterceptor(ThreadContext threadContext, BackendRegistry backendRegistry, AuditLog auditLog) {
+        public AuthNGrpcInterceptor(ThreadContext threadContext, BackendRegistry backendRegistry, AuditLog auditLog, Settings settings) {
             this.threadContext = threadContext;
             this.backendRegistry = backendRegistry;
             this.auditLog = auditLog;
+            this.settings = settings;
         }
 
         @Override
@@ -173,6 +177,8 @@ public class SecurityGrpcFilter implements GrpcInterceptorProvider {
                 if (user != null) {
                     auditLog.logSucceededLogin(user.getName(), false, null, requestChannel);
                 }
+
+                DlsRequestHeadersUtil.extractAndStoreDlsRequestHeaders(requestChannel, threadContext, settings);
 
                 // Caller was authorized - Proceed with request
                 return serverCallHandler.startCall(serverCall, metadata);

--- a/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityRestFilter.java
@@ -63,6 +63,7 @@ import org.opensearch.security.configuration.CompatConfig;
 import org.opensearch.security.dlic.rest.api.AllowlistApiAction;
 import org.opensearch.security.privileges.PrivilegesEvaluatorResponse;
 import org.opensearch.security.privileges.RestLayerPrivilegesEvaluator;
+import org.opensearch.security.privileges.dlsfls.DlsRequestHeadersUtil;
 import org.opensearch.security.securityconf.impl.AllowlistingSettings;
 import org.opensearch.security.ssl.http.netty.Netty4HttpRequestHeaderVerifier;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
@@ -189,6 +190,8 @@ public class SecurityRestFilter {
             final SecurityRequestChannel requestChannel = SecurityRequestFactory.from(request, channel);
             // for audit logging
             final SecurityRequestChannel filteredRequestChannel = SecurityRequestFactory.from(filteredRequest, channel);
+
+            DlsRequestHeadersUtil.extractAndStoreDlsRequestHeaders(requestChannel, threadContext, settings);
 
             // Authenticate request
             if (!NettyAttribute.popFrom(request, Netty4HttpRequestHeaderVerifier.IS_AUTHENTICATED).orElse(false)) {

--- a/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
+++ b/src/main/java/org/opensearch/security/privileges/PrivilegesEvaluationContext.java
@@ -11,9 +11,11 @@
 package org.opensearch.security.privileges;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -23,6 +25,7 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexAbstraction;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.OptionallyResolvedIndices;
+import org.opensearch.security.privileges.dlsfls.DlsRequestHeadersUtil;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.user.User;
 import org.opensearch.tasks.Task;
@@ -72,6 +75,11 @@ public class PrivilegesEvaluationContext {
 
     private final ActionRequestMetadata<?, ?> actionRequestMetadata;
 
+    /**
+     * allowlisted headers can be accessed in DLS queries.
+     */
+    private final List<DlsRequestHeadersUtil.DlsRequestHeader> headersForDls;
+
     public PrivilegesEvaluationContext(
         User user,
         ImmutableSet<String> mappedRoles,
@@ -82,7 +90,8 @@ public class PrivilegesEvaluationContext {
         IndexNameExpressionResolver indexNameExpressionResolver,
         IndicesRequestResolver indicesRequestResolver,
         Supplier<ClusterState> clusterStateSupplier,
-        ActionPrivileges actionPrivileges
+        ActionPrivileges actionPrivileges,
+        List<DlsRequestHeadersUtil.DlsRequestHeader> headersForDls
     ) {
         this.user = user;
         this.mappedRoles = mappedRoles;
@@ -94,6 +103,7 @@ public class PrivilegesEvaluationContext {
         this.task = task;
         this.actionRequestMetadata = actionRequestMetadata;
         this.actionPrivileges = actionPrivileges;
+        this.headersForDls = (headersForDls == null) ? List.of() : headersForDls;
     }
 
     public User getUser() {
@@ -179,6 +189,10 @@ public class PrivilegesEvaluationContext {
 
     @Override
     public String toString() {
+        final var headersForDlsOutput = headersForDls.isEmpty()
+            ? ""
+            : ", headersForDls[keys]="
+                + headersForDls.stream().map(DlsRequestHeadersUtil.DlsRequestHeader::name).collect(Collectors.joining(", "));
         return "PrivilegesEvaluationContext{"
             + "user="
             + user
@@ -191,10 +205,15 @@ public class PrivilegesEvaluationContext {
             + resolvedIndices
             + ", mappedRoles="
             + mappedRoles
+            + headersForDlsOutput
             + '}';
     }
 
     public ConcurrentHashMap<String, Boolean> hasFlsOrFieldMaskingCache() {
         return hasFlsOrFieldMaskingCache;
+    }
+
+    public List<DlsRequestHeadersUtil.DlsRequestHeader> getHeadersForDls() {
+        return headersForDls;
     }
 }

--- a/src/main/java/org/opensearch/security/privileges/UserAttributes.java
+++ b/src/main/java/org/opensearch/security/privileges/UserAttributes.java
@@ -12,7 +12,6 @@ package org.opensearch.security.privileges;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import com.google.common.base.Joiner;
@@ -21,7 +20,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.text.StringSubstitutor;
 
 /**
- * Support for interpolating user attributes used in index patterns and DLS queries.
+ * Support for interpolating user attributes and headers used in index patterns and DLS queries.
  *
  * This code was moved over from ConfigModelV7.
  */
@@ -52,6 +51,9 @@ public class UserAttributes {
         );
         replacementsWithDots.putAll(user.getCustomAttributesMap());
 
+        context.getHeadersForDls()
+            .forEach(header -> replacementsWithDots.put("attr.header." + header.name().toLowerCase(), header.serialize()));
+
         // we also support referencing variables with underscores instead of dots => we need both in our lookup table.
         final var replacements = new HashMap<>(replacementsWithDots);
         replacementsWithDots.forEach((k, v) -> replacements.put(k.replace(".", "_"), v));
@@ -61,7 +63,7 @@ public class UserAttributes {
         return orig;
     }
 
-    private static String toQuotedCommaSeparatedString(final Set<String> roles) {
+    private static String toQuotedCommaSeparatedString(final Iterable<String> roles) {
         return Joiner.on(',').join(Iterables.transform(roles, s -> {
             return new StringBuilder(s.length() + 2).append('"').append(s).append('"').toString();
         }));

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesEvaluatorImpl.java
@@ -104,6 +104,7 @@ import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.traceAction;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS;
 
 /**
  * The current implementation for action privilege evaluation.
@@ -303,7 +304,8 @@ public class PrivilegesEvaluatorImpl implements PrivilegesEvaluator {
             resolver,
             indicesRequestResolver,
             clusterStateSupplier,
-            actionPrivileges
+            actionPrivileges,
+            threadContext.getTransient(OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS)
         );
     }
 

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/nextgen/PrivilegesEvaluatorImpl.java
@@ -73,6 +73,8 @@ import org.opensearch.security.user.User;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS;
+
 /**
  * A next generation implementation of PrivilegesEvaluator with the following properties:
  * <ul>
@@ -240,7 +242,8 @@ public class PrivilegesEvaluatorImpl implements org.opensearch.security.privileg
             indexNameExpressionResolver,
             indicesRequestResolver,
             clusterStateSupplier,
-            actionPrivileges
+            actionPrivileges,
+            threadContext.getTransient(OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS)
         );
     }
 

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsRequestHeadersUtil.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsRequestHeadersUtil.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.dlsfls;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.security.filter.SecurityRequestChannel;
+
+import tools.jackson.core.type.TypeReference;
+
+import static java.util.function.Function.identity;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS;
+import static org.opensearch.security.support.ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS_CONFIG;
+
+/**
+ * Utilities to handle request headers which are made available as for substitution in DLS queries.
+ * These headers must be whitelisted in the config (see {@link org.opensearch.security.support.ConfigConstants#OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS_CONFIG})
+ * and are validated against the regex specified in the config. They are then stored in the thread context for usage in
+ * DLS queries and forwarded to other nodes if necessary.
+ *
+ * <p>
+ * This feature is in addition to the user attributes which are also made available for substitution, see {@link org.opensearch.security.privileges.UserAttributes}.
+ * </p>
+ */
+public class DlsRequestHeadersUtil {
+    private static final Logger log = LogManager.getLogger(DlsRequestHeadersUtil.class);
+
+    private DlsRequestHeadersUtil() {}
+
+    /**
+     * Arbitrary upper limit on the amount of supported headers to prevent a DOS attack.
+     * Since the headers are forwarded to requests to other shards sending a too big amount of headers could
+     * negatively impact other shards.
+     */
+    private static final int MAX_HEADER_COUNT = 256;
+
+    /**
+     * It is possible to reference HTTP / gRPC headers in DLS queries. To achieve this, they are extracted from the
+     * request and stored in the thread context in a manner where they will also be available if the request is
+     * forwarded.
+     */
+    public static void extractAndStoreDlsRequestHeaders(
+        final SecurityRequestChannel securityRequestChannel,
+        final ThreadContext threadContext,
+        final Settings settings
+    ) {
+        final var allowedDlsRequestHeaders = getDlsRequestHeaderSettings(settings);
+
+        final Map<String, List<String>> rawDlsRequestHeaders = securityRequestChannel.getHeaders() == null
+            ? Map.of()
+            : securityRequestChannel.getHeaders()
+                .entrySet()
+                .stream()
+                .filter(e -> allowedDlsRequestHeaders.keySet().stream().anyMatch(a -> a.equalsIgnoreCase(e.getKey())))
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        final var totalHeaderCount = rawDlsRequestHeaders.values().stream().mapToInt(List::size).sum();
+
+        if (totalHeaderCount > MAX_HEADER_COUNT) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "found %d headers for DLS variables which exceeds the global maximum of %d",
+                    totalHeaderCount,
+                    MAX_HEADER_COUNT
+                )
+            );
+        }
+
+        final var dlsRequestHeaders = rawDlsRequestHeaders.entrySet()
+            .stream()
+            .map(e -> toDlsRequestHeader(allowedDlsRequestHeaders.get(e.getKey().toLowerCase()), e.getKey(), e.getValue()))
+            .toList();
+
+        log.debug(
+            "found {} headers with a total of {} values which matched one of the {} allowlisted headers for DLS variables: {}",
+            dlsRequestHeaders.size(),
+            totalHeaderCount,
+            allowedDlsRequestHeaders.size(),
+            rawDlsRequestHeaders.keySet()
+        );
+        log.trace("allowlisted headers: {}", allowedDlsRequestHeaders);
+
+        // store it transiently for usage in this thread
+        threadContext.putTransient(OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS, dlsRequestHeaders);
+
+        // and as a header so that it is passed on to other threads / instances, where it will be restored into a transient entry
+        // See SecurityRequestHandler#messageReceivedDecorate
+        if (!dlsRequestHeaders.isEmpty()) {
+            final var serializedDlsRequestHeaders = DefaultObjectMapper.objectMapper()
+                .writerFor(new TypeReference<List<DlsRequestHeader>>() {
+                })
+                .writeValueAsString(dlsRequestHeaders);
+            threadContext.putHeader(OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS, serializedDlsRequestHeaders);
+        }
+    }
+
+    /**
+     * Validates the request header and, if it is valid, turns it into a {@link DlsRequestHeader}.
+     * @throws IllegalArgumentException if the header value does not match the configured regex or has more than
+     *                                  one value if it is flagged as single-value
+     */
+    private static DlsRequestHeader toDlsRequestHeader(
+        final DlsRequestHeaderSettings dlsRequestHeaderSettings,
+        final String headerName,
+        final List<String> headerValues
+    ) {
+        for (final var headerValue : headerValues) {
+            if (!dlsRequestHeaderSettings.validationPattern().matcher(headerValue).matches()) {
+                throw new IllegalArgumentException(
+                    String.format("header %s does not match the specified pattern and has thus been rejected!", headerName)
+                );
+            }
+            if (headerValue.length() > dlsRequestHeaderSettings.maxValueLength()) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "header %s exceeds the maximum defined length! (%d > %d)",
+                        headerName,
+                        headerValue.length(),
+                        dlsRequestHeaderSettings.maxValueLength()
+                    )
+                );
+            }
+        }
+
+        if (dlsRequestHeaderSettings.isMultiValue()) {
+            return new MultiValueDlsRequestHeader(headerName, headerValues);
+        } else {
+            if (headerValues.size() != 1) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Received %d entries for header %s, but expected it to be a single value!",
+                        headerValues.size(),
+                        headerName
+                    )
+                );
+            }
+            return new SingleValueDlsRequestHeader(headerName, headerValues.getFirst());
+        }
+    }
+
+    public static Map<String, DlsRequestHeaderSettings> getDlsRequestHeaderSettings(final Settings settings) {
+        final var allowedDlsRequestHeaderSettings = settings.getGroups(OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS_CONFIG);
+        return allowedDlsRequestHeaderSettings.values()
+            .stream()
+            .map(
+                s -> new DlsRequestHeaderSettings(
+                    s.get("name"),
+                    s.getAsBoolean("isMultiValue", false),
+                    // by default only match empty values => regex *must* be specified by admin
+                    Pattern.compile(s.get("validationRegex", "^$")),
+                    s.getAsInt("maxValueLength", 256)
+                )
+            )
+            .collect(Collectors.toUnmodifiableMap(e -> e.name.toLowerCase(), identity()));
+    }
+
+    /**
+     * Represents the settings for a request header as specified in the config.
+     */
+    public record DlsRequestHeaderSettings(String name, boolean isMultiValue, Pattern validationPattern, int maxValueLength) {
+    }
+
+    /**
+     * Represents an actual request header which matched one of the configured DLS request headers.
+     * Jackson serialisation is used for the transport between different nodes.
+     */
+    @JsonTypeInfo(use = JsonTypeInfo.Id.SIMPLE_NAME, include = JsonTypeInfo.As.PROPERTY, property = "class")
+    @JsonSubTypes({
+        @JsonSubTypes.Type(value = SingleValueDlsRequestHeader.class),
+        @JsonSubTypes.Type(value = MultiValueDlsRequestHeader.class), })
+    public interface DlsRequestHeader {
+        /**
+         * @return the name of the request header.
+         */
+        String name();
+
+        /**
+         * Returns the value(s) of the request header.
+         *
+         * <p>SAFETY: The safety of the value for usage in substitution in a query
+         * entirely depends on the configuration of the regex in the config. It is the responsibility of the admin to
+         * ensure that the regex is safe and does not allow for injection attacks!</p>
+         *
+         * @return the header value(s) formatted for usage in a DLS query.
+         */
+        String serialize();
+    }
+
+    public record SingleValueDlsRequestHeader(String name, String value) implements DlsRequestHeader, Serializable {
+        @Override
+        public String serialize() {
+            return this.value;
+        }
+    }
+
+    public record MultiValueDlsRequestHeader(String name, List<String> values) implements DlsRequestHeader, Serializable {
+        @Override
+        public String serialize() {
+            return values.stream().map(s -> "\"" + s + "\"").collect(Collectors.joining(","));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -398,6 +398,10 @@ public class ConfigConstants {
     public static final String SECURITY_UNSUPPORTED_LOAD_STATIC_RESOURCES = SECURITY_SETTINGS_PREFIX + "unsupported.load_static_resources";
     public static final String SECURITY_UNSUPPORTED_ACCEPT_INVALID_CONFIG = SECURITY_SETTINGS_PREFIX + "unsupported.accept_invalid_config";
 
+    public static final String OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS_CONFIG = SECURITY_SETTINGS_PREFIX
+        + "unsupported.dls.allowed_request_headers";
+    public static final String OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS = OPENSEARCH_SECURITY_CONFIG_PREFIX + "dls_request_headers";
+
     public static final String SECURITY_PROTECTED_INDICES_ENABLED_KEY = SECURITY_SETTINGS_PREFIX + "protected_indices.enabled";
     public static final Boolean SECURITY_PROTECTED_INDICES_ENABLED_DEFAULT = false;
     public static final String SECURITY_PROTECTED_INDICES_KEY = SECURITY_SETTINGS_PREFIX + "protected_indices.indices";

--- a/src/main/java/org/opensearch/security/support/HTTPHelper.java
+++ b/src/main/java/org/opensearch/security/support/HTTPHelper.java
@@ -28,8 +28,7 @@ package org.opensearch.security.support;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 
 import org.apache.logging.log4j.Logger;
 
@@ -85,17 +84,23 @@ public class HTTPHelper {
     }
 
     public static boolean containsBadHeader(final SecurityRequest request) {
-
-        final Map<String, List<String>> headers;
-
-        if (request != null && (headers = request.getHeaders()) != null) {
-            for (final String key : headers.keySet()) {
-                if (key != null && key.trim().toLowerCase().startsWith(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_PREFIX.toLowerCase())) {
-                    return true;
-                }
-            }
+        if (request == null || request.getHeaders() == null) {
+            return false;
         }
 
-        return false;
+        return request.getHeaders()
+            .keySet()
+            .stream()
+            .filter(Objects::nonNull)
+            .map(String::toLowerCase)
+            .anyMatch(HTTPHelper::isSecurityConfigPrefix);
+    }
+
+    private static boolean isSecurityConfigPrefix(final String header) {
+        // most headers use the legacy opendistro prefix => check that first for speed reasons
+        // the header is already lowercased in the stream above, so we can use startsWith directly; the constants
+        // are also lowercase (which is ensured by HTTPHelperTest#ensureSecurityConfigPrefixConstantsAreLowercase).
+        return header.startsWith(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_PREFIX)
+            || header.startsWith(ConfigConstants.OPENSEARCH_SECURITY_CONFIG_PREFIX);
     }
 }

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -37,6 +37,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -177,6 +178,10 @@ public class SecurityInterceptor {
                 getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS).split(",")
             );
             requestHeadersToCopy.removeAll(Task.REQUEST_HEADERS); // Special case where this header is preserved during stashContext.
+        }
+
+        if (!Strings.isNullOrEmpty(getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS))) {
+            requestHeadersToCopy.add(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS);
         }
 
         final Supplier<ThreadContext.StoredContext> restorableContextSupplier = getThreadContext().newRestorableContext(true);

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -28,6 +28,7 @@ package org.opensearch.security.transport;
 
 import java.net.InetSocketAddress;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -42,9 +43,11 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.extensions.ExtensionsManager;
 import org.opensearch.search.internal.ShardSearchRequest;
+import org.opensearch.security.DefaultObjectMapper;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.AuditLog.Origin;
+import org.opensearch.security.privileges.dlsfls.DlsRequestHeadersUtil;
 import org.opensearch.security.ssl.SslExceptionHandler;
 import org.opensearch.security.ssl.transport.PrincipalExtractor;
 import org.opensearch.security.ssl.transport.SSLConfig;
@@ -61,6 +64,8 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportChannel;
 import org.opensearch.transport.TransportRequest;
 import org.opensearch.transport.TransportRequestHandler;
+
+import tools.jackson.core.type.TypeReference;
 
 import static org.opensearch.security.OpenSearchSecurityPlugin.isActionTraceEnabled;
 
@@ -120,6 +125,17 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
         if (!Strings.isNullOrEmpty(originHeader)) {
             getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN, originHeader);
+        }
+
+        // restore headers used for DLS
+        final var dlsRequestHeadersAsString = getThreadContext().getHeader(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS);
+        if (!Strings.isNullOrEmpty(dlsRequestHeadersAsString)) {
+            final List<DlsRequestHeadersUtil.DlsRequestHeader> dlsRequestHeaders = DefaultObjectMapper.readValue(
+                dlsRequestHeadersAsString,
+                new TypeReference<>() {
+                }
+            );
+            getThreadContext().putTransient(ConfigConstants.OPENSEARCH_SECURITY_DLS_REQUEST_HEADERS, dlsRequestHeaders);
         }
 
         try {

--- a/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/integration/BasicAuditlogTest.java
@@ -293,7 +293,9 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
 
         testJustAuthenticated();
         TestAuditlogImpl.clear();
-        testBadHeader();
+        testBadOpenDistroHeader();
+        TestAuditlogImpl.clear();
+        testBadOpenSearchHeader();
         TestAuditlogImpl.clear();
         testMissingPriv();
         TestAuditlogImpl.clear();
@@ -370,19 +372,23 @@ public class BasicAuditlogTest extends AbstractAuditlogUnitTest {
         validateMsgs(TestAuditlogImpl.messages);
     }
 
-    public void testBadHeader() throws Exception {
+    private void testBadHeader(final String headerName) throws Exception {
 
-        HttpResponse response = rh.executeGetRequest(
-            "",
-            new BasicHeader("_opendistro_security_bad", "bad"),
-            encodeBasicHeader("admin", "admin")
-        );
+        HttpResponse response = rh.executeGetRequest("", new BasicHeader(headerName, "bad"), encodeBasicHeader("admin", "admin"));
         assertThat(response.getStatusCode(), is(HttpStatus.SC_FORBIDDEN));
         Assert.assertFalse(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("AUTHENTICATED"));
         Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("BAD_HEADERS"));
-        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains("_opendistro_security_bad"));
+        Assert.assertTrue(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.sb.toString().contains(headerName));
         assertThat(TestAuditlogImpl.sb.toString(), TestAuditlogImpl.messages.size(), is(1));
         validateMsgs(TestAuditlogImpl.messages);
+    }
+
+    public void testBadOpenDistroHeader() throws Exception {
+        testBadHeader("_opendistro_security_bad");
+    }
+
+    public void testBadOpenSearchHeader() throws Exception {
+        testBadHeader("_opensearch_security_bad");
     }
 
     public void testMissingPriv() throws Exception {

--- a/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/RestLayerPrivilegesEvaluatorTest.java
@@ -11,6 +11,7 @@
 
 package org.opensearch.security.privileges;
 
+import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -163,7 +164,8 @@ public class RestLayerPrivilegesEvaluatorTest {
                     null,
                     null,
                     null,
-                    actionPrivileges
+                    actionPrivileges,
+                    List.of()
                 );
             }
 

--- a/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
+++ b/src/test/java/org/opensearch/security/privileges/UserAttributesUnitTest.java
@@ -48,7 +48,8 @@ public class UserAttributesUnitTest {
             null,
             null,
             null,
-            null
+            null,
+            List.of()
         );
 
         String stringWithPlaceholders = """

--- a/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluatorTest.java
+++ b/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/SystemIndexAccessEvaluatorTest.java
@@ -182,7 +182,8 @@ public class SystemIndexAccessEvaluatorTest {
             indexNameExpressionResolver,
             new IndicesRequestResolver(indexNameExpressionResolver),
             () -> clusterState,
-            actionPrivileges
+            actionPrivileges,
+            List.of()
         );
     }
 

--- a/src/test/java/org/opensearch/security/support/HTTPHelperTest.java
+++ b/src/test/java/org/opensearch/security/support/HTTPHelperTest.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+package org.opensearch.security.support;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class HTTPHelperTest {
+
+    /**
+     * For performance reasons we don't want to call toLowerCase() on the config prefix constants every time we use them.
+     * This test ensures that the constants are already in lowercase.
+     * If for whatever reason you have to make them not fully lowercase make sure to update HTTPHelper#isSecurityConfigPrefix.
+     */
+    @Test
+    public void ensureSecurityConfigPrefixConstantsAreLowercase() {
+        assertThat(
+            ConfigConstants.OPENDISTRO_SECURITY_CONFIG_PREFIX,
+            equalTo(ConfigConstants.OPENDISTRO_SECURITY_CONFIG_PREFIX.toLowerCase())
+        );
+        assertThat(
+            ConfigConstants.OPENSEARCH_SECURITY_CONFIG_PREFIX,
+            equalTo(ConfigConstants.OPENSEARCH_SECURITY_CONFIG_PREFIX.toLowerCase())
+        );
+    }
+
+}


### PR DESCRIPTION
### Description
* Category: Enhancement

with this it is now possible to specify request headers which should be
available as substitutions in DLS queries. both HTTP and gRPC headers
are supported.

the headers have to be configured under the config key
`plugins.security.unsupported.dls.allowed_request_headers`. this is a
map (the key doesn't matter) with the following content for each entry:
* `name`: the actual name of the gRPC / HTTP header (case-insensitive)
* `isMultiValue`: whether the header can have more than one value
  (default: `false`)
* `validationRegex`: a regex to ensure that the header value cannot be
  used for code injection into the DLS query
* `maxValueLength`: the maximum length each header value is allowed to
  have (default: 256)

since DLS query substitution is pure string substitution and headers,
unlike other user attributes, are fully under the control of the caller
(and thus a potential attacker) the content must be carefully validated
to ensure that it does not pose a risk. for this the `validationRegex`
needs to be used - by default it rejects all content, thus it must be
configured explicitly. it should be configured to only allow explicitly
the patterns which are absolutely needed.

due to the risk associated with this feature it is currently being
treated as unsupported/experimental and will also not be documented.

if you, dear reader, stumble upon this PR / commit please beware: only
use this is if you are absolutely sure that you know what you are doing!
you have been warned!

the substitution is done using `${attr.header.[header name]}`, e.g.
`${attr.header.x-example-header}`.
if `isMultiValue` is set to `true` then the substitution will always
contain quotes around the values and has to be treated as a list, i.e.
you should enclose it in `[]`:
```
{ "terms": { "testfield": [${attr.header.x-example-header-mv}] } }
```
while if `isMultiValue` is set to `false` then the value will be added
verbatim and you need to quote it:
```
{ "term": { "testfield": "${attr.header.x-example-header}" } }
```

to prevent the risk of DOS attacks through the header forwarding both a
limit on the length of header values has been introduced (configurable
per header, see `maxValueLength`; default: 256 characters) as well as a
global limit on the amount of headers (see
`DlsRequestHeadersUtil#MAX_HEADER_COUNT`; arbitrarily set to 256) has
been introduced.

the config options can only be set via the config file (they are
intentionally not marked as `Dynamic`) so that it has to be a clear
decision to set this. this restriction can be lifted at a later point.

once #6311 is implemented the risk posed by this feature will go down
since then it will no longer be possible to modify the query with a
crafted request (which this feature tries to prevent by having the admin
specify a regex for the validation).

the tests for gRPC have been moved to a separate test class due to the
bug reported in #6431 which leads to flaky gRPC tests with multi-node
test clusters.

### Issues Resolved
resolves #6265

### Testing
integration tests, manual tests

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented - intentionally undocumented!
- [ ] ~New Roles/Permissions have a corresponding security dashboards plugin PR~
- [ ] ~API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
