### PR TITLE
fix(audit): dedup bulk audit events by only iterating BulkShardRequest

### DIFF
--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -129,26 +129,31 @@ public class AuditActionFilter implements ActionFilter {
         }
 
         // Skip requests targeting the audit index (prevent self-referential loop).
-        // BulkRequest does not implement IndicesRequest, so its target indices are
-        // gathered from its sub-items; a single-doc write to the audit index arrives
-        // here as a BulkRequest (via TransportSingleItemBulkWriteAction) and must be
-        // guarded too, otherwise the standard summary path below would leak an event.
-        String[] targetIndices = null;
+        // IndicesRequest guard: any-match (e.g., BulkShardRequest whose shard belongs
+        // to the audit index is suppressed entirely — matches FGAC's behavior where
+        // internal/system writes are never audited).
+        // BulkRequest guard: all-match — only suppress when EVERY sub-item targets the
+        // audit index. A single-doc write to the audit index arrives here as a
+        // BulkRequest (via TransportSingleItemBulkWriteAction) with one item, so
+        // all-match catches it. Mixed BulkRequests (normal + audit-index items) still
+        // produce a summary event; the per-item guard in logBulkItem() and the
+        // IndicesRequest guard on the BulkShardRequest handle individual audit-index
+        // items at the shard level.
         if (request instanceof IndicesRequest) {
-            targetIndices = ((IndicesRequest) request).indices();
-        } else if (request instanceof BulkRequest) {
-            targetIndices = ((BulkRequest) request).requests()
-                .stream()
-                .map(DocWriteRequest::index)
-                .filter(idx -> idx != null)
-                .toArray(String[]::new);
-        }
-        if (targetIndices != null) {
-            for (String idx : targetIndices) {
-                if (isAuditIndex(idx)) {
-                    chain.proceed(task, action, request, listener);
-                    return;
+            String[] indices = ((IndicesRequest) request).indices();
+            if (indices != null) {
+                for (String idx : indices) {
+                    if (isAuditIndex(idx)) {
+                        chain.proceed(task, action, request, listener);
+                        return;
+                    }
                 }
+            }
+        } else if (request instanceof BulkRequest) {
+            List<? extends DocWriteRequest<?>> bulkItems = ((BulkRequest) request).requests();
+            if (!bulkItems.isEmpty() && bulkItems.stream().allMatch(r -> r.index() != null && isAuditIndex(r.index()))) {
+                chain.proceed(task, action, request, listener);
+                return;
             }
         }
 

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -182,9 +182,13 @@ public class AuditActionFilter implements ActionFilter {
         }
 
         // Bulk request handling — log each sub-operation separately.
-        // Only iterates on BulkShardRequest (shard-level), not BulkRequest (coordinating node),
-        // to avoid duplicate audit events. A bulk request traverses the action chain twice:
-        // first as BulkRequest at the coordinating node, then as BulkShardRequest at the data node.
+        // Only iterates on BulkShardRequest (shard-level), not BulkRequest, to avoid
+        // duplicate audit events. Both passes run through ActionFilters on the coordinating
+        // node: TransportBulkAction first handles the BulkRequest, then fans out to
+        // shardBulkAction.execute() with a BulkShardRequest before TransportReplicationAction
+        // reroutes to the primary shard. The reroute to the (possibly remote) data node goes
+        // through the transport request handler, which does not re-run ActionFilters, so the
+        // data node never re-audits.
         if (filter.shouldResolveBulkRequests() && request instanceof BulkShardRequest) {
             try {
                 TransportAddress remoteAddress = request.remoteAddress();
@@ -245,7 +249,7 @@ public class AuditActionFilter implements ActionFilter {
                 String[] distinctIndices = bulkRequest.requests()
                     .stream()
                     .map(r -> r.index())
-                    .filter(idx -> idx != null)
+                    .filter(idx -> idx != null && !isAuditIndex(idx))
                     .distinct()
                     .toArray(String[]::new);
                 if (distinctIndices.length > 0) {

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -128,15 +128,26 @@ public class AuditActionFilter implements ActionFilter {
             return;
         }
 
-        // Skip requests targeting the audit index (prevent self-referential loop)
+        // Skip requests targeting the audit index (prevent self-referential loop).
+        // BulkRequest does not implement IndicesRequest, so its target indices are
+        // gathered from its sub-items; a single-doc write to the audit index arrives
+        // here as a BulkRequest (via TransportSingleItemBulkWriteAction) and must be
+        // guarded too, otherwise the standard summary path below would leak an event.
+        String[] targetIndices = null;
         if (request instanceof IndicesRequest) {
-            String[] indices = ((IndicesRequest) request).indices();
-            if (indices != null) {
-                for (String idx : indices) {
-                    if (isAuditIndex(idx)) {
-                        chain.proceed(task, action, request, listener);
-                        return;
-                    }
+            targetIndices = ((IndicesRequest) request).indices();
+        } else if (request instanceof BulkRequest) {
+            targetIndices = ((BulkRequest) request).requests()
+                .stream()
+                .map(DocWriteRequest::index)
+                .filter(idx -> idx != null)
+                .toArray(String[]::new);
+        }
+        if (targetIndices != null) {
+            for (String idx : targetIndices) {
+                if (isAuditIndex(idx)) {
+                    chain.proceed(task, action, request, listener);
+                    return;
                 }
             }
         }

--- a/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
+++ b/src/main/java/org/opensearch/security/filter/AuditActionFilter.java
@@ -166,7 +166,10 @@ public class AuditActionFilter implements ActionFilter {
         }
 
         // Bulk request handling — log each sub-operation separately.
-        if (filter.shouldResolveBulkRequests() && (request instanceof BulkShardRequest || request instanceof BulkRequest)) {
+        // Only iterates on BulkShardRequest (shard-level), not BulkRequest (coordinating node),
+        // to avoid duplicate audit events. A bulk request traverses the action chain twice:
+        // first as BulkRequest at the coordinating node, then as BulkShardRequest at the data node.
+        if (filter.shouldResolveBulkRequests() && request instanceof BulkShardRequest) {
             try {
                 TransportAddress remoteAddress = request.remoteAddress();
                 if (remoteAddress == null) {
@@ -176,24 +179,9 @@ public class AuditActionFilter implements ActionFilter {
                 Map<String, List<String>> headers = threadPool.getThreadContext().getTransient(ConfigConstants.SECURITY_AUDIT_REST_HEADERS);
                 Map<String, List<String>> filteredHeaders = AuditHeaderUtils.filterHeaders(headers, filter);
 
-                if (request instanceof BulkShardRequest) {
-                    BulkShardRequest bulkShardRequest = (BulkShardRequest) request;
-                    for (BulkItemRequest item : bulkShardRequest.items()) {
-                        logBulkItem(
-                            item.request(),
-                            action,
-                            task,
-                            effectiveUser,
-                            remoteAddress,
-                            filteredHeaders,
-                            bulkShardRequest.shardId()
-                        );
-                    }
-                } else {
-                    BulkRequest bulkRequest = (BulkRequest) request;
-                    for (DocWriteRequest<?> innerRequest : bulkRequest.requests()) {
-                        logBulkItem(innerRequest, action, task, effectiveUser, remoteAddress, filteredHeaders, null);
-                    }
+                BulkShardRequest bulkShardRequest = (BulkShardRequest) request;
+                for (BulkItemRequest item : bulkShardRequest.items()) {
+                    logBulkItem(item.request(), action, task, effectiveUser, remoteAddress, filteredHeaders, bulkShardRequest.shardId());
                 }
             } catch (Exception e) {
                 log.error("Failed to log bulk audit events for action '{}': {}", action, e.getMessage(), e);

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -21,6 +21,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
+import org.opensearch.action.bulk.BulkItemRequest;
+import org.opensearch.action.bulk.BulkRequest;
+import org.opensearch.action.bulk.BulkShardRequest;
+import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.action.support.ActionRequestMetadata;
@@ -32,6 +36,8 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
 import org.opensearch.core.common.transport.TransportAddress;
+import org.opensearch.core.index.Index;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.security.OpenSearchSecurityPlugin;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.security.auditlog.config.AuditConfig;
@@ -54,6 +60,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -493,5 +500,263 @@ public class AuditActionFilterTest {
         // This is a known limitation: the prefix won't match resolved index names.
         Settings settings = Settings.builder().put("plugins.security.audit.config.index", "audit-YYYY.MM.dd").build();
         assertThat(OpenSearchSecurityPlugin.getAuditIndexPrefix(settings), equalTo("audit-YYYY.MM.dd"));
+    }
+
+    // =====================================================================
+    // Bulk request handling — dedup (only BulkShardRequest iterates items)
+    // =====================================================================
+
+    private AuditActionFilter createFilterWithResolveBulk(boolean resolveBulk) {
+        Settings settings = Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_RESOLVE_BULK_REQUESTS, resolveBulk).build();
+        return new AuditActionFilter(auditLog, clusterService, threadPool, AuditConfig.from(settings).getFilter(), "security-auditlog");
+    }
+
+    private BulkShardRequest mockBulkShardRequest(String index, int itemCount) {
+        BulkShardRequest request = mock(BulkShardRequest.class);
+        ShardId shardId = new ShardId(new Index(index, "uuid"), 0);
+        when(request.shardId()).thenReturn(shardId);
+        when(request.indices()).thenReturn(new String[] { index });
+
+        BulkItemRequest[] items = new BulkItemRequest[itemCount];
+        for (int i = 0; i < itemCount; i++) {
+            IndexRequest indexRequest = new IndexRequest(index).id("doc-" + i);
+            items[i] = new BulkItemRequest(i, indexRequest);
+        }
+        when(request.items()).thenReturn(items);
+        return request;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestLogsPerItem() throws Exception {
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkShardRequest request = mockBulkShardRequest("my-index", 3);
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Should log 3 per-item audit events (one per BulkItemRequest)
+        verify(auditLog, times(3)).logRequestAudit(any(AuditMessage.class));
+        // Chain should proceed
+        verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestPerItemContainsShardId() throws Exception {
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkShardRequest request = mockBulkShardRequest("my-index", 1);
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        ArgumentCaptor<AuditMessage> captor = ArgumentCaptor.forClass(AuditMessage.class);
+        verify(auditLog).logRequestAudit(captor.capture());
+
+        AuditMessage msg = captor.getValue();
+        Map<String, Object> fields = msg.getAsMap();
+        // Shard ID should be present in the per-item event
+        assertThat(fields.get(AuditMessage.SHARD_ID), notNullValue());
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkRequestDoesNotIterateItems() throws Exception {
+        // BulkRequest should NOT produce per-item events — it falls through to standard path
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkRequest request = new BulkRequest();
+        request.add(
+            new IndexRequest("my-index").id("doc-1").source("{\"field\":\"val1\"}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+        request.add(
+            new IndexRequest("my-index").id("doc-2").source("{\"field\":\"val2\"}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+        request.add(
+            new IndexRequest("other-index").id("doc-3").source("{\"field\":\"val3\"}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Should log exactly 1 summary audit event (NOT 3 per-item events)
+        verify(auditLog, times(1)).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkRequestSummaryContainsDistinctIndices() throws Exception {
+        // The single summary event for BulkRequest should list distinct target indices
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkRequest request = new BulkRequest();
+        request.add(new IndexRequest("index-a").id("1").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON));
+        request.add(new IndexRequest("index-b").id("2").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON));
+        request.add(new IndexRequest("index-a").id("3").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON));
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
+
+        ArgumentCaptor<AuditMessage> captor = ArgumentCaptor.forClass(AuditMessage.class);
+        verify(auditLog).logRequestAudit(captor.capture());
+
+        AuditMessage msg = captor.getValue();
+        Map<String, Object> fields = msg.getAsMap();
+        String[] indices = (String[]) fields.get(AuditMessage.INDICES);
+        // Should contain distinct indices: index-a, index-b (not duplicated)
+        assertThat(indices, notNullValue());
+        assertThat(indices.length, equalTo(2));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestSkipsWhenResolveBulkDisabled() throws Exception {
+        // When resolve_bulk_requests is false, BulkShardRequest falls through to standard path
+        AuditActionFilter noResolveFilter = createFilterWithResolveBulk(false);
+
+        BulkShardRequest request = mockBulkShardRequest("my-index", 3);
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        noResolveFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Should log exactly 1 event (standard path), NOT 3 per-item events
+        verify(auditLog, times(1)).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestSkipsAuditIndexItems() throws Exception {
+        // Items targeting the audit index should be skipped in per-item iteration
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkShardRequest request = mock(BulkShardRequest.class);
+        ShardId shardId = new ShardId(new Index("security-auditlog-2026.08.10", "uuid"), 0);
+        when(request.shardId()).thenReturn(shardId);
+        when(request.indices()).thenReturn(new String[] { "security-auditlog-2026.08.10" });
+
+        // All items target the audit index
+        BulkItemRequest[] items = new BulkItemRequest[2];
+        for (int i = 0; i < 2; i++) {
+            IndexRequest indexRequest = new IndexRequest("security-auditlog-2026.08.10").id("doc-" + i);
+            items[i] = new BulkItemRequest(i, indexRequest);
+        }
+        when(request.items()).thenReturn(items);
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // The top-level self-loop guard catches it (indices() returns audit index)
+        // so no audit events at all
+        verify(auditLog, never()).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestMixedItemsSkipsOnlyAuditIndexItems() throws Exception {
+        // Mix of normal and audit-index items — only normal items get logged
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkShardRequest request = mock(BulkShardRequest.class);
+        ShardId shardId = new ShardId(new Index("my-index", "uuid"), 0);
+        when(request.shardId()).thenReturn(shardId);
+        // indices() returns a non-audit index so top-level guard doesn't fire
+        when(request.indices()).thenReturn(new String[] { "my-index" });
+
+        BulkItemRequest[] items = new BulkItemRequest[3];
+        // Item 0: normal index
+        items[0] = new BulkItemRequest(0, new IndexRequest("my-index").id("doc-0"));
+        // Item 1: audit index — should be skipped
+        items[1] = new BulkItemRequest(1, new IndexRequest("security-auditlog-2026.08.10").id("audit-doc"));
+        // Item 2: normal index
+        items[2] = new BulkItemRequest(2, new IndexRequest("my-index").id("doc-2"));
+
+        when(request.items()).thenReturn(items);
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Only 2 events logged (items 0 and 2); item 1 (audit index) is skipped
+        verify(auditLog, times(2)).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkShardRequestWithEmptyItems() throws Exception {
+        // Empty items array — no audit events, but chain still proceeds and returns early
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkShardRequest request = mock(BulkShardRequest.class);
+        ShardId shardId = new ShardId(new Index("my-index", "uuid"), 0);
+        when(request.shardId()).thenReturn(shardId);
+        when(request.indices()).thenReturn(new String[] { "my-index" });
+        when(request.items()).thenReturn(new BulkItemRequest[0]);
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // No items to iterate — no audit events
+        verify(auditLog, never()).logRequestAudit(any(AuditMessage.class));
+        // Chain should still proceed (early return after bulk block)
+        verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkRequestTargetingAuditIndexNotSuppressedByTopLevelGuard() throws Exception {
+        // BulkRequest doesn't implement IndicesRequest, so the top-level self-loop guard
+        // won't catch it. It produces a single summary event (documenting known behavior).
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkRequest request = new BulkRequest();
+        request.add(
+            new IndexRequest("security-auditlog-2026.08.10").id("audit-1").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // BulkRequest falls through to standard path — top-level guard doesn't fire
+        // because BulkRequest doesn't implement IndicesRequest. One summary event logged.
+        verify(auditLog, times(1)).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
     }
 }

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -646,8 +646,10 @@ public class AuditActionFilterTest {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
-    public void testBulkShardRequestSkipsAuditIndexItems() throws Exception {
-        // Items targeting the audit index should be skipped in per-item iteration
+    public void testBulkShardRequestTargetingAuditIndexSuppressedByTopLevelGuard() throws Exception {
+        // A BulkShardRequest whose shard belongs to the audit index is caught by the
+        // top-level self-loop guard (BulkShardRequest implements IndicesRequest, and its
+        // indices() returns the audit index), so it returns early before per-item iteration.
         AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
 
         BulkShardRequest request = mock(BulkShardRequest.class);
@@ -655,7 +657,7 @@ public class AuditActionFilterTest {
         when(request.shardId()).thenReturn(shardId);
         when(request.indices()).thenReturn(new String[] { "security-auditlog-2026.08.10" });
 
-        // All items target the audit index
+        // All items target the audit index (matches the shard's index in a real request)
         BulkItemRequest[] items = new BulkItemRequest[2];
         for (int i = 0; i < 2; i++) {
             IndexRequest indexRequest = new IndexRequest("security-auditlog-2026.08.10").id("doc-" + i);
@@ -670,8 +672,7 @@ public class AuditActionFilterTest {
 
         bulkFilter.apply(task, "indices:data/write/bulk[s]", request, ActionRequestMetadata.empty(), listener, chain);
 
-        // The top-level self-loop guard catches it (indices() returns audit index)
-        // so no audit events at all
+        // Top-level guard fires (indices() returns the audit index) — no events, chain proceeds.
         verify(auditLog, never()).logRequestAudit(any(AuditMessage.class));
         verify(chain).proceed(task, "indices:data/write/bulk[s]", request, listener);
     }
@@ -737,9 +738,10 @@ public class AuditActionFilterTest {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
-    public void testBulkRequestTargetingAuditIndexNotSuppressedByTopLevelGuard() throws Exception {
-        // BulkRequest doesn't implement IndicesRequest, so the top-level self-loop guard
-        // won't catch it. It produces a single summary event (documenting known behavior).
+    public void testBulkRequestTargetingAuditIndexIsSuppressedByTopLevelGuard() throws Exception {
+        // A single-doc write to the audit index arrives here as a BulkRequest (via
+        // TransportSingleItemBulkWriteAction). BulkRequest doesn't implement IndicesRequest,
+        // so the top-level guard inspects its sub-item indices to prevent a self-referential loop.
         AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
 
         BulkRequest request = new BulkRequest();
@@ -754,9 +756,32 @@ public class AuditActionFilterTest {
 
         bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
 
-        // BulkRequest falls through to standard path — top-level guard doesn't fire
-        // because BulkRequest doesn't implement IndicesRequest. One summary event logged.
-        verify(auditLog, times(1)).logRequestAudit(any(AuditMessage.class));
+        // Top-level guard fires on the audit-index sub-item — no event, chain still proceeds.
+        verify(auditLog, never()).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkRequestWithAnyAuditIndexItemIsSuppressed() throws Exception {
+        // If a BulkRequest mixes normal and audit-index sub-items, the top-level guard's
+        // any-match semantics suppress the whole request (mirrors IndicesRequest behavior).
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkRequest request = new BulkRequest();
+        request.add(new IndexRequest("my-index").id("1").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON));
+        request.add(
+            new IndexRequest("security-auditlog-2026.08.10").id("2").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
+
+        verify(auditLog, never()).logRequestAudit(any(AuditMessage.class));
         verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
     }
 }

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -763,13 +763,44 @@ public class AuditActionFilterTest {
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Test
-    public void testBulkRequestWithAnyAuditIndexItemIsSuppressed() throws Exception {
-        // If a BulkRequest mixes normal and audit-index sub-items, the top-level guard's
-        // any-match semantics suppress the whole request (mirrors IndicesRequest behavior).
+    public void testBulkRequestWithMixedAuditIndexItemsProducesSummaryEvent() throws Exception {
+        // A mixed BulkRequest (normal + audit-index sub-items) is NOT suppressed by
+        // the top-level guard because it uses all-match semantics: only suppress when
+        // ALL items target the audit index. Mixed requests fall through to the standard
+        // summary path, producing one event listing all distinct target indices. The
+        // audit-index items are handled later at the shard level (BulkShardRequest
+        // IndicesRequest guard + per-item guard in logBulkItem).
         AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
 
         BulkRequest request = new BulkRequest();
         request.add(new IndexRequest("my-index").id("1").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON));
+        request.add(
+            new IndexRequest("security-auditlog-2026.08.10").id("2").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
+
+        Task task = mock(Task.class);
+        when(task.getId()).thenReturn(1L);
+        ActionFilterChain chain = mock(ActionFilterChain.class);
+        ActionListener<ActionResponse> listener = mock(ActionListener.class);
+
+        bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
+
+        // Mixed BulkRequest produces a summary event (not suppressed by all-match guard)
+        verify(auditLog).logRequestAudit(any(AuditMessage.class));
+        verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
+    public void testBulkRequestWithAllAuditIndexItemsIsSuppressed() throws Exception {
+        // A BulkRequest where ALL sub-items target the audit index is suppressed by
+        // the all-match guard. This covers multi-item bulk writes from the audit sink.
+        AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
+
+        BulkRequest request = new BulkRequest();
+        request.add(
+            new IndexRequest("security-auditlog-2026.08.10").id("1").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
+        );
         request.add(
             new IndexRequest("security-auditlog-2026.08.10").id("2").source("{}", org.opensearch.core.xcontent.MediaTypeRegistry.JSON)
         );

--- a/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditActionFilterTest.java
@@ -767,8 +767,9 @@ public class AuditActionFilterTest {
         // A mixed BulkRequest (normal + audit-index sub-items) is NOT suppressed by
         // the top-level guard because it uses all-match semantics: only suppress when
         // ALL items target the audit index. Mixed requests fall through to the standard
-        // summary path, producing one event listing all distinct target indices. The
-        // audit-index items are handled later at the shard level (BulkShardRequest
+        // summary path, producing one event listing the distinct target indices. The
+        // audit index is filtered out of that summary so it never leaks into the event;
+        // the audit-index items are handled later at the shard level (BulkShardRequest
         // IndicesRequest guard + per-item guard in logBulkItem).
         AuditActionFilter bulkFilter = createFilterWithResolveBulk(true);
 
@@ -786,8 +787,16 @@ public class AuditActionFilterTest {
         bulkFilter.apply(task, "indices:data/write/bulk", request, ActionRequestMetadata.empty(), listener, chain);
 
         // Mixed BulkRequest produces a summary event (not suppressed by all-match guard)
-        verify(auditLog).logRequestAudit(any(AuditMessage.class));
+        ArgumentCaptor<AuditMessage> captor = ArgumentCaptor.forClass(AuditMessage.class);
+        verify(auditLog).logRequestAudit(captor.capture());
         verify(chain).proceed(task, "indices:data/write/bulk", request, listener);
+
+        // The summary's INDICES lists only the normal index — the audit index is
+        // filtered out and must not appear in the summary event.
+        AuditMessage msg = captor.getValue();
+        String[] indices = (String[]) msg.getAsMap().get(AuditMessage.INDICES);
+        assertThat(indices, notNullValue());
+        assertThat(indices, arrayContaining("my-index"));
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
### Description

**Category:** Bug fix

A bulk request runs through `ActionFilters` twice, both times on the
coordinating node: first as a `BulkRequest`, then as a `BulkShardRequest` when
`TransportBulkAction` fans out to `shardBulkAction.execute()` (before
`TransportReplicationAction` reroutes to the primary shard). The reroute to the
(possibly remote) data node goes through the transport request handler, which
does not re-run `ActionFilters`, so the data node never re-audits.
`AuditActionFilter` previously iterated sub-items for **both** passes, emitting
duplicate per-item `REQUEST_AUDIT` events for every bulk sub-operation.

**Why these changes are required:**
Duplicate audit events inflate the audit log, distort audit-based metrics and
alerting, and make it appear that each bulk sub-operation happened twice. Audit
records must reflect each operation exactly once.

**Old behavior (before):**
The bulk-handling block matched both `BulkShardRequest` and `BulkRequest`. Both
passes iterated the sub-items, so every bulk sub-operation produced two per-item
`REQUEST_AUDIT` events — one from the `BulkRequest` pass and one from the
`BulkShardRequest` pass, both on the coordinating node.

**New behavior (after):**
Only `BulkShardRequest` (shard-level) iterates sub-items, so each sub-operation
is audited exactly once and carries its shard ID. A `BulkRequest` targeting
normal indices falls through to the standard path, producing one summary
`REQUEST_AUDIT` event listing the distinct target indices (the audit index is
filtered out of that list, so it never leaks into the summary event).

Because a single-doc write to the audit index arrives as a `BulkRequest` (via
`TransportSingleItemBulkWriteAction`) — and `BulkRequest` does not implement
`IndicesRequest` — the top-level self-loop guard was extended to inspect a
`BulkRequest`'s sub-item indices. It suppresses the request (zero events) only
when **every** sub-item targets the audit index (all-match semantics), so a
pure audit-index bulk write is dropped before reaching either the bulk or
summary path. A mixed `BulkRequest` (normal + audit-index items) is not
suppressed; it falls through to the summary path, where the audit index is
excluded from the summary's indices. The existing `BulkShardRequest` top-level
and per-item audit-index self-loop guards are preserved.

### Testing

Unit testing (`AuditActionFilterTest`) — added bulk-path tests, full suite green
(32 tests, 0 failures). Also ran `spotlessApply`, `compileJava`,
`compileTestJava`, and `integrationTest` — all clean. Tests cover:

- Per-item logging — `BulkShardRequest` emits one event per sub-item.
- Shard ID presence — per-item events carry the shard ID.
- `resolve_bulk_requests` disabled — `BulkShardRequest` falls through to the standard single-event path.
- Audit-index self-loop skipping:
  - `BulkShardRequest` top-level guard (shard belongs to the audit index → zero events).
  - `BulkShardRequest` per-item guard (mixed items skip only the audit-index item).
  - `BulkRequest` guard (all-match — a bulk write where every sub-item targets the audit index is suppressed → zero events).
- Empty items — no events, chain still proceeds.
- `BulkRequest` summary — normal-index `BulkRequest` produces one summary event listing distinct target indices, with no per-item iteration.
- `BulkRequest` mixed summary — a mixed `BulkRequest` (normal + audit-index items) produces one summary event whose indices exclude the audit index.
- Integration: `StandaloneAuditDisabledModeTest.shouldNotProduceEventsForAuditIndexWrites` passes (the regression this fix addresses).

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
