### PR TITLE
[Backport 2.19] Scale legacy alias resolution with bounded indices-lookup access (#6312)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/IndexResolverReplacerAliasScaleIntegTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/IndexResolverReplacerAliasScaleIntegTests.java
@@ -1,0 +1,98 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
+import org.opensearch.action.admin.indices.create.CreateIndexRequest;
+import org.opensearch.client.Client;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.TestSecurityConfig.Role;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+/**
+ * End-to-end check that requests targeting a single exact alias or a simple prefix remain healthy when the cluster
+ * holds a very large number of aliases (the SentinelOne V2286487402 shape). This exercises the real transport path
+ * through {@link org.opensearch.security.resolver.IndexResolverReplacer} rather than the unit-level helper.
+ */
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class IndexResolverReplacerAliasScaleIntegTests {
+
+    private static final int ALIAS_COUNT = 5_000;
+    private static final int EXACT_REQUEST_COUNT = 100;
+    private static final int PREFIX_REQUEST_COUNT = 25;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+
+    private static final TestSecurityConfig.User READER = new TestSecurityConfig.User("alias_scale_reader").roles(
+        new Role("alias_scale_reader_role").indexPermissions("read").on(INDEX, ALIAS_PREFIX + "*")
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(READER, TestSecurityConfig.User.USER_ADMIN)
+        .build();
+
+    @BeforeClass
+    public static void createAliasHeavyClusterState() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            client.admin().indices().create(new CreateIndexRequest(INDEX)).actionGet();
+
+            // Add all aliases in a single request so cluster state is updated once.
+            IndicesAliasesRequest request = new IndicesAliasesRequest();
+            for (int i = 0; i < ALIAS_COUNT; i++) {
+                request.addAliasAction(new AliasActions(ADD).indices(INDEX).alias(ALIAS_PREFIX + i));
+            }
+            client.admin().indices().aliases(request).actionGet();
+        }
+    }
+
+    @Test
+    public void repeatedExactConcreteIndexRequestsWithManyAliases() {
+        assertRepeatedSearches(INDEX, EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedExactAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + (ALIAS_COUNT - 1), EXACT_REQUEST_COUNT);
+    }
+
+    @Test
+    public void repeatedPrefixAliasRequestsWithManyAliases() {
+        assertRepeatedSearches(ALIAS_PREFIX + "49*", PREFIX_REQUEST_COUNT);
+    }
+
+    private static void assertRepeatedSearches(String indexExpression, int requestCount) {
+        try (TestRestClient client = cluster.getRestClient(READER)) {
+            for (int i = 0; i < requestCount; i++) {
+                TestRestClient.HttpResponse response = client.get(indexExpression + "/_search?size=0");
+                assertThat("Request " + i + " for " + indexExpression, response.getStatusCode(), equalTo(200));
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
+++ b/src/main/java/org/opensearch/security/resolver/IndexResolverReplacer.java
@@ -38,6 +38,7 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Supplier;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
@@ -303,15 +304,9 @@ public class IndexResolverReplacer {
                 final Set<String> dateResolvedLocalRequestedPatterns = localRequestedPatterns.stream()
                     .map(resolver::resolveDateMathExpression)
                     .collect(Collectors.toSet());
-                final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
                 // fill matchingAliases
-                final Map<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
-                matchingAliases = lookup.entrySet()
-                    .stream()
-                    .filter(e -> e.getValue().getType() == ALIAS)
-                    .map(Map.Entry::getKey)
-                    .filter(dateResolvedMatcher)
-                    .collect(Collectors.toSet());
+                final SortedMap<String, IndexAbstraction> lookup = state.metadata().getIndicesLookup();
+                matchingAliases = resolveMatchingAliases(lookup, dateResolvedLocalRequestedPatterns);
 
                 final boolean isDebugEnabled = log.isDebugEnabled();
                 try {
@@ -408,6 +403,114 @@ public class IndexResolverReplacer {
 
             return resolved;
         }
+    }
+
+    /**
+     * Resolves the set of aliases matching the given (already date-math-resolved) patterns.
+     *
+     * The indices lookup ({@link org.opensearch.cluster.metadata.Metadata#getIndicesLookup()}) is a natural-ordering
+     * {@code TreeMap}. For exact names and simple prefix patterns ({@code "foo*"}) we can answer from a point lookup or a
+     * bounded {@code subMap} range instead of streaming and wildcard-matching the entire lookup (which can hold hundreds
+     * of thousands of abstractions). Any pattern that is not exact or a simple prefix (question marks, embedded stars,
+     * regex, etc.) forces the original full-scan path, so the result set is always identical to the legacy behavior.
+     *
+     * @param lookup the cluster indices lookup, sorted with natural String ordering
+     * @param dateResolvedLocalRequestedPatterns the requested patterns after date-math resolution
+     * @return the names of all aliases matching any of the patterns
+     */
+    static Set<String> resolveMatchingAliases(SortedMap<String, IndexAbstraction> lookup, Set<String> dateResolvedLocalRequestedPatterns) {
+        boolean canUseBoundedLookup = true;
+        for (String pattern : dateResolvedLocalRequestedPatterns) {
+            if (WildcardMatcher.isExact(pattern) == false && isSimplePrefixPattern(pattern) == false) {
+                canUseBoundedLookup = false;
+                break;
+            }
+        }
+
+        if (canUseBoundedLookup) {
+            final Set<String> matchingAliases = new HashSet<>();
+            for (String pattern : dateResolvedLocalRequestedPatterns) {
+                if (WildcardMatcher.isExact(pattern)) {
+                    // Exact name: a single point lookup, keep it only if it is actually an alias. A null pattern is
+                    // treated as WildcardMatcher.NONE by the full-scan path (matches nothing) and would NPE on the
+                    // natural-ordering TreeMap#get, so it is skipped to preserve identical semantics.
+                    if (pattern == null) {
+                        continue;
+                    }
+                    final IndexAbstraction indexAbstraction = lookup.get(pattern);
+                    if (indexAbstraction != null && indexAbstraction.getType() == ALIAS) {
+                        matchingAliases.add(pattern);
+                    }
+                } else {
+                    // Simple prefix "p*": PrefixMatcher matches via literal String.startsWith(prefix), so the matching
+                    // keys are exactly the range [prefix, prefixUpperBound). Note trailing "*" means zero-or-more, so
+                    // the prefix itself (e.g. "foo" for "foo*") is included because it is the inclusive lower bound.
+                    final String prefix = pattern.substring(0, pattern.length() - 1);
+                    final SortedMap<String, IndexAbstraction> range;
+                    final String upperBound = incrementForUpperBound(prefix);
+                    if (upperBound == null) {
+                        // prefix consists entirely of Character.MAX_VALUE; there is no strictly-greater bound, so every
+                        // key >= prefix is a candidate.
+                        range = lookup.tailMap(prefix);
+                    } else {
+                        range = lookup.subMap(prefix, upperBound);
+                    }
+                    for (Map.Entry<String, IndexAbstraction> entry : range.entrySet()) {
+                        if (entry.getValue().getType() == ALIAS) {
+                            matchingAliases.add(entry.getKey());
+                        }
+                    }
+                }
+            }
+            return matchingAliases;
+        }
+
+        // Fallback: complex patterns (embedded/multiple stars, "?", regex) require the original full scan.
+        final WildcardMatcher dateResolvedMatcher = WildcardMatcher.from(dateResolvedLocalRequestedPatterns);
+        return lookup.entrySet()
+            .stream()
+            .filter(e -> e.getValue().getType() == ALIAS)
+            .map(Map.Entry::getKey)
+            .filter(dateResolvedMatcher)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * Returns true only for a pattern of the form {@code "prefix*"} where the trailing {@code *} is the ONLY special
+     * character. This mirrors {@link WildcardMatcher#from(String)} routing such patterns to a literal-{@code startsWith}
+     * {@code PrefixMatcher}: no {@code ?}, no additional {@code *}, and not a {@code /regex/}. Any other pattern must go
+     * through the full-scan fallback. A bare {@code "*"} is excluded (length must be &gt; 1), so the prefix is never empty.
+     */
+    static boolean isSimplePrefixPattern(String pattern) {
+        if (pattern == null || pattern.length() <= 1) {
+            return false;
+        }
+        if (pattern.startsWith("/") && pattern.endsWith("/")) {
+            return false;
+        }
+        if (pattern.indexOf('?') != -1) {
+            return false;
+        }
+        // The single '*' must be the final character (and thus the only '*').
+        return pattern.indexOf('*') == pattern.length() - 1;
+    }
+
+    /**
+     * Computes the exclusive upper bound for a {@code subMap} range covering all strings that start with {@code prefix},
+     * by incrementing the last character that is not {@link Character#MAX_VALUE} and truncating after it. Returns
+     * {@code null} when the prefix is composed entirely of {@code Character.MAX_VALUE} code units, in which case no
+     * strictly-greater bound exists and callers must use {@code tailMap(prefix)} instead. {@code prefix} is guaranteed
+     * non-empty by {@link #isSimplePrefixPattern(String)}.
+     */
+    static String incrementForUpperBound(String prefix) {
+        final char[] chars = prefix.toCharArray();
+        for (int i = chars.length - 1; i >= 0; i--) {
+            if (chars[i] != Character.MAX_VALUE) {
+                chars[i]++;
+                return new String(chars, 0, i + 1);
+            }
+        }
+        return null;
     }
 
     // dnfof

--- a/src/test/java/org/opensearch/security/resolver/IndexResolverReplacerTest.java
+++ b/src/test/java/org/opensearch/security/resolver/IndexResolverReplacerTest.java
@@ -1,0 +1,312 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.resolver;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.Test;
+
+import org.opensearch.cluster.metadata.IndexAbstraction;
+import org.opensearch.security.support.WildcardMatcher;
+import org.opensearch.security.util.MockIndexMetadataBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+
+public class IndexResolverReplacerTest {
+
+    private static final int ALIAS_COUNT = 10_000;
+    private static final String INDEX = "alias-scale-index";
+    private static final String ALIAS_PREFIX = "alias-scale-";
+    private static final SortedMap<String, IndexAbstraction> ALIAS_HEAVY_LOOKUP = createAliasHeavyLookup();
+
+    // ---------------------------------------------------------------------
+    // Instrumentation tests: prove the bounded path does NOT scan the full
+    // lookup for exact names and simple prefix patterns.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void exactConcreteIndexDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(INDEX)), empty());
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void exactAliasDoesNotTraverseAliasLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+        String alias = ALIAS_PREFIX + (ALIAS_COUNT - 1);
+
+        assertThat(IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(alias)), containsInAnyOrder(alias));
+        assertThat(lookup.getCalls, equalTo(1));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(0));
+    }
+
+    @Test
+    public void prefixAliasPatternUsesBoundedLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "999*")),
+            containsInAnyOrder(
+                ALIAS_PREFIX + "999",
+                ALIAS_PREFIX + "9990",
+                ALIAS_PREFIX + "9991",
+                ALIAS_PREFIX + "9992",
+                ALIAS_PREFIX + "9993",
+                ALIAS_PREFIX + "9994",
+                ALIAS_PREFIX + "9995",
+                ALIAS_PREFIX + "9996",
+                ALIAS_PREFIX + "9997",
+                ALIAS_PREFIX + "9998",
+                ALIAS_PREFIX + "9999"
+            )
+        );
+        assertThat(lookup.getCalls, equalTo(0));
+        assertThat(lookup.fullEntrySetCalls, equalTo(0));
+        assertThat(lookup.subMapCalls, equalTo(1));
+        assertThat(lookup.subMapEntryCount, equalTo(11));
+    }
+
+    @Test
+    public void complexAliasPatternFallsBackToFullLookup() {
+        TrackingSortedMap lookup = aliasHeavyLookup();
+
+        assertThat(
+            IndexResolverReplacer.resolveMatchingAliases(lookup, Set.of(ALIAS_PREFIX + "9?9")),
+            containsInAnyOrder(matchingAliases(ALIAS_PREFIX + "9?9").toArray(new String[0]))
+        );
+        assertThat(lookup.fullEntrySetCalls, equalTo(1));
+    }
+
+    // ---------------------------------------------------------------------
+    // Differential / property test: for a broad set of patterns, the bounded
+    // path (resolveMatchingAliases) MUST return exactly the same alias set as
+    // the reference full-scan + WildcardMatcher path. This is the core
+    // semantic-equivalence guarantee.
+    // ---------------------------------------------------------------------
+
+    @Test
+    public void boundedPathMatchesFullScanForAllPatternClasses() {
+        SortedMap<String, IndexAbstraction> lookup = differentialLookup();
+
+        List<String> patterns = List.of(
+            // exact alias
+            "logs-app-1",
+            // exact concrete index (must NOT be returned as an alias)
+            "index-app",
+            // exact name that does not exist at all
+            "does-not-exist",
+            // exact data stream name (not an alias)
+            "ds-metrics",
+            // simple prefix matching many aliases
+            "logs-*",
+            // prefix that is also a full alias name minus star (zero-or-more => includes "logs-app")
+            "logs-app*",
+            // prefix matching a single alias
+            "logs-app-11*",
+            // prefix matching nothing
+            "zzz-*",
+            // bare star handled by isLocalAll upstream, but must be safe here as a full-scan fallback
+            "*",
+            // complex: embedded question mark
+            "logs-app-?",
+            // complex: embedded star
+            "logs-*-1",
+            // complex: leading star (contains)
+            "*app-1",
+            // regex form
+            "/logs-.*/",
+            // prefix whose literal chars include regex-special characters (must stay literal via PrefixMatcher)
+            "weird.name[*",
+            // exact name containing regex-special characters
+            "weird.name[0]"
+        );
+
+        for (String pattern : patterns) {
+            assertPatternEquivalent(lookup, Set.of(pattern));
+        }
+
+        // Mixed sets combining bounded-eligible and fallback patterns.
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-app-2"));
+        assertPatternEquivalent(lookup, Set.of("logs-app-1*", "metrics-*"));
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-*-1")); // exact + complex => whole set falls back
+        assertPatternEquivalent(lookup, Set.of("logs-app-1", "logs-app-2*", "index-app"));
+        assertPatternEquivalent(lookup, Set.<String>of()); // empty pattern set
+
+        // A null pattern must match nothing (as WildcardMatcher.NONE) rather than NPE on TreeMap#get.
+        Set<String> withNull = new HashSet<>();
+        withNull.add(null);
+        withNull.add("logs-app-1");
+        assertPatternEquivalent(lookup, withNull);
+    }
+
+    @Test
+    public void upperBoundCarryEdgeCasesDoNotThrow() {
+        // Aliases whose names end in the maximum char, so the naive "increment last char" upper bound would carry
+        // past Character.MAX_VALUE and produce an invalid subMap range. The hardened incrementForUpperBound +
+        // tailMap fallback must handle this and still match the full-scan reference.
+        char max = Character.MAX_VALUE;
+        String maxAlias = "z" + max;
+        String maxAlias2 = "z" + max + max;
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices("idx");
+        builder.alias(maxAlias).of("idx");
+        builder.alias(maxAlias2).of("idx");
+        builder.alias("z" + max + "a").of("idx");
+        builder.alias("plain").of("idx");
+        SortedMap<String, IndexAbstraction> lookup = new TreeMap<>(builder.build());
+
+        // "z￿*" -> prefix "z￿"; increment carries to "z" -> ... exercised via isSimplePrefixPattern.
+        assertPatternEquivalent(lookup, Set.of("z" + max + "*"));
+        // A prefix consisting solely of the max char forces the tailMap branch.
+        MockIndexMetadataBuilder b2 = MockIndexMetadataBuilder.indices("idx2");
+        b2.alias(String.valueOf(max)).of("idx2");
+        b2.alias(max + "tail").of("idx2");
+        b2.alias("normal").of("idx2");
+        SortedMap<String, IndexAbstraction> lookup2 = new TreeMap<>(b2.build());
+        assertPatternEquivalent(lookup2, Set.of(max + "*"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------
+
+    private static void assertPatternEquivalent(SortedMap<String, IndexAbstraction> lookup, Set<String> patterns) {
+        Set<String> bounded = IndexResolverReplacer.resolveMatchingAliases(lookup, patterns);
+        Set<String> reference = fullScanReference(lookup, patterns);
+        assertThat("pattern set " + patterns + " must resolve identically via bounded and full-scan paths", bounded, equalTo(reference));
+    }
+
+    /** The original (pre-optimization) implementation, used as the differential oracle. */
+    private static Set<String> fullScanReference(SortedMap<String, IndexAbstraction> lookup, Set<String> patterns) {
+        if (patterns.isEmpty()) {
+            return new HashSet<>();
+        }
+        final WildcardMatcher matcher = WildcardMatcher.from(patterns);
+        return lookup.entrySet()
+            .stream()
+            .filter(e -> e.getValue().getType() == IndexAbstraction.Type.ALIAS)
+            .map(java.util.Map.Entry::getKey)
+            .filter(matcher)
+            .collect(Collectors.toSet());
+    }
+
+    private static SortedMap<String, IndexAbstraction> differentialLookup() {
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices("index-app", "index-metrics");
+        // aliases on index-app
+        for (int i = 1; i <= 20; i++) {
+            builder.alias("logs-app-" + i).of("index-app");
+        }
+        builder.alias("logs-app").of("index-app");
+        builder.alias("metrics-app-1").of("index-metrics");
+        builder.alias("metrics-app-2").of("index-metrics");
+        // aliases with regex-special characters in the name to prove literal handling
+        builder.alias("weird.name[0]").of("index-app");
+        builder.alias("weird.name[1]").of("index-app");
+        // a data stream (type DATA_STREAM, not ALIAS) to ensure it is never returned
+        builder.dataStream("ds-metrics");
+        return new TreeMap<>(builder.build());
+    }
+
+    private static TrackingSortedMap aliasHeavyLookup() {
+        return new TrackingSortedMap(ALIAS_HEAVY_LOOKUP);
+    }
+
+    private static SortedMap<String, IndexAbstraction> createAliasHeavyLookup() {
+        MockIndexMetadataBuilder builder = MockIndexMetadataBuilder.indices(INDEX);
+        for (int i = 0; i < ALIAS_COUNT; i++) {
+            builder.alias(ALIAS_PREFIX + i).of(INDEX);
+        }
+        return new TreeMap<>(builder.build());
+    }
+
+    private static Collection<String> matchingAliases(String pattern) {
+        return IntStream.range(0, ALIAS_COUNT)
+            .mapToObj(i -> ALIAS_PREFIX + i)
+            .filter(WildcardMatcher.from(pattern))
+            .collect(Collectors.toList());
+    }
+
+    /** SortedMap wrapper that counts point-lookups, full entrySet scans, and subMap ranges. */
+    private static class TrackingSortedMap extends AbstractMap<String, IndexAbstraction> implements SortedMap<String, IndexAbstraction> {
+
+        private final SortedMap<String, IndexAbstraction> delegate;
+        private int getCalls;
+        private int fullEntrySetCalls;
+        private int subMapCalls;
+        private int subMapEntryCount;
+
+        private TrackingSortedMap(SortedMap<String, IndexAbstraction> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public IndexAbstraction get(Object key) {
+            getCalls++;
+            return delegate.get(key);
+        }
+
+        @Override
+        public Set<Entry<String, IndexAbstraction>> entrySet() {
+            fullEntrySetCalls++;
+            return delegate.entrySet();
+        }
+
+        @Override
+        public Comparator<? super String> comparator() {
+            return delegate.comparator();
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> subMap(String fromKey, String toKey) {
+            subMapCalls++;
+            SortedMap<String, IndexAbstraction> result = delegate.subMap(fromKey, toKey);
+            subMapEntryCount += result.size();
+            return result;
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> headMap(String toKey) {
+            return delegate.headMap(toKey);
+        }
+
+        @Override
+        public SortedMap<String, IndexAbstraction> tailMap(String fromKey) {
+            return delegate.tailMap(fromKey);
+        }
+
+        @Override
+        public String firstKey() {
+            return delegate.firstKey();
+        }
+
+        @Override
+        public String lastKey() {
+            return delegate.lastKey();
+        }
+    }
+}


### PR DESCRIPTION
Backports #6312 to 2.19 (cherry picked from commit 7e7d0c22b167624c888e187b296d46b685055045)

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
