### PR TITLE
fix(audit): Require explicit opt-in for standalone audit logging

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/DisabledModeAuditTestUtils.java
+++ b/src/integrationTest/java/org/opensearch/security/DisabledModeAuditTestUtils.java
@@ -40,6 +40,8 @@ public final class DisabledModeAuditTestUtils {
                 Map.of(
                     ConfigConstants.SECURITY_DISABLED,
                     true,
+                    ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                    true,
                     "plugins.security.audit.type",
                     TestRuleAuditLogSink.class.getName(),
                     "plugins.security.audit.config.log_request_body",

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditComplianceDocTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditComplianceDocTest.java
@@ -41,6 +41,8 @@ public class StandaloneAuditComplianceDocTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_COMPLIANCE_HISTORY_WRITE_WATCHED_INDICES,
@@ -58,6 +60,8 @@ public class StandaloneAuditComplianceDocTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
@@ -263,6 +267,8 @@ public class StandaloneAuditComplianceDocTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledCategoryTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDisabledCategoryTest.java
@@ -38,6 +38,8 @@ public class StandaloneAuditDisabledCategoryTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.SECURITY_AUDIT_CONFIG_DISABLED_CATEGORIES,
@@ -70,6 +72,8 @@ public class StandaloneAuditDisabledCategoryTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicComplianceSettingsTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicComplianceSettingsTest.java
@@ -38,6 +38,8 @@ public class StandaloneAuditDynamicComplianceSettingsTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 // Start with compliance enabled and watching "compliance-*" indices

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicConfigTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicConfigTest.java
@@ -34,7 +34,16 @@ public class StandaloneAuditDynamicConfigTest {
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .anonymousAuth(false)
         .loadConfigurationIntoIndex(false)
-        .nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true, "plugins.security.audit.type", TestRuleAuditLogSink.class.getName()))
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName()
+            )
+        )
         .sslOnly(true)
         .build();
 

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicFilterSettingsTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditDynamicFilterSettingsTest.java
@@ -39,6 +39,8 @@ public class StandaloneAuditDynamicFilterSettingsTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 // Start with body enabled (default)

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditFilterFeaturesTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditFilterFeaturesTest.java
@@ -40,6 +40,8 @@ public class StandaloneAuditFilterFeaturesTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY,
@@ -64,6 +66,8 @@ public class StandaloneAuditFilterFeaturesTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_REQUESTS,
@@ -82,6 +86,8 @@ public class StandaloneAuditFilterFeaturesTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_LOG_REQUEST_BODY,
@@ -99,6 +105,8 @@ public class StandaloneAuditFilterFeaturesTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
@@ -120,6 +128,8 @@ public class StandaloneAuditFilterFeaturesTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_IGNORE_USERS,
@@ -139,6 +149,8 @@ public class StandaloneAuditFilterFeaturesTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditLoggingTest.java
@@ -34,7 +34,16 @@ public class StandaloneAuditLoggingTest {
     public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .anonymousAuth(false)
         .loadConfigurationIntoIndex(false)
-        .nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true, "plugins.security.audit.type", TestRuleAuditLogSink.class.getName()))
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
+                "plugins.security.audit.type",
+                TestRuleAuditLogSink.class.getName()
+            )
+        )
         .sslOnly(true)
         .build();
 

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditMtlsTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditMtlsTest.java
@@ -38,6 +38,8 @@ public class StandaloneAuditMtlsTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 "plugins.security.ssl.http.clientauth_mode",

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditSinksTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditSinksTest.java
@@ -38,7 +38,16 @@ public class StandaloneAuditSinksTest {
     public static LocalCluster internalSinkCluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
         .anonymousAuth(false)
         .loadConfigurationIntoIndex(false)
-        .nodeSettings(Map.of(ConfigConstants.SECURITY_SSL_ONLY, true, "plugins.security.audit.type", "internal_opensearch"))
+        .nodeSettings(
+            Map.of(
+                ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
+                "plugins.security.audit.type",
+                "internal_opensearch"
+            )
+        )
         .sslOnly(true)
         .build();
 
@@ -49,6 +58,8 @@ public class StandaloneAuditSinksTest {
         .nodeSettings(
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
+                true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
                 true,
                 "plugins.security.audit.type",
                 "log4j",

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditTransportInterceptTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditTransportInterceptTest.java
@@ -39,6 +39,8 @@ public class StandaloneAuditTransportInterceptTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 ConfigConstants.OPENDISTRO_SECURITY_AUDIT_ENABLE_TRANSPORT,

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditWebhookSinkTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditWebhookSinkTest.java
@@ -46,6 +46,8 @@ public class StandaloneAuditWebhookSinkTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 "plugins.security.audit.config.webhook.url",

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -376,8 +376,9 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         this.localClient = localClient;
         final Settings settings = environment.settings();
         final IndexNameExpressionResolver resolver = new IndexNameExpressionResolver(threadPool.getThreadContext());
+        final boolean standaloneEnabled = SecuritySettings.AUDIT_ENABLE_STANDALONE.get(settings);
         final String auditType = settings.get(ConfigConstants.SECURITY_AUDIT_TYPE_DEFAULT, null);
-        if (auditType != null) {
+        if (standaloneEnabled && auditType != null) {
             AuditLogImpl auditLogImpl = new AuditLogImpl(
                 settings,
                 configPath,
@@ -469,6 +470,14 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 auditLogImpl.getComplianceConfig().setWatchedReadFields(newValue);
             });
         } else {
+            if (!standaloneEnabled && auditType != null) {
+                log.info(
+                    "Audit type '{}' is configured but standalone audit is not enabled. "
+                        + "Set '{}' to true to enable audit logging in non-FGAC modes.",
+                    auditType,
+                    ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE
+                );
+            }
             auditLog = new NullAuditLog();
         }
     }
@@ -1746,6 +1755,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
         // Dynamic audit toggle — works in all modes (FGAC, SSL-only, disabled)
         settings.add(SecuritySettings.AUDIT_ENABLED_SETTING);
+        settings.add(SecuritySettings.AUDIT_ENABLE_STANDALONE);
 
         // Protected index settings
         settings.add(

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -205,6 +205,7 @@ public class ConfigConstants {
     public static final int SECURITY_PASSWORD_HASHING_ARGON2_VERSION_DEFAULT = 19;
 
     public static final String SECURITY_AUDIT_TYPE_DEFAULT = SECURITY_SETTINGS_PREFIX + "audit.type";
+    public static final String SECURITY_AUDIT_ENABLE_STANDALONE = SECURITY_SETTINGS_PREFIX + "audit.enable_standalone";
     public static final String SECURITY_AUDIT_ENABLED = SECURITY_SETTINGS_PREFIX + "audit.enabled";
     public static final String SECURITY_AUDIT_CONFIG_DEFAULT = SECURITY_SETTINGS_PREFIX + "audit.config";
     public static final String SECURITY_AUDIT_CONFIG_ROUTES = SECURITY_SETTINGS_PREFIX + "audit.routes";

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -71,6 +71,12 @@ public class SecuritySettings {
         Setting.Property.Sensitive
     );
 
+    public static final Setting<Boolean> AUDIT_ENABLE_STANDALONE = Setting.boolSetting(
+        ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+        false,
+        Setting.Property.NodeScope
+    );
+
     // Dynamic audit filter settings
     private static final String AUDIT_CONFIG_PREFIX = "plugins.security.audit.config.";
 


### PR DESCRIPTION
### Description

Standalone audit logging previously activated whenever `plugins.security.audit.type` was configured, regardless of whether the user intended to enable audit in non-FGAC modes. This caused unintended audit index writes in environments where the demo installer (`install_demo_configuration`) set `audit.type: internal_opensearch` but security was subsequently disabled.

The issue manifested in the opensearch-build CI pipeline for **RPM** and **DEB** distributions (not Docker, which skips the demo installer when `DISABLE_SECURITY_PLUGIN=true`). The tar install script, DEB `postinst`, and RPM post-install hooks unconditionally run `install_demo_configuration` when the security plugin jars exist — writing `audit.type` into `opensearch.yml`. When the test harness then sets `plugins.security.disabled: true`, the `audit.type` setting remains, causing standalone audit to activate and write to `security-auditlog-*` indices. These in-flight write tasks were caught by ISM's `waitForRunningTasks` teardown, causing intermittent test failures.

**Old behavior:** Standalone audit activated whenever `plugins.security.audit.type` was set in `opensearch.yml`, even from stale demo configuration.

**New behavior:** Standalone audit requires **both** settings to activate:
```yaml
plugins.security.audit.enable_standalone: true
plugins.security.audit.type: log4j  # or internal_opensearch, webhook, etc.
```

When `audit.type` is configured but `enable_standalone` is not set, an informational log message guides the user:
```
Audit type 'internal_opensearch' is configured but standalone audit is not enabled. Set 'plugins.security.audit.enable_standalone' to true to enable audit logging in non-FGAC modes.
```

The setting is static (`NodeScope` only) and requires a node restart to change.

### Issues Resolved

- Resolves test failures reported in https://github.com/opensearch-project/index-management/pull/1709
- Related: https://github.com/opensearch-project/index-management-dashboards-plugin/issues/1457
- Related build-repo fix: https://github.com/opensearch-project/opensearch-build/pull/6341

### Testing

- **Unit tests (43):** AuditActionFilterTest (11), AuditTransportInterceptorTest (11), DisabledCategoriesTest (6), AuditConfigFilterTest (15) — all pass
- **Integration tests (85):** StandaloneAuditLoggingTest, StandaloneAuditDisabledCategoryTest, StandaloneAuditMtlsTest, StandaloneAuditSinksTest, StandaloneAuditWebhookSinkTest, StandaloneAuditFilterFeaturesTest, StandaloneAuditTransportInterceptTest, StandaloneAuditDynamicConfigTest, StandaloneAuditDynamicFilterSettingsTest, StandaloneAuditDynamicComplianceSettingsTest, StandaloneAuditComplianceDocTest, StandaloneAuditDisabledModeTest, StandaloneAuditDisabledModeToggleTest — all pass

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
