### PR TITLE
Fix HttpClient hostname verification and LDAP test ports

### DIFF
--- a/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
+++ b/src/main/java/org/opensearch/security/auditlog/sink/WebhookSink.java
@@ -33,6 +33,7 @@ import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuil
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.ContentType;
@@ -390,6 +391,7 @@ public class WebhookSink extends AuditLogSink {
                     null,
                     null,
                     SSLBufferMode.STATIC,
+                    HostnameVerificationPolicy.CLIENT,
                     NoopHostnameVerifier.INSTANCE
                 );
 
@@ -410,6 +412,7 @@ public class WebhookSink extends AuditLogSink {
                 null,
                 null,
                 SSLBufferMode.STATIC,
+                HostnameVerificationPolicy.CLIENT,
                 new DefaultHostnameVerifier()
             );
 

--- a/src/main/java/org/opensearch/security/httpclient/HttpClient.java
+++ b/src/main/java/org/opensearch/security/httpclient/HttpClient.java
@@ -39,6 +39,7 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBu
 import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
@@ -283,6 +284,7 @@ public class HttpClient implements Closeable {
                 supportedProtocols,
                 supportedCipherSuites,
                 SSLBufferMode.STATIC,
+                HostnameVerificationPolicy.CLIENT,
                 hnv
             );
 

--- a/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
+++ b/src/main/java/org/opensearch/security/tools/SecurityAdmin.java
@@ -71,6 +71,7 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBu
 import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.HttpHost;
@@ -1480,6 +1481,7 @@ public class SecurityAdmin {
                 .setSslContext(sslContext)
                 .setTlsVersions(supportedProtocols)
                 .setCiphers(supportedCipherSuites)
+                .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
                 .setHostnameVerifier(hnv)
                 // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
                 .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {

--- a/src/test/java/org/opensearch/security/auth/ldap/srv/LdapServer.java
+++ b/src/test/java/org/opensearch/security/auth/ldap/srv/LdapServer.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import org.opensearch.security.test.helper.file.FileHelper;
-import org.opensearch.security.test.helper.network.SocketUtils;
 
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
@@ -121,11 +120,8 @@ final class LdapServer {
         );
         // final SSLUtil clientSSLUtil = new SSLUtil(new TrustStoreTrustManager(serverKeyStorePath));
 
-        ldapPort = SocketUtils.findAvailableTcpPort();
-        ldapsPort = SocketUtils.findAvailableTcpPort();
-
-        listenerConfigs.add(InMemoryListenerConfig.createLDAPConfig("ldap", null, ldapPort, serverSSLUtil.createSSLSocketFactory()));
-        listenerConfigs.add(InMemoryListenerConfig.createLDAPSConfig("ldaps", ldapsPort, serverSSLUtil.createSSLServerSocketFactory()));
+        listenerConfigs.add(InMemoryListenerConfig.createLDAPConfig("ldap", null, 0, serverSSLUtil.createSSLSocketFactory()));
+        listenerConfigs.add(InMemoryListenerConfig.createLDAPSConfig("ldaps", 0, serverSSLUtil.createSSLServerSocketFactory()));
 
         return listenerConfigs;
     }
@@ -165,6 +161,8 @@ final class LdapServer {
             /* Clear entries from server. */
             server.clear();
             server.startListening();
+            ldapPort = server.getListenPort("ldap");
+            ldapsPort = server.getListenPort("ldaps");
             return loadLdifFiles(ldifFiles);
         } catch (LDAPException ldape) {
             if (ldape.getMessage().contains("java.net.BindException")) {

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -47,6 +47,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.hc.client5.http.config.TlsConfig;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.Header;
@@ -184,6 +185,7 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
                 TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
                     .setSslContext(sslContext)
                     .setTlsVersions(new String[] { "TLSv1", "TLSv1.1", "TLSv1.2", "SSLv3" })
+                    .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
                     .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                     // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
                     .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {

--- a/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
+++ b/src/test/java/org/opensearch/security/test/helper/rest/RestHelper.java
@@ -63,6 +63,7 @@ import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.ConnectionClosedException;
@@ -370,6 +371,7 @@ public class RestHelper {
                 protocols,
                 null,
                 SSLBufferMode.STATIC,
+                HostnameVerificationPolicy.CLIENT,
                 NoopHostnameVerifier.INSTANCE
             );
 


### PR DESCRIPTION
## Description

Apache HttpClient 5.6 applies `HostnameVerificationPolicy.BOTH` when a custom `HostnameVerifier` is supplied without an explicit policy. As a result, JSSE performs hostname verification before the configured verifier runs, which makes `NoopHostnameVerifier` ineffective. This breaks SecurityAdmin's `-nhnv` option and test clients that intentionally disable hostname verification.

This change explicitly selects `HostnameVerificationPolicy.CLIENT` wherever Security supplies a custom hostname verifier. Strict connections continue to use `DefaultHostnameVerifier`, while explicit opt-out paths once again use `NoopHostnameVerifier` as intended.

The embedded LDAP test server now also asks the operating system to allocate its LDAP and LDAPS listener ports. This removes the race between probing an available port and binding it, including the possibility that both listeners select the same unbound port.

## Testing

- `./gradlew spotlessApply compileJava compileTestJava`
- `./gradlew citest --tests 'org.opensearch.security.SecurityAdminTests.testSecurityAdminHostnameVerificationEnforced' --tests 'org.opensearch.security.SecurityAdminTests.testSecurityAdminHostnameVerificationNotEnforced' --tests 'org.opensearch.security.auth.ldap.LdapBackendTest'`
- `./gradlew sslTest --tests 'org.opensearch.security.ssl.SSLTest.testHttpsAndNodeSSLPemEnc' --tests 'org.opensearch.security.ssl.SSLTest.testSSLPemEncWithInsecureSettings'`
- `./gradlew citest --tests 'org.opensearch.security.httpclient.HttpClientTest' --tests 'org.opensearch.security.auditlog.sink.WebhookAuditLogTest'`
