### PR TITLE
feat: Enable standalone audit logging in disabled security mode

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DisabledModeAuditTestUtils.java
+++ b/src/integrationTest/java/org/opensearch/security/DisabledModeAuditTestUtils.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.util.Map;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+
+/**
+ * Shared test utilities for disabled-mode audit integration tests.
+ * Reduces duplication between StandaloneAuditDisabledModeTest and
+ * StandaloneAuditDisabledModeToggleTest.
+ */
+public final class DisabledModeAuditTestUtils {
+
+    private DisabledModeAuditTestUtils() {
+        // utility class
+    }
+
+    /**
+     * Creates a standard LocalCluster configured for disabled security mode with
+     * audit logging enabled, including compliance write/read watched settings.
+     */
+    public static LocalCluster createDisabledModeAuditCluster() {
+        return new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+            .anonymousAuth(false)
+            .loadConfigurationIntoIndex(false)
+            .nodeSettings(
+                Map.of(
+                    ConfigConstants.SECURITY_DISABLED,
+                    true,
+                    "plugins.security.audit.type",
+                    TestRuleAuditLogSink.class.getName(),
+                    "plugins.security.audit.config.log_request_body",
+                    true,
+                    "plugins.security.audit.config.resolve_indices",
+                    true,
+                    "plugins.security.audit.config.resolve_bulk_requests",
+                    true,
+                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
+                    "watched-*",
+                    ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
+                    "read-watched"
+                )
+            )
+            .sslOnly(true)
+            .build();
+    }
+
+    /**
+     * Checks whether an audit message belongs to the given category and contains
+     * the specified index name in its {@link AuditMessage#INDICES} field.
+     */
+    public static boolean messageMatchesIndex(AuditMessage msg, AuditCategory category, String indexName) {
+        if (msg.getCategory() != category) return false;
+        Map<String, Object> fields = msg.getAsMap();
+        Object indices = fields.get(AuditMessage.INDICES);
+        if (indices == null) return false;
+        String[] indexArr = (String[]) indices;
+        for (String idx : indexArr) {
+            if (indexName.equals(idx)) return true;
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether an audit message contains the specified index name in its
+     * {@link AuditMessage#INDICES} field, regardless of category.
+     */
+    public static boolean messageHasIndex(AuditMessage msg, String indexName) {
+        Map<String, Object> fields = msg.getAsMap();
+        Object indices = fields.get(AuditMessage.INDICES);
+        if (indices == null) return false;
+        String[] indexArr = (String[]) indices;
+        for (String idx : indexArr) {
+            if (indexName.equals(idx)) return true;
+        }
+        return false;
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
@@ -16,12 +16,11 @@ import org.junit.Test;
 
 import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.auditlog.impl.AuditMessage;
-import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.audit.AuditLogsRule;
-import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
-import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.opensearch.security.DisabledModeAuditTestUtils.messageMatchesIndex;
 
 /**
  * Comprehensive integration tests for audit logging in disabled security mode
@@ -34,31 +33,8 @@ import org.opensearch.test.framework.cluster.TestRestClient;
  */
 public class StandaloneAuditDisabledModeTest {
 
-    // --- Cluster with security disabled + audit enabled ---
     @ClassRule
-    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
-        .anonymousAuth(false)
-        .loadConfigurationIntoIndex(false)
-        .nodeSettings(
-            Map.of(
-                ConfigConstants.SECURITY_DISABLED,
-                true,
-                "plugins.security.audit.type",
-                TestRuleAuditLogSink.class.getName(),
-                "plugins.security.audit.config.log_request_body",
-                true,
-                "plugins.security.audit.config.resolve_indices",
-                true,
-                "plugins.security.audit.config.resolve_bulk_requests",
-                true,
-                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
-                "watched-*",
-                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
-                "read-watched"
-            )
-        )
-        .sslOnly(true)
-        .build();
+    public static LocalCluster cluster = DisabledModeAuditTestUtils.createDisabledModeAuditCluster();
 
     @Rule
     public AuditLogsRule auditLogsRule = new AuditLogsRule();
@@ -73,17 +49,7 @@ public class StandaloneAuditDisabledModeTest {
             client.putJson("disabled-test/_doc/1?refresh=true", "{\"msg\": \"hello from disabled mode\"}");
         }
 
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-test".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-test"));
     }
 
     @Test
@@ -120,16 +86,8 @@ public class StandaloneAuditDisabledModeTest {
 
         // In disabled mode without mTLS client auth, there's no user identity
         auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            if (!messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-nouser")) return false;
             Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            boolean isOurs = false;
-            for (String idx : indexArr) {
-                if ("disabled-nouser".equals(idx)) isOurs = true;
-            }
-            if (!isOurs) return false;
             // effective_user should be absent (no auth in disabled mode)
             return fields.get(AuditMessage.REQUEST_EFFECTIVE_USER) == null;
         });
@@ -175,29 +133,8 @@ public class StandaloneAuditDisabledModeTest {
             client.postJson("_bulk?refresh=true", bulkBody);
         }
 
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-bulk-a".equals(idx)) return true;
-            }
-            return false;
-        });
-
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-bulk-b".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-bulk-a"));
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-bulk-b"));
     }
 
     // =====================================================================

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
@@ -332,59 +332,6 @@ public class StandaloneAuditDisabledModeTest {
     }
 
     // =====================================================================
-    // Dynamic settings — verify PUT _cluster/settings works in disabled mode
-    // =====================================================================
-
-    @Test
-    public void shouldToggleAuditOffAndBackOnViaClusterSettings() {
-        // Disable audit
-        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
-            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": false}}");
-        }
-
-        auditLogsRule.waitForAuditLogs();
-
-        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
-            client.putJson("disabled-toggle/_doc/1?refresh=true", "{\"val\": \"should-not-appear\"}");
-        }
-
-        auditLogsRule.waitForAuditLogs();
-        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-toggle".equals(idx)) return true;
-            }
-            return false;
-        });
-
-        // Re-enable
-        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
-            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": true}}");
-        }
-
-        auditLogsRule.waitForAuditLogs();
-
-        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
-            client.putJson("disabled-toggle-back/_doc/1?refresh=true", "{\"val\": \"should-appear\"}");
-        }
-
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-toggle-back".equals(idx)) return true;
-            }
-            return false;
-        });
-    }
-
-    // =====================================================================
     // Index resolution — wildcards still resolve in disabled mode
     // =====================================================================
 

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeTest.java
@@ -1,0 +1,453 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+/**
+ * Comprehensive integration tests for audit logging in disabled security mode
+ * (plugins.security.disabled: true). Verifies that REQUEST_AUDIT, TRANSPORT_AUDIT,
+ * COMPLIANCE_DOC_WRITE, and COMPLIANCE_DOC_READ all function correctly when the
+ * security plugin is disabled but audit logging is configured.
+ *
+ * These tests mirror the ssl-only mode tests to prove the same code paths work
+ * identically in disabled mode after the onIndexModule gate change.
+ */
+public class StandaloneAuditDisabledModeTest {
+
+    // --- Cluster with security disabled + audit enabled ---
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_DISABLED,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName(),
+                "plugins.security.audit.config.log_request_body",
+                true,
+                "plugins.security.audit.config.resolve_indices",
+                true,
+                "plugins.security.audit.config.resolve_bulk_requests",
+                true,
+                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
+                "watched-*",
+                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
+                "read-watched"
+            )
+        )
+        .sslOnly(true)
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    // =====================================================================
+    // REQUEST_AUDIT — basic event production
+    // =====================================================================
+
+    @Test
+    public void shouldProduceRequestAuditForIndexWrite() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-test/_doc/1?refresh=true", "{\"msg\": \"hello from disabled mode\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-test".equals(idx)) return true;
+            }
+            return false;
+        });
+    }
+
+    @Test
+    public void shouldProduceRequestAuditForSearch() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-search/_doc/1?refresh=true", "{\"field\": \"value\"}");
+            client.postJson("disabled-search/_search", "{\"query\": {\"match_all\": {}}}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            return msg.getPrivilege() != null && msg.getPrivilege().contains("indices:data/read/search");
+        });
+    }
+
+    @Test
+    public void shouldCaptureRemoteAddressInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.get("_cluster/health");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            return fields.get(AuditMessage.REMOTE_ADDRESS) != null;
+        });
+    }
+
+    @Test
+    public void shouldNotHaveEffectiveUserInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-nouser/_doc/1?refresh=true", "{\"data\": \"test\"}");
+        }
+
+        // In disabled mode without mTLS client auth, there's no user identity
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            boolean isOurs = false;
+            for (String idx : indexArr) {
+                if ("disabled-nouser".equals(idx)) isOurs = true;
+            }
+            if (!isOurs) return false;
+            // effective_user should be absent (no auth in disabled mode)
+            return fields.get(AuditMessage.REQUEST_EFFECTIVE_USER) == null;
+        });
+    }
+
+    @Test
+    public void shouldLogRequestBody() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-body/_doc/1?refresh=true", "{\"secret\": \"disabled-mode-payload\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            String body = msg.getRequestBody();
+            return body != null && body.contains("disabled-mode-payload");
+        });
+    }
+
+    @Test
+    public void shouldLogRestHeaders() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-headers/_doc/1?refresh=true", "{\"data\": \"headers-test\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            return fields.get(AuditMessage.REST_REQUEST_HEADERS) != null;
+        });
+    }
+
+    // =====================================================================
+    // REQUEST_AUDIT — bulk handling
+    // =====================================================================
+
+    @Test
+    public void shouldLogPerItemEventsForBulkInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            String bulkBody = "{ \"index\": { \"_index\": \"disabled-bulk-a\", \"_id\": \"1\" } }\n"
+                + "{ \"field\": \"value-a\" }\n"
+                + "{ \"index\": { \"_index\": \"disabled-bulk-b\", \"_id\": \"2\" } }\n"
+                + "{ \"field\": \"value-b\" }\n";
+            client.postJson("_bulk?refresh=true", bulkBody);
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-bulk-a".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-bulk-b".equals(idx)) return true;
+            }
+            return false;
+        });
+    }
+
+    // =====================================================================
+    // TRANSPORT_AUDIT — inter-node events
+    // =====================================================================
+
+    @Test
+    public void shouldProduceTransportAuditEventsInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-transport/_doc/1?refresh=true", "{\"val\": \"transport-test\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.TRANSPORT_AUDIT);
+    }
+
+    @Test
+    public void shouldCaptureShardActionInTransportEvent() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-shard/_doc/1?refresh=true", "{\"val\": \"shard-test\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.TRANSPORT_AUDIT) return false;
+            return msg.getPrivilege() != null && msg.getPrivilege().contains("[s][p]");
+        });
+    }
+
+    // =====================================================================
+    // COMPLIANCE_DOC_WRITE — document write tracking
+    // =====================================================================
+
+    @Test
+    public void shouldProduceComplianceDocWriteForWatchedIndex() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("watched-disabled/_doc/1?refresh=true", "{\"name\": \"sensitive\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+    }
+
+    @Test
+    public void shouldNotProduceComplianceDocWriteForUnwatchedIndex() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("unwatched-disabled/_doc/1?refresh=true", "{\"name\": \"not-tracked\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.COMPLIANCE_DOC_WRITE) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.RESOLVED_INDICES);
+            return indices != null && indices.toString().contains("unwatched-disabled");
+        });
+    }
+
+    @Test
+    public void shouldCaptureDocIdInComplianceWriteEvent() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("watched-docid-disabled/_doc/my-id-123?refresh=true", "{\"field\": \"value\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.COMPLIANCE_DOC_WRITE) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object docId = fields.get(AuditMessage.ID);
+            return "my-id-123".equals(docId);
+        });
+    }
+
+    @Test
+    public void shouldProduceComplianceWriteForUpdateInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("watched-update-disabled/_doc/1?refresh=true", "{\"field\": \"original\"}");
+            client.postJson("watched-update-disabled/_update/1?refresh=true", "{\"doc\": {\"field\": \"modified\"}}");
+        }
+
+        auditLogsRule.assertAtLeast(2, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+    }
+
+    @Test
+    public void shouldProduceComplianceWriteForDeleteInDisabledMode() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("watched-delete-disabled/_doc/1?refresh=true", "{\"field\": \"to-delete\"}");
+            client.delete("watched-delete-disabled/_doc/1?refresh=true");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+    }
+
+    @Test
+    public void shouldMatchWildcardPatternForWatchedWriteIndex() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("watched-logs-disabled-2026/_doc/1?refresh=true", "{\"data\": \"wildcard-match\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+    }
+
+    // =====================================================================
+    // COMPLIANCE_DOC_READ — document read tracking
+    // =====================================================================
+
+    @Test
+    public void shouldProduceComplianceDocReadForWatchedFields() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("read-watched/_doc/1?refresh=true", "{\"name\": \"secret-name\", \"public\": \"visible\"}");
+            client.get("read-watched/_search");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_READ);
+    }
+
+    @Test
+    public void shouldNotProduceComplianceDocReadForUnwatchedIndex() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("not-read-watched-disabled/_doc/1?refresh=true", "{\"name\": \"not-tracked\"}");
+            client.get("not-read-watched-disabled/_search");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_READ);
+    }
+
+    @Test
+    public void shouldProduceComplianceReadForGetById() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("read-watched/_doc/get-disabled?refresh=true", "{\"name\": \"get-by-id\"}");
+            client.get("read-watched/_doc/get-disabled");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_READ);
+    }
+
+    // =====================================================================
+    // Dynamic settings — verify PUT _cluster/settings works in disabled mode
+    // =====================================================================
+
+    @Test
+    public void shouldToggleAuditOffAndBackOnViaClusterSettings() {
+        // Disable audit
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": false}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-toggle/_doc/1?refresh=true", "{\"val\": \"should-not-appear\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-toggle".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        // Re-enable
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": true}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-toggle-back/_doc/1?refresh=true", "{\"val\": \"should-appear\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-toggle-back".equals(idx)) return true;
+            }
+            return false;
+        });
+    }
+
+    // =====================================================================
+    // Index resolution — wildcards still resolve in disabled mode
+    // =====================================================================
+
+    @Test
+    public void shouldResolveWildcardIndicesToActualNames() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-resolve-test/_doc/1?refresh=true", "{\"field\": \"value\"}");
+            client.get("disabled-resolve-*/_search");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object resolved = fields.get(AuditMessage.RESOLVED_INDICES);
+            if (resolved == null) return false;
+            String[] resolvedArr = (String[]) resolved;
+            for (String idx : resolvedArr) {
+                if ("disabled-resolve-test".equals(idx)) return true;
+            }
+            return false;
+        });
+    }
+
+    // =====================================================================
+    // Ignore patterns — verify filtering works in disabled mode
+    // =====================================================================
+
+    @Test
+    public void shouldNeverLogInternalActions() {
+        // Internal actions are always suppressed — just do a normal request and
+        // verify no internal:* events appear
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-internal/_doc/1?refresh=true", "{\"data\": \"test\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            return msg.getPrivilege() != null && msg.getPrivilege().startsWith("internal:");
+        });
+    }
+
+    // =====================================================================
+    // Self-loop guard — audit index writes not audited
+    // =====================================================================
+
+    @Test
+    public void shouldNotProduceEventsForAuditIndexWrites() {
+        // Write directly to an index matching the audit index prefix
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("security-auditlog-2026.07.14/_doc/1?refresh=true", "{\"audit\": \"self-loop-test\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if (idx != null && idx.startsWith("security-auditlog")) return true;
+            }
+            return false;
+        });
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeToggleTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeToggleTest.java
@@ -1,0 +1,676 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensearch.security.auditlog.impl.AuditCategory;
+import org.opensearch.security.auditlog.impl.AuditMessage;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.audit.AuditLogsRule;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+/**
+ * Integration tests for dynamically toggling audit settings via cluster settings
+ * in disabled security mode (plugins.security.disabled: true). Isolated in its
+ * own class so that if a toggle test fails mid-way (leaving settings in a modified
+ * state), it does not cause flaky behavior in other audit tests.
+ *
+ * Mirrors the SSL-only dynamic settings tests (StandaloneAuditDynamicConfigTest,
+ * StandaloneAuditDynamicFilterSettingsTest, StandaloneAuditDynamicComplianceSettingsTest)
+ * to prove the same dynamic configuration paths work in disabled mode.
+ */
+public class StandaloneAuditDisabledModeToggleTest {
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_DISABLED,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName(),
+                "plugins.security.audit.config.log_request_body",
+                true,
+                "plugins.security.audit.config.resolve_indices",
+                true,
+                "plugins.security.audit.config.resolve_bulk_requests",
+                true,
+                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
+                "watched-*",
+                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
+                "read-watched"
+            )
+        )
+        .sslOnly(true)
+        .build();
+
+    @Rule
+    public AuditLogsRule auditLogsRule = new AuditLogsRule();
+
+    // =====================================================================
+    // audit.enabled — toggle on/off at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldToggleAuditOffAndBackOnViaClusterSettings() {
+        // Disable audit
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": false}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-toggle/_doc/1?refresh=true", "{\"val\": \"should-not-appear\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-toggle".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        // Re-enable
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": true}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-toggle-back/_doc/1?refresh=true", "{\"val\": \"should-appear\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-toggle-back".equals(idx)) return true;
+            }
+            return false;
+        });
+    }
+
+    @Test
+    public void shouldDisableAuditAndSuppressAllEvents() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable audit via cluster setting
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": false}}");
+
+            // These should NOT be audited
+            client.get("_cluster/health");
+            client.putJson("toggle-suppress/_doc/1", "{\"field\": \"value\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(
+            0,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && (msg.getPrivilege().contains("cluster:monitor/health") || msg.getPrivilege().contains("indices:data/write"))
+        );
+
+        // Re-enable
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.enabled\": true}}");
+        }
+    }
+
+    // =====================================================================
+    // log_request_body — toggle off at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldStopLoggingBodyWhenDisabledAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable request body logging dynamically
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.log_request_body\": false}}");
+
+            // This request's body should NOT appear in audit
+            client.postJson("disabled-body-toggle/_search", "{\"query\": {\"match_all\": {}}}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            if (msg.getPrivilege() == null || !msg.getPrivilege().contains("indices:data/read/search")) return false;
+            return msg.getRequestBody() == null;
+        });
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.log_request_body\": true}}");
+        }
+    }
+
+    @Test
+    public void shouldResumeLoggingBodyWhenReenabledAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Ensure body logging is enabled
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.log_request_body\": true}}");
+
+            client.postJson("disabled-body-resume/_search", "{\"query\": {\"term\": {\"status\": \"active\"}}}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            if (msg.getPrivilege() == null || !msg.getPrivilege().contains("indices:data/read/search")) return false;
+            String body = msg.getRequestBody();
+            return body != null && body.contains("active");
+        });
+    }
+
+    // =====================================================================
+    // ignore_requests — add at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldIgnoreRequestsAddedAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Dynamically ignore search requests
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": [\"indices:data/read/search\"]}}"
+            );
+
+            // Search should now be suppressed
+            client.postJson("disabled-ignore-req/_search", "{\"query\": {\"match_all\": {}}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(
+            0,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().equals("indices:data/read/search")
+        );
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": []}}");
+        }
+    }
+
+    @Test
+    public void shouldStopIgnoringRequestsWhenCleared() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // First ignore, then clear
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": [\"indices:data/read/search\"]}}"
+            );
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": []}}");
+
+            // Search should now be logged again
+            client.postJson("disabled-unignore/_search", "{\"query\": {\"match_all\": {}}}");
+        }
+
+        auditLogsRule.assertAtLeast(
+            1,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("indices:data/read/search")
+        );
+    }
+
+    // =====================================================================
+    // disabled_categories — disable REQUEST_AUDIT at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldDisableCategoryAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable REQUEST_AUDIT category dynamically
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": [\"REQUEST_AUDIT\"]}}"
+            );
+
+            // This should NOT produce a REQUEST_AUDIT event
+            client.get("_cluster/health");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(
+            0,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("cluster:monitor/health")
+        );
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": []}}");
+        }
+    }
+
+    @Test
+    public void shouldReenableCategoryAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable then re-enable
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": [\"REQUEST_AUDIT\"]}}"
+            );
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": []}}");
+
+            // Should be logged again
+            client.get("_cluster/health");
+        }
+
+        auditLogsRule.assertAtLeast(
+            1,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("cluster:monitor/health")
+        );
+    }
+
+    // =====================================================================
+    // resolve_indices — toggle at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldStopResolvingIndicesWhenDisabledAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Create an index first
+            client.putJson("disabled-resolve-dyn/_doc/1?refresh=true", "{\"field\": \"value\"}");
+
+            // Disable index resolution
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.resolve_indices\": false}}");
+
+            // Search — should NOT have resolved_indices field
+            client.get("disabled-resolve-dyn/_search");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            if (msg.getPrivilege() == null || !msg.getPrivilege().contains("indices:data/read/search")) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            // resolved_indices should be absent when resolve_indices=false
+            return fields.get(AuditMessage.RESOLVED_INDICES) == null;
+        });
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.resolve_indices\": true}}");
+        }
+    }
+
+    // =====================================================================
+    // resolve_bulk_requests — toggle at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldToggleBulkResolutionAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Enable bulk resolution dynamically
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.resolve_bulk_requests\": true}}");
+
+            String bulkBody = "{ \"index\": { \"_index\": \"disabled-dyn-bulk-a\", \"_id\": \"1\" } }\n"
+                + "{ \"field\": \"a\" }\n"
+                + "{ \"index\": { \"_index\": \"disabled-dyn-bulk-b\", \"_id\": \"2\" } }\n"
+                + "{ \"field\": \"b\" }\n";
+            client.postJson("_bulk?refresh=true", bulkBody);
+        }
+
+        // Should see per-item events with individual index names
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-dyn-bulk-a".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.resolve_bulk_requests\": false}}");
+        }
+    }
+
+    // =====================================================================
+    // Transport layer — disable TRANSPORT_AUDIT at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldSuppressTransportEventsWhenCategoryDisabledAtRuntime() {
+        // First verify TRANSPORT_AUDIT events are produced
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-transport-dyn/_doc/1?refresh=true", "{\"val\": \"before-disable\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.TRANSPORT_AUDIT);
+
+        // Now disable TRANSPORT_AUDIT dynamically
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": [\"TRANSPORT_AUDIT\"]}}"
+            );
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        // Index again — TRANSPORT_AUDIT should be suppressed
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-transport-dyn/_doc/2?refresh=true", "{\"val\": \"after-disable\"}");
+        }
+
+        // Should still get REQUEST_AUDIT but no TRANSPORT_AUDIT for this second write
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-transport-dyn".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": []}}");
+        }
+    }
+
+    @Test
+    public void shouldResumeTransportEventsWhenCategoryReenabledAtRuntime() {
+        // Disable TRANSPORT_AUDIT
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": [\"TRANSPORT_AUDIT\"]}}"
+            );
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        // Re-enable by clearing disabled categories
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.disabled_transport_categories\": []}}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        // Index a doc — TRANSPORT_AUDIT should now appear again
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-transport-reenable/_doc/1?refresh=true", "{\"val\": \"back\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.TRANSPORT_AUDIT);
+    }
+
+    // =====================================================================
+    // compliance.enabled — toggle at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldStopComplianceWriteEventsWhenDisabledAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable compliance at runtime
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.enabled\": false}}");
+
+            // Write to watched index — should NOT produce compliance event
+            client.putJson("watched-compliance-toggle/_doc/1?refresh=true", "{\"name\": \"should-not-track\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.enabled\": true}}");
+        }
+    }
+
+    @Test
+    public void shouldResumeComplianceWriteEventsWhenReenabled() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable then re-enable
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.enabled\": false}}");
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.enabled\": true}}");
+
+            // Write should be tracked again
+            client.putJson("watched-compliance-resume/_doc/1?refresh=true", "{\"name\": \"tracked-again\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+    }
+
+    // =====================================================================
+    // write_watched_indices — change at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldTrackNewWatchedIndexAddedAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Change watched indices to a new pattern at runtime
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.write_watched_indices\": [\"disabled-dyn-watch-*\"]}}"
+            );
+
+            // Write to the new watched pattern
+            client.putJson("disabled-dyn-watch-test/_doc/1?refresh=true", "{\"secret\": \"new-pattern\"}");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.write_watched_indices\": [\"watched-*\"]}}"
+            );
+        }
+    }
+
+    @Test
+    public void shouldStopTrackingOldPatternWhenWatchedIndicesChanged() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Change watched indices to something else
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.write_watched_indices\": [\"only-this-disabled-*\"]}}"
+            );
+
+            // Write to the OLD pattern — should NOT produce compliance event
+            client.putJson("watched-old-pattern/_doc/1?refresh=true", "{\"name\": \"old-pattern\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_WRITE);
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.write_watched_indices\": [\"watched-*\"]}}"
+            );
+        }
+    }
+
+    // =====================================================================
+    // read_watched_fields — change at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldTrackReadForDynamicallyAddedWatchedFields() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Set read watched fields dynamically
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.read_watched_fields\": [\"disabled-dyn-read-watch\"]}}"
+            );
+
+            // Create and search the watched index
+            client.putJson("disabled-dyn-read-watch/_doc/1?refresh=true", "{\"name\": \"dynamic-secret\", \"value\": 42}");
+            client.get("disabled-dyn-read-watch/_search");
+        }
+
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_READ);
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.read_watched_fields\": []}}");
+        }
+    }
+
+    @Test
+    public void shouldStopTrackingReadWhenWatchedFieldsCleared() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // First set a watch, then clear it
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.compliance.read_watched_fields\": [\"disabled-clear-read\"]}}"
+            );
+            client.putJson("disabled-clear-read/_doc/1?refresh=true", "{\"name\": \"tracked\"}");
+
+            // Clear the watch
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.compliance.read_watched_fields\": []}}");
+
+            // Search should NOT produce compliance read event now
+            client.get("disabled-clear-read/_search");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> msg.getCategory() == AuditCategory.COMPLIANCE_DOC_READ);
+    }
+
+    // =====================================================================
+    // ignore_requests — unified suppression across REST and transport layers
+    // =====================================================================
+
+    @Test
+    public void shouldSuppressBothRestAndTransportEventsWithSameIgnorePattern() {
+        // Add a pattern that matches write actions — affects both layers
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": [\"indices:data/write/*\"]}}"
+            );
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        // Send a write — should be suppressed at BOTH REQUEST_AUDIT and TRANSPORT_AUDIT
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-unified-ignore/_doc/1?refresh=true", "{\"data\": \"suppressed\"}");
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        // No REQUEST_AUDIT events for write actions on this index
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
+            if (msg.getPrivilege() == null || !msg.getPrivilege().startsWith("indices:data/write")) return false;
+            Map<String, Object> fields = msg.getAsMap();
+            Object indices = fields.get(AuditMessage.INDICES);
+            if (indices == null) return false;
+            String[] indexArr = (String[]) indices;
+            for (String idx : indexArr) {
+                if ("disabled-unified-ignore".equals(idx)) return true;
+            }
+            return false;
+        });
+
+        // No TRANSPORT_AUDIT events for write actions either
+        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
+            if (msg.getCategory() != AuditCategory.TRANSPORT_AUDIT) return false;
+            return msg.getPrivilege() != null && msg.getPrivilege().startsWith("indices:data/write");
+        });
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.ignore_requests\": []}}");
+        }
+    }
+
+    // =====================================================================
+    // exclude_sensitive_headers — toggle at runtime
+    // =====================================================================
+
+    @Test
+    public void shouldToggleSensitiveHeaderExclusionAtRuntime() {
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            // Disable sensitive header exclusion
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.exclude_sensitive_headers\": false}}");
+
+            client.get("_cluster/health");
+        }
+
+        // When exclude_sensitive_headers=false, all headers pass through unfiltered
+        // Verify events still flow correctly with the setting changed
+        auditLogsRule.assertAtLeast(
+            1,
+            (AuditMessage msg) -> msg.getCategory() == AuditCategory.REQUEST_AUDIT
+                && msg.getPrivilege() != null
+                && msg.getPrivilege().contains("cluster:monitor/health")
+        );
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.exclude_sensitive_headers\": true}}");
+        }
+    }
+
+    // =====================================================================
+    // disabled_rest_categories should NOT suppress TRANSPORT_AUDIT
+    // =====================================================================
+
+    @Test
+    public void shouldNotSuppressTransportAuditWhenOnlyRestCategoryDisabled() {
+        // Disable TRANSPORT_AUDIT via REST categories only (should not affect transport interceptor)
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson(
+                "_cluster/settings",
+                "{\"persistent\": {\"plugins.security.audit.config.disabled_rest_categories\": [\"TRANSPORT_AUDIT\"]}}"
+            );
+        }
+
+        auditLogsRule.waitForAuditLogs();
+
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("disabled-rest-cat-test/_doc/1?refresh=true", "{\"val\": \"still-logged\"}");
+        }
+
+        // TRANSPORT_AUDIT events should still appear — REST category disable doesn't affect transport
+        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> msg.getCategory() == AuditCategory.TRANSPORT_AUDIT);
+
+        // Reset
+        try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
+            client.putJson("_cluster/settings", "{\"persistent\": {\"plugins.security.audit.config.disabled_rest_categories\": []}}");
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeToggleTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledModeToggleTest.java
@@ -16,12 +16,12 @@ import org.junit.Test;
 
 import org.opensearch.security.auditlog.impl.AuditCategory;
 import org.opensearch.security.auditlog.impl.AuditMessage;
-import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.test.framework.audit.AuditLogsRule;
-import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
-import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.opensearch.security.DisabledModeAuditTestUtils.messageHasIndex;
+import static org.opensearch.security.DisabledModeAuditTestUtils.messageMatchesIndex;
 
 /**
  * Integration tests for dynamically toggling audit settings via cluster settings
@@ -36,29 +36,7 @@ import org.opensearch.test.framework.cluster.TestRestClient;
 public class StandaloneAuditDisabledModeToggleTest {
 
     @ClassRule
-    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
-        .anonymousAuth(false)
-        .loadConfigurationIntoIndex(false)
-        .nodeSettings(
-            Map.of(
-                ConfigConstants.SECURITY_DISABLED,
-                true,
-                "plugins.security.audit.type",
-                TestRuleAuditLogSink.class.getName(),
-                "plugins.security.audit.config.log_request_body",
-                true,
-                "plugins.security.audit.config.resolve_indices",
-                true,
-                "plugins.security.audit.config.resolve_bulk_requests",
-                true,
-                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
-                "watched-*",
-                ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_READ_WATCHED_FIELDS,
-                "read-watched"
-            )
-        )
-        .sslOnly(true)
-        .build();
+    public static LocalCluster cluster = DisabledModeAuditTestUtils.createDisabledModeAuditCluster();
 
     @Rule
     public AuditLogsRule auditLogsRule = new AuditLogsRule();
@@ -81,16 +59,7 @@ public class StandaloneAuditDisabledModeToggleTest {
         }
 
         auditLogsRule.waitForAuditLogs();
-        auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-toggle".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertExactlyScanAll(0, msg -> messageHasIndex(msg, "disabled-toggle"));
 
         // Re-enable
         try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
@@ -103,17 +72,7 @@ public class StandaloneAuditDisabledModeToggleTest {
             client.putJson("disabled-toggle-back/_doc/1?refresh=true", "{\"val\": \"should-appear\"}");
         }
 
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-toggle-back".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-toggle-back"));
     }
 
     @Test
@@ -339,17 +298,7 @@ public class StandaloneAuditDisabledModeToggleTest {
         }
 
         // Should see per-item events with individual index names
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-dyn-bulk-a".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-dyn-bulk-a"));
 
         // Reset
         try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
@@ -386,17 +335,7 @@ public class StandaloneAuditDisabledModeToggleTest {
         }
 
         // Should still get REQUEST_AUDIT but no TRANSPORT_AUDIT for this second write
-        auditLogsRule.assertAtLeast(1, (AuditMessage msg) -> {
-            if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-transport-dyn".equals(idx)) return true;
-            }
-            return false;
-        });
+        auditLogsRule.assertAtLeast(1, msg -> messageMatchesIndex(msg, AuditCategory.REQUEST_AUDIT, "disabled-transport-dyn"));
 
         // Reset
         try (TestRestClient client = cluster.getSecurityDisabledRestClient()) {
@@ -595,14 +534,7 @@ public class StandaloneAuditDisabledModeToggleTest {
         auditLogsRule.assertExactlyScanAll(0, (AuditMessage msg) -> {
             if (msg.getCategory() != AuditCategory.REQUEST_AUDIT) return false;
             if (msg.getPrivilege() == null || !msg.getPrivilege().startsWith("indices:data/write")) return false;
-            Map<String, Object> fields = msg.getAsMap();
-            Object indices = fields.get(AuditMessage.INDICES);
-            if (indices == null) return false;
-            String[] indexArr = (String[]) indices;
-            for (String idx : indexArr) {
-                if ("disabled-unified-ignore".equals(idx)) return true;
-            }
-            return false;
+            return messageHasIndex(msg, "disabled-unified-ignore");
         });
 
         // No TRANSPORT_AUDIT events for write actions either

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -1193,8 +1193,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
             }.toListener());
 
             indexModule.addIndexEventListener(cr);
-        } else if (!disabled && !client && auditLog != null && !(auditLog instanceof NullAuditLog)) {
-            // Non-FGAC mode: register compliance listener for standalone audit
+        } else if ((disabled || SSLConfig.isSslOnlyMode()) && !client && auditLog != null && !(auditLog instanceof NullAuditLog)) {
+            // Non-FGAC mode (SSL-only or disabled): register compliance listener for standalone audit
             final ComplianceIndexingOperationListener ciol = new ComplianceIndexingOperationListenerImpl(auditLog, threadPool);
             indexModule.addIndexOperationListener(ciol);
 


### PR DESCRIPTION
Enable audit logging as an independent capability in disabled mode (`plugins.security.disabled: true`) without requiring any security features — no TLS, no authentication, no authorization.

### Description

**Category:** New feature

**Why these changes are required?**

Users running OpenSearch with security fully disabled (common in development, log analytics, and internal observability clusters) have no audit trail. Compliance frameworks (SOC2, HIPAA, PCI-DSS, GDPR) require audit logs even when access control is not configured. With SSL-only mode audit logging (#6304), this extends standalone audit to cover the remaining non-FGAC mode.

**What is the old behavior before changes and new behavior after changes?**

- **Before:** In disabled mode (`plugins.security.disabled: true`), the compliance `IndexingOperationListener` was not registered because the condition explicitly excluded `disabled` mode. Document-level compliance tracking (`COMPLIANCE_DOC_WRITE`, `COMPLIANCE_DOC_READ`) did not work.
- **After:** The condition now includes disabled mode alongside SSL-only, enabling full compliance tracking. All audit features from SSL-only mode now work in disabled mode — plain HTTP, no TLS required anywhere.

### What's Different from SSL-only Mode

| | SSL-only | Disabled |
|---|---|---|
| TLS on REST | Required | Not required (plain HTTP) |
| TLS on Transport | Required | Not required |
| Authentication | None | None |
| Authorization | None | None |
| Client cert identity (mTLS) | Available | Not available (no TLS) |
| User identity in events | Source IP + cert CN (if mTLS) | Source IP only |

### Event Example (Disabled Mode)

```json
{
  "audit_cluster_name": "my-cluster",
  "audit_node_name": "node-1",
  "audit_category": "REQUEST_AUDIT",
  "audit_request_origin": "REST",
  "audit_request_layer": "TRANSPORT",
  "audit_request_remote_address": "192.168.1.10",
  "audit_transport_request_type": "IndexRequest",
  "audit_request_privilege": "indices:data/write/index",
  "audit_trace_indices": ["my-index"],
  "audit_trace_resolved_indices": ["my-index"],
  "audit_request_body": "{\"name\":\"test\",\"status\":\"active\"}",
  "audit_rest_request_headers": {
    "Content-Type": ["application/json"],
    "User-Agent": ["curl/8.17.0"]
  },
  "audit_trace_task_id": "node-1:42",
  "@timestamp": "2026-07-23T14:30:00.000+00:00",
  "audit_format_version": 4
}
```

Note: No `audit_request_effective_user` or `audit_request_effective_user_is_admin` — no users exist in disabled mode.

### Compliance Doc Write Event (Disabled Mode)

```json
{
  "audit_category": "COMPLIANCE_DOC_WRITE",
  "audit_compliance_operation": "CREATE",
  "audit_compliance_doc_version": 1,
  "audit_trace_doc_id": "1",
  "audit_trace_indices": ["watched-index"],
  "audit_trace_shard_id": 0,
  "audit_compliance_diff_content": "[{\"op\":\"add\",\"path\":\"/name\",\"value\":\"test\"}]",
  "audit_compliance_diff_is_noop": false,
  "@timestamp": "2026-07-23T14:30:00.100+00:00",
  "audit_format_version": 4
}
```

### Transport Audit Event (Disabled Mode)

```json
{
  "audit_category": "TRANSPORT_AUDIT",
  "audit_request_privilege": "indices:data/write/bulk[s][p]",
  "audit_transport_request_type": "BulkShardRequest",
  "audit_request_layer": "TRANSPORT",
  "audit_trace_shard_id": 0,
  "audit_trace_task_id": "node-2:88",
  "audit_request_remote_address": "10.0.0.2",
  "@timestamp": "2026-07-23T14:30:00.200+00:00",
  "audit_format_version": 4
}
```

Note on action suffixes: `[s]` = shard-routed, `[p]` = primary shard, `[r]` = replica shard. So `bulk[s][p]` means "bulk write executing on the primary shard."

### Configuration

```yaml
plugins.security.disabled: true
plugins.security.audit.type: log4j  # or internal_opensearch, webhook

# All the same audit settings as SSL-only mode work:
plugins.security.audit.config.log_request_body: true
plugins.security.audit.config.resolve_indices: true
plugins.security.audit.config.resolve_bulk_requests: true
plugins.security.audit.config.enable_transport: true
plugins.security.audit.compliance.enabled: true
opendistro_security.compliance.history.write.watched_indices: "my-*"
opendistro_security.compliance.history.read.watched_fields: "my-*"
```

### Code Change

2-line change in `OpenSearchSecurityPlugin.onIndexModule()`:

```java
// Before:
} else if (!disabled && !client && auditLog != null && !(auditLog instanceof NullAuditLog)) {

// After:
} else if ((disabled || SSLConfig.isSslOnlyMode()) && !client && auditLog != null && !(auditLog instanceof NullAuditLog)) {
```

This registers the compliance `IndexingOperationListener` in disabled mode (it was previously excluded by the `!disabled` check). All other audit infrastructure (`initStandaloneAuditIfEnabled`, `AuditActionFilter`, `AuditTransportInterceptor`) was already wired for disabled mode in #6304.

### Issues Resolved

Resolves #6340

### Testing

- **Integration tests:** 20 new tests in `StandaloneAuditDisabledModeTest` covering:
  - REQUEST_AUDIT for all HTTP operations (GET, PUT, POST, DELETE, bulk, update)
  - TRANSPORT_AUDIT for shard-level inter-node communication
  - COMPLIANCE_DOC_WRITE for watched index tracking with diffs
  - COMPLIANCE_DOC_READ for field-level read tracking
  - Dynamic settings toggle without restart
  - Bulk per-item event handling
  - Index resolution (wildcard → concrete)
  - Self-loop guard (audit index writes not re-audited)
  - Absence of user identity fields (no auth = no user)
  - Ignore-requests filtering
- **Manual testing:** Tarball distribution (disabled mode, log4j sink, plain HTTP) on dev desktop verified all features

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request created
- [x] Commits are signed per the DCO using --signoff

### Related
- SSL-only audit logging: #6304 (merged)
- PR review follow-up: #6321 (merged)
- Broader vision: [PROPOSAL] Standalone Audit Logging Plugin for OpenSearch .github#501
- Unified disabled_categories: #6271 (merged)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
