### PR TITLE
Expose dynamic audit config via cluster settings in SSL-only mode

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditFgacFilterUnchangedTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditFgacFilterUnchangedTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+
+/**
+ * FGAC regression guard for the settings-filter narrowing.
+ *
+ * The narrowing in {@code OpenSearchSecurityPlugin.getSettingsFilter()} is gated to SSL-only mode; an FGAC
+ * node must keep filtering the entire {@code plugins.security.audit.*} subtree. In FGAC the real audit config
+ * lives in the {@code .opendistro_security} index (managed via the security REST API), not cluster settings,
+ * so nothing under that subtree should surface from a settings response.
+ *
+ * The audit config value is set statically (node settings) rather than via {@code PUT _cluster/settings}: the
+ * dynamic audit settings are registered {@code Property.Sensitive}, and in FGAC {@code SecurityFilter} blocks a
+ * runtime cluster-settings update to a sensitive key unless the caller holds a {@code restapi.roles_enabled}
+ * role. That write guard is orthogonal to the read filter under test here; setting the value statically
+ * exercises the read filter directly (it strips the subtree regardless of how the value was configured).
+ * Statically-set values surface via {@code GET _nodes/settings}, so that is where we assert the filter applies.
+ */
+public class StandaloneAuditFgacFilterUnchangedTest {
+
+    private static final String AUDIT_CONFIG_PREFIX = ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX; // plugins.security.audit.config.
+    // Values that must NOT surface in FGAC because the broad audit.* filter still applies.
+    private static final String FGAC_HIDDEN_TOKEN = "fgac_should_be_hidden";
+    // A nested endpoint credential (not Property.Filtered): only the endpoints.* pattern hides it. Setting it in
+    // FGAC guards against a future refactor accidentally applying the SSL-only narrow filter to all modes.
+    private static final String FGAC_ENDPOINT_SECRET = "fgac_endpoint_should_be_hidden";
+
+    private static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(
+        new TestSecurityConfig.Role("all_access").clusterPermissions("*").indexPermissions("*").on("*")
+    );
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .nodeSettings(
+            // Statically configure a dynamic audit setting plus a nested endpoint credential; the broad FGAC
+            // filter (plugins.security.audit.*, which covers both config.* and endpoints.*) must strip both.
+            Map.of(
+                AUDIT_CONFIG_PREFIX + "ignore_users",
+                List.of(FGAC_HIDDEN_TOKEN),
+                ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + ".fgacsink.config.password",
+                FGAC_ENDPOINT_SECRET
+            )
+        )
+        .users(ADMIN_USER)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .build();
+
+    @Test
+    public void fgacModeStillFiltersAuditSettings() {
+        try (TestRestClient client = cluster.getRestClient(ADMIN_USER)) {
+            // Statically-set node settings surface via _nodes/settings; the broad audit.* filter must strip them.
+            HttpResponse get = client.get("_nodes/settings?flat_settings=true");
+            assertThat(get.getBody(), get.getStatusCode(), equalTo(200));
+            // FGAC keeps the broad filter, so the audit subtree must NOT come back — neither the config.* key
+            // nor the endpoints.* group setting (proving both patterns still apply in non-SSL-only mode).
+            assertThat(get.getBody(), not(containsString(AUDIT_CONFIG_PREFIX + "ignore_users")));
+            assertThat(get.getBody(), not(containsString(FGAC_HIDDEN_TOKEN)));
+            assertThat(get.getBody(), not(containsString(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS)));
+            assertThat(get.getBody(), not(containsString(FGAC_ENDPOINT_SECRET)));
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/StandaloneAuditSettingsFilterTest.java
+++ b/src/integrationTest/java/org/opensearch/security/StandaloneAuditSettingsFilterTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.support.SecuritySettings;
+import org.opensearch.test.framework.audit.TestRuleAuditLogSink;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Verifies the settings filter behaviour for standalone audit in SSL-only mode.
+ *
+ * In SSL-only mode there is no {@code .opendistro_security} index, so the audit configuration lives in
+ * cluster settings and the dashboards audit panel reads it back via {@code GET _cluster/settings}. The
+ * security plugin's {@code getSettingsFilter()} previously stripped the entire {@code plugins.security.audit.*}
+ * subtree from settings responses, which also hid the (non-secret) dynamic config the panel needs. The filter
+ * was narrowed in SSL-only mode to strip only the credential-bearing group settings
+ * ({@code plugins.security.audit.endpoints.*} / {@code .routes.*}).
+ *
+ * These tests lock in that behaviour: the dynamic config is now readable, while the credential-bearing sink
+ * settings stay hidden. Secrets on the default endpoint (username/password/webhook.url) are additionally
+ * registered with {@code Property.Filtered}, so OpenSearch core strips them regardless of this filter.
+ */
+public class StandaloneAuditSettingsFilterTest {
+
+    // A value that must never appear in a settings response.
+    private static final String SECRET_PASSWORD = "TOPSECRET_SINK_PASSWORD";
+    private static final String SECRET_USERNAME = "secret_sink_user";
+    private static final String SECRET_WEBHOOK_URL = "https://secret.example.test/audit-hook";
+    // Nested credentials on secondary endpoints/routes. Unlike the default-endpoint secrets above, these keys
+    // are NOT Property.Filtered, so only the plugins.security.audit.endpoints.* / .routes.* filters hide them.
+    private static final String SECRET_ENDPOINT_VALUE = "SECRET_ENDPOINT_CREDENTIAL";
+    private static final String SECRET_ROUTE_VALUE = "SECRET_ROUTE_CREDENTIAL";
+    // Static external-sink infrastructure config that lives directly under config.* (not endpoints/routes) and is
+    // NOT panel-managed. Registered Property.Filtered so core strips it regardless of the narrowed audit filter.
+    private static final String SECRET_SIEM_HOST = "secret-siem.internal.test:9200";
+    private static final String SECRET_CIPHER = "SECRET_CIPHER_TLS_MARKER";
+    private static final String SECRET_PROTOCOL = "SECRET_PROTOCOL_TLS_MARKER";
+
+    private static final String AUDIT_CONFIG_PREFIX = ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX; // plugins.security.audit.config.
+    private static final String COMPLIANCE_PREFIX = SecuritySettings.COMPLIANCE_PREFIX; // plugins.security.audit.compliance.
+
+    @ClassRule
+    public static LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.SINGLENODE)
+        .anonymousAuth(false)
+        .loadConfigurationIntoIndex(false)
+        .nodeSettings(
+            Map.ofEntries(
+                Map.entry(ConfigConstants.SECURITY_SSL_ONLY, true),
+                Map.entry(ConfigConstants.SECURITY_AUDIT_ENABLE_STANDALONE, true),
+                Map.entry("plugins.security.audit.type", TestRuleAuditLogSink.class.getName()),
+                // Non-secret dynamic config set statically: must SURFACE after the filter is narrowed.
+                Map.entry(AUDIT_CONFIG_PREFIX + "disabled_rest_categories", List.of("GRANTED_PRIVILEGES")),
+                // Credential-bearing default-endpoint settings (Property.Filtered): must stay HIDDEN.
+                Map.entry(AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_USERNAME, SECRET_USERNAME),
+                Map.entry(AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_PASSWORD, SECRET_PASSWORD),
+                Map.entry(AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_WEBHOOK_URL, SECRET_WEBHOOK_URL),
+                // A secondary endpoint with a nested credential and no "type" (SinkProvider logs and skips it,
+                // so the node still boots). Only the endpoints.* filter keeps this credential out of responses.
+                Map.entry(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS + ".secretsink.config.password", SECRET_ENDPOINT_VALUE),
+                // A route under a non-category key (AuditMessageRouter logs and skips unknown categories, so the
+                // node still boots). Only the routes.* filter keeps this credential out of responses.
+                Map.entry(ConfigConstants.SECURITY_AUDIT_CONFIG_ROUTES + ".secretroute.config.token", SECRET_ROUTE_VALUE),
+                // Static external-sink infrastructure config under config.* (host list + TLS ciphers/protocols).
+                // These are NOT covered by the endpoints.*/routes.* filters; they must stay hidden via Property.Filtered.
+                Map.entry(
+                    AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_HTTP_ENDPOINTS,
+                    List.of(SECRET_SIEM_HOST)
+                ),
+                Map.entry(
+                    AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_CIPHERS,
+                    List.of(SECRET_CIPHER)
+                ),
+                Map.entry(
+                    AUDIT_CONFIG_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_PROTOCOLS,
+                    List.of(SECRET_PROTOCOL)
+                )
+            )
+        )
+        .sslOnly(true)
+        .build();
+
+    /**
+     * The bug fix: dynamic audit config written through cluster settings is readable back via
+     * GET _cluster/settings (previously the whole subtree was stripped by the broad
+     * plugins.security.audit.* filter).
+     *
+     * The filter operates at the prefix level, so covering both dynamic subtrees
+     * (audit.config.* and audit.compliance.*) across both value shapes (list + bool) is sufficient
+     * to prove all ~17 dynamic settings flow through — exhaustively PUT-ing every key would only
+     * re-test the same prefix match.
+     */
+    @Test
+    public void dynamicAuditConfigIsReadableViaClusterSettings() {
+        // A representative slice of the ~17 dynamic settings: both prefixes, list + bool.
+        String body = "{\"persistent\":{"
+            + "\""
+            + AUDIT_CONFIG_PREFIX
+            + "ignore_users\":[\"ignore_users_token\"],"
+            + "\""
+            + AUDIT_CONFIG_PREFIX
+            + "disabled_rest_categories\":[\"GRANTED_PRIVILEGES\"],"
+            + "\""
+            + AUDIT_CONFIG_PREFIX
+            + "log_request_body\":false,"
+            + "\""
+            + COMPLIANCE_PREFIX
+            + "enabled\":false,"
+            + "\""
+            + COMPLIANCE_PREFIX
+            + "read_watched_fields\":[\"read_watched_token\"],"
+            + "\""
+            + COMPLIANCE_PREFIX
+            + "write_watched_indices\":[\"write_watched_token\"]"
+            + "}}";
+
+        try (TestRestClient client = cluster.getRestClient()) {
+            HttpResponse put = client.putJson("_cluster/settings", body);
+            assertThat(put.getBody(), put.getStatusCode(), equalTo(200));
+
+            HttpResponse get = client.get("_cluster/settings?flat_settings=true");
+            assertThat(get.getBody(), get.getStatusCode(), equalTo(200));
+            String read = get.getBody();
+
+            // Both subtrees and both value shapes must come back through the narrowed filter.
+            assertThat(read, containsString(AUDIT_CONFIG_PREFIX + "ignore_users"));
+            assertThat(read, containsString("ignore_users_token"));
+            assertThat(read, containsString(AUDIT_CONFIG_PREFIX + "disabled_rest_categories"));
+            assertThat(read, containsString(AUDIT_CONFIG_PREFIX + "log_request_body"));
+            assertThat(read, containsString(COMPLIANCE_PREFIX + "enabled"));
+            assertThat(read, containsString(COMPLIANCE_PREFIX + "read_watched_fields"));
+            assertThat(read, containsString("read_watched_token"));
+            assertThat(read, containsString(COMPLIANCE_PREFIX + "write_watched_indices"));
+            assertThat(read, containsString("write_watched_token"));
+        }
+    }
+
+    /**
+     * Narrowing the filter must not expose credentials. Statically-configured settings surface via
+     * GET _nodes/settings; the non-secret config is now visible, but the Filtered sink secrets and the
+     * endpoints/routes group settings must not appear.
+     */
+    @Test
+    public void auditSecretsAreNotExposedInNodeSettings() {
+        try (TestRestClient client = cluster.getRestClient()) {
+            HttpResponse get = client.get("_nodes/settings?flat_settings=true");
+            assertThat(get.getBody(), get.getStatusCode(), equalTo(200));
+            String body = get.getBody();
+
+            // Non-secret audit config surfaces now that the wildcard is narrowed in SSL-only mode.
+            assertThat(body, containsString(AUDIT_CONFIG_PREFIX + "disabled_rest_categories"));
+
+            // Credential-bearing values must never appear.
+            assertThat(body, not(containsString(SECRET_PASSWORD)));
+            assertThat(body, not(containsString(SECRET_USERNAME)));
+            assertThat(body, not(containsString(SECRET_WEBHOOK_URL)));
+
+            // The credential-bearing group settings stay filtered out, including the nested endpoint/route
+            // credentials (which are not Property.Filtered, so only our endpoints.*/routes.* filters protect them).
+            assertThat(body, not(containsString(SECRET_ENDPOINT_VALUE)));
+            assertThat(body, not(containsString(SECRET_ROUTE_VALUE)));
+            assertThat(body, not(containsString(ConfigConstants.SECURITY_AUDIT_CONFIG_ENDPOINTS)));
+            assertThat(body, not(containsString(ConfigConstants.SECURITY_AUDIT_CONFIG_ROUTES)));
+
+            // Static external-sink infrastructure under config.* (host list, TLS ciphers/protocols) is not covered
+            // by the endpoints.*/routes.* filters; Property.Filtered must keep it out of settings responses so
+            // narrowing the audit wildcard does not disclose backend audit topology to unauthenticated clients.
+            assertThat(body, not(containsString(SECRET_SIEM_HOST)));
+            assertThat(body, not(containsString(SECRET_CIPHER)));
+            assertThat(body, not(containsString(SECRET_PROTOCOL)));
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2091,6 +2091,15 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         settings.add(SecuritySettings.AUDIT_ACTION_GROUPS);
 
         // Security - Audit - Sink
+        //
+        // IMPORTANT: In SSL-only mode the settings filter no longer blanket-strips the entire
+        // plugins.security.audit.config.* subtree — it only strips the credential-bearing group
+        // settings (endpoints.* / routes.*). Every secret registered directly under config.*
+        // (passwords, tokens, webhook URLs, PEM material, host lists, TLS ciphers/protocols, etc.)
+        // MUST carry Property.Filtered individually. If you add a new sink credential under this
+        // prefix, add Property.Filtered to its registration — otherwise it will be exposed to
+        // unauthenticated settings readers in SSL-only mode.
+        // See: allSensitiveConfigSettingsAreFiltered() test for automated enforcement.
         settings.add(
             Setting.simpleString(
                 ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_OPENSEARCH_INDEX,
@@ -2154,9 +2163,10 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                 ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_HTTP_ENDPOINTS,
                 Lists.newArrayList("localhost:9200"),
                 Function.identity(),
-                Property.NodeScope
+                Property.NodeScope,
+                Property.Filtered
             )
-        ); // not filtered here
+        ); // Filtered: static external-sink infrastructure (host list), not panel-managed dynamic config
         settings.add(
             Setting.simpleString(
                 ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX + ConfigConstants.SECURITY_AUDIT_CONFIG_USERNAME,
@@ -2260,18 +2270,20 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
                     + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_CIPHERS,
                 Collections.emptyList(),
                 Function.identity(),
-                Property.NodeScope
+                Property.NodeScope,
+                Property.Filtered
             )
-        );// not filtered here
+        );// Filtered: static external-sink TLS config, not panel-managed dynamic config
         settings.add(
             Setting.listSetting(
                 ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX
                     + ConfigConstants.SECURITY_AUDIT_EXTERNAL_OPENSEARCH_ENABLED_SSL_PROTOCOLS,
                 Collections.emptyList(),
                 Function.identity(),
-                Property.NodeScope
+                Property.NodeScope,
+                Property.Filtered
             )
-        );// not filtered here
+        );// Filtered: static external-sink TLS config, not panel-managed dynamic config
 
         // Webhooks
         settings.add(
@@ -2725,7 +2737,18 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         settingsFilter.add("plugins.security.authcz.*");
         settingsFilter.add("plugins.security.password.*");
         settingsFilter.add("plugins.security.unsupported.*");
-        settingsFilter.add("plugins.security.audit.*");
+        // In SSL-only (standalone audit) mode there is no security index, so the audit config is stored in
+        // cluster settings and the dashboards audit panel must read it back via GET _cluster/settings. Narrow
+        // the audit filter to expose the dynamic config (plugins.security.audit.config.* and .compliance.*)
+        // while keeping the credential-bearing sink settings (endpoints/routes) hidden. Secrets registered with
+        // Property.Filtered (sink username/password/webhook.url, pem*, salt) remain stripped by core regardless.
+        // FGAC keeps the original broad filter (its real config lives in the security index, not cluster settings).
+        if (SSLConfig.isSslOnlyMode()) {
+            settingsFilter.add("plugins.security.audit.endpoints.*");
+            settingsFilter.add("plugins.security.audit.routes.*");
+        } else {
+            settingsFilter.add("plugins.security.audit.*");
+        }
         settingsFilter.add("plugins.security.compliance.*");
         return settingsFilter;
     }

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -184,7 +184,7 @@ public class SecuritySettings {
     );
 
     // Dynamic compliance settings
-    private static final String COMPLIANCE_PREFIX = "plugins.security.audit.compliance.";
+    public static final String COMPLIANCE_PREFIX = "plugins.security.audit.compliance.";
 
     public static final Setting<Boolean> COMPLIANCE_ENABLED = Setting.boolSetting(
         COMPLIANCE_PREFIX + "enabled",

--- a/src/test/java/org/opensearch/security/auditlog/AuditConfigSettingsFilterSafetyTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/AuditConfigSettingsFilterSafetyTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security.auditlog;
+
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.OpenSearchSecurityPlugin;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Safety net: every setting registered under {@code plugins.security.audit.config.*} whose key
+ * contains a secret-ish substring MUST carry {@link Setting.Property#Filtered}. In SSL-only mode
+ * the broad wildcard filter no longer covers this subtree, so individual {@code Property.Filtered}
+ * annotations are the only thing keeping credentials out of unauthenticated settings responses.
+ *
+ * If this test fails you likely added a new sink credential under {@code config.*} without
+ * {@code Property.Filtered} — add it and see the comment in
+ * {@code OpenSearchSecurityPlugin#getSettings()} at the "Security - Audit - Sink" block.
+ */
+public class AuditConfigSettingsFilterSafetyTest {
+
+    @Test
+    public void allSensitiveConfigSettingsAreFiltered() {
+        Settings disabled = Settings.builder().put(ConfigConstants.SECURITY_DISABLED, true).build();
+        // Matches credential-bearing or security-sensitive key suffixes under config.*.
+        // Intentionally broad to catch new sink credentials added without Property.Filtered.
+        // If this test fails on a genuinely non-secret key, add it to an exclusion list
+        // rather than weakening the pattern.
+        Pattern secretish = Pattern.compile(
+            "password|username|token|webhook|pemkey|pemcert|pemtrustedcas"
+                + "|salt|jks|http_endpoints|ssl_|cert_alias|keystore|truststore|pkcs|secret"
+        );
+
+        for (Setting<?> s : new OpenSearchSecurityPlugin(disabled, null).getSettings()) {
+            String key = s.getKey();
+            if (key.startsWith(ConfigConstants.SECURITY_AUDIT_CONFIG_DEFAULT_PREFIX) && secretish.matcher(key).find()) {
+                assertThat(key + " must be Property.Filtered", s.getProperties().contains(Setting.Property.Filtered), equalTo(true));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Narrow the audit settings filter in SSL-only (standalone audit) mode so the non-secret dynamic audit configuration is readable via `GET _cluster/settings`, while continuing to hide the credential-bearing sink settings.

* Why these changes are required?

  In SSL-only mode there is no `.opendistro_security` index, so the audit configuration is stored in cluster settings and is managed through `PUT`/`GET _cluster/settings`. The standalone audit configuration panel in the security dashboards plugin reads its state back through `GET _cluster/settings`. `OpenSearchSecurityPlugin.getSettingsFilter()` stripped the entire `plugins.security.audit.*` subtree from settings responses, which also hid the ~17 non-secret dynamic config keys the panel needs. Writes worked (the filter only affects reads), but reads came back empty — the panel could not display the current configuration.

* What is the old behavior before changes and new behavior after changes?

  * Old: `getSettingsFilter()` always added `plugins.security.audit.*`, so the whole subtree — including the non-secret dynamic config — was stripped from every settings response in every mode.
  * New: in SSL-only mode the filter strips only the credential-bearing group settings (`plugins.security.audit.endpoints.*` and `plugins.security.audit.routes.*`); the dynamic config (`plugins.security.audit.config.*` and `plugins.security.audit.compliance.*`) is now returned. FGAC and all other modes keep the original broad `plugins.security.audit.*` filter, because their real audit config lives in the security index, not cluster settings.

  Credential safety is preserved:
  * The default-endpoint secrets (`username`, `password`, `webhook.url`, `pem*`, `salt`) are registered with `Property.Filtered`, so OpenSearch core strips them from settings responses regardless of this filter.
  * The nested credentials on secondary endpoints/routes are not `Property.Filtered`, so they are kept out of responses by the retained `endpoints.*` / `routes.*` filters.

  Additionally, three static external-sink settings under `config.*` — `http_endpoints` (the backend audit host list), `enabled_ssl_ciphers`, and `enabled_ssl_protocols` — were previously hidden only by the broad `plugins.security.audit.*` wildcard and carry no `Property.Filtered` annotation. Narrowing the wildcard would have exposed this infrastructure topology to unauthenticated clients in SSL-only mode via `GET _nodes/settings`. These are static (non-dynamic) sink settings the audit panel does not manage, so they are now registered `Property.Filtered` alongside their credential siblings — closing the disclosure in all modes with no functional impact (the sink still reads them directly from settings).

 * Note for backport: Adding Property.Filtered to http_endpoints, enabled_ssl_ciphers, and enabled_ssl_protocols means these settings will also disappear from _nodes/settings output in FGAC/default mode (not just SSL-only). This is intentional — they are static external-sink infrastructure config that should not have been exposed to settings readers in any mode.

### Issues Resolved

Read-path gap for the standalone audit configuration panel in SSL-only mode.

### Testing

Added two integration tests under `src/integrationTest`:

* `StandaloneAuditSettingsFilterTest` (SSL-only mode):
  * `dynamicAuditConfigIsReadableViaClusterSettings` — writes a representative slice of the dynamic settings across both prefixes (`config.*` and `compliance.*`) and both value shapes (list + boolean) via `PUT _cluster/settings`, then asserts they come back through `GET _cluster/settings`. The filter is prefix-based, so covering both subtrees and both value shapes proves all ~17 dynamic keys flow through.
  * `auditSecretsAreNotExposedInNodeSettings` — statically configures the `Property.Filtered` default-endpoint secrets plus a secondary endpoint credential and a route credential, then asserts via `GET _nodes/settings` that the non-secret config surfaces while none of the secret values or the `endpoints.*` / `routes.*` keys appear. Also configures `http_endpoints`, `enabled_ssl_ciphers`, and `enabled_ssl_protocols` under `config.*` and asserts they stay hidden (regression guard for the `Property.Filtered` additions).

* `StandaloneAuditFgacFilterUnchangedTest` (FGAC mode):
  * `fgacModeStillFiltersAuditSettings` — statically configures a dynamic audit setting and a nested `endpoints.*` credential, then asserts the broad `plugins.security.audit.*` filter still strips both from `GET _nodes/settings`, confirming the narrowing is gated to SSL-only mode and does not change FGAC behavior. (The values are set statically rather than via `PUT` because in FGAC `SecurityFilter` blocks a runtime cluster-settings update to a sensitive key unless the caller holds a `restapi.roles_enabled` role — a write guard orthogonal to the read filter under test.)


### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented (code comments on the filter behavior)
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request created
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.