### PR TITLE
Add missing -Dopensearch.version and -Dbuild.snapshot to integtest.sh (security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -555,14 +555,25 @@ subprojects {
 allprojects {
     repositories {
         mavenLocal()
+        def shibbolethRepo = maven {
+            name = "shibboleth-releases"
+            url = "https://build.shibboleth.net/maven/releases"
+        }
         maven { url = "https://build.shibboleth.net/nexus/content/repositories/releases" }
-        maven { url = "build.shibboleth.net/maven/releases" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url = "https://artifacts.opensearch.org/snapshots/lucene/" }
         maven { url = "https://plugins.gradle.org/m2/" }
+        exclusiveContent {
+            forRepositories(shibbolethRepo)
+            filter {
+                includeGroup "org.opensaml"
+                includeGroup "net.shibboleth"
+                includeGroup "net.shibboleth.utilities"
+            }
+        }
     }
 
     afterEvaluate {

--- a/scripts/integtest.sh
+++ b/scripts/integtest.sh
@@ -51,7 +51,7 @@ while getopts ":h:b:p:s:c:v:n:t:m:u:" arg; do
             OPENSEARCH_VERSION=$OPTARG
             ;;
         n)
-            # Do nothing as we're not consuming this param.
+            SNAPSHOT=$OPTARG
             ;;
         u)
             COMMON_UTILS_VERSION=$OPTARG
@@ -84,6 +84,11 @@ then
   SECURITY_ENABLED="true"
 fi
 
+if [ -z "$SNAPSHOT" ]
+then
+  SNAPSHOT="false"
+fi
+
 OPENSEARCH_REQUIRED_VERSION="2.12.0"
 if [ -z "$CREDENTIAL" ]
 then
@@ -104,4 +109,4 @@ fi
 USERNAME=`echo $CREDENTIAL | awk -F ':' '{print $1}'`
 PASSWORD=`echo $CREDENTIAL | awk -F ':' '{print $2}'`
 
-./gradlew integTestRemote -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dsecurity_enabled=$SECURITY_ENABLED -Dtests.clustername=$CLUSTER_NAME -Dhttps=true -Duser=$USERNAME -Dpassword=$PASSWORD
+./gradlew integTestRemote -Dopensearch.version=$OPENSEARCH_VERSION -Dbuild.snapshot=$SNAPSHOT -Dtests.rest.cluster="$BIND_ADDRESS:$BIND_PORT" -Dtests.cluster="$BIND_ADDRESS:$BIND_PORT" -Dsecurity_enabled=$SECURITY_ENABLED -Dtests.clustername=$CLUSTER_NAME -Dhttps=true -Duser=$USERNAME -Dpassword=$PASSWORD


### PR DESCRIPTION
### Description
Add missing -Dopensearch.version and -Dbuild.snapshot to integtest.sh (security)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5169921924