### PR TITLE
Support multiple ResourceProviders per shared resource index

### DIFF
--- a/spi/src/main/java/org/opensearch/security/spi/resources/ResourceProvider.java
+++ b/spi/src/main/java/org/opensearch/security/spi/resources/ResourceProvider.java
@@ -47,4 +47,36 @@ public interface ResourceProvider {
         return null;
     }
 
+    /**
+     * JSON pointer path (dot-notation is also accepted for backward compatibility) to the field
+     * containing the resource owner's username on documents of this type. Used by the
+     * {@code POST /_plugins/_security/api/resources/migrate} endpoint to attribute legacy docs
+     * without requiring a single global {@code username_path} in the request payload.
+     *
+     * <p>When multiple providers register on the same resource index, each provider may declare a
+     * type-specific path (for example, {@code monitor.user.name} and {@code workflow.user.name});
+     * the migrate endpoint resolves the type first via {@link #typeField()} and then reads the
+     * owner from the matching provider's path.
+     *
+     * <p>Returning {@code null} (the default) preserves the legacy behavior of falling back to the
+     * request-level {@code username_path}.
+     *
+     * @return the JSON pointer path (with or without a leading {@code /}) or {@code null} if this
+     *         provider does not declare a per-type owner path
+     */
+    default String ownerNamePath() {
+        return null;
+    }
+
+    /**
+     * JSON pointer path to the field containing the resource owner's backend roles on documents of
+     * this type. See {@link #ownerNamePath()} for the resolution rules and fallback semantics.
+     *
+     * @return the JSON pointer path (with or without a leading {@code /}) or {@code null} if this
+     *         provider does not declare a per-type backend-roles path
+     */
+    default String ownerBackendRolesPath() {
+        return null;
+    }
+
 }

--- a/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
+++ b/src/main/java/org/opensearch/security/resources/ResourcePluginInfo.java
@@ -151,37 +151,38 @@ public class ResourcePluginInfo {
     /**
      * Resolves the resource type for the given index operation and resource index.
      * <p>
-     * The method acquires a read lock and selects the first registered provider whose resource index name
-     * matches {@code resourceIndex}. If such a provider defines a {@code typeField}, the value of that
-     * field is extracted from {@code indexOp} via {@link #extractFieldFromIndexOp(String, Engine.Index)}.
-     * If {@code typeField} is not defined, it is assumed that the index hosts a single resource type and
-     * the provider's configured resource type is returned.
+     * The method iterates over every registered {@link ResourceProvider} whose resource index name
+     * matches {@code resourceIndex}. For each candidate:
+     * <ul>
+     *   <li>If the provider does not declare a {@link ResourceProvider#typeField()}, its
+     *   configured resource type is returned. This preserves the single-type-per-index behavior
+     *   for plugins that don't need to discriminate.</li>
+     *   <li>Otherwise the provider's {@code typeField} is extracted from {@code indexOp}; the
+     *   first provider whose extraction yields a non-null value wins.</li>
+     * </ul>
+     * This allows multiple providers to share an index (for example, monitors and workflows both
+     * living in {@code .opendistro-alerting-config}) by declaring type-specific paths for their
+     * {@code typeField} — the first path that resolves on a given document identifies the type.
      * <p>
-     * If no provider is found for the supplied {@code resourceIndex}, {@code null} is returned.
-     *
-     * @param resourceIndex the name of the resource index associated with the index operation
-     * @param indexOp       the index operation from which a dynamic type field may be extracted
-     * @return the resolved resource type, or {@code null} if no matching provider exists for {@code resourceIndex}
+     * If no provider is registered for {@code resourceIndex}, {@code null} is returned.
      */
     public String getResourceTypeForIndexOp(String resourceIndex, Engine.Index indexOp) {
         lock.readLock().lock();
         try {
-            // Eagerly use type field from first matching provider of same index as the indexOp
-            // If typeField is not present, assume single resource type per index and return type from provider
-            var provider = typeToProvider.values()
-                .stream()
-                .filter(p -> p.resourceIndexName().equals(resourceIndex))
-                .findFirst()
-                .orElse(null);
-            if (provider == null) {
-                // should not happen
-                return null;
+            for (ResourceProvider provider : typeToProvider.values()) {
+                if (!provider.resourceIndexName().equals(resourceIndex)) {
+                    continue;
+                }
+                if (provider.typeField() == null) {
+                    // Single-type-per-index provider — its own resourceType() is the answer.
+                    return provider.resourceType();
+                }
+                String extracted = extractFieldFromIndexOp(provider.typeField(), indexOp);
+                if (extracted != null) {
+                    return extracted;
+                }
             }
-            if (provider.typeField() != null) {
-                return extractFieldFromIndexOp(provider.typeField(), indexOp);
-            }
-            // If `typeField` is not defined, assume single type to index and return type from provider
-            return provider.resourceType();
+            return null;
         } finally {
             lock.readLock().unlock();
         }

--- a/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
@@ -11,6 +11,7 @@ package org.opensearch.security.resources.api.migrate;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -157,6 +158,11 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
 
         // Extract fields - validation already done by RequestContentValidator framework via FieldConfiguration
         String sourceIndex = body.get("source_index").asText();
+
+        // Request-level owner paths (username_path / backend_roles_path) are still required at the
+        // schema layer, preserving backward compatibility for single-type-per-index callers.
+        // ResourceProviders may override them per-type via ownerNamePath() / ownerBackendRolesPath()
+        // when a single request needs to attribute owners for multiple types sharing an index.
         String userNamePath = body.get("username_path").asText();
         String backendRolesPath = body.get("backend_roles_path").asText();
 
@@ -178,6 +184,12 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
         // first non-null value.
         List<String> typePaths = new ArrayList<>();
 
+        // Per-type owner paths. When a provider declares ownerNamePath()/ownerBackendRolesPath()
+        // these take precedence over the request-level username_path/backend_roles_path so a
+        // single migrate call can attribute owners for multiple types sharing one index.
+        Map<String, String> typeToOwnerNamePath = new HashMap<>();
+        Map<String, String> typeToOwnerBackendRolesPath = new HashMap<>();
+
         // Validate each type + its accessLevel
         for (Map.Entry<String, String> entry : typeToDefaultAccessLevel.entrySet()) {
             String type = entry.getKey();
@@ -193,6 +205,12 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
 
             if (provider.typeField() != null) {
                 typePaths.add(provider.typeField());
+            }
+            if (provider.ownerNamePath() != null) {
+                typeToOwnerNamePath.put(type, provider.ownerNamePath());
+            }
+            if (provider.ownerBackendRolesPath() != null) {
+                typeToOwnerBackendRolesPath.put(type, provider.ownerBackendRolesPath());
             }
 
             // Allowed access-levels for this type
@@ -244,35 +262,31 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                 for (SearchHit hit : hits) {
                     JsonNode rec = Utils.toJsonNode(hit.getSourceAsString());
                     String id = hit.getId();
-                    String username = rec.at(userNamePath.startsWith("/") ? userNamePath : ("/" + userNamePath)).asText(null);
 
-                    // backend_roles as an actual array
-                    JsonNode backendRolesNode = rec.at(backendRolesPath.startsWith("/") ? backendRolesPath : ("/" + backendRolesPath));
+                    // 1) Classify the doc's type first — subsequent owner-path resolution may be
+                    // type-scoped via provider.ownerNamePath()/ownerBackendRolesPath(). A null
+                    // type is not an error here: createNewSharingRecords records the id under
+                    // MigrationStats#skippedNoType so the caller sees which docs were skipped.
+                    String type = classifyDocType(rec, typePaths, typeToDefaultAccessLevel, resourcePluginInfo, sourceIndex);
+
+                    // 2) Resolve owner paths: prefer per-provider (per-type) paths, fall back to
+                    // the request-level paths. When type is null we can't pick a per-type path,
+                    // so we degrade to the request-level fallback (which may itself be null).
+                    String effectiveUserNamePath = type != null ? typeToOwnerNamePath.getOrDefault(type, userNamePath) : userNamePath;
+                    String effectiveBackendRolesPath = type != null
+                        ? typeToOwnerBackendRolesPath.getOrDefault(type, backendRolesPath)
+                        : backendRolesPath;
+
+                    String username = effectiveUserNamePath == null ? null : rec.at(jsonPointer(effectiveUserNamePath)).asText(null);
+
                     List<String> backendRoles = new ArrayList<>();
-                    if (backendRolesNode.isArray()) {
-                        for (JsonNode br : backendRolesNode) {
-                            backendRoles.add(br.asText());
-                        }
-                    }
-
-                    String type = null;
-                    if (!typePaths.isEmpty()) {
-                        // Try each registered type-field path; first non-null value wins.
-                        for (String typePath : typePaths) {
-                            type = rec.at("/" + typePath.replace(".", "/")).asText(null);
-                            if (type != null) {
-                                break;
+                    if (effectiveBackendRolesPath != null) {
+                        JsonNode backendRolesNode = rec.at(jsonPointer(effectiveBackendRolesPath));
+                        if (backendRolesNode.isArray()) {
+                            for (JsonNode br : backendRolesNode) {
+                                backendRoles.add(br.asText());
                             }
                         }
-                    } else if (!typeToDefaultAccessLevel.isEmpty()) {
-                        type = typeToDefaultAccessLevel.keySet().iterator().next();
-                    } else {
-                        // no type field and no explicit access level map — infer from the single registered type for this index
-                        type = resourcePluginInfo.currentProtectedTypes()
-                            .stream()
-                            .filter(t -> sourceIndex.equals(resourcePluginInfo.indexByType(t)))
-                            .findFirst()
-                            .orElse(null);
                     }
 
                     // Extract parent ID if the provider declares a parentIdField
@@ -299,9 +313,14 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
             ClearScrollRequest clear = new ClearScrollRequest();
             clear.addScrollId(scrollId);
             client.clearScroll(clear).actionGet();
-            // fail fast if any type in the results has no resolvable access level
+            // fail fast if any classifiable type in the results has no resolvable access level.
+            // Docs whose type couldn't be classified (type == null) are counted under
+            // MigrationStats#skippedNoType downstream and don't need an access level.
             for (SourceDoc doc : results) {
                 String type = doc.type();
+                if (type == null) {
+                    continue;
+                }
                 if (!typeToDefaultAccessLevel.containsKey(type) && resourcePluginInfo.getDefaultAccessLevel(type) == null) {
                     return ValidationResult.error(
                         RestStatus.BAD_REQUEST,
@@ -541,6 +560,49 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                 });
             }
         };
+    }
+
+    /**
+     * Convert a caller-supplied path expression (either dot-notation or JSON pointer) to a
+     * JSON pointer suitable for {@link JsonNode#at(String)}. Package-private for testability.
+     */
+    static String jsonPointer(String path) {
+        return path.startsWith("/") ? path : ("/" + path.replace(".", "/"));
+    }
+
+    /**
+     * Determine a document's resource type using, in order:
+     * <ol>
+     *   <li>the JSON pointer at each registered type-field path (first non-null value wins);</li>
+     *   <li>the single key in {@code typeToDefaultAccessLevel} when no type paths are declared;</li>
+     *   <li>a single-type inference when neither of the above is available.</li>
+     * </ol>
+     * Returns {@code null} when the document can't be classified. Package-private for testability.
+     */
+    static String classifyDocType(
+        JsonNode rec,
+        List<String> typePaths,
+        Map<String, String> typeToDefaultAccessLevel,
+        ResourcePluginInfo resourcePluginInfo,
+        String sourceIndex
+    ) {
+        if (!typePaths.isEmpty()) {
+            for (String typePath : typePaths) {
+                String type = rec.at(jsonPointer(typePath)).asText(null);
+                if (type != null) {
+                    return type;
+                }
+            }
+            return null;
+        }
+        if (!typeToDefaultAccessLevel.isEmpty()) {
+            return typeToDefaultAccessLevel.keySet().iterator().next();
+        }
+        return resourcePluginInfo.currentProtectedTypes()
+            .stream()
+            .filter(t -> sourceIndex.equals(resourcePluginInfo.indexByType(t)))
+            .findFirst()
+            .orElse(null);
     }
 
     record SourceDoc(String resourceId, String username, List<String> backendRoles, String type, String parentId) {

--- a/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
+++ b/src/main/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiAction.java
@@ -172,7 +172,11 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
             ? Collections.emptyMap()
             : Utils.toMapOfStrings(defaultAccessNode);
 
-        String typePath = null;
+        // Collect the type-field JSON pointer for each registered type. When multiple providers
+        // share an index, each provider may declare a type-specific path (e.g. `monitor.type` /
+        // `workflow.type`); the per-doc classifier below tries each candidate and picks the
+        // first non-null value.
+        List<String> typePaths = new ArrayList<>();
 
         // Validate each type + its accessLevel
         for (Map.Entry<String, String> entry : typeToDefaultAccessLevel.entrySet()) {
@@ -187,7 +191,9 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                 return ValidationResult.error(RestStatus.BAD_REQUEST, badRequestMessage(message));
             }
 
-            typePath = provider.typeField();
+            if (provider.typeField() != null) {
+                typePaths.add(provider.typeField());
+            }
 
             // Allowed access-levels for this type
             Set<String> accessLevels = resourcePluginInfo.flattenedForType(type).actionGroups();
@@ -249,9 +255,15 @@ public class MigrateResourceSharingInfoApiAction extends AbstractApiAction {
                         }
                     }
 
-                    String type;
-                    if (typePath != null) {
-                        type = rec.at("/" + typePath.replace(".", "/")).asText(null);
+                    String type = null;
+                    if (!typePaths.isEmpty()) {
+                        // Try each registered type-field path; first non-null value wins.
+                        for (String typePath : typePaths) {
+                            type = rec.at("/" + typePath.replace(".", "/")).asText(null);
+                            if (type != null) {
+                                break;
+                            }
+                        }
                     } else if (!typeToDefaultAccessLevel.isEmpty()) {
                         type = typeToDefaultAccessLevel.keySet().iterator().next();
                     } else {

--- a/src/test/java/org/opensearch/security/resources/ResourcePluginInfoTests.java
+++ b/src/test/java/org/opensearch/security/resources/ResourcePluginInfoTests.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.StringField;
+import org.apache.lucene.index.IndexableField;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.index.engine.Engine;
+import org.opensearch.index.mapper.ParsedDocument;
+import org.opensearch.security.spi.resources.ResourceProvider;
+import org.opensearch.security.spi.resources.ResourceSharingExtension;
+import org.opensearch.security.spi.resources.client.ResourceSharingClient;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ResourcePluginInfo#getResourceTypeForIndexOp}.
+ */
+public class ResourcePluginInfoTests {
+
+    private ResourcePluginInfo resourcePluginInfo;
+
+    @Before
+    public void setUp() {
+        resourcePluginInfo = new ResourcePluginInfo();
+    }
+
+    @Test
+    public void testSingleProviderNoTypeField() {
+        registerProviders(List.of("monitor"), ".alerting-config", null);
+        resourcePluginInfo.updateProtectedTypes(List.of("monitor"));
+
+        Engine.Index indexOp = mockIndexOp();
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
+        assertEquals("monitor", result);
+    }
+
+    @Test
+    public void testSingleProviderWithTypeField() {
+        registerProviders(List.of("monitor"), ".alerting-config", "monitor.type");
+        resourcePluginInfo.updateProtectedTypes(List.of("monitor"));
+
+        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
+        assertEquals("monitor", result);
+    }
+
+    @Test
+    public void testMultipleProvidersFirstProviderResolves() {
+        registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
+        resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
+
+        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
+        assertEquals("monitor", result);
+    }
+
+    @Test
+    public void testMultipleProvidersSecondProviderResolves() {
+        registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
+        resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
+
+        // Only workflow.type present — monitor.type returns null
+        Engine.Index indexOp = mockIndexOp(new StringField("workflow.type", "workflow", Field.Store.NO));
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
+        assertEquals("workflow", result);
+    }
+
+    @Test
+    public void testMultipleProvidersNeitherResolves() {
+        registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
+        resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
+
+        Engine.Index indexOp = mockIndexOp(); // no type fields
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
+        assertNull(result);
+    }
+
+    @Test
+    public void testUnknownIndexReturnsNull() {
+        registerProviders(List.of("monitor"), ".alerting-config", "monitor.type");
+        resourcePluginInfo.updateProtectedTypes(List.of("monitor"));
+
+        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        String result = resourcePluginInfo.getResourceTypeForIndexOp(".some-other-index", indexOp);
+        assertNull(result);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+    private void registerProviders(List<String> types, String indexName, String sharedTypeField) {
+        ResourceSharingExtension extension = new ResourceSharingExtension() {
+            @Override
+            public Set<ResourceProvider> getResourceProviders() {
+                var providers = new java.util.LinkedHashSet<ResourceProvider>();
+                for (String type : types) {
+                    providers.add(new ResourceProvider() {
+                        @Override
+                        public String resourceType() {
+                            return type;
+                        }
+
+                        @Override
+                        public String resourceIndexName() {
+                            return indexName;
+                        }
+
+                        @Override
+                        public String typeField() {
+                            return sharedTypeField;
+                        }
+                    });
+                }
+                return providers;
+            }
+
+            @Override
+            public void assignResourceSharingClient(ResourceSharingClient client) {
+            }
+        };
+        resourcePluginInfo.setResourceSharingExtensions(Set.of(extension));
+    }
+
+    private void registerProviders(String type1, String tf1, String type2, String tf2, String indexName) {
+        ResourceSharingExtension extension = new ResourceSharingExtension() {
+            @Override
+            public Set<ResourceProvider> getResourceProviders() {
+                var providers = new java.util.LinkedHashSet<ResourceProvider>();
+                providers.add(makeProvider(type1, indexName, tf1));
+                providers.add(makeProvider(type2, indexName, tf2));
+                return providers;
+            }
+
+            @Override
+            public void assignResourceSharingClient(ResourceSharingClient client) {
+            }
+        };
+        resourcePluginInfo.setResourceSharingExtensions(Set.of(extension));
+    }
+
+    private ResourceProvider makeProvider(String type, String index, String typeField) {
+        return new ResourceProvider() {
+            @Override
+            public String resourceType() {
+                return type;
+            }
+
+            @Override
+            public String resourceIndexName() {
+                return index;
+            }
+
+            @Override
+            public String typeField() {
+                return typeField;
+            }
+        };
+    }
+
+    private Engine.Index mockIndexOp(IndexableField... fields) {
+        Engine.Index indexOp = mock(Engine.Index.class);
+        ParsedDocument parsedDoc = mock(ParsedDocument.class);
+        org.opensearch.index.mapper.ParseContext.Document rootDoc =
+            new org.opensearch.index.mapper.ParseContext.Document();
+        for (IndexableField field : fields) {
+            rootDoc.add(field);
+        }
+        when(indexOp.parsedDoc()).thenReturn(parsedDoc);
+        when(parsedDoc.rootDoc()).thenReturn(rootDoc);
+        return indexOp;
+    }
+}

--- a/src/test/java/org/opensearch/security/resources/ResourcePluginInfoTests.java
+++ b/src/test/java/org/opensearch/security/resources/ResourcePluginInfoTests.java
@@ -56,7 +56,7 @@ public class ResourcePluginInfoTests {
         registerProviders(List.of("monitor"), ".alerting-config", "monitor.type");
         resourcePluginInfo.updateProtectedTypes(List.of("monitor"));
 
-        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        Engine.Index indexOp = mockMonitorDoc();
         String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
         assertEquals("monitor", result);
     }
@@ -66,7 +66,7 @@ public class ResourcePluginInfoTests {
         registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
         resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
 
-        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        Engine.Index indexOp = mockMonitorDoc();
         String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
         assertEquals("monitor", result);
     }
@@ -76,8 +76,7 @@ public class ResourcePluginInfoTests {
         registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
         resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
 
-        // Only workflow.type present — monitor.type returns null
-        Engine.Index indexOp = mockIndexOp(new StringField("workflow.type", "workflow", Field.Store.NO));
+        Engine.Index indexOp = mockWorkflowDoc();
         String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
         assertEquals("workflow", result);
     }
@@ -87,7 +86,8 @@ public class ResourcePluginInfoTests {
         registerProviders("monitor", "monitor.type", "workflow", "workflow.type", ".alerting-config");
         resourcePluginInfo.updateProtectedTypes(Arrays.asList("monitor", "workflow"));
 
-        Engine.Index indexOp = mockIndexOp(); // no type fields
+        // A metadata doc — no monitor.* or workflow.* fields, just top-level metadata.*
+        Engine.Index indexOp = mockIndexOp(new StringField("metadata.monitor_id", "abc123", Field.Store.NO));
         String result = resourcePluginInfo.getResourceTypeForIndexOp(".alerting-config", indexOp);
         assertNull(result);
     }
@@ -97,7 +97,7 @@ public class ResourcePluginInfoTests {
         registerProviders(List.of("monitor"), ".alerting-config", "monitor.type");
         resourcePluginInfo.updateProtectedTypes(List.of("monitor"));
 
-        Engine.Index indexOp = mockIndexOp(new StringField("monitor.type", "monitor", Field.Store.NO));
+        Engine.Index indexOp = mockMonitorDoc();
         String result = resourcePluginInfo.getResourceTypeForIndexOp(".some-other-index", indexOp);
         assertNull(result);
     }
@@ -131,8 +131,7 @@ public class ResourcePluginInfoTests {
             }
 
             @Override
-            public void assignResourceSharingClient(ResourceSharingClient client) {
-            }
+            public void assignResourceSharingClient(ResourceSharingClient client) {}
         };
         resourcePluginInfo.setResourceSharingExtensions(Set.of(extension));
     }
@@ -148,8 +147,7 @@ public class ResourcePluginInfoTests {
             }
 
             @Override
-            public void assignResourceSharingClient(ResourceSharingClient client) {
-            }
+            public void assignResourceSharingClient(ResourceSharingClient client) {}
         };
         resourcePluginInfo.setResourceSharingExtensions(Set.of(extension));
     }
@@ -173,11 +171,63 @@ public class ResourcePluginInfoTests {
         };
     }
 
+    /**
+     * Builds an {@link Engine.Index} mock whose {@code parsedDoc().rootDoc()} contains the flat
+     * set of Lucene fields that the alerting plugin's mapper would produce for a real monitor
+     * document. The source JSON stored in {@code .opendistro-alerting-config} for a monitor looks
+     * like:
+     *
+     * <pre>{@code
+     * {
+     *   "monitor": {
+     *     "type": "monitor",
+     *     "schema_version": 8,
+     *     "name": "my-monitor",
+     *     "monitor_type": "query_level_monitor",
+     *     "user": { "name": "alice", "backend_roles": ["engineering"] },
+     *     "enabled": true,
+     *     "schedule": { "period": { "interval": 5, "unit": "MINUTES" } },
+     *     ...
+     *   }
+     * }
+     * }</pre>
+     *
+     * After the mapper indexes this doc, {@code parsedDoc().rootDoc()} exposes each JSON leaf as
+     * a Lucene field with the JSON pointer path flattened onto a dot-joined field name — that's
+     * what {@code extractFieldFromIndexOp} reads via {@code rootDoc.getFields("monitor.type")}.
+     */
+    private Engine.Index mockMonitorDoc() {
+        return mockIndexOp(
+            new StringField("monitor.type", "monitor", Field.Store.NO),
+            new StringField("monitor.name", "my-monitor", Field.Store.NO),
+            new StringField("monitor.monitor_type", "query_level_monitor", Field.Store.NO),
+            new StringField("monitor.user.name", "alice", Field.Store.NO),
+            new StringField("monitor.user.backend_roles", "engineering", Field.Store.NO),
+            new StringField("monitor.enabled", "true", Field.Store.NO)
+        );
+    }
+
+    /**
+     * Same shape as {@link #mockMonitorDoc()}, but for a workflow document. Workflows and
+     * monitors share {@code .opendistro-alerting-config}, distinguished only by the wrapper key
+     * (and therefore by which {@code <wrapper>.type} Lucene field is present).
+     */
+    private Engine.Index mockWorkflowDoc() {
+        return mockIndexOp(
+            new StringField("workflow.type", "workflow", Field.Store.NO),
+            new StringField("workflow.name", "my-workflow", Field.Store.NO),
+            new StringField("workflow.workflow_type", "composite", Field.Store.NO),
+            new StringField("workflow.user.name", "bob", Field.Store.NO),
+            new StringField("workflow.user.backend_roles", "ml", Field.Store.NO),
+            new StringField("workflow.enabled", "true", Field.Store.NO),
+            new StringField("workflow.owner", "alerting", Field.Store.NO)
+        );
+    }
+
     private Engine.Index mockIndexOp(IndexableField... fields) {
         Engine.Index indexOp = mock(Engine.Index.class);
         ParsedDocument parsedDoc = mock(ParsedDocument.class);
-        org.opensearch.index.mapper.ParseContext.Document rootDoc =
-            new org.opensearch.index.mapper.ParseContext.Document();
+        org.opensearch.index.mapper.ParseContext.Document rootDoc = new org.opensearch.index.mapper.ParseContext.Document();
         for (IndexableField field : fields) {
             rootDoc.add(field);
         }

--- a/src/test/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiActionTests.java
+++ b/src/test/java/org/opensearch/security/resources/api/migrate/MigrateResourceSharingInfoApiActionTests.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.resources.api.migrate;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.opensearch.security.resources.ResourcePluginInfo;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link MigrateResourceSharingInfoApiAction#classifyDocType} and
+ * {@link MigrateResourceSharingInfoApiAction#jsonPointer}.
+ */
+public class MigrateResourceSharingInfoApiActionTests {
+
+    private ObjectMapper mapper;
+    private ResourcePluginInfo resourcePluginInfo;
+
+    @Before
+    public void setUp() {
+        mapper = new ObjectMapper();
+        resourcePluginInfo = new ResourcePluginInfo();
+    }
+
+    @Test
+    public void classifyResolvesFromFirstTypePath() throws Exception {
+        JsonNode monitorDoc = mapper.readTree("{ \"monitor\": { \"type\": \"monitor\", \"name\": \"m1\" } }");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            monitorDoc,
+            List.of("monitor.type", "workflow.type"),
+            Collections.emptyMap(),
+            resourcePluginInfo,
+            ".alerting-config"
+        );
+        assertEquals("monitor", result);
+    }
+
+    @Test
+    public void classifyResolvesFromSecondTypePath() throws Exception {
+        JsonNode workflowDoc = mapper.readTree("{ \"workflow\": { \"type\": \"workflow\", \"name\": \"w1\" } }");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            workflowDoc,
+            List.of("monitor.type", "workflow.type"),
+            Collections.emptyMap(),
+            resourcePluginInfo,
+            ".alerting-config"
+        );
+        assertEquals("workflow", result);
+    }
+
+    @Test
+    public void classifyReturnsNullWhenNoTypePathMatches() throws Exception {
+        JsonNode metadataDoc = mapper.readTree("{ \"metadata\": { \"monitor_id\": \"abc123\" } }");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            metadataDoc,
+            List.of("monitor.type", "workflow.type"),
+            Collections.emptyMap(),
+            resourcePluginInfo,
+            ".alerting-config"
+        );
+        assertNull(result);
+    }
+
+    @Test
+    public void classifyFallsBackToFirstAccessLevelKey() throws Exception {
+        // No typePaths declared; typeToDefaultAccessLevel has entries — first key wins.
+        JsonNode anyDoc = mapper.readTree("{ \"foo\": \"bar\" }");
+        Map<String, String> typeToAccess = new LinkedHashMap<>();
+        typeToAccess.put("model_group", "read_only");
+        typeToAccess.put("workflow", "read_write");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            anyDoc,
+            Collections.emptyList(),
+            typeToAccess,
+            resourcePluginInfo,
+            ".some-index"
+        );
+        assertEquals("model_group", result);
+    }
+
+    @Test
+    public void classifyFallsBackToSingleRegisteredType() throws Exception {
+        // No typePaths, no access-level map — infer from the sole registered protected type for
+        // this index. Mock ResourcePluginInfo to bypass the OpensearchDynamicSetting wiring that a
+        // real instance requires.
+        ResourcePluginInfo mockInfo = mock(ResourcePluginInfo.class);
+        when(mockInfo.currentProtectedTypes()).thenReturn(List.of("model_group"));
+        when(mockInfo.indexByType("model_group")).thenReturn(".ml-model-groups");
+
+        JsonNode anyDoc = mapper.readTree("{ \"whatever\": {} }");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            anyDoc,
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            mockInfo,
+            ".ml-model-groups"
+        );
+        assertEquals("model_group", result);
+    }
+
+    @Test
+    public void classifyReturnsNullWhenNothingResolvableAndIndexUnknown() throws Exception {
+        ResourcePluginInfo mockInfo = mock(ResourcePluginInfo.class);
+        when(mockInfo.currentProtectedTypes()).thenReturn(Collections.emptyList());
+
+        JsonNode anyDoc = mapper.readTree("{ \"whatever\": {} }");
+        String result = MigrateResourceSharingInfoApiAction.classifyDocType(
+            anyDoc,
+            Collections.emptyList(),
+            Collections.emptyMap(),
+            mockInfo,
+            ".not-registered"
+        );
+        assertNull(result);
+    }
+
+    @Test
+    public void jsonPointerAcceptsDotNotation() {
+        assertEquals("/monitor/user/name", MigrateResourceSharingInfoApiAction.jsonPointer("monitor.user.name"));
+    }
+
+    @Test
+    public void jsonPointerPreservesLeadingSlash() {
+        assertEquals("/monitor/user/name", MigrateResourceSharingInfoApiAction.jsonPointer("/monitor/user/name"));
+    }
+
+}


### PR DESCRIPTION
## Summary

Extends the resource-sharing framework so multiple `ResourceProvider`s can share a single resource index (motivating case: alerting registers both `monitor` and `workflow` on `.opendistro-alerting-config`). Three related changes; each keeps existing single-provider-per-index plugins unchanged in behavior.

### 1. `ResourcePluginInfo.getResourceTypeForIndexOp` iterates all matching providers

The method previously used `findFirst()` on providers matching an index and asked only that provider's `typeField` to classify the incoming document. When two providers share an index, only one could classify docs correctly — the loser's `typeField` resolves to null and the `postIndex` listener silently skips recording a sharing entry.

Now iterates every provider whose `resourceIndexName` matches:
- No `typeField` declared: fall back to the provider's static `resourceType()` (preserves current single-type-per-index behavior).
- Otherwise, extract the provider's `typeField` from the index op; the first provider whose extraction yields a non-null value wins.

### 2. SPI: per-provider owner paths on `ResourceProvider`

`ResourceProvider` gains two default methods, both returning `null`:

```java
default String ownerNamePath()          { return null; }
default String ownerBackendRolesPath()  { return null; }
```

Existing providers (ml-commons, flow-framework, reporting, sample-resource-plugin) don't override them → they return null → the migrate endpoint falls back to the request-level `username_path` / `backend_roles_path` (still mandatory). Zero behavior change.

Multi-type-per-index plugins can now declare type-specific paths (e.g. `/monitor/user/name` on the monitor provider, `/workflow/user/name` on the workflow provider) so a single `POST /_plugins/_security/api/resources/migrate` call can attribute owners for both types without pre-processing.

### 3. Migrate endpoint changes

- **Per-doc classifier**: iterates every registered `typeField` (mirrors change #1 but on the JSON pointer path used at migrate time).
- **Per-doc owner paths**: uses the classified type's provider `ownerNamePath` / `ownerBackendRolesPath` when declared, falls back to the request-level paths otherwise.
- **Skip unclassifiable docs**: previously a single doc the classifier couldn't type would 400 the whole call. Now those docs are recorded under `MigrationStats#skippedNoType` and the migration proceeds — matches the existing behavior for docs classified but missing an owner.

### 4. Extracted helpers + unit tests

- `classifyDocType(...)` — the type-resolution ladder (per-type paths → access-level map fallback → single-registered-type inference).
- `jsonPointer(String)` — normalize a dot-notation or JSON pointer path.
- 8 unit tests for the migrate action + 6 for `getResourceTypeForIndexOp` covering: single/multiple providers, resolves/no-resolves, request-level fallback, unknown index.

## Backward compatibility

- All SPI additions default to null; existing plugins compile and run unchanged.
- Sample-plugin migrate ITs (16/16) pass, including the "missing `username_path`" negative test.
- Request schema unchanged: `username_path` and `backend_roles_path` remain mandatory (validated at `mandatoryKeys`).

## Motivating case

`opensearch-project/alerting#2180` registers both `monitor` and `workflow` on `.opendistro-alerting-config`. Verified locally end-to-end against this build: legacy monitor → RSC enabled → 403 → `POST /_plugins/_security/api/resources/migrate` → alice recovers access. Alerting no longer needs a plugin-side migration endpoint. See [design note on #4500](https://github.com/opensearch-project/security/issues/4500#issuecomment-5062337215).

## Companion PRs

- `opensearch-project/alerting#2180` — uses the new SPI methods, drops the alerting-side `_migrate_to_rsc` endpoint.
- `opensearch-project/documentation-website` (draft, will open after this merges) — updates the migrate API doc to note per-provider owner paths and the `skippedResources` semantics.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented (companion PR to opensearch-project/documentation-website)
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR (n/a)
- [ ] API changes companion pull request created (request schema unchanged; only SPI + response semantics extended)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.