### PR TITLE
Scale legacy alias resolution with bounded indices-lookup access

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/IndexResolverReplacerAliasScaleIntegTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/IndexResolverReplacerAliasScaleIntegTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.int_tests;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.data.TestIndex;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.matcher.RestMatchers.isOk;
+
+public class IndexResolverReplacerAliasScaleIntegTests {
+
+    private static final int ALIAS_COUNT = 5_000;
+    private static final int EXACT_REQUEST_COUNT = 100;
+    private static final int PREFIX_REQUEST_COUNT = 25;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+
+    private static final TestIndex TEST_INDEX = TestIndex.name(INDEX).documentCount(1).build();
+    private static final TestSecurityConfig.User READER = new TestSecurityConfig.User("alias_scale_reader").roles(
+        new Role("alias_scale_reader_role").indexPermissions("read").on(INDEX, ALIAS_PREFIX + "*")
+    );
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(READER, TestSecurityConfig.User.USER_ADMIN)
+        .indices(TEST_INDEX)
+        .build();
+
+    @BeforeClass
+    public static void createAliasHeavyClusterState() {
+        StringBuilder body = new StringBuilder(ALIAS_COUNT * 80).append("{\"actions\":[");
+        for (int i = 0; i < ALIAS_COUNT; i++) {
+            if (i != 0) {
+                body.append(',');
+            }
+            body.append("{\"add\":{\"index\":\"").append(INDEX).append("\",\"alias\":\"").append(ALIAS_PREFIX).append(i).append("\"}}");
+        }
+        body.append("]}");
+
+        try (TestRestClient adminClient = cluster.getAdminCertRestClient()) {
+            assertThat(adminClient.postJson("_aliases", body.toString()), isOk());
+        }
+    }
+
+    @Test
+    public void repeatedExactConcreteIndexRequestsWithManyAliases() {
+        assertRepeatedSearches(INDEX, EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedExactAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + (ALIAS_COUNT - 1), EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedPrefixAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + "49*", PREFIX_REQUEST_COUNT);
+    }
+
+    private static void assertRepeatedSearches(String indexExpression, int requestCount) {
+        try (TestRestClient client = cluster.getRestClient(READER)) {
+            for (int i = 0; i < requestCount; i++) {
+                assertThat("Request " + i + " for " + indexExpression, client.get(indexExpression + "/_search?size=0"), isOk());
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacer.java
@@ -39,6 +39,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -312,15 +313,9 @@ public class IndexResolverReplacer {
                 final Set<String> dateResolvedLocalRequestedPatterns = localRequestedPatterns.stream()
                     .map(resolver::resolveDateMathExpression)
                     .collect(Collectors.toSet());
-                final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
                 // fill matchingAliases
-                final Map<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
-                matchingAliases = lookup.entrySet()
-                    .stream()
-                    .filter(e -> e.getValue().getType() == ALIAS)
-                    .map(Map.Entry::getKey)
-                    .filter(dateResolvedMatcher)
-                    .collect(Collectors.toSet());
+                final SortedMap<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
+                matchingAliases = resolveMatchingAliases(lookup, dateResolvedLocalRequestedPatterns);
 
                 final boolean isDebugEnabled = log.isDebugEnabled();
                 try {
@@ -426,6 +421,114 @@ public class IndexResolverReplacer {
 
             return resolved;
         }
+    }
+
+    /**
+     * Resolves the set of aliases matching the given (already date-math-resolved) patterns.
+     *
+     * The indices lookup ({@link org.opensearch.cluster.metadata.Metadata#getIndicesLookup()}) is a natural-ordering
+     * {@code TreeMap}. For exact names and simple prefix patterns ({@code "foo*"}) we can answer from a point lookup or a
+     * bounded {@code subMap} range instead of streaming and wildcard-matching the entire lookup (which can hold hundreds
+     * of thousands of abstractions). Any pattern that is not exact or a simple prefix (question marks, embedded stars,
+     * regex, etc.) forces the original full-scan path, so the result set is always identical to the legacy behavior.
+     *
+     * @param lookup the cluster indices lookup, sorted with natural String ordering
+     * @param dateResolvedLocalRequestedPatterns the requested patterns after date-math resolution
+     * @return the names of all aliases matching any of the patterns
+     */
+    static Set<String> resolveMatchingAliases(SortedMap<String, IndexAbstraction> lookup, Set<String> dateResolvedLocalRequestedPatterns) {
+        boolean canUseBoundedLookup = true;
+        for (String pattern : dateResolvedLocalRequestedPatterns) {
+            if (WildcardMatcher.isExact(pattern) == false && isSimplePrefixPattern(pattern) == false) {
+                canUseBoundedLookup = false;
+                break;
+            }
+        }
+
+        if (canUseBoundedLookup) {
+            final Set<String> matchingAliases = new HashSet<>();
+            for (String pattern : dateResolvedLocalRequestedPatterns) {
+                if (WildcardMatcher.isExact(pattern)) {
+                    // Exact name: a single point lookup, keep it only if it is actually an alias. A null pattern is
+                    // treated as WildcardMatcher.NONE by the full-scan path (matches nothing) and would NPE on the
+                    // natural-ordering TreeMap#get, so it is skipped to preserve identical semantics.
+                    if (pattern == null) {
+                        continue;
+                    }
+                    final IndexAbstraction indexAbstraction = lookup.get(pattern);
+                    if (indexAbstraction != null && indexAbstraction.getType() == ALIAS) {
+                        matchingAliases.add(pattern);
+                    }
+                } else {
+                    // Simple prefix "p*": PrefixMatcher matches via literal String.startsWith(prefix), so the matching
+                    // keys are exactly the range [prefix, prefixUpperBound). Note trailing "*" means zero-or-more, so
+                    // the prefix itself (e.g. "foo" for "foo*") is included because it is the inclusive lower bound.
+                    final String prefix = pattern.substring(0, pattern.length() - 1);
+                    final SortedMap<String, IndexAbstraction> range;
+                    final String upperBound = incrementForUpperBound(prefix);
+                    if (upperBound == null) {
+                        // prefix consists entirely of Character.MAX_VALUE; there is no strictly-greater bound, so every
+                        // key >= prefix is a candidate.
+                        range = lookup.tailMap(prefix);
+                    } else {
+                        range = lookup.subMap(prefix, upperBound);
+                    }
+                    for (Map.Entry<String, IndexAbstraction> entry : range.entrySet()) {
+                        if (entry.getValue().getType() == ALIAS) {
+                            matchingAliases.add(entry.getKey());
+                        }
+                    }
+                }
+            }
+            return matchingAliases;
+        }
+
+        // Fallback: complex patterns (embedded/multiple stars, "?", regex) require the original full scan.
+        final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
+        return lookup.entrySet()
+            .stream()
+            .filter(e -> e.getValue().getType() == ALIAS)
+            .map(Map.Entry::getKey)
+            .filter(dateResolvedMatcher)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns true only for a pattern of the form {@code "prefix*"} where the trailing {@code *} is the ONLY special
+     * character. This mirrors {@link WildcardMatcher#from(String)} routing such patterns to a literal-{@code startsWith}
+     * {@code PrefixMatcher}: no {@code ?}, no additional {@code *}, and not a {@code /regex/}. Any other pattern must go
+     * through the full-scan fallback. A bare {@code "*"} is excluded (length must be &gt; 1), so the prefix is never empty.
+     */
+    static boolean isSimplePrefixPattern(String pattern) {
+        if (pattern == null || pattern.length() <= 1) {
+            return false;
+        }
+        if (pattern.startsWith("/") && pattern.endsWith("/")) {
+            return false;
+        }
+        if (pattern.indexOf('?') != -1) {
+            return false;
+        }
+        // The single '*' must be the final character (and thus the only '*').
+        return pattern.indexOf('*') == pattern.length() - 1;
+    }
+
+    /**
+     * Computes the exclusive upper bound for a {@code subMap} range covering all strings that start with {@code prefix},
+     * by incrementing the last character that is not {@link Character#MAX_VALUE} and truncating after it. Returns
+     * {@code null} when the prefix is composed entirely of {@code Character.MAX_VALUE} code units, in which case no
+     * strictly-greater bound exists and callers must use {@code tailMap(prefix)} instead. {@code prefix} is guaranteed
+     * non-empty by {@link #isSimplePrefixPattern(String)}.
+     */
+    static String incrementForUpperBound(String prefix) {
+        final char[] chars = prefix.toCharArray();
+        for (int i = chars.length - 1; i >= 0; i--) {
+            if (chars[i] != Character.MAX_VALUE) {
+                chars[i]++;
+                return new String(chars, 0, i + 1);
+            }
+        }
+        return null;
     }
 
     // dnfof

--- a/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
+++ b/src/test/java/org/opensearch/security/privileges/actionlevel/legacy/IndexResolverReplacerTest.java
@@ -1,0 +1,308 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.actionlevel.legacy;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.security.support.WildcardMatcher;
+import org.opensearch.security.util.MockIndexMetadataBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexResolverReplacerTest {
+
+    private static final int ALIAS_COUNT = 10_000;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+    private static final SortedMap<String, IndexAbstraction> ALIAS_HEAVY_LOOKUP = createAliasHeavyLookup();
+
+    // ---------------------------------------------------------------------
+    // Instrumentation tests: prove the bounded path does NOT scan the full
+    // lookup for exact names and simple prefix patterns.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void exactConcreteIndexDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(INDEX)), empty());
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void exactAliasDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+        String alias = ALIAS_PREFIX + (ALIAS_COUNT - 1);
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(alias)), containsInAnyOrder(alias));
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void prefixAliasPatternUsesBoundedLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "999*")),
+            containsInAnyOrder(
+                ALIAS_PREFIX + "999",
+                ALIAS_PREFIX + "9990",
+                ALIAS_PREFIX + "9991",
+                ALIAS_PREFIX + "9992",
+                ALIAS_PREFIX + "9993",
+                ALIAS_PREFIX + "9994",
+                ALIAS_PREFIX + "9995",
+                ALIAS_PREFIX + "9996",
+                ALIAS_PREFIX + "9997",
+                ALIAS_PREFIX + "9998",
+                ALIAS_PREFIX + "9999"
+            )
+        );
+        assertThat(lookup.getCalls, equalTo(0));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(1));
+        assertThat(lookup.subMapEntryCount, equalTo(11));
+    }
+
+    @Test
+    public void complexAliasPatternFallsBackToFullLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "9?9")),
+            containsInAnyOrder(matchingAliases(ALIAS_PREFIX + "9?9").toArray(new String[0]))
+        );
+        assertThat(lookup.fullEntrySetCalls, equalTo(1));
+    }
+
+    // ---------------------------------------------------------------------
+    // Differential / property test: for a broad set of patterns, the bounded
+    // path (resolveMatchingAliases) MUST return exactly the same alias set as
+    // the reference full-scan + WildcardMatcher path. This is the core
+    // semantic-equivalence guarantee.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void boundedPathMatchesFullScanForAllPatternClasses() {
+        SortedMap<String, IndexAbstraction> lookup = differentialLookup();
+
+        List<String> patterns = List.of(
+            // exact alias
+            "logs-app-1",
+            // exact concrete index (must NOT be returned as an alias)
+            "index-app",
+            // exact name that does not exist at all
+            "does-not-exist",
+            // exact data stream name (not an alias)
+            "ds-metrics",
+            // simple prefix matching many aliases
+            "logs-*",
+            // prefix that is also a full alias name minus star (zero-or-more => includes "logs-app")
+            "logs-app*",
+            // prefix matching a single alias
+            "logs-app-11*",
+            // prefix matching nothing
+            "zzz-*",
+            // bare star handled by isLocalAll upstream, but must be safe here as a full-scan fallback
+            "*",
+            // complex: embedded question mark
+            "logs-app-?",
+            // complex: embedded star
+            "logs-*-1",
+            // complex: leading star (contains)
+            "*app-1",
+            // regex form
+            "/logs-.*/",
+            // prefix whose literal chars include regex-special characters (must stay literal via PrefixMatcher)
+            "weird.name[*",
+            // exact name containing regex-special characters
+            "weird.name[0]"
+        );
+
+        for (String pattern : patterns) {
+            assertPatternEquivalent(lookup, Set.of(pattern));
+        }
+
+        // Mixed sets combining bounded-eligible and fallback patterns.
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-app-2"));
+        assertPatternEquivalent(lookup, Set.of("logs-app-1*", "metrics-*"));
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-*-1")); // exact + complex => whole set falls back
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-app-2*", "index-app"));
+        assertPatternEquivalent(lookup, Set.<String>of()); // empty pattern set
+
+        // A null pattern must match nothing (as WildcardMatcher.NONE) rather than NPE on TreeMap#get.
+        Set<String> withNull = new HashSet<>();
+        withNull.add(null);
+        withNull.add("logs-app-1");
+        assertPatternEquivalent(lookup, withNull);
+    }
+
+    @Test
+    public void upperBoundCarryEdgeCasesDoNotThrow() {
+        // Aliases whose names end in the maximum char, so the naive "increment last char" upper bound would carry
+        // past Character.MAX_VALUE and produce an invalid subMap range. The hardened incrementForUpperBound +
+        // tailMap fallback must handle this and still match the full-scan reference.
+        char max = Character.MAX_VALUE;
+        String maxAlias = "z" + max;
+        String maxAlias2 = "z" + max + max;
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices("idx");
+        builder.alias(maxAlias).of("idx");
+        builder.alias(maxAlias2).of("idx");
+        builder.alias("z" + max + "a").of("idx");
+        builder.alias("plain").of("idx");
+        SortedMap<String, IndexAbstraction> lookup = new TreeMap<>(builder.build());
+
+        assertPatternEquivalent(lookup, Set.of("z" + max + "*"));
+        // A prefix consisting solely of the max char forces the tailMap branch.
+        MockIndexMetadataBuilder b2 = MockIndexMetadataBuilder.indices("idx2");
+        b2.alias(String.valueOf(max)).of("idx2");
+        b2.alias(max + "tail").of("idx2");
+        b2.alias("normal").of("idx2");
+        SortedMap<String, IndexAbstraction> lookup2 = new TreeMap<>(b2.build());
+        assertPatternEquivalent(lookup2, Set.of(max + "*"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static void assertPatternEquivalent(SortedMap<String, IndexAbstraction> lookup, Set<String> patterns) {
+        Set<String> bounded = IndexResolverReplacer.resolveMatchingAliases(lookup, patterns);
+        Set<String> reference = fullScanReference(lookup, patterns);
+        assertThat("pattern set " + patterns + " must resolve identically via bounded and full-scan paths", bounded, equalTo(reference));
+    }
+
+    /** The original (pre-optimization) implementation, used as the differential oracle. */
+    private static Set<String> fullScanReference(SortedMap<String, IndexAbstraction> lookup, Set<String> patterns) {
+        if (patterns.isEmpty()) {
+            return new HashSet<>();
+        }
+        final WildcardMatcher matcher = WildcardMatcher.from(patterns);
+        return lookup.entrySet()
+            .stream()
+            .filter(e -> e.getValue().getType() == IndexAbstraction.Type.ALIAS)
+            .map(java.util.Map.Entry::getKey)
+            .filter(matcher)
+            .collect(Collectors.toSet());
+    }
+
+    private static SortedMap<String, IndexAbstraction> differentialLookup() {
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices("index-app", "index-metrics");
+        for (int i = 1; i <= 20; i++) {
+            builder.alias("logs-app-" + i).of("index-app");
+        }
+        builder.alias("logs-app").of("index-app");
+        builder.alias("metrics-app-1").of("index-metrics");
+        builder.alias("metrics-app-2").of("index-metrics");
+        builder.alias("weird.name[0]").of("index-app");
+        builder.alias("weird.name[1]").of("index-app");
+        builder.dataStream("ds-metrics");
+        return new TreeMap<>(builder.build());
+    }
+
+    private static TrackingSortedMap aliasHeavyLookup() {
+        return new TrackingSortedMap(ALIAS_HEAVY_LOOKUP);
+    }
+
+    private static SortedMap<String, IndexAbstraction> createAliasHeavyLookup() {
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices(INDEX);
+        for (int i = 0; i < ALIAS_COUNT; i++) {
+            builder.alias(ALIAS_PREFIX + i).of(INDEX);
+        }
+        return new TreeMap<>(builder.build());
+    }
+
+    private static Collection<String> matchingAliases(String pattern) {
+        return IntStream.range(0, ALIAS_COUNT)
+            .mapToObj(i -> ALIAS_PREFIX + i)
+            .filter(WildcardMatcher.from(pattern))
+            .collect(Collectors.toList());
+    }
+
+    /** SortedMap wrapper that counts point-lookups, full entrySet scans, and subMap ranges. */
+    private static class TrackingSortedMap extends AbstractMap<String, IndexAbstraction> implements SortedMap<String, IndexAbstraction> {
+
+        private final SortedMap<String, IndexAbstraction> delegate;
+        private int getCalls;
+        private int fullEntrySetCalls;
+        private int subMapCalls;
+        private int subMapEntryCount;
+
+        private TrackingSortedMap(SortedMap<String, IndexAbstraction> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public IndexAbstraction get(Object key) {
+            getCalls++;
+            return delegate.get(key);
+        }
+
+        @Override
+        public Set<Entry<String, IndexAbstraction>> entrySet() {
+            fullEntrySetCalls++;
+            return delegate.entrySet();
+        }
+
+        @Override
+        public Comparator<? super String> comparator() {
+            return delegate.comparator();
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> subMap(String fromKey, String toKey) {
+            subMapCalls++;
+            SortedMap<String, IndexAbstraction> result = delegate.subMap(fromKey, toKey);
+            subMapEntryCount += result.size();
+            return result;
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> headMap(String toKey) {
+            return delegate.headMap(toKey);
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> tailMap(String fromKey) {
+            return delegate.tailMap(fromKey);
+        }
+
+        @Override
+        public String firstKey() {
+            return delegate.firstKey();
+        }
+
+        @Override
+        public String lastKey() {
+            return delegate.lastKey();
+        }
+    }
+}


### PR DESCRIPTION
On every non-_all request, privilege evaluation streamed the entire indices lookup (a TreeMap of all index abstractions) and filtered it with a WildcardMatcher to find matching aliases. On clusters with hundreds of thousands of aliases this is ~500ms of CPU per request even when the request names a single exact alias or a simple prefix.

Resolve exact names via a point lookup and simple prefix patterns via a bounded subMap range over the naturally-ordered lookup; fall back to the original full scan only for complex patterns (?, embedded/multiple *, regex). Result sets are identical to the previous behavior (proved by a differential test).

Hardening over the original approach: robust subMap upper-bound carry handling for prefixes ending in Character.MAX_VALUE (tailMap fallback) and a null-pattern guard, both of which the naive increment/point-lookup would have broken.

Supersedes [cwperks#110](https://github.com/cwperks/security/pull/110).

### Issues Resolved
- Address #5367 

### Testing
unit testing, integration testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
