### PR TITLE
Add Eclipse P2 mirror to avoid download.eclipse.org outages (security)

### DIFF
--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -39,7 +39,7 @@ runs:
         java-version: 21
 
     - name: Build
-      uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       with:
         cache-disabled: true
         arguments: assemble

--- a/.github/actions/create-bwc-build/action.yaml
+++ b/.github/actions/create-bwc-build/action.yaml
@@ -38,12 +38,15 @@ runs:
         distribution: temurin # Temurin is a distribution of adoptium
         java-version: 21
 
-    - name: Build
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       with:
         cache-disabled: true
-        arguments: assemble
-        build-root-directory: ${{ inputs.plugin-branch }}
+
+    - name: Build
+      run: ./gradlew assemble
+      working-directory: ${{ inputs.plugin-branch }}
+      shell: bash
 
     - id: get-opensearch-version
       run: |

--- a/.github/actions/run-bwc-suite/action.yaml
+++ b/.github/actions/run-bwc-suite/action.yaml
@@ -36,19 +36,14 @@ runs:
       with:
         plugin-branch: ${{ inputs.plugin-next-branch }}
 
-    - name: Run BWC tests
+    - name: Setup Gradle
       uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       with:
         cache-disabled: true
-        arguments: |
-          -p bwc-test
-          bwcTestSuite
-          -Dtests.security.manager=false
-          -Dtests.opensearch.secure=true
-          -Dtests.opensearch.username=${{ inputs.username }}
-          -Dtests.opensearch.password=${{ inputs.password }}
-          -Dbwc.version.previous=${{ steps.build-previous.outputs.built-version }}
-          -Dbwc.version.next=${{ steps.build-next.outputs.built-version }} -i
+
+    - name: Run BWC tests
+      run: ./gradlew -p bwc-test bwcTestSuite -Dtests.security.manager=false -Dtests.opensearch.secure=true -Dtests.opensearch.username=${{ inputs.username }} -Dtests.opensearch.password=${{ inputs.password }} -Dbwc.version.previous=${{ steps.build-previous.outputs.built-version }} -Dbwc.version.next=${{ steps.build-next.outputs.built-version }} -i
+      shell: bash
 
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
       if: always()

--- a/.github/actions/run-bwc-suite/action.yaml
+++ b/.github/actions/run-bwc-suite/action.yaml
@@ -37,7 +37,7 @@ runs:
         plugin-branch: ${{ inputs.plugin-next-branch }}
 
     - name: Run BWC tests
-      uses: gradle/actions/setup-gradle@d9c87d481d55275bb5441eef3fe0e46805f9ef70 # v3.5.0
+      uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5
       with:
         cache-disabled: true
         arguments: |

--- a/gradle/formatting.gradle
+++ b/gradle/formatting.gradle
@@ -14,7 +14,7 @@ allprojects {
 				'\\#java|\\#org.apache|\\#org.hamcrest|\\#org.opensearch|\\#'
 			)
 			removeUnusedImports()
-			eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+			eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
 			trimTrailingWhitespace()
 			endWithNewline();
 			custom 'Replace illegal HttpStatus import w/ correct one', {


### PR DESCRIPTION
### Description
Add `withP2Mirrors` to Spotless eclipse formatter to use `ci.opensearch.org/eclipse/` CloudFront mirror instead of hitting `download.eclipse.org` directly. This prevents CI failures when Eclipse's download server is down or slow.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).