### PR TITLE
fix(audit): Address PR review feedback from #6304

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1222,7 +1222,6 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     cs,
                     threadPool,
                     ((AbstractAuditLog) auditLog).getFilter(),
-                    new IndexNameExpressionResolver(threadPool.getThreadContext()),
                     getAuditIndexPrefix(pluginSettings)
                 )
             );

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -466,6 +466,15 @@ public class AuditConfig {
             return ignoredAuditUsersMatcher.test(user);
         }
 
+        /**
+         * Check if user is included in audit.
+         * @param user
+         * @return true if user is included in audit logging
+         */
+        public boolean isAuditEnabled(String user) {
+            return !ignoredAuditUsersMatcher.test(user);
+        }
+
         @VisibleForTesting
         WildcardMatcher getIgnoredAuditRequestsMatcher() {
             return ignoredAuditRequestsMatcher;

--- a/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
+++ b/src/main/java/org/opensearch/security/auditlog/config/AuditConfig.java
@@ -459,7 +459,7 @@ public class AuditConfig {
 
         /**
          * Check if user is excluded from audit.
-         * @param user
+         * @param user effective user name (from FGAC user or SSL principal)
          * @return true if user is excluded from audit logging
          */
         public boolean isAuditDisabled(String user) {
@@ -468,7 +468,7 @@ public class AuditConfig {
 
         /**
          * Check if user is included in audit.
-         * @param user
+         * @param user effective user name (from FGAC user or SSL principal)
          * @return true if user is included in audit logging
          */
         public boolean isAuditEnabled(String user) {

--- a/src/main/java/org/opensearch/security/compliance/ComplianceReadIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceReadIndexSearcherWrapper.java
@@ -87,7 +87,22 @@ public class ComplianceReadIndexSearcherWrapper implements CheckedFunction<Direc
         }
 
         @Override
-        public void numericFieldRead(FieldInfo fieldInfo, Number value) {
+        public void intFieldRead(FieldInfo fieldInfo, int value) {
+            fieldReadCallback.numericFieldRead(fieldInfo, value);
+        }
+
+        @Override
+        public void longFieldRead(FieldInfo fieldInfo, long value) {
+            fieldReadCallback.numericFieldRead(fieldInfo, value);
+        }
+
+        @Override
+        public void floatFieldRead(FieldInfo fieldInfo, float value) {
+            fieldReadCallback.numericFieldRead(fieldInfo, value);
+        }
+
+        @Override
+        public void doubleFieldRead(FieldInfo fieldInfo, double value) {
             fieldReadCallback.numericFieldRead(fieldInfo, value);
         }
 

--- a/src/main/java/org/opensearch/security/compliance/ComplianceReadIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/compliance/ComplianceReadIndexSearcherWrapper.java
@@ -10,42 +10,29 @@ package org.opensearch.security.compliance;
 
 import java.io.IOException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.apache.lucene.codecs.StoredFieldsReader;
 import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.FilterDirectoryReader;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.StoredFieldVisitor;
-import org.apache.lucene.index.StoredFields;
+import org.apache.lucene.index.FieldInfo;
 
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.CheckedFunction;
-import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.index.IndexService;
-import org.opensearch.index.shard.ShardUtils;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.threadpool.ThreadPool;
 
 /**
- * A lightweight reader wrapper that provides compliance read tracking
- * (COMPLIANCE_DOC_READ) without DLS/FLS. For use in non-FGAC modes
- * where SecurityFlsDlsIndexSearcherWrapper is not registered.
+ * Compliance-specific read tracking wrapper. Delegates to the generic
+ * {@link ReadInterceptIndexSearcherWrapper} with a compliance-aware predicate
+ * and a {@link FieldReadHandler} that fires {@link FieldReadCallback} for
+ * COMPLIANCE_DOC_READ audit events.
  *
- * Reuses FieldReadCallback directly with FieldMaskingRule.ALLOW_ALL
- * (no field masking since no FLS is active).
+ * For use in non-FGAC modes where SecurityFlsDlsIndexSearcherWrapper is not registered.
  */
 public class ComplianceReadIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
 
-    private static final Logger log = LogManager.getLogger(ComplianceReadIndexSearcherWrapper.class);
-
-    private final IndexService indexService;
-    private final ThreadPool threadPool;
-    private final ClusterService clusterService;
-    private final AuditLog auditLog;
+    private final ReadInterceptIndexSearcherWrapper delegate;
 
     public ComplianceReadIndexSearcherWrapper(
         IndexService indexService,
@@ -53,241 +40,60 @@ public class ComplianceReadIndexSearcherWrapper implements CheckedFunction<Direc
         ClusterService clusterService,
         AuditLog auditLog
     ) {
-        this.indexService = indexService;
-        this.threadPool = threadPool;
-        this.clusterService = clusterService;
-        this.auditLog = auditLog;
+        this.delegate = new ReadInterceptIndexSearcherWrapper(indexName -> {
+            ComplianceConfig config = auditLog.getComplianceConfig();
+            return config != null && config.readHistoryEnabledForIndex(indexName);
+        }, shardId -> new ComplianceFieldReadHandler(threadPool.getThreadContext(), indexService, clusterService, auditLog, shardId));
     }
 
     @Override
     public DirectoryReader apply(DirectoryReader reader) throws IOException {
-        final ComplianceConfig complianceConfig = auditLog.getComplianceConfig();
-        if (complianceConfig == null || !complianceConfig.readHistoryEnabledForIndex(indexService.index().getName())) {
-            return reader;
-        }
-
-        final ShardId shardId = ShardUtils.extractShardId(reader);
-        return new ComplianceDirectoryReader(reader, indexService, threadPool.getThreadContext(), clusterService, auditLog, shardId);
+        return delegate.apply(reader);
     }
 
-    static class ComplianceDirectoryReader extends FilterDirectoryReader {
+    /**
+     * Compliance-specific implementation of {@link FieldReadHandler}.
+     * Wraps {@link FieldReadCallback} to produce COMPLIANCE_DOC_READ audit events.
+     */
+    private static class ComplianceFieldReadHandler implements FieldReadHandler {
 
-        private final IndexService indexService;
-        private final ThreadContext threadContext;
-        private final ClusterService clusterService;
-        private final AuditLog auditLog;
-        private final ShardId shardId;
+        private final FieldReadCallback fieldReadCallback;
 
-        public ComplianceDirectoryReader(
-            DirectoryReader in,
-            IndexService indexService,
+        ComplianceFieldReadHandler(
             ThreadContext threadContext,
-            ClusterService clusterService,
-            AuditLog auditLog,
-            ShardId shardId
-        ) throws IOException {
-            super(in, new ComplianceSubReaderWrapper(indexService, threadContext, clusterService, auditLog, shardId));
-            this.indexService = indexService;
-            this.threadContext = threadContext;
-            this.clusterService = clusterService;
-            this.auditLog = auditLog;
-            this.shardId = shardId;
-        }
-
-        @Override
-        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
-            return new ComplianceDirectoryReader(in, indexService, threadContext, clusterService, auditLog, shardId);
-        }
-
-        @Override
-        public CacheHelper getReaderCacheHelper() {
-            return in.getReaderCacheHelper();
-        }
-    }
-
-    private static class ComplianceSubReaderWrapper extends FilterDirectoryReader.SubReaderWrapper {
-
-        private final IndexService indexService;
-        private final ThreadContext threadContext;
-        private final ClusterService clusterService;
-        private final AuditLog auditLog;
-        private final ShardId shardId;
-
-        ComplianceSubReaderWrapper(
             IndexService indexService,
-            ThreadContext threadContext,
             ClusterService clusterService,
             AuditLog auditLog,
             ShardId shardId
         ) {
-            this.indexService = indexService;
-            this.threadContext = threadContext;
-            this.clusterService = clusterService;
-            this.auditLog = auditLog;
-            this.shardId = shardId;
+            this.fieldReadCallback = new FieldReadCallback(
+                threadContext,
+                indexService,
+                clusterService,
+                auditLog,
+                FieldMasking.FieldMaskingRule.ALLOW_ALL,
+                shardId
+            );
         }
 
         @Override
-        public LeafReader wrap(LeafReader reader) {
-            return new ComplianceLeafReader(reader, indexService, threadContext, clusterService, auditLog, shardId);
-        }
-    }
-
-    static class ComplianceLeafReader extends SequentialStoredFieldsLeafReader {
-
-        private final IndexService indexService;
-        private final ThreadContext threadContext;
-        private final ClusterService clusterService;
-        private final AuditLog auditLog;
-        private final ShardId shardId;
-
-        ComplianceLeafReader(
-            LeafReader in,
-            IndexService indexService,
-            ThreadContext threadContext,
-            ClusterService clusterService,
-            AuditLog auditLog,
-            ShardId shardId
-        ) {
-            super(in);
-            this.indexService = indexService;
-            this.threadContext = threadContext;
-            this.clusterService = clusterService;
-            this.auditLog = auditLog;
-            this.shardId = shardId;
+        public void binaryFieldRead(FieldInfo fieldInfo, byte[] value) {
+            fieldReadCallback.binaryFieldRead(fieldInfo, value);
         }
 
         @Override
-        protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
-            return new ComplianceStoredFieldsReader(reader);
+        public void stringFieldRead(FieldInfo fieldInfo, String value) {
+            fieldReadCallback.stringFieldRead(fieldInfo, value);
         }
 
         @Override
-        public StoredFields storedFields() throws IOException {
-            return new ComplianceStoredFields(in.storedFields());
+        public void numericFieldRead(FieldInfo fieldInfo, Number value) {
+            fieldReadCallback.numericFieldRead(fieldInfo, value);
         }
 
         @Override
-        public CacheHelper getCoreCacheHelper() {
-            return in.getCoreCacheHelper();
-        }
-
-        @Override
-        public CacheHelper getReaderCacheHelper() {
-            return in.getReaderCacheHelper();
-        }
-
-        private class ComplianceStoredFieldsReader extends StoredFieldsReader {
-            private final StoredFieldsReader in;
-
-            ComplianceStoredFieldsReader(StoredFieldsReader storedFieldsReader) {
-                this.in = storedFieldsReader;
-            }
-
-            @Override
-            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
-                StoredFieldVisitor wrapped = new ComplianceFieldVisitor(visitor);
-                try {
-                    in.document(docID, wrapped);
-                } finally {
-                    ((ComplianceFieldVisitor) wrapped).finished();
-                }
-            }
-
-            @Override
-            public StoredFieldsReader clone() {
-                return new ComplianceStoredFieldsReader(in.clone());
-            }
-
-            @Override
-            public void checkIntegrity() throws IOException {
-                in.checkIntegrity();
-            }
-
-            @Override
-            public void close() throws IOException {
-                in.close();
-            }
-        }
-
-        private class ComplianceStoredFields extends StoredFields {
-            private final StoredFields in;
-
-            ComplianceStoredFields(StoredFields storedFields) {
-                this.in = storedFields;
-            }
-
-            @Override
-            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
-                StoredFieldVisitor wrapped = new ComplianceFieldVisitor(visitor);
-                try {
-                    in.document(docID, wrapped);
-                } finally {
-                    ((ComplianceFieldVisitor) wrapped).finished();
-                }
-            }
-        }
-
-        private class ComplianceFieldVisitor extends StoredFieldVisitor {
-            private final StoredFieldVisitor delegate;
-            private final FieldReadCallback fieldReadCallback;
-
-            ComplianceFieldVisitor(StoredFieldVisitor delegate) {
-                this.delegate = delegate;
-                this.fieldReadCallback = new FieldReadCallback(
-                    threadContext,
-                    indexService,
-                    clusterService,
-                    auditLog,
-                    FieldMasking.FieldMaskingRule.ALLOW_ALL,
-                    shardId
-                );
-            }
-
-            @Override
-            public void binaryField(org.apache.lucene.index.FieldInfo fieldInfo, byte[] value) throws IOException {
-                fieldReadCallback.binaryFieldRead(fieldInfo, value);
-                delegate.binaryField(fieldInfo, value);
-            }
-
-            @Override
-            public void stringField(org.apache.lucene.index.FieldInfo fieldInfo, String value) throws IOException {
-                fieldReadCallback.stringFieldRead(fieldInfo, value);
-                delegate.stringField(fieldInfo, value);
-            }
-
-            @Override
-            public void intField(org.apache.lucene.index.FieldInfo fieldInfo, int value) throws IOException {
-                fieldReadCallback.numericFieldRead(fieldInfo, value);
-                delegate.intField(fieldInfo, value);
-            }
-
-            @Override
-            public void longField(org.apache.lucene.index.FieldInfo fieldInfo, long value) throws IOException {
-                fieldReadCallback.numericFieldRead(fieldInfo, value);
-                delegate.longField(fieldInfo, value);
-            }
-
-            @Override
-            public void floatField(org.apache.lucene.index.FieldInfo fieldInfo, float value) throws IOException {
-                fieldReadCallback.numericFieldRead(fieldInfo, value);
-                delegate.floatField(fieldInfo, value);
-            }
-
-            @Override
-            public void doubleField(org.apache.lucene.index.FieldInfo fieldInfo, double value) throws IOException {
-                fieldReadCallback.numericFieldRead(fieldInfo, value);
-                delegate.doubleField(fieldInfo, value);
-            }
-
-            @Override
-            public Status needsField(org.apache.lucene.index.FieldInfo fieldInfo) throws IOException {
-                return delegate.needsField(fieldInfo);
-            }
-
-            public void finished() {
-                fieldReadCallback.finished();
-            }
+        public void finished() {
+            fieldReadCallback.finished();
         }
     }
 }

--- a/src/main/java/org/opensearch/security/compliance/FieldReadHandler.java
+++ b/src/main/java/org/opensearch/security/compliance/FieldReadHandler.java
@@ -21,7 +21,13 @@ public interface FieldReadHandler {
 
     void stringFieldRead(FieldInfo fieldInfo, String value);
 
-    void numericFieldRead(FieldInfo fieldInfo, Number value);
+    void intFieldRead(FieldInfo fieldInfo, int value);
+
+    void longFieldRead(FieldInfo fieldInfo, long value);
+
+    void floatFieldRead(FieldInfo fieldInfo, float value);
+
+    void doubleFieldRead(FieldInfo fieldInfo, double value);
 
     /**
      * Called after all fields for a single document have been read.

--- a/src/main/java/org/opensearch/security/compliance/FieldReadHandler.java
+++ b/src/main/java/org/opensearch/security/compliance/FieldReadHandler.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.compliance;
+
+import org.apache.lucene.index.FieldInfo;
+
+/**
+ * Generic interface for handling field-level read interceptions.
+ * Implementations decide what to do when a stored field is read
+ * (e.g., compliance audit logging, access tracking, analytics).
+ */
+public interface FieldReadHandler {
+
+    void binaryFieldRead(FieldInfo fieldInfo, byte[] value);
+
+    void stringFieldRead(FieldInfo fieldInfo, String value);
+
+    void numericFieldRead(FieldInfo fieldInfo, Number value);
+
+    /**
+     * Called after all fields for a single document have been read.
+     * Implementations should flush/finalize any pending work here.
+     */
+    void finished();
+}

--- a/src/main/java/org/opensearch/security/compliance/ReadInterceptIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/compliance/ReadInterceptIndexSearcherWrapper.java
@@ -30,7 +30,7 @@ import org.opensearch.index.shard.ShardUtils;
  * to a {@link FieldReadHandler}. Reusable for any feature that needs to
  * observe field-level reads (compliance tracking, access logging, analytics, etc.).
  *
- * @see ComplianceReadIndexSearcherWrapper for the compliance-specific consumer
+ * @see ComplianceReadIndexSearcherWrapper — the current compliance-specific consumer
  */
 public class ReadInterceptIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
 
@@ -198,25 +198,25 @@ public class ReadInterceptIndexSearcherWrapper implements CheckedFunction<Direct
 
             @Override
             public void intField(org.apache.lucene.index.FieldInfo fieldInfo, int value) throws IOException {
-                handler.numericFieldRead(fieldInfo, value);
+                handler.intFieldRead(fieldInfo, value);
                 delegate.intField(fieldInfo, value);
             }
 
             @Override
             public void longField(org.apache.lucene.index.FieldInfo fieldInfo, long value) throws IOException {
-                handler.numericFieldRead(fieldInfo, value);
+                handler.longFieldRead(fieldInfo, value);
                 delegate.longField(fieldInfo, value);
             }
 
             @Override
             public void floatField(org.apache.lucene.index.FieldInfo fieldInfo, float value) throws IOException {
-                handler.numericFieldRead(fieldInfo, value);
+                handler.floatFieldRead(fieldInfo, value);
                 delegate.floatField(fieldInfo, value);
             }
 
             @Override
             public void doubleField(org.apache.lucene.index.FieldInfo fieldInfo, double value) throws IOException {
-                handler.numericFieldRead(fieldInfo, value);
+                handler.doubleFieldRead(fieldInfo, value);
                 delegate.doubleField(fieldInfo, value);
             }
 

--- a/src/main/java/org/opensearch/security/compliance/ReadInterceptIndexSearcherWrapper.java
+++ b/src/main/java/org/opensearch/security/compliance/ReadInterceptIndexSearcherWrapper.java
@@ -1,0 +1,229 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.compliance;
+
+import java.io.IOException;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import org.apache.lucene.codecs.StoredFieldsReader;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FilterDirectoryReader;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.apache.lucene.index.StoredFields;
+
+import org.opensearch.common.CheckedFunction;
+import org.opensearch.common.lucene.index.SequentialStoredFieldsLeafReader;
+import org.opensearch.core.index.shard.ShardId;
+import org.opensearch.index.shard.ShardUtils;
+
+/**
+ * A generic reader wrapper that intercepts stored field reads and delegates
+ * to a {@link FieldReadHandler}. Reusable for any feature that needs to
+ * observe field-level reads (compliance tracking, access logging, analytics, etc.).
+ *
+ * @see ComplianceReadIndexSearcherWrapper for the compliance-specific consumer
+ */
+public class ReadInterceptIndexSearcherWrapper implements CheckedFunction<DirectoryReader, DirectoryReader, IOException> {
+
+    private final Predicate<String> shouldIntercept;
+    private final Function<ShardId, FieldReadHandler> handlerFactory;
+
+    /**
+     * @param shouldIntercept predicate that decides per-index whether to activate interception
+     * @param handlerFactory creates a new handler instance per document read, given the ShardId
+     */
+    public ReadInterceptIndexSearcherWrapper(Predicate<String> shouldIntercept, Function<ShardId, FieldReadHandler> handlerFactory) {
+        this.shouldIntercept = shouldIntercept;
+        this.handlerFactory = handlerFactory;
+    }
+
+    @Override
+    public DirectoryReader apply(DirectoryReader reader) throws IOException {
+        final ShardId shardId = ShardUtils.extractShardId(reader);
+        if (shardId == null || !shouldIntercept.test(shardId.getIndexName())) {
+            return reader;
+        }
+        return new InterceptDirectoryReader(reader, () -> handlerFactory.apply(shardId));
+    }
+
+    static class InterceptDirectoryReader extends FilterDirectoryReader {
+
+        private final Supplier<FieldReadHandler> handlerFactory;
+
+        InterceptDirectoryReader(DirectoryReader in, Supplier<FieldReadHandler> handlerFactory) throws IOException {
+            super(in, new InterceptSubReaderWrapper(handlerFactory));
+            this.handlerFactory = handlerFactory;
+        }
+
+        @Override
+        protected DirectoryReader doWrapDirectoryReader(DirectoryReader in) throws IOException {
+            return new InterceptDirectoryReader(in, handlerFactory);
+        }
+
+        @Override
+        public CacheHelper getReaderCacheHelper() {
+            return in.getReaderCacheHelper();
+        }
+    }
+
+    private static class InterceptSubReaderWrapper extends FilterDirectoryReader.SubReaderWrapper {
+
+        private final Supplier<FieldReadHandler> handlerFactory;
+
+        InterceptSubReaderWrapper(Supplier<FieldReadHandler> handlerFactory) {
+            this.handlerFactory = handlerFactory;
+        }
+
+        @Override
+        public LeafReader wrap(LeafReader reader) {
+            return new InterceptLeafReader(reader, handlerFactory);
+        }
+    }
+
+    static class InterceptLeafReader extends SequentialStoredFieldsLeafReader {
+
+        private final Supplier<FieldReadHandler> handlerFactory;
+
+        InterceptLeafReader(LeafReader in, Supplier<FieldReadHandler> handlerFactory) {
+            super(in);
+            this.handlerFactory = handlerFactory;
+        }
+
+        @Override
+        protected StoredFieldsReader doGetSequentialStoredFieldsReader(StoredFieldsReader reader) {
+            return new InterceptStoredFieldsReader(reader, handlerFactory);
+        }
+
+        @Override
+        public StoredFields storedFields() throws IOException {
+            return new InterceptStoredFields(in.storedFields(), handlerFactory);
+        }
+
+        @Override
+        public CacheHelper getCoreCacheHelper() {
+            return in.getCoreCacheHelper();
+        }
+
+        @Override
+        public CacheHelper getReaderCacheHelper() {
+            return in.getReaderCacheHelper();
+        }
+
+        private static class InterceptStoredFieldsReader extends StoredFieldsReader {
+            private final StoredFieldsReader in;
+            private final Supplier<FieldReadHandler> handlerFactory;
+
+            InterceptStoredFieldsReader(StoredFieldsReader in, Supplier<FieldReadHandler> handlerFactory) {
+                this.in = in;
+                this.handlerFactory = handlerFactory;
+            }
+
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                FieldReadHandler handler = handlerFactory.get();
+                StoredFieldVisitor wrapped = new InterceptFieldVisitor(visitor, handler);
+                try {
+                    in.document(docID, wrapped);
+                } finally {
+                    handler.finished();
+                }
+            }
+
+            @Override
+            public StoredFieldsReader clone() {
+                return new InterceptStoredFieldsReader(in.clone(), handlerFactory);
+            }
+
+            @Override
+            public void checkIntegrity() throws IOException {
+                in.checkIntegrity();
+            }
+
+            @Override
+            public void close() throws IOException {
+                in.close();
+            }
+        }
+
+        private static class InterceptStoredFields extends StoredFields {
+            private final StoredFields in;
+            private final Supplier<FieldReadHandler> handlerFactory;
+
+            InterceptStoredFields(StoredFields in, Supplier<FieldReadHandler> handlerFactory) {
+                this.in = in;
+                this.handlerFactory = handlerFactory;
+            }
+
+            @Override
+            public void document(int docID, StoredFieldVisitor visitor) throws IOException {
+                FieldReadHandler handler = handlerFactory.get();
+                StoredFieldVisitor wrapped = new InterceptFieldVisitor(visitor, handler);
+                try {
+                    in.document(docID, wrapped);
+                } finally {
+                    handler.finished();
+                }
+            }
+        }
+
+        private static class InterceptFieldVisitor extends StoredFieldVisitor {
+            private final StoredFieldVisitor delegate;
+            private final FieldReadHandler handler;
+
+            InterceptFieldVisitor(StoredFieldVisitor delegate, FieldReadHandler handler) {
+                this.delegate = delegate;
+                this.handler = handler;
+            }
+
+            @Override
+            public void binaryField(org.apache.lucene.index.FieldInfo fieldInfo, byte[] value) throws IOException {
+                handler.binaryFieldRead(fieldInfo, value);
+                delegate.binaryField(fieldInfo, value);
+            }
+
+            @Override
+            public void stringField(org.apache.lucene.index.FieldInfo fieldInfo, String value) throws IOException {
+                handler.stringFieldRead(fieldInfo, value);
+                delegate.stringField(fieldInfo, value);
+            }
+
+            @Override
+            public void intField(org.apache.lucene.index.FieldInfo fieldInfo, int value) throws IOException {
+                handler.numericFieldRead(fieldInfo, value);
+                delegate.intField(fieldInfo, value);
+            }
+
+            @Override
+            public void longField(org.apache.lucene.index.FieldInfo fieldInfo, long value) throws IOException {
+                handler.numericFieldRead(fieldInfo, value);
+                delegate.longField(fieldInfo, value);
+            }
+
+            @Override
+            public void floatField(org.apache.lucene.index.FieldInfo fieldInfo, float value) throws IOException {
+                handler.numericFieldRead(fieldInfo, value);
+                delegate.floatField(fieldInfo, value);
+            }
+
+            @Override
+            public void doubleField(org.apache.lucene.index.FieldInfo fieldInfo, double value) throws IOException {
+                handler.numericFieldRead(fieldInfo, value);
+                delegate.doubleField(fieldInfo, value);
+            }
+
+            @Override
+            public Status needsField(org.apache.lucene.index.FieldInfo fieldInfo) throws IOException {
+                return delegate.needsField(fieldInfo);
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -25,9 +25,9 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
-import org.opensearch.action.support.IndicesOptions;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.OptionallyResolvedIndices;
+import org.opensearch.cluster.metadata.ResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.core.action.ActionListener;
@@ -63,7 +63,6 @@ public class AuditActionFilter implements ActionFilter {
     private final AuditLog auditLog;
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
-    private final IndexNameExpressionResolver resolver;
     private final AuditConfig.Filter filter;
     private final String auditIndexPrefix;
 
@@ -72,14 +71,12 @@ public class AuditActionFilter implements ActionFilter {
         ClusterService clusterService,
         ThreadPool threadPool,
         AuditConfig.Filter filter,
-        IndexNameExpressionResolver resolver,
         String auditIndexPrefix
     ) {
         this.auditLog = auditLog;
         this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.filter = filter;
-        this.resolver = resolver;
         this.auditIndexPrefix = auditIndexPrefix;
 
         if (auditIndexPrefix == null || auditIndexPrefix.isEmpty()) {
@@ -226,17 +223,14 @@ public class AuditActionFilter implements ActionFilter {
                 String[] indices = ((IndicesRequest) request).indices();
                 msg.addIndices(indices);
 
-                // Resolve wildcards to actual index names
-                if (filter.shouldResolveIndices() && indices != null && indices.length > 0) {
-                    try {
-                        String[] resolved = resolver.concreteIndexNames(
-                            clusterService.state(),
-                            IndicesOptions.lenientExpandOpen(),
-                            indices
-                        );
-                        msg.addResolvedIndices(resolved);
-                    } catch (Exception e) {
-                        // Index resolution can fail if cluster state isn't ready — log raw indices only
+                // Resolve wildcards to actual index names using framework-resolved indices
+                if (filter.shouldResolveIndices()) {
+                    OptionallyResolvedIndices optionalResolved = actionRequestMetadata.resolvedIndices();
+                    if (optionalResolved instanceof ResolvedIndices resolvedIndices) {
+                        String[] resolved = resolvedIndices.local().namesOfIndices(clusterService.state()).toArray(String[]::new);
+                        if (resolved.length > 0) {
+                            msg.addResolvedIndices(resolved);
+                        }
                     }
                 }
             } else if (request instanceof BulkRequest) {

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -100,10 +100,11 @@ public class AuditActionFilter implements ActionFilter {
     }
 
     /**
-     * Run before authentication/authorization filters so audit captures the
-     * original request even if a later filter rejects it. The existing
-     * SecurityFilter uses Integer.MIN_VALUE; we use a less extreme value
-     * to leave room for other "must run early" filters without colliding.
+     * Only registered in SSL-only / disabled modes where SecurityFilter is not
+     * registered (see OpenSearchSecurityPlugin#getActionFilters). The two filters
+     * are mutually exclusive by design. The low order value is chosen so audit
+     * runs before any other action filter that might mutate the request; it does
+     * not (and cannot) precede SecurityFilter's Integer.MIN_VALUE.
      */
     private static final int AUDIT_FILTER_ORDER = -200;
 

--- a/src/main/java/org/opensearch/security/filter/AuditTransportInterceptor.java
+++ b/src/main/java/org/opensearch/security/filter/AuditTransportInterceptor.java
@@ -107,7 +107,7 @@ public class AuditTransportInterceptor implements TransportInterceptor {
                         String principal = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_PRINCIPAL);
                         User user = threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_USER);
                         String effectiveUser = user != null ? user.getName() : principal;
-                        if (effectiveUser == null || !filter.isAuditDisabled(effectiveUser)) {
+                        if (effectiveUser == null || filter.isAuditEnabled(effectiveUser)) {
                             logTransportEvent(action, request, task);
                         }
                     }

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -67,7 +67,8 @@ public class SecuritySettings {
         ConfigConstants.SECURITY_AUDIT_ENABLED,
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     // Dynamic audit filter settings
@@ -77,42 +78,48 @@ public class SecuritySettings {
         AUDIT_CONFIG_PREFIX + "log_request_body",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> AUDIT_RESOLVE_BULK_REQUESTS = Setting.boolSetting(
         AUDIT_CONFIG_PREFIX + "resolve_bulk_requests",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> AUDIT_RESOLVE_INDICES = Setting.boolSetting(
         AUDIT_CONFIG_PREFIX + "resolve_indices",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> AUDIT_EXCLUDE_SENSITIVE_HEADERS = Setting.boolSetting(
         AUDIT_CONFIG_PREFIX + "exclude_sensitive_headers",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> AUDIT_ENABLE_REST = Setting.boolSetting(
         AUDIT_CONFIG_PREFIX + "enable_rest",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> AUDIT_ENABLE_TRANSPORT = Setting.boolSetting(
         AUDIT_CONFIG_PREFIX + "enable_transport",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_DISABLED_CATEGORIES = Setting.listSetting(
@@ -120,7 +127,8 @@ public class SecuritySettings {
         Collections.emptyList(),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_DISABLED_REST_CATEGORIES = Setting.listSetting(
@@ -128,7 +136,8 @@ public class SecuritySettings {
         List.of("AUTHENTICATED", "GRANTED_PRIVILEGES"),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_DISABLED_TRANSPORT_CATEGORIES = Setting.listSetting(
@@ -136,7 +145,8 @@ public class SecuritySettings {
         List.of("AUTHENTICATED", "GRANTED_PRIVILEGES"),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_IGNORE_USERS = Setting.listSetting(
@@ -144,7 +154,8 @@ public class SecuritySettings {
         List.of("kibanaserver"),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_IGNORE_REQUESTS = Setting.listSetting(
@@ -152,7 +163,8 @@ public class SecuritySettings {
         Collections.emptyList(),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> AUDIT_IGNORE_HEADERS = Setting.listSetting(
@@ -160,7 +172,8 @@ public class SecuritySettings {
         Collections.emptyList(),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     // Dynamic compliance settings
@@ -170,7 +183,8 @@ public class SecuritySettings {
         COMPLIANCE_PREFIX + "enabled",
         true,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> COMPLIANCE_WRITE_WATCHED_INDICES = Setting.listSetting(
@@ -178,42 +192,48 @@ public class SecuritySettings {
         Collections.emptyList(),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> COMPLIANCE_WRITE_METADATA_ONLY = Setting.boolSetting(
         COMPLIANCE_PREFIX + "write_metadata_only",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> COMPLIANCE_WRITE_LOG_DIFFS = Setting.boolSetting(
         COMPLIANCE_PREFIX + "write_log_diffs",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> COMPLIANCE_EXTERNAL_CONFIG_ENABLED = Setting.boolSetting(
         COMPLIANCE_PREFIX + "external_config",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> COMPLIANCE_INTERNAL_CONFIG_ENABLED = Setting.boolSetting(
         COMPLIANCE_PREFIX + "internal_config",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<Boolean> COMPLIANCE_READ_METADATA_ONLY = Setting.boolSetting(
         COMPLIANCE_PREFIX + "read_metadata_only",
         false,
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> COMPLIANCE_READ_WATCHED_FIELDS = Setting.listSetting(
@@ -221,7 +241,8 @@ public class SecuritySettings {
         Collections.emptyList(),
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> COMPLIANCE_READ_IGNORE_USERS = Setting.listSetting(
@@ -229,7 +250,8 @@ public class SecuritySettings {
         AuditConfig.DEFAULT_IGNORED_USERS,
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 
     public static final Setting<List<String>> COMPLIANCE_WRITE_IGNORE_USERS = Setting.listSetting(
@@ -237,6 +259,7 @@ public class SecuritySettings {
         AuditConfig.DEFAULT_IGNORED_USERS,
         Function.identity(),
         Setting.Property.NodeScope,
-        Setting.Property.Dynamic
+        Setting.Property.Dynamic,
+        Setting.Property.Sensitive
     );
 }

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -79,14 +79,7 @@ public class AuditActionFilterTest {
         when(clusterService.localNode()).thenReturn(node);
         when(clusterService.getClusterName()).thenReturn(new ClusterName("test-cluster"));
 
-        filter = new AuditActionFilter(
-            auditLog,
-            clusterService,
-            threadPool,
-            AuditConfig.Filter.DEFAULT,
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
-            "security-auditlog"
-        );
+        filter = new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.Filter.DEFAULT, "security-auditlog");
     }
 
     @SuppressWarnings("unchecked")
@@ -286,7 +279,6 @@ public class AuditActionFilterTest {
             clusterService,
             threadPool,
             AuditConfig.from(ignoreSettings).getFilter(),
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
             "security-auditlog"
         );
 
@@ -316,7 +308,6 @@ public class AuditActionFilterTest {
             clusterService,
             threadPool,
             AuditConfig.from(ignoreSettings).getFilter(),
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
             "security-auditlog"
         );
 
@@ -343,7 +334,6 @@ public class AuditActionFilterTest {
             clusterService,
             threadPool,
             AuditConfig.from(ignoreSettings).getFilter(),
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
             "security-auditlog"
         );
 
@@ -382,14 +372,7 @@ public class AuditActionFilterTest {
     @Test
     public void testNullPrefixDoesNotSuppressEvents() throws Exception {
         // Construct filter with null prefix — should still log events (guard disabled)
-        AuditActionFilter nullPrefixFilter = new AuditActionFilter(
-            auditLog,
-            clusterService,
-            threadPool,
-            AuditConfig.Filter.DEFAULT,
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
-            null
-        );
+        AuditActionFilter nullPrefixFilter = new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.Filter.DEFAULT, null);
 
         SearchRequest request = new SearchRequest("security-auditlog-2026.07.16");
         ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
@@ -406,14 +389,7 @@ public class AuditActionFilterTest {
     @Test
     public void testEmptyPrefixDoesNotSuppressEvents() throws Exception {
         // Construct filter with empty prefix — should still log events (guard disabled)
-        AuditActionFilter emptyPrefixFilter = new AuditActionFilter(
-            auditLog,
-            clusterService,
-            threadPool,
-            AuditConfig.Filter.DEFAULT,
-            new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
-            ""
-        );
+        AuditActionFilter emptyPrefixFilter = new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.Filter.DEFAULT, "");
 
         SearchRequest request = new SearchRequest("any-index");
         ActionFilterChain<SearchRequest, ActionResponse> chain = mock(ActionFilterChain.class);
@@ -438,14 +414,7 @@ public class AuditActionFilterTest {
         logger.setLevel(Level.WARN);
 
         try {
-            new AuditActionFilter(
-                auditLog,
-                clusterService,
-                threadPool,
-                AuditConfig.Filter.DEFAULT,
-                new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
-                null
-            );
+            new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.Filter.DEFAULT, null);
 
             boolean foundWarning = logCaptor.getAllValues()
                 .stream()
@@ -471,14 +440,7 @@ public class AuditActionFilterTest {
         logger.setLevel(Level.WARN);
 
         try {
-            new AuditActionFilter(
-                auditLog,
-                clusterService,
-                threadPool,
-                AuditConfig.Filter.DEFAULT,
-                new org.opensearch.cluster.metadata.IndexNameExpressionResolver(threadPool.getThreadContext()),
-                ""
-            );
+            new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.Filter.DEFAULT, "");
 
             boolean foundWarning = logCaptor.getAllValues()
                 .stream()


### PR DESCRIPTION
- Add Setting.Property.Sensitive to all audit and compliance dynamic settings so only security admins can toggle them at runtime.
- Add isAuditEnabled(String user) method to AuditConfig.Filter for readability; update AuditTransportInterceptor to use it.
- Replace IndexNameExpressionResolver with actionRequestMetadata .resolvedIndices() in AuditActionFilter — framework-level resolution that is evaluator-agnostic and handles data streams/aliases. Remove unused resolver field and constructor parameter.
- Refactor ComplianceReadIndexSearcherWrapper into generic reusable components: FieldReadHandler interface, ReadInterceptIndexSearcherWrapper (generic wrapper accepting predicate + handler factory), and ComplianceReadIndexSearcherWrapper as a thin compliance-specific consumer. Correctly passes ShardId from reader to handler.

### Description

Follow-up to #6304 (Standalone Audit Logging for SSL-only mode) addressing review feedback from @cwperks.
  
## Changes
  
  1. **Setting.Property.Sensitive** — Added to all audit and compliance dynamic settings so only security admins can toggle them at runtime.
  
  2. **isAuditEnabled()** — Added `isAuditEnabled(String user)` to `AuditConfig.Filter` for readability. Updated `AuditTransportInterceptor` to use it instead of `!isAuditDisabled()`.
  
  3. **Use actionRequestMetadata.resolvedIndices()** — Replaced `IndexNameExpressionResolver` in `AuditActionFilter` with framework-level resolution from `ActionRequestMetadata`.
  Evaluator-agnostic, handles data streams/aliases, no duplicate work.
  
  4. **Generic ComplianceReadIndexSearcherWrapper** — Refactored into reusable components:
     - `FieldReadHandler` interface (generic field read interception contract)
     - `ReadInterceptIndexSearcherWrapper` (generic wrapper accepting predicate + handler factory)
     - `ComplianceReadIndexSearcherWrapper` (thin compliance-specific consumer)
  
  ## Testing
  
  - All unit tests pass (`AuditActionFilterTest`, `AuditTransportInterceptorTest`)
  - All integration tests pass (`StandaloneAudit*` — 85+ tests)
  - Existing FGAC tests unaffected

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
