### PR TITLE
Switch from snakeyaml to snakeyaml-engine for YAML processing

### DIFF
--- a/src/main/java/org/opensearch/security/resources/ResourceAccessLevelHelper.java
+++ b/src/main/java/org/opensearch/security/resources/ResourceAccessLevelHelper.java
@@ -9,7 +9,6 @@
 package org.opensearch.security.resources;
 
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -19,7 +18,8 @@ import org.opensearch.security.securityconf.impl.CType;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.security.securityconf.impl.v7.ActionGroupsV7;
 
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 /**
  * Helper class to load `resource-access-levels.yml` file for all resource sharing extensions.
@@ -49,9 +49,10 @@ public class ResourceAccessLevelHelper {
             }
 
             try (var in = url.openStream()) {
-                String yaml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                Load yaml = new Load(LoadSettings.builder().build());
+                @SuppressWarnings("unchecked")
+                Map<String, Object> root = (Map<String, Object>) yaml.loadFromInputStream(in);
 
-                Map<String, Object> root = new Yaml().load(yaml);
                 if (root == null) {
                     log.info("Empty resource-access-levels.yml for {}", ext.getClass().getName());
                     continue;

--- a/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
+++ b/src/main/java/org/opensearch/security/tools/democonfig/SecuritySettingsConfigurer.java
@@ -31,8 +31,11 @@ import org.opensearch.security.hasher.PasswordHasher;
 import org.opensearch.security.hasher.PasswordHasherFactory;
 import org.opensearch.security.support.ConfigConstants;
 
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
@@ -80,8 +83,9 @@ public class SecuritySettingsConfigurer {
         }
 
         try (BufferedReader br = new BufferedReader(new FileReader(installer.OPENSEARCH_CONF_FILE, StandardCharsets.UTF_8))) {
-            Yaml yaml = new Yaml();
-            Map<String, Object> yamlData = yaml.load(br);
+            Load yaml = new Load(LoadSettings.builder().build());
+            @SuppressWarnings("unchecked")
+            Map<String, Object> yamlData = (Map<String, Object>) yaml.loadFromReader(br);
             if (yamlData == null) return false;
 
             String[] requiredSettings = {
@@ -135,8 +139,9 @@ public class SecuritySettingsConfigurer {
         // Check if the configuration file contains security settings
         if (installer.OPENSEARCH_CONF_FILE != null && new File(installer.OPENSEARCH_CONF_FILE).exists()) {
             try (BufferedReader br = new BufferedReader(new FileReader(installer.OPENSEARCH_CONF_FILE, StandardCharsets.UTF_8))) {
-                Yaml yaml = new Yaml();
-                Map<String, Object> yamlData = yaml.load(br);
+                Load yaml = new Load(LoadSettings.builder().build());
+                @SuppressWarnings("unchecked")
+                Map<String, Object> yamlData = (Map<String, Object>) yaml.loadFromReader(br);
                 if (yamlData != null) {
                     // Check for flat keys
                     for (String key : yamlData.keySet()) {
@@ -298,10 +303,8 @@ public class SecuritySettingsConfigurer {
 
         try (FileWriter writer = new FileWriter(installer.OPENSEARCH_CONF_FILE, StandardCharsets.UTF_8, true)) {
             writer.write(configHeader);
-            Yaml yaml = new Yaml();
-            DumperOptions options = new DumperOptions();
-            options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-            String yamlString = yaml.dump(securityConfigAsMap);
+            Dump yaml = new Dump(DumpSettings.builder().setDefaultFlowStyle(FlowStyle.BLOCK).build());
+            String yamlString = yaml.dumpToString(securityConfigAsMap);
             writer.write(yamlString);
             writer.write(configFooter);
         } catch (IOException e) {


### PR DESCRIPTION
### Description
Switch from `snakeyaml` to `snakeyaml-engine` for YAML processing (aligning with Jackson 3.x upgrade). Once https://github.com/opensearch-project/OpenSearch/issues/22197 gets merge, the `snakeyaml`  will not be bundled with OpenSearch server anymore, as such using `snakeyaml-engine` instead.

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/22197

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Covered by standard tests

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
