### PR TITLE
Fix parent-child query detection across classloaders

### DIFF
--- a/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
+++ b/src/main/java/org/opensearch/security/util/ParentChildrenQueryDetector.java
@@ -13,10 +13,11 @@ import org.apache.lucene.search.BooleanClause;
 
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
-import org.opensearch.join.query.HasChildQueryBuilder;
-import org.opensearch.join.query.HasParentQueryBuilder;
 
 public final class ParentChildrenQueryDetector implements QueryBuilderVisitor {
+
+    private static final String HAS_PARENT_QUERY_NAME = "has_parent";
+    private static final String HAS_CHILD_QUERY_NAME = "has_child";
 
     private boolean queryPresent = false;
 
@@ -36,7 +37,8 @@ public final class ParentChildrenQueryDetector implements QueryBuilderVisitor {
      */
     @Override
     public void accept(QueryBuilder queryBuilder) {
-        if (queryBuilder instanceof HasParentQueryBuilder || queryBuilder instanceof HasChildQueryBuilder) {
+        String queryName = queryBuilder.getWriteableName();
+        if (HAS_PARENT_QUERY_NAME.equals(queryName) || HAS_CHILD_QUERY_NAME.equals(queryName)) {
             queryPresent = true;
         }
     }

--- a/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
+++ b/src/test/java/org/opensearch/security/util/ParentChildrenQueryDetectorTest.java
@@ -13,6 +13,7 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.junit.Test;
 
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermQueryBuilder;
 import org.opensearch.join.query.HasChildQueryBuilder;
@@ -20,6 +21,9 @@ import org.opensearch.join.query.HasParentQueryBuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ParentChildrenQueryDetectorTest {
 
@@ -40,6 +44,22 @@ public class ParentChildrenQueryDetectorTest {
     @Test
     public void topLevelHasChildQueryShouldBeDetected() {
         HasChildQueryBuilder query = new HasChildQueryBuilder("my_type", QueryBuilders.termQuery("field", "value"), ScoreMode.None);
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void hasParentQueryShouldBeDetectedByWriteableName() {
+        QueryBuilder query = mock(QueryBuilder.class, CALLS_REAL_METHODS);
+        when(query.getWriteableName()).thenReturn("has_parent");
+
+        assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
+    }
+
+    @Test
+    public void hasChildQueryShouldBeDetectedByWriteableName() {
+        QueryBuilder query = mock(QueryBuilder.class, CALLS_REAL_METHODS);
+        when(query.getWriteableName()).thenReturn("has_child");
 
         assertThat(ParentChildrenQueryDetector.hasParentOrChildQuery(query), equalTo(true));
     }


### PR DESCRIPTION
## Description

Detect `has_parent` and `has_child` queries by their registered `NamedWriteable` names instead of using `instanceof` against the concrete parent-join query builder classes.

The Security plugin bundles `parent-join-client`, while an installed OpenSearch distribution loads the parent-join module with a separate classloader. As a result, the query builder instance created by Core and the class referenced by Security have the same class name but different class identities, causing both `instanceof` checks to return false.

This could bypass the filter-level DLS guard for parent/child queries. In a locally installed distribution, the affected TLQ-DLS `has_parent` request returned HTTP 200 before this change instead of the expected rejection. With this change, it returns HTTP 500 with `Unable to handle filter level DLS for parent or child queries`.

The existing integration test did not expose this because it loads both plugins on the test JVM application classloader.

## Changes

- Compare `QueryBuilder#getWriteableName()` with the registered `has_parent` and `has_child` names.
- Remove runtime type references to the parent-join query builder classes from the detector.
- Add tests using generic `QueryBuilder` instances to verify detection is based on the registered name rather than concrete class identity.

## Validation

- `./gradlew :test --tests 'org.opensearch.security.util.ParentChildrenQueryDetectorTest' -Pcrypto.standard=FIPS-140-3`
- `./gradlew :integrationTest --tests 'org.opensearch.security.ParentChildRelationTests.hasParentWithTlqDls' -Pcrypto.standard=FIPS-140-3`
- `./gradlew :precommit -Pcrypto.standard=FIPS-140-3`
- Built the Security plugin and installed it into a locally built OpenSearch distribution; verified the TLQ-DLS `has_parent` request is rejected with the expected HTTP 500 response under the real separated classloader topology.

The aggregate multi-project `precommit` invocation additionally encountered pre-existing forbidden-API findings for `URL.openStream()` in the sample-resource plugin; the scoped root `:precommit` task passes.
