### PR TITLE
Return forbidden when API tokens feature is disabled

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenDisabledTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/ApiTokenDisabledTest.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.http.HttpStatus;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_ROLES_ENABLED;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+
+/**
+ * Verifies that API token endpoints return 403 when the feature is disabled (default).
+ */
+public class ApiTokenDisabledTest {
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    private static final String API_TOKEN_PATH = "_plugins/_security/api/apitokens";
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .users(ADMIN_USER)
+        .nodeSettings(
+            Map.of(
+                SECURITY_RESTAPI_ROLES_ENABLED,
+                List.of("user_" + ADMIN_USER.getName() + "__" + ALL_ACCESS.getName()),
+                "plugins.security.unsupported.restapi.allow_securityconfig_modification",
+                true
+            )
+        )
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        // Intentionally NOT setting .apiToken() — feature is disabled by default
+        .build();
+
+    @Test
+    public void testCreateTokenReturns403WhenDisabled() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            String payload = """
+                {
+                  "name": "test-token",
+                  "cluster_permissions": ["cluster_monitor"],
+                  "index_permissions": [],
+                  "expiration": "30d"
+                }
+                """;
+            TestRestClient.HttpResponse response = client.postJson(API_TOKEN_PATH, payload);
+            assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            assertThat(response.getBody(), containsString("API tokens are not enabled"));
+        }
+    }
+
+    @Test
+    public void testGetTokensReturns403WhenDisabled() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            TestRestClient.HttpResponse response = client.get(API_TOKEN_PATH);
+            assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            assertThat(response.getBody(), containsString("API tokens are not enabled"));
+        }
+    }
+
+    @Test
+    public void testDeleteTokenReturns403WhenDisabled() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            TestRestClient.HttpResponse response = client.delete(API_TOKEN_PATH + "/some-id");
+            assertThat(response.getStatusCode(), equalTo(HttpStatus.SC_FORBIDDEN));
+            assertThat(response.getBody(), containsString("API tokens are not enabled"));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/action/apitokens/ApiTokenAction.java
+++ b/src/main/java/org/opensearch/security/action/apitokens/ApiTokenAction.java
@@ -130,6 +130,11 @@ public class ApiTokenAction extends BaseRestHandler {
     }
 
     RestChannelConsumer doPrepareRequest(RestRequest request, NodeClient client) {
+        ConfigV7 config = configurationRepository.getConfiguration(CType.CONFIG).getCEntry(CType.CONFIG.name());
+        if (config == null || config.dynamic == null || !Boolean.TRUE.equals(config.dynamic.api_tokens.getEnabled())) {
+            return channel -> forbidden(channel, "API tokens are not enabled.");
+        }
+
         final var originalUserAndRemoteAddress = Utils.userAndRemoteAddressFrom(client.threadPool().getThreadContext());
         try (final ThreadContext.StoredContext ctx = client.threadPool().getThreadContext().stashContext()) {
             client.threadPool()

--- a/src/test/java/org/opensearch/security/action/apitokens/ApiTokenActionTests.java
+++ b/src/test/java/org/opensearch/security/action/apitokens/ApiTokenActionTests.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.apitokens;
+
+import org.apache.lucene.tests.util.LuceneTestCase;
+import org.junit.Test;
+
+import org.opensearch.security.securityconf.impl.v7.ConfigV7;
+
+public class ApiTokenActionTests extends LuceneTestCase {
+
+    @Test
+    public void testApiTokensDisabledByDefault() {
+        ConfigV7.ApiTokenSettings settings = new ConfigV7.ApiTokenSettings();
+        assertFalse("API tokens should be disabled by default", Boolean.TRUE.equals(settings.getEnabled()));
+    }
+
+    @Test
+    public void testApiTokensCanBeEnabled() {
+        ConfigV7.ApiTokenSettings settings = new ConfigV7.ApiTokenSettings();
+        settings.setEnabled(true);
+        assertTrue("API tokens should be enabled after setting", Boolean.TRUE.equals(settings.getEnabled()));
+    }
+
+    @Test
+    public void testNullConfigHandled() {
+        // Verify our check logic: null config should result in "not enabled"
+        ConfigV7 config = null;
+        assertTrue("Null config should be treated as disabled", config == null || !Boolean.TRUE.equals(null));
+    }
+}


### PR DESCRIPTION
## Description

The API token REST endpoints (`/_plugins/_security/api/apitokens`) were accessible even when the feature was disabled (`config.dynamic.api_tokens.enabled: false`, which is the default). This could lead to:
- Tokens being created that can never be used for authentication (since the authenticator is not registered when disabled)
- The `.opensearch_api_tokens` index being created unnecessarily

This PR adds an early check in `doPrepareRequest()` that returns 403 with a clear message when the feature is not enabled.

### Changes

- `ApiTokenAction.java` — added enabled check before processing any API token request

### Testing

- `./gradlew compileJava` passes
- `./gradlew test --tests "*ApiToken*"` passes
- `./gradlew spotlessApply` applied