### PR TITLE
Support wildcard matching in WLM principal username/role rules

### DIFF
--- a/src/main/java/org/opensearch/security/auth/PrincipalAttribute.java
+++ b/src/main/java/org/opensearch/security/auth/PrincipalAttribute.java
@@ -123,6 +123,7 @@ public enum PrincipalAttribute implements Attribute {
         builder.endObject();
     }
 
+    @Override
     public List<MatchLabel<String>> findAttributeMatches(
         AttributeExtractor<String> attributeExtractor,
         AttributeValueStore<String, String> attributeValueStore
@@ -130,7 +131,7 @@ public enum PrincipalAttribute implements Attribute {
         Map<String, Float> scoreMap = new HashMap<>();
 
         for (String value : attributeExtractor.extract()) {
-            List<MatchLabel<String>> matches = attributeValueStore.getExactMatch(value);
+            List<MatchLabel<String>> matches = attributeValueStore.getMatches(value);
             String subField = parsePrincipalValue(value)[0];
             assert WEIGHTED_SUBFIELDS.containsKey(subField);
             for (MatchLabel<String> entry : matches) {

--- a/src/test/java/org/opensearch/security/auth/PrincipalAttributeTests.java
+++ b/src/test/java/org/opensearch/security/auth/PrincipalAttributeTests.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.auth;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.collections4.trie.PatriciaTrie;
+import org.junit.Test;
+
+import org.opensearch.rule.MatchLabel;
+import org.opensearch.rule.attribute_extractor.AttributeExtractor;
+import org.opensearch.rule.autotagging.Attribute;
+import org.opensearch.rule.storage.AttributeValueStore;
+import org.opensearch.rule.storage.DefaultAttributeValueStore;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PrincipalAttributeTests {
+
+    private static AttributeExtractor<String> extractorFor(String... values) {
+        return new AttributeExtractor<>() {
+            @Override
+            public Attribute getAttribute() {
+                return PrincipalAttribute.PRINCIPAL;
+            }
+
+            @Override
+            public Iterable<String> extract() {
+                return List.of(values);
+            }
+
+            @Override
+            public LogicalOperator getLogicalOperator() {
+                return LogicalOperator.OR;
+            }
+        };
+    }
+
+    private static Set<String> featureValues(List<MatchLabel<String>> matches) {
+        return matches.stream().map(MatchLabel::getFeatureValue).collect(Collectors.toSet());
+    }
+
+    @Test
+    public void testExactUsernameStillMatches() {
+        AttributeValueStore<String, String> store = new DefaultAttributeValueStore<>(new PatriciaTrie<>());
+        store.put("username|alice", "group_a");
+
+        List<MatchLabel<String>> matches = PrincipalAttribute.PRINCIPAL.findAttributeMatches(extractorFor("username|alice"), store);
+        assertEquals(Set.of("group_a"), featureValues(matches));
+    }
+
+    @Test
+    public void testExactUsernameDoesNotPrefixMatch() {
+        // A stored value without a trailing wildcard must not match a longer request value.
+        AttributeValueStore<String, String> store = new DefaultAttributeValueStore<>(new PatriciaTrie<>());
+        store.put("username|dev", "group_a");
+
+        List<MatchLabel<String>> matches = PrincipalAttribute.PRINCIPAL.findAttributeMatches(extractorFor("username|dev_john"), store);
+        assertTrue(matches.isEmpty());
+    }
+
+    @Test
+    public void testWildcardUsernamePrefixMatches() {
+        // A stored value ending in '*' prefix-matches request usernames sharing the stem.
+        AttributeValueStore<String, String> store = new DefaultAttributeValueStore<>(new PatriciaTrie<>());
+        store.put("username|dev*", "group_a");
+
+        assertEquals(
+            Set.of("group_a"),
+            featureValues(PrincipalAttribute.PRINCIPAL.findAttributeMatches(extractorFor("username|dev"), store))
+        );
+        assertEquals(
+            Set.of("group_a"),
+            featureValues(PrincipalAttribute.PRINCIPAL.findAttributeMatches(extractorFor("username|dev_john"), store))
+        );
+    }
+
+    @Test
+    public void testWildcardRoleAppliesRoleWeight() {
+        // Role matches are scored by the role subfield weight (0.09), not the username weight.
+        AttributeValueStore<String, String> store = new DefaultAttributeValueStore<>(new PatriciaTrie<>());
+        store.put("role|admin*", "group_a");
+
+        List<MatchLabel<String>> matches = PrincipalAttribute.PRINCIPAL.findAttributeMatches(extractorFor("role|administrator"), store);
+        assertEquals(1, matches.size());
+        assertEquals("group_a", matches.get(0).getFeatureValue());
+        // request "role|administrator" (18 chars) against stem "role|admin" (10 chars) -> 10/18, times role weight 0.09.
+        assertEquals(10f / 18f * 0.09f, matches.get(0).getMatchScore(), 1e-6f);
+    }
+}


### PR DESCRIPTION
### Description
WLM auto-tagging rules on `principal.username`/`principal.role` were matched exactly, so a rule like `username: ["dev*"]` matched only the literal user `dev`, not `dev_john`. This switches `PrincipalAttribute.findAttributeMatches` from `getExactMatch` to the wildcard-aware `getMatches`, so a trailing `*` now prefix-matches, consistent with how roles mappings and `index_pattern` rules behave.

Values without a trailing `*` continue to match exactly, and the existing username/role subfield weighting is unchanged.

Depends on opensearch-project/OpenSearch#22461 (makes `getMatches` distinguish exact vs. trailing-wildcard values), which is merged.

### Issues Resolved
Relates to opensearch-project/OpenSearch#22456

### Testing
Added `PrincipalAttributeTests` covering exact match, exact-not-prefix, wildcard prefix match, and role-weight scoring.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] API changes companion pull request created
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.