### PR TITLE
fix(audit): Add missing enable_standalone setting to StandaloneAuditB…

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditBodyLoggingExclusionTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditBodyLoggingExclusionTest.java
@@ -37,6 +37,8 @@ public class StandaloneAuditBodyLoggingExclusionTest {
             Map.of(
                 ConfigConstants.SECURITY_SSL_ONLY,
                 true,
+                ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE,
+                true,
                 "plugins.security.audit.type",
                 TestRuleAuditLogSink.class.getName(),
                 "plugins.security.audit.config.log_request_body",


### PR DESCRIPTION
## Description

Add missing `plugins.security.audit.enable_standalone=true` setting to `StandaloneAuditBodyLoggingExclusionTest`, fixing deterministic test failures that block all downstream PRs.

**Category:** Bug fix

### Why these changes are required?

After PR #6368 made standalone audit logging opt-in (requiring explicit `enable_standalone=true`), PR #6347 merged with a new integration test (`StandaloneAuditBodyLoggingExclusionTest`) that was developed against the old behavior where standalone audit was auto-enabled in SSL-only mode. The test never included the now-mandatory setting, causing all 10 test methods to fail deterministically on main.

### What is the old behavior before changes and new behavior after changes?

- **Before:** `StandaloneAuditBodyLoggingExclusionTest` initializes with `NullAuditLog` → `AuditActionFilter` never registers → zero `REQUEST_AUDIT` events produced → all assertions timeout after 3s with "0L match predicate"
- **After:** Test correctly sets `enable_standalone=true` → real `AuditLogImpl` initializes → `AuditActionFilter` registers → `REQUEST_AUDIT` events flow to `TestRuleAuditLogSink` → assertions pass

### Issues Resolved

Fixes CI failures on main introduced by the merge of #6347 after #6368:
- All 10 `StandaloneAuditBodyLoggingExclusionTest` methods failing
- Blocking integration-tests on downstream PRs (#6344, #6349, etc.)

### Is this a backport?

No.

### Testing

- [x] Ran `StandaloneAuditBodyLoggingExclusionTest` locally — all 10 methods pass after fix (previously all 10 failed)
- [x] Ran companion `AuditBodyLoggingExclusionTest` alongside — still passes (no regression)

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
