### PR TITLE
Clarify cluster node request classification

### DIFF
--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1118,10 +1118,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
                 @Override
                 public void onNewReaderContext(ReaderContext readerContext) {
-                    final boolean interClusterRequest = HeaderHelper.isInterClusterRequest(threadPool.getThreadContext());
+                    final boolean localClusterNodeRequest = HeaderHelper.isLocalClusterNodeRequest(threadPool.getThreadContext());
                     if (Origin.LOCAL.toString()
                         .equals(threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN))
-                        && (interClusterRequest || HeaderHelper.isDirectRequest(threadPool.getThreadContext()))
+                        && (localClusterNodeRequest || HeaderHelper.isDirectRequest(threadPool.getThreadContext()))
 
                     ) {
                         readerContext.putInContext("_opendistro_security_scroll_auth_local", Boolean.TRUE);
@@ -1135,10 +1135,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
                 @Override
                 public void onNewScrollContext(ReaderContext readerContext) {
-                    final boolean interClusterRequest = HeaderHelper.isInterClusterRequest(threadPool.getThreadContext());
+                    final boolean localClusterNodeRequest = HeaderHelper.isLocalClusterNodeRequest(threadPool.getThreadContext());
                     if (Origin.LOCAL.toString()
                         .equals(threadPool.getThreadContext().getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN))
-                        && (interClusterRequest || HeaderHelper.isDirectRequest(threadPool.getThreadContext()))
+                        && (localClusterNodeRequest || HeaderHelper.isDirectRequest(threadPool.getThreadContext()))
 
                     ) {
                         readerContext.putInContext("_opendistro_security_scroll_auth_local", Boolean.TRUE);

--- a/src/main/java/org/opensearch/security/action/whoami/TransportWhoAmIAction.java
+++ b/src/main/java/org/opensearch/security/action/whoami/TransportWhoAmIAction.java
@@ -69,8 +69,8 @@ public class TransportWhoAmIAction extends HandledTransportAction<WhoAmIRequest,
             : user.getName();
         final boolean isAdmin = adminDNs.isAdminDN(dn);
         final boolean isAuthenticated = isAdmin ? true : user != null;
-        final boolean isNodeCertificateRequest = HeaderHelper.isInterClusterRequest(threadPool.getThreadContext())
-            || HeaderHelper.isTrustedClusterRequest(threadPool.getThreadContext());
+        final boolean isNodeCertificateRequest = HeaderHelper.isLocalClusterNodeRequest(threadPool.getThreadContext())
+            || HeaderHelper.isRemoteClusterNodeRequest(threadPool.getThreadContext());
 
         listener.onResponse(new WhoAmIResponse(dn, isAdmin, isAuthenticated, isNodeCertificateRequest));
 

--- a/src/main/java/org/opensearch/security/filter/SecurityFilter.java
+++ b/src/main/java/org/opensearch/security/filter/SecurityFilter.java
@@ -222,14 +222,14 @@ public class SecurityFilter implements ActionFilter {
                 threadContext.putPersistent(ConfigConstants.OPENDISTRO_SECURITY_AUTHENTICATED_USER, new UserSubjectImpl(threadPool, user));
             }
             final boolean userIsAdmin = isUserAdmin(user, adminDns);
-            final boolean interClusterRequest = HeaderHelper.isInterClusterRequest(threadContext);
-            final boolean trustedClusterRequest = HeaderHelper.isTrustedClusterRequest(threadContext);
+            final boolean localClusterNodeRequest = HeaderHelper.isLocalClusterNodeRequest(threadContext);
+            final boolean remoteClusterNodeRequest = HeaderHelper.isRemoteClusterNodeRequest(threadContext);
             final boolean confRequest = "true".equals(
                 HeaderHelper.getSafeFromHeader(threadContext, ConfigConstants.OPENDISTRO_SECURITY_CONF_REQUEST_HEADER)
             );
             final boolean passThroughRequest = action.startsWith("indices:admin/seq_no") || action.equals(WhoAmIAction.NAME);
 
-            final boolean internalRequest = (interClusterRequest || HeaderHelper.isDirectRequest(threadContext))
+            final boolean internalRequest = (localClusterNodeRequest || HeaderHelper.isDirectRequest(threadContext))
                 && action.startsWith("internal:")
                 && !action.startsWith("internal:transport/proxy");
 
@@ -337,7 +337,7 @@ public class SecurityFilter implements ActionFilter {
             }
 
             if (Origin.LOCAL.toString().equals(threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN))
-                && (interClusterRequest || HeaderHelper.isDirectRequest(threadContext))
+                && (localClusterNodeRequest || HeaderHelper.isDirectRequest(threadContext))
                 && (injectedRoles == null)
                 && (user == null)) {
 
@@ -355,12 +355,14 @@ public class SecurityFilter implements ActionFilter {
                 boolean skipSecurityIfDualMode = threadContext.getTransient(
                     ConfigConstants.SECURITY_SSL_DUAL_MODE_SKIP_SECURITY
                 ) == Boolean.TRUE;
-                if ((interClusterRequest || trustedClusterRequest || request.remoteAddress() == null)
+                if ((localClusterNodeRequest || remoteClusterNodeRequest || request.remoteAddress() == null)
                     && !compatConfig.transportInterClusterAuthEnabled()) {
                     chain.proceed(task, action, request, listener);
                     return;
-                } else if ((interClusterRequest || trustedClusterRequest || request.remoteAddress() == null || skipSecurityIfDualMode)
-                    && compatConfig.transportInterClusterPassiveAuthEnabled()) {
+                } else if ((localClusterNodeRequest
+                    || remoteClusterNodeRequest
+                    || request.remoteAddress() == null
+                    || skipSecurityIfDualMode) && compatConfig.transportInterClusterPassiveAuthEnabled()) {
                         log.info("Transport auth in passive mode and no user found. Injecting default user");
                         user = User.DEFAULT_TRANSPORT_USER;
                         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, user);

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsLegacyHeaders.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsLegacyHeaders.java
@@ -73,7 +73,7 @@ public class DlsFlsLegacyHeaders {
     ) throws PrivilegesEvaluationException {
         DlsFlsLegacyHeaders preparedHeaders = new DlsFlsLegacyHeaders(context, config, metadata, doFilterLevelDls);
 
-        if (context.getRequest() instanceof ClusterSearchShardsRequest && HeaderHelper.isTrustedClusterRequest(threadContext)) {
+        if (context.getRequest() instanceof ClusterSearchShardsRequest && HeaderHelper.isRemoteClusterNodeRequest(threadContext)) {
             // Special case: Another cluster tries to initiate a cross cluster search and will talk directly to
             // the shards on our cluster. In this case, we do send the information as response headers.
             // The other cluster has code to correctly evaluate these response headers

--- a/src/main/java/org/opensearch/security/support/HeaderHelper.java
+++ b/src/main/java/org/opensearch/security/support/HeaderHelper.java
@@ -35,7 +35,7 @@ import org.opensearch.security.user.User;
 
 public class HeaderHelper {
 
-    public static boolean isInterClusterRequest(final ThreadContext context) {
+    public static boolean isLocalClusterNodeRequest(final ThreadContext context) {
         return context.getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_INTERCLUSTER_REQUEST) == Boolean.TRUE;
     }
 
@@ -67,7 +67,7 @@ public class HeaderHelper {
             return null;
         }
 
-        if (isInterClusterRequest(context) || isTrustedClusterRequest(context) || isDirectRequest(context)) {
+        if (isLocalClusterNodeRequest(context) || isRemoteClusterNodeRequest(context) || isDirectRequest(context)) {
             return context.getHeader(headerName);
         }
 
@@ -85,7 +85,7 @@ public class HeaderHelper {
         return null;
     }
 
-    public static boolean isTrustedClusterRequest(final ThreadContext context) {
+    public static boolean isRemoteClusterNodeRequest(final ThreadContext context) {
         return context.getTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST) == Boolean.TRUE;
     }
 }

--- a/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityRequestHandler.java
@@ -267,8 +267,8 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
             // if transport channel is not a netty channel but a direct or local channel (e.g. send via network) then allow it (regardless
             // of beeing a internal: or shard request)
             // also allow when issued from a remote cluster for cross cluster search
-            if (!HeaderHelper.isInterClusterRequest(getThreadContext())
-                && !HeaderHelper.isTrustedClusterRequest(getThreadContext())
+            if (!HeaderHelper.isLocalClusterNodeRequest(getThreadContext())
+                && !HeaderHelper.isRemoteClusterNodeRequest(getThreadContext())
                 && !HeaderHelper.isExtensionRequest(getThreadContext())
                 && !task.getAction().equals("internal:transport/handshake")
                 && (task.getAction().startsWith("internal:") || task.getAction().contains("["))) {
@@ -310,9 +310,9 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
                     getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_ORIGIN, Origin.TRANSPORT.toString());
                 }
 
-                // network intercluster request or cross search cluster request
-                if (!(HeaderHelper.isInterClusterRequest(getThreadContext())
-                    || HeaderHelper.isTrustedClusterRequest(getThreadContext())
+                // local cluster node request or cross-cluster request
+                if (!(HeaderHelper.isLocalClusterNodeRequest(getThreadContext())
+                    || HeaderHelper.isRemoteClusterNodeRequest(getThreadContext())
                     || HeaderHelper.isExtensionRequest(getThreadContext()))) {
                     final OpenSearchException exception = ExceptionUtils.clusterWrongNodeCertConfigException(principal);
                     log.error(exception.toString());
@@ -379,13 +379,13 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
         final String principal
     ) throws Exception {
 
-        boolean isInterClusterRequest = requestEvalProvider.isInterClusterRequest(request, localCerts, peerCerts, principal);
+        boolean isNodeCertificateRequest = requestEvalProvider.isInterClusterRequest(request, localCerts, peerCerts, principal);
         final boolean isTraceEnabled = log.isTraceEnabled();
-        if (isInterClusterRequest) {
+        if (isNodeCertificateRequest) {
             if (cs.getClusterName().value().equals(getThreadContext().getHeader("_opendistro_security_remotecn"))) {
 
                 if (isTraceEnabled && !action.startsWith("internal:")) {
-                    log.trace("Is inter cluster request ({}/{}/{})", action, request.getClass(), request.remoteAddress());
+                    log.trace("Is local cluster node request ({}/{}/{})", action, request.getClass(), request.remoteAddress());
                 }
 
                 getThreadContext().putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_INTERCLUSTER_REQUEST, Boolean.TRUE);
@@ -395,7 +395,7 @@ public class SecurityRequestHandler<T extends TransportRequest> extends Security
 
         } else {
             if (isTraceEnabled) {
-                log.trace("Is not an inter cluster request");
+                log.trace("Is not a node certificate request");
             }
         }
 

--- a/src/test/java/org/opensearch/security/support/HeaderHelperTests.java
+++ b/src/test/java/org/opensearch/security/support/HeaderHelperTests.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.support;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class HeaderHelperTests extends OpenSearchTestCase {
+
+    public void testLocalClusterNodeRequest() {
+        final ThreadContext context = new ThreadContext(Settings.EMPTY);
+
+        assertFalse(HeaderHelper.isLocalClusterNodeRequest(context));
+
+        context.putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_INTERCLUSTER_REQUEST, Boolean.TRUE);
+
+        assertTrue(HeaderHelper.isLocalClusterNodeRequest(context));
+        assertFalse(HeaderHelper.isRemoteClusterNodeRequest(context));
+    }
+
+    public void testRemoteClusterNodeRequest() {
+        final ThreadContext context = new ThreadContext(Settings.EMPTY);
+
+        assertFalse(HeaderHelper.isRemoteClusterNodeRequest(context));
+
+        context.putTransient(ConfigConstants.OPENDISTRO_SECURITY_SSL_TRANSPORT_TRUSTED_CLUSTER_REQUEST, Boolean.TRUE);
+
+        assertTrue(HeaderHelper.isRemoteClusterNodeRequest(context));
+        assertFalse(HeaderHelper.isLocalClusterNodeRequest(context));
+    }
+}

--- a/src/test/java/org/opensearch/security/support/HeaderHelperTests.java
+++ b/src/test/java/org/opensearch/security/support/HeaderHelperTests.java
@@ -8,11 +8,12 @@
 
 package org.opensearch.security.support;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
+
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
-import org.opensearch.test.OpenSearchTestCase;
 
-public class HeaderHelperTests extends OpenSearchTestCase {
+public class HeaderHelperTests extends LuceneTestCase {
 
     public void testLocalClusterNodeRequest() {
         final ThreadContext context = new ThreadContext(Settings.EMPTY);


### PR DESCRIPTION
## What changed

- rename `HeaderHelper.isInterClusterRequest()` to `isLocalClusterNodeRequest()`
- rename `HeaderHelper.isTrustedClusterRequest()` to `isRemoteClusterNodeRequest()`
- update authorization call sites, local variables, comments, and trace messages
- add focused tests for the local and remote classifications

## Why

The existing names invert current OpenSearch terminology: the
`interClusterRequest` transient represents a request from another node in the
local cluster, while `trustedClusterRequest` represents a node request from a
different cluster. The new names make security-sensitive branches easier to
audit.

This is a terminology-only change. The existing transient keys and request
classification behavior remain unchanged.

## Validation

- `./gradlew :precommit -Pcrypto.standard=FIPS-140-3`
- `./gradlew test --tests 'org.opensearch.security.support.HeaderHelperTests' -Pcrypto.standard=FIPS-140-3`
- `./gradlew citest --tests 'org.opensearch.security.support.HeaderHelperTests' -Pcrypto.standard=FIPS-140-3`
