### PR TITLE
Limit tenant checks to multi-doc actions

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/int_tests/DashboardMultiTenancyIntTests.java
@@ -1000,6 +1000,27 @@ public class DashboardMultiTenancyIntTests {
     }
 
     /**
+     * Verifies that the paginated list indices API is not denied when its internal monitor
+     * requests operate on a concrete page that includes dashboards tenant indices.
+     */
+    @Test
+    public void listIndices_withTenantHeader_shouldNotBeDenied() {
+        // Only run once (not for every parameterized user)
+        if (!user.equals(WILDCARD_TENANT_USER)) {
+            return;
+        }
+
+        try (TestRestClient restClient = cluster.getRestClient(WILDCARD_TENANT_USER)) {
+            TestRestClient.HttpResponse response = restClient.get(
+                "_list/indices/.kib*",
+                new BasicHeader("securitytenant", "human_resources")
+            );
+
+            assertThat(response, isOk());
+        }
+    }
+
+    /**
      * Verifies that deliberately targeting another tenant's concrete index in a multi-document
      * request is denied. This is the cross-tenant protection that the interceptor provides:
      * users should not be able to directly access .kibana_{hash}_{tenant} indices that belong

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/legacy/PrivilegesInterceptor.java
@@ -241,7 +241,10 @@ public class PrivilegesInterceptor {
             // We check originalRequested (what the user explicitly specified) rather than allIndices
             // (the fully resolved set) to avoid false positives from broad queries like _cat/indices
             // where tenant indices are incidentally included in the resolution.
-            if (!requestedResolved.isLocalAll()) {
+            if ((request instanceof BulkRequest
+                || request instanceof MultiGetRequest
+                || request instanceof MultiSearchRequest
+                || request instanceof MultiTermVectorsRequest) && !requestedResolved.isLocalAll()) {
                 final Set<String> originalRequested = requestedResolved.getOriginalRequested();
 
                 for (String idx : originalRequested) {


### PR DESCRIPTION
## Description

Narrows the legacy Dashboards multi-tenancy concrete-index check to the multi-document request types it is intended to protect: bulk, multi-get, multi-search, and multi-term-vectors.

The check was being applied to every action. As a result, APIs such as `_list/indices` were denied when they issued internal `indices:monitor/stats` and `cluster:monitor/health` requests against a page containing a concrete Dashboards tenant index.

This is a tactical fix for #6327. A follow-up can carry trusted request provenance from the originating list-indices request so Security can distinguish internal derived requests from user requests that explicitly target a concrete tenant index.

## Testing

- Added an integration test covering `_list/indices/.kib*` with a tenant header.
- Existing cross-tenant multi-document request coverage remains enabled.
- `./gradlew :integrationTest --tests 'org.opensearch.security.privileges.int_tests.DashboardMultiTenancyIntTests' -Pcrypto.standard=FIPS-140-3`
- `./gradlew :precommit -Pcrypto.standard=FIPS-140-3`

The aggregate `precommit` task also reaches the sample resource plugin and currently fails on two pre-existing forbidden `URL.openStream()` uses in its transport actions; the root `:precommit` task passes.
