### PR TITLE
Move shibboleth repos before Maven Central to avoid 429 (security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -555,14 +555,14 @@ subprojects {
 allprojects {
     repositories {
         mavenLocal()
+        maven { url = "https://build.shibboleth.net/nexus/content/repositories/releases" }
+        maven { url = "build.shibboleth.net/maven/releases" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
-        maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url = "https://artifacts.opensearch.org/snapshots/lucene/" }
-        maven { url = "https://build.shibboleth.net/nexus/content/repositories/releases" }
-        maven { url = "build.shibboleth.net/maven/releases" }
+        maven { url = "https://plugins.gradle.org/m2/" }
     }
 
     afterEvaluate {

--- a/libs/opensaml/build.gradle
+++ b/libs/opensaml/build.gradle
@@ -7,13 +7,13 @@ apply plugin: 'maven-publish'
 buildscript {
     repositories {
         mavenLocal()
+        maven { url = "https://build.shibboleth.net/nexus/content/groups/public" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
-        maven { url = "https://plugins.gradle.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url = "https://artifacts.opensearch.org/snapshots/lucene/" }
-        maven { url = "https://build.shibboleth.net/nexus/content/groups/public" }
+        maven { url = "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {


### PR DESCRIPTION
### Description
Move shibboleth repos before Maven Central to avoid 429 (security)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803