### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -555,8 +555,8 @@ subprojects {
 allprojects {
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -554,6 +555,7 @@ subprojects {
 allprojects {
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -45,8 +45,8 @@ ext {
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -59,8 +59,8 @@ buildscript {
 
 repositories {
     mavenLocal()
-    maven { url = "https://ci.opensearch.org/m2/" }
     maven { url = "https://ci.opensearch.org/maven2/" }
+    maven { url = "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url = "https://plugins.gradle.org/m2/" }

--- a/bwc-test/build.gradle
+++ b/bwc-test/build.gradle
@@ -45,6 +45,7 @@ ext {
 buildscript {
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -58,6 +59,7 @@ buildscript {
 
 repositories {
     mavenLocal()
+    maven { url = "https://ci.opensearch.org/m2/" }
     maven { url = "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'maven-publish'
 buildscript {
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -7,8 +7,8 @@ apply plugin: 'maven-publish'
 buildscript {
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@
 
 pluginManagement {
     repositories {
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
         gradlePluginPortal()
         mavenCentral()

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,8 +6,8 @@
 
 pluginManagement {
     repositories {
-        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (security)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).