### PR TITLE
Support wait_for_completion on Security configuration write APIs (#6337)

### DIFF
--- a/src/integrationTest/java/org/opensearch/security/api/WaitForCompletionRestApiIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/api/WaitForCompletionRestApiIntegrationTest.java
@@ -1,0 +1,244 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.api;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.security.DefaultObjectMapper;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.TestRestClient;
+import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
+
+import tools.jackson.databind.JsonNode;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * End-to-end coverage for {@code wait_for_completion} on Security configuration write APIs
+ * (issue <a href="https://github.com/opensearch-project/security/issues/6337">#6337</a>).
+ *
+ * <p>Covers, per acceptance criterion:
+ * <ul>
+ *   <li>synchronous success (backwards compatibility — parameter omitted or set to {@code true}),</li>
+ *   <li>synchronous failure (invalid body still surfaces as 400 even when the async param is set),</li>
+ *   <li>asynchronous success (task-id response and task lookup),</li>
+ *   <li>task cancellation is refused (non-cancellable by design).</li>
+ * </ul>
+ *
+ * <p>Async is exercised against every endpoint that opts in to {@code supportsAsync()} in this PR:
+ * Roles, RolesMapping, InternalUsers, Tenants, Audit. Roles is used as the representative for
+ * the sync/back-compat cases since the payload is smaller than InternalUsers or Audit.
+ */
+public class WaitForCompletionRestApiIntegrationTest extends AbstractApiIntegrationTest {
+
+    @ClassRule
+    public static LocalCluster localCluster = clusterBuilder().build();
+
+    // ---------- helpers ----------
+
+    private static final String VALID_ROLE_BODY = """
+        {
+          "cluster_permissions": ["cluster_composite_ops_ro"],
+          "index_permissions": [
+            { "index_patterns": ["logs-*"], "allowed_actions": ["read"] }
+          ]
+        }
+        """;
+
+    private static final String INVALID_ROLE_BODY = """
+        {
+          "cluster_permissions": ["cluster_composite_ops_ro"],
+          "unknown_field": true
+        }
+        """;
+
+    private static final String VALID_INTERNALUSER_BODY = """
+        { "password": "TestPassword_123!", "backend_roles": ["backend"] }
+        """;
+
+    private static final String VALID_ROLESMAPPING_BODY = """
+        { "backend_roles": ["some_backend_role"], "hosts": [], "users": [] }
+        """;
+
+    private static final String VALID_TENANT_BODY = """
+        { "description": "test tenant" }
+        """;
+
+    /**
+     * Poll {@code _tasks/{taskId}?wait_for_completion=true&timeout=30s} — a single call that blocks
+     * until the task finishes. Returns the parsed response body.
+     */
+    private JsonNode awaitTaskCompletion(final TestRestClient client, final String taskId) throws Exception {
+        final HttpResponse resp = client.get("_tasks/" + taskId + "?wait_for_completion=true&timeout=30s");
+        assertThat("Task lookup failed: " + resp.getBody(), resp.getStatusCode(), is(200));
+        return DefaultObjectMapper.readTree(resp.getBody());
+    }
+
+    private String extractTaskId(final HttpResponse resp) throws Exception {
+        assertThat("Async submission failed: " + resp.getBody(), resp.getStatusCode(), is(200));
+        final JsonNode json = DefaultObjectMapper.readTree(resp.getBody());
+        assertThat("Async response missing 'task' field: " + resp.getBody(), json.has("task"), is(true));
+        final String taskId = json.get("task").asText();
+        assertThat("Task ID should be non-empty", taskId, notNullValue());
+        assertThat("Task ID should be nodeId:taskId shape", taskId, containsString(":"));
+        return taskId;
+    }
+
+    // ---------- sync / backwards-compatibility ----------
+
+    @Test
+    public void syncPutRole_defaultBehavior_unchanged() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse resp = client.putJson(apiPath("roles", "sync_role_default"), VALID_ROLE_BODY);
+            // First-time create returns 201 CREATED as it always did
+            assertThat(resp.getBody(), resp.getStatusCode(), is(201));
+            assertThat(resp.getBody(), containsString("created"));
+            // Idempotent second call becomes an update — 200 OK, "updated" message
+            final HttpResponse update = client.putJson(apiPath("roles", "sync_role_default"), VALID_ROLE_BODY);
+            assertThat(update.getBody(), update.getStatusCode(), is(200));
+            assertThat(update.getBody(), containsString("updated"));
+        }
+    }
+
+    @Test
+    public void syncPutRole_explicitWaitForCompletionTrue_sameAsDefault() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse resp = client.putJson(apiPath("roles", "sync_role_explicit") + "?wait_for_completion=true", VALID_ROLE_BODY);
+            assertThat(resp.getBody(), resp.getStatusCode(), is(201));
+            assertThat(resp.getBody(), containsString("created"));
+        }
+    }
+
+    @Test
+    public void invalidBody_returnsSyncErrorEvenWhenAsyncRequested() throws Exception {
+        // Validation happens before task submission, so bad requests still surface as 400 —
+        // clients don't get a task ID for something that never runs.
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse resp = client.putJson(apiPath("roles", "invalid_role") + "?wait_for_completion=false", INVALID_ROLE_BODY);
+            assertThat(resp.getBody(), resp.getStatusCode(), is(400));
+            assertThat(resp.getBody(), not_(containsString("\"task\"")));
+        }
+    }
+
+    // hamcrest 'not' would collide with a static import site above — inline wrapper
+    private static org.hamcrest.Matcher<String> not_(org.hamcrest.Matcher<String> inner) {
+        return org.hamcrest.CoreMatchers.not(inner);
+    }
+
+    // ---------- async: per-endpoint smoke ----------
+
+    @Test
+    public void asyncPutRole_returnsTaskIdAndPersists() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse submit = client.putJson(apiPath("roles", "async_role") + "?wait_for_completion=false", VALID_ROLE_BODY);
+            final String taskId = extractTaskId(submit);
+            final JsonNode taskJson = awaitTaskCompletion(client, taskId);
+            assertThat("Task should complete: " + taskJson, taskJson.path("completed").asBoolean(), is(true));
+            assertThat(
+                "Stored task result should carry the success message",
+                taskJson.at("/response/message").asText(),
+                equalTo("'async_role' created.")
+            );
+            // Confirm the write actually applied and is readable via the sync GET path
+            final HttpResponse readBack = client.get(apiPath("roles", "async_role"));
+            assertThat(readBack.getBody(), readBack.getStatusCode(), is(200));
+        }
+    }
+
+    @Test
+    public void asyncPutInternalUser_returnsTaskIdAndPersists() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse submit = client.putJson(
+                apiPath("internalusers", "async_user") + "?wait_for_completion=false",
+                VALID_INTERNALUSER_BODY
+            );
+            final String taskId = extractTaskId(submit);
+            final JsonNode taskJson = awaitTaskCompletion(client, taskId);
+            assertThat("Task should complete: " + taskJson, taskJson.path("completed").asBoolean(), is(true));
+            assertThat(taskJson.at("/response/message").asText(), equalTo("'async_user' created."));
+        }
+    }
+
+    @Test
+    public void asyncPutRolesMapping_returnsTaskId() throws Exception {
+        // Prerequisite: create the role the mapping references; do it sync so the mapping write
+        // has something to point at.
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            client.putJson(apiPath("roles", "mapping_target_role"), VALID_ROLE_BODY);
+            final HttpResponse submit = client.putJson(
+                apiPath("rolesmapping", "mapping_target_role") + "?wait_for_completion=false",
+                VALID_ROLESMAPPING_BODY
+            );
+            final String taskId = extractTaskId(submit);
+            final JsonNode taskJson = awaitTaskCompletion(client, taskId);
+            assertThat("Task should complete: " + taskJson, taskJson.path("completed").asBoolean(), is(true));
+        }
+    }
+
+    @Test
+    public void asyncPutTenant_returnsTaskId() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse submit = client.putJson(
+                apiPath("tenants", "async_tenant") + "?wait_for_completion=false",
+                VALID_TENANT_BODY
+            );
+            final String taskId = extractTaskId(submit);
+            final JsonNode taskJson = awaitTaskCompletion(client, taskId);
+            assertThat("Task should complete: " + taskJson, taskJson.path("completed").asBoolean(), is(true));
+        }
+    }
+
+    @Test
+    public void asyncAuditEndpoint_acceptsWaitForCompletionParam() throws Exception {
+        // Audit config has a bespoke body schema (full AuditConfig JSON), so we don't try to
+        // successfully mutate it here — that's covered by the existing audit integration tests.
+        // What we verify is that the shared plumbing accepts wait_for_completion=false on the
+        // audit route (i.e. AuditApiAction's consumeParameters override doesn't leak the param
+        // as unrecognized). A PUT with an intentionally minimal body returns a 4xx validation
+        // error, NOT a 400 "unrecognized parameter" error.
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            final HttpResponse resp = client.putJson(apiPath("audit", "config") + "?wait_for_completion=false", "{}");
+            assertThat(
+                "wait_for_completion must not be treated as an unrecognized parameter: " + resp.getBody(),
+                resp.getBody(),
+                not_(containsString("unrecognized parameter"))
+            );
+        }
+    }
+
+    // ---------- cancellation: rejected ----------
+
+    @Test
+    public void submittedTask_isNotCancellable() throws Exception {
+        try (TestRestClient client = localCluster.getRestClient(ADMIN_USER)) {
+            // Submit and immediately try to cancel. TransportCancelTasksAction returns 200 OK at
+            // the top level even for non-cancellable tasks; the actual rejection surfaces inside
+            // `node_failures[*].caused_by` as an IllegalArgumentException whose reason contains
+            // "doesn't support cancellation". If our task ever accidentally becomes cancellable
+            // (e.g. by inheriting from CancellableTask), that error message disappears and this
+            // assertion catches the regression.
+            final HttpResponse submit = client.putJson(apiPath("roles", "noncancel_role") + "?wait_for_completion=false", VALID_ROLE_BODY);
+            final String taskId = extractTaskId(submit);
+            final HttpResponse cancel = client.post("_tasks/" + taskId + "/_cancel");
+            assertThat(
+                "Cancel body must indicate the task doesn't support cancellation: " + cancel.getBody(),
+                cancel.getBody(),
+                containsString("doesn't support cancellation")
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -144,7 +144,9 @@ import org.opensearch.security.action.apitokens.ApiTokenAction;
 import org.opensearch.security.action.apitokens.ApiTokenRepository;
 import org.opensearch.security.action.apitokens.ApiTokenUpdateAction;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
+import org.opensearch.security.action.configupdate.SecurityConfigWriteAction;
 import org.opensearch.security.action.configupdate.TransportConfigUpdateAction;
+import org.opensearch.security.action.configupdate.TransportSecurityConfigWriteAction;
 import org.opensearch.security.action.onbehalf.CreateOnBehalfOfTokenAction;
 import org.opensearch.security.action.whoami.TransportWhoAmIAction;
 import org.opensearch.security.action.whoami.WhoAmIAction;
@@ -1064,6 +1066,7 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
         List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> actions = new ArrayList<>(1);
         if (!disabled && !SSLConfig.isSslOnlyMode()) {
             actions.add(new ActionHandler<>(ConfigUpdateAction.INSTANCE, TransportConfigUpdateAction.class));
+            actions.add(new ActionHandler<>(SecurityConfigWriteAction.INSTANCE, TransportSecurityConfigWriteAction.class));
             actions.add(new ActionHandler<>(ApiTokenUpdateAction.INSTANCE, ApiTokenUpdateAction.TransportAction.class));
             // external storage does not support reload and does not provide SSL certs info
             if (!ExternalSecurityKeyStore.hasExternalSslContext(settings)) {

--- a/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteAction.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.configupdate;
+
+import org.opensearch.action.ActionType;
+
+/**
+ * ActionType that persists a Security configuration document to the security index and then
+ * broadcasts a {@link ConfigUpdateAction} to every node so each one reloads the affected config.
+ *
+ * <p>The whole persistence + fan-out lifecycle runs under a single OpenSearch {@link
+ * org.opensearch.tasks.Task}. This is what enables clients to submit REST configuration writes
+ * with {@code wait_for_completion=false} and monitor progress via the standard Tasks API.
+ *
+ * <p>The task is intentionally <b>not</b> cancellable: because a mid-fan-out cancellation could
+ * leave the security index updated but only a subset of nodes reloaded, the request is only ever
+ * allowed to run to completion. See issue #6337 for the design discussion.
+ */
+public class SecurityConfigWriteAction extends ActionType<SecurityConfigWriteResponse> {
+
+    public static final SecurityConfigWriteAction INSTANCE = new SecurityConfigWriteAction();
+    public static final String NAME = "cluster:admin/opendistro_security/api/write_config";
+
+    protected SecurityConfigWriteAction() {
+        super(NAME, SecurityConfigWriteResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteRequest.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteRequest.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.configupdate;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.tasks.TaskId;
+import org.opensearch.tasks.Task;
+
+/**
+ * Request carrying everything required to persist a serialized Security configuration to the
+ * security index and then fan out a reload to all nodes.
+ *
+ * <p>The task created for this request is intentionally a plain {@link Task} (not a {@link
+ * org.opensearch.tasks.CancellableTask}), so {@code POST /_tasks/{id}/_cancel} against it is
+ * rejected by {@code TransportCancelTasksAction} with {@code "doesn't support cancellation"}.
+ */
+public class SecurityConfigWriteRequest extends ActionRequest {
+
+    private final String cType;
+    private final BytesReference content;
+    private final long seqNo;
+    private final long primaryTerm;
+    private final String securityIndex;
+    private final String description;
+    private final String successMessage;
+    private final RestStatus successStatus;
+
+    public SecurityConfigWriteRequest(
+        final String cType,
+        final BytesReference content,
+        final long seqNo,
+        final long primaryTerm,
+        final String securityIndex,
+        final String description,
+        final String successMessage,
+        final RestStatus successStatus
+    ) {
+        this.cType = cType;
+        this.content = content;
+        this.seqNo = seqNo;
+        this.primaryTerm = primaryTerm;
+        this.securityIndex = securityIndex;
+        this.description = description == null ? "" : description;
+        this.successMessage = successMessage;
+        this.successStatus = successStatus;
+    }
+
+    public SecurityConfigWriteRequest(final StreamInput in) throws IOException {
+        super(in);
+        this.cType = in.readString();
+        this.content = in.readBytesReference();
+        this.seqNo = in.readLong();
+        this.primaryTerm = in.readLong();
+        this.securityIndex = in.readString();
+        this.description = in.readString();
+        this.successMessage = in.readString();
+        this.successStatus = in.readEnum(RestStatus.class);
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(cType);
+        out.writeBytesReference(content);
+        out.writeLong(seqNo);
+        out.writeLong(primaryTerm);
+        out.writeString(securityIndex);
+        out.writeString(description);
+        out.writeString(successMessage);
+        out.writeEnum(successStatus);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        // Defer to server-side validation on the actual index write; there are no cheap client-side
+        // preconditions worth checking here beyond non-null fields, which the constructor enforces
+        // implicitly by producing an unusable request if any are null.
+        if (Strings.isNullOrEmpty(cType) || content == null || Strings.isNullOrEmpty(securityIndex) || successStatus == null) {
+            final var e = new ActionRequestValidationException();
+            e.addValidationError("cType, content, securityIndex and successStatus are required");
+            return e;
+        }
+        return null;
+    }
+
+    @Override
+    public boolean getShouldStoreResult() {
+        // Always true: this request is only submitted from the async pre-branch in
+        // AbstractApiAction, where the whole point is to make the outcome retrievable later via
+        // GET /_tasks/{id}. Sync writes never reach this code path.
+        return true;
+    }
+
+    @Override
+    public Task createTask(
+        final long id,
+        final String type,
+        final String action,
+        final TaskId parentTaskId,
+        final Map<String, String> headers
+    ) {
+        // Plain Task on purpose — see class-level Javadoc for why cancellation is not supported.
+        return new Task(id, type, action, getDescription(), parentTaskId, headers);
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCType() {
+        return cType;
+    }
+
+    public BytesReference getContent() {
+        return content;
+    }
+
+    public long getSeqNo() {
+        return seqNo;
+    }
+
+    public long getPrimaryTerm() {
+        return primaryTerm;
+    }
+
+    public String getSecurityIndex() {
+        return securityIndex;
+    }
+
+    public String getSuccessMessage() {
+        return successMessage;
+    }
+
+    public RestStatus getSuccessStatus() {
+        return successStatus;
+    }
+}

--- a/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteResponse.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/SecurityConfigWriteResponse.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.configupdate;
+
+import java.io.IOException;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * Response returned by {@link SecurityConfigWriteAction}. Body shape matches the message emitted
+ * by the pre-existing synchronous save path (see {@code Responses.payload}):
+ *
+ * <pre>{@code
+ * {
+ *   "status": "CREATED"|"OK",
+ *   "message": "'my_role' created."
+ * }
+ * }</pre>
+ *
+ * <p>Deliberately does not include configuration contents. When the task result is stored in
+ * {@code .tasks} (via {@code setShouldStoreResult(true)} on the async path), only the values above
+ * are persisted, so standard {@code _tasks} authorization is sufficient to satisfy the "do not
+ * expose Security configuration contents" acceptance criterion from issue #6337.
+ */
+public class SecurityConfigWriteResponse extends ActionResponse implements ToXContentObject {
+
+    private final RestStatus status;
+    private final String message;
+
+    public SecurityConfigWriteResponse(final RestStatus status, final String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public SecurityConfigWriteResponse(final StreamInput in) throws IOException {
+        super(in);
+        this.status = in.readEnum(RestStatus.class);
+        this.message = in.readString();
+    }
+
+    @Override
+    public void writeTo(final StreamOutput out) throws IOException {
+        out.writeEnum(status);
+        out.writeString(message);
+    }
+
+    @Override
+    public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        builder.startObject();
+        builder.field("status", status.name());
+        builder.field("message", message);
+        builder.endObject();
+        return builder;
+    }
+
+    public RestStatus getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/opensearch/security/action/configupdate/TransportSecurityConfigWriteAction.java
+++ b/src/main/java/org/opensearch/security/action/configupdate/TransportSecurityConfigWriteAction.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.action.configupdate;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+/**
+ * Transport action that persists a Security configuration document and then broadcasts a
+ * {@link ConfigUpdateAction} so every node reloads the affected config. The listener is only
+ * completed once the cluster-wide reload has been acknowledged, mirroring exactly the sync path
+ * in {@code AbstractApiAction.saveAndUpdateConfigsAsync}.
+ *
+ * <p>The whole operation runs under one {@link Task}. When a REST client submits with
+ * {@code wait_for_completion=false}, the task result is stored in {@code .tasks} and can be
+ * polled via {@code GET /_tasks/{id}}. Cancellation is not supported (see
+ * {@link SecurityConfigWriteAction} class-level docs).
+ */
+public class TransportSecurityConfigWriteAction extends HandledTransportAction<SecurityConfigWriteRequest, SecurityConfigWriteResponse> {
+
+    private static final Logger LOGGER = LogManager.getLogger(TransportSecurityConfigWriteAction.class);
+
+    private final Client client;
+
+    @Inject
+    public TransportSecurityConfigWriteAction(
+        final TransportService transportService,
+        final ActionFilters actionFilters,
+        final Client client
+    ) {
+        super(SecurityConfigWriteAction.NAME, transportService, actionFilters, SecurityConfigWriteRequest::new);
+        this.client = client;
+    }
+
+    @Override
+    protected void doExecute(
+        final Task task,
+        final SecurityConfigWriteRequest request,
+        final ActionListener<SecurityConfigWriteResponse> listener
+    ) {
+        final IndexRequest indexRequest = new IndexRequest(request.getSecurityIndex()).id(request.getCType())
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .setIfSeqNo(request.getSeqNo())
+            .setIfPrimaryTerm(request.getPrimaryTerm())
+            .source(request.getCType(), request.getContent());
+
+        // Step 1: write the config document. Optimistic concurrency is enforced by the
+        // (seqNo, primaryTerm) preconditions above — a stale write surfaces as
+        // VersionConflictEngineException and is propagated to the task listener untouched.
+        client.index(indexRequest, ActionListener.wrap(indexResponse -> {
+            // Step 2: fan out a reload request so every node re-reads the changed config from
+            // the index. This is the same mechanism the pre-existing sync path uses via
+            // ConfigUpdatingActionListener. We only complete the task listener after every node
+            // acknowledges, so callers polling _tasks/{id} see the operation as in-progress
+            // until the cluster is consistent.
+            final var configUpdate = new org.opensearch.security.action.configupdate.ConfigUpdateRequest(
+                new String[] { request.getCType() }
+            );
+            client.execute(ConfigUpdateAction.INSTANCE, configUpdate, ActionListener.wrap(configUpdateResponse -> {
+                if (configUpdateResponse.hasFailures()) {
+                    // Surface the first per-node failure. The full failure list is available on
+                    // configUpdateResponse for anyone consuming the raw response object, but the
+                    // stored task result only carries the exception message.
+                    listener.onFailure(configUpdateResponse.failures().get(0));
+                    return;
+                }
+                listener.onResponse(new SecurityConfigWriteResponse(request.getSuccessStatus(), request.getSuccessMessage()));
+            }, e -> {
+                LOGGER.debug("Cluster-wide config reload failed for {}", request.getCType(), e);
+                listener.onFailure(e);
+            }));
+        }, e -> {
+            LOGGER.debug("Persisting configuration to security index failed for {}", request.getCType(), e);
+            listener.onFailure(e);
+        }));
+    }
+}

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AbstractApiAction.java
@@ -38,6 +38,7 @@ import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.common.transport.TransportAddress;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentHelper;
 import org.opensearch.index.engine.VersionConflictEngineException;
 import org.opensearch.rest.BaseRestHandler;
@@ -49,6 +50,8 @@ import org.opensearch.rest.RestRequestFilter;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
 import org.opensearch.security.action.configupdate.ConfigUpdateRequest;
 import org.opensearch.security.action.configupdate.ConfigUpdateResponse;
+import org.opensearch.security.action.configupdate.SecurityConfigWriteAction;
+import org.opensearch.security.action.configupdate.SecurityConfigWriteRequest;
 import org.opensearch.security.dlic.rest.support.Utils;
 import org.opensearch.security.dlic.rest.validation.EndpointValidator;
 import org.opensearch.security.dlic.rest.validation.RequestContentValidator;
@@ -121,11 +124,99 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
     private void buildDefaultRequestHandlers(final RequestHandler.RequestHandlersBuilder builder) {
         builder.withAccessHandler(request -> securityApiDependencies.restApiAuthorizationEvaluator().isCurrentUserAdminFor(endpoint))
             .withSaveOrUpdateConfigurationHandler(this::saveOrUpdateConfiguration)
+            .withAsyncTaskSubmitter(this::maybeSubmitAsTask)
             .add(Method.POST, methodNotImplementedHandler)
             .add(Method.PATCH, methodNotImplementedHandler)
             .onGetRequest(this::processGetRequest)
             .onChangeRequest(Method.DELETE, this::processDeleteRequest)
             .onChangeRequest(Method.PUT, this::processPutRequest);
+    }
+
+    /**
+     * Endpoint-level opt-in for the {@code wait_for_completion} query parameter and the OpenSearch
+     * task framework. When {@code false} (the default), every change request is handled fully
+     * synchronously and {@code wait_for_completion} is ignored, exactly matching the pre-existing
+     * behavior. Subclasses that override this to {@code true} allow callers to pass
+     * {@code wait_for_completion=false}, in which case the update is submitted as a Task and
+     * {@code {"task":"nodeId:taskId"}} is returned immediately.
+     */
+    protected boolean supportsAsync() {
+        return false;
+    }
+
+    /**
+     * Pre-branch invoked from {@link RequestHandler.RequestHandlersBuilder#onChangeRequest} before
+     * the sync save path. Returns {@code true} only when the endpoint has opted in via
+     * {@link #supportsAsync()} <b>and</b> the caller passed {@code wait_for_completion=false} — the
+     * update is then dispatched through the task framework, a task-id response is written to the
+     * channel, and the caller is expected to skip the sync path.
+     *
+     * <p>Any other combination returns {@code false}, so the existing sync path handles the request
+     * unchanged.
+     */
+    private boolean maybeSubmitAsTask(
+        final RestChannel channel,
+        final RestRequest request,
+        final Client client,
+        final SecurityDynamicConfiguration<?> configuration,
+        final String entityName,
+        final String successMessage,
+        final RestStatus successStatus
+    ) {
+        if (!supportsAsync()) {
+            return false;
+        }
+        if (request.paramAsBoolean("wait_for_completion", true)) {
+            return false;
+        }
+        if (!(client instanceof NodeClient)) {
+            // Defensive: this handler always runs off a NodeClient today, so this branch is
+            // effectively unreachable — but avoid a runtime ClassCastException if that ever
+            // changes and gracefully fall back to sync execution.
+            LOGGER.debug("Client is not a NodeClient; cannot submit as task, falling back to sync path");
+            return false;
+        }
+        final NodeClient nodeClient = (NodeClient) client;
+        final CType<?> cType = getConfigType();
+
+        configuration.removeStatic();
+        final BytesReference content;
+        try {
+            content = XContentHelper.toXContent(configuration, XContentType.JSON, ToXContent.EMPTY_PARAMS, false);
+        } catch (final IOException e) {
+            throw ExceptionsHelper.convertToOpenSearchException(e);
+        }
+
+        final String description = entityName == null ? cType.toLCString() : cType.toLCString() + "/" + entityName;
+        final SecurityConfigWriteRequest updateRequest = new SecurityConfigWriteRequest(
+            cType.toLCString(),
+            content,
+            configuration.getSeqNo(),
+            configuration.getPrimaryTerm(),
+            securityApiDependencies.securityIndexName(),
+            description,
+            successMessage,
+            successStatus
+        );
+
+        // Persist the eventual task result in .tasks so callers can retrieve it via
+        // GET /_tasks/{task_id} after completion. The request itself always signals this via
+        // getShouldStoreResult() — see SecurityConfigWriteRequest.
+        final org.opensearch.tasks.Task task = nodeClient.executeLocally(
+            SecurityConfigWriteAction.INSTANCE,
+            updateRequest,
+            org.opensearch.tasks.LoggingTaskListener.instance()
+        );
+
+        try (final XContentBuilder builder = channel.newBuilder()) {
+            builder.startObject();
+            builder.field("task", nodeClient.getLocalNodeId() + ":" + task.getId());
+            builder.endObject();
+            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+        } catch (final IOException e) {
+            throw ExceptionsHelper.convertToOpenSearchException(e);
+        }
+        return true;
     }
 
     protected final ValidationResult<SecurityConfiguration> processDeleteRequest(final RestRequest request) throws IOException {
@@ -591,6 +682,10 @@ public abstract class AbstractApiAction extends BaseRestHandler implements RestR
         // consume all parameters first so we can return a correct HTTP status,
         // not 400
         consumeParameters(request);
+        // Consume the async opt-in flag centrally (not in consumeParameters), so subclasses that
+        // override consumeParameters — and don't call super — still don't reject
+        // ?wait_for_completion=... as an unrecognized parameter.
+        request.paramAsBoolean("wait_for_completion", true);
 
         // check if .opendistro_security index has been initialized
         if (!ensureIndexExists()) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/AuditApiAction.java
@@ -263,6 +263,11 @@ public class AuditApiAction extends AbstractApiAction {
     }
 
     @Override
+    protected boolean supportsAsync() {
+        return true;
+    }
+
+    @Override
     protected void consumeParameters(RestRequest request) {}
 
     private void auditApiRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/InternalUsersApiAction.java
@@ -136,6 +136,11 @@ public class InternalUsersApiAction extends AbstractApiAction {
         return CType.INTERNALUSERS;
     }
 
+    @Override
+    protected boolean supportsAsync() {
+        return true;
+    }
+
     private void internalUsersApiRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {
         requestHandlersBuilder.onGetRequest(
             request -> ValidationResult.success(request).map(this::processGetRequest).map(securityConfiguration -> {

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RequestHandler.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RequestHandler.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.common.CheckedFunction;
 import org.opensearch.common.TriConsumer;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.rest.RestChannel;
 import org.opensearch.rest.RestRequest;
@@ -29,10 +30,8 @@ import org.opensearch.security.dlic.rest.validation.ValidationResult;
 import org.opensearch.security.securityconf.impl.SecurityDynamicConfiguration;
 import org.opensearch.transport.client.Client;
 
-import static org.opensearch.security.dlic.rest.api.Responses.created;
 import static org.opensearch.security.dlic.rest.api.Responses.forbidden;
 import static org.opensearch.security.dlic.rest.api.Responses.methodNotImplemented;
-import static org.opensearch.security.dlic.rest.api.Responses.ok;
 import static org.opensearch.security.dlic.rest.api.Responses.response;
 
 @FunctionalInterface
@@ -43,6 +42,30 @@ public interface RequestHandler {
     RequestHandler accessDeniedHandler = (channel, request, client) -> forbidden(channel, "Access denied");
 
     void handle(final RestChannel channel, final RestRequest request, final Client client) throws IOException;
+
+    /**
+     * Optional pre-branch invoked before the synchronous save path. When the endpoint has opted in
+     * to async execution (via {@link AbstractApiAction#supportsAsync()}) and the caller passed
+     * {@code wait_for_completion=false}, the implementation submits the update through the task
+     * framework and writes a {@code {"task":"nodeId:taskId"}} response to {@code channel}, returning
+     * {@code true} so the outer handler skips the sync path.
+     *
+     * <p>Returning {@code false} indicates the sync path should proceed unchanged.
+     */
+    @FunctionalInterface
+    interface AsyncTaskSubmitter {
+        boolean trySubmit(
+            RestChannel channel,
+            RestRequest request,
+            Client client,
+            SecurityDynamicConfiguration<?> configuration,
+            String entityName,
+            String successMessage,
+            RestStatus successStatus
+        );
+
+        AsyncTaskSubmitter NEVER = (channel, request, client, configuration, entityName, successMessage, successStatus) -> false;
+    }
 
     final class RequestHandlersBuilder {
 
@@ -64,6 +87,8 @@ public interface RequestHandler {
             Client,
             SecurityDynamicConfiguration<?>,
             AbstractApiAction.OnSucessActionListener<IndexResponse>> saveOrUpdateConfigurationHandler;
+
+        private AsyncTaskSubmitter asyncTaskSubmitter = AsyncTaskSubmitter.NEVER;
 
         private Predicate<RestRequest> accessHandler;
 
@@ -129,6 +154,11 @@ public interface RequestHandler {
             return this;
         }
 
+        RequestHandlersBuilder withAsyncTaskSubmitter(final AsyncTaskSubmitter asyncTaskSubmitter) {
+            this.asyncTaskSubmitter = Objects.requireNonNull(asyncTaskSubmitter, "asyncTaskSubmitter can't be null");
+            return this;
+        }
+
         public RequestHandlersBuilder onGetRequest(
             final CheckedFunction<RestRequest, ValidationResult<SecurityConfiguration>, IOException> mapper
         ) {
@@ -136,7 +166,7 @@ public interface RequestHandler {
             add(
                 RestRequest.Method.GET,
                 (channel, request, client) -> mapper.apply(request)
-                    .valid(securityConfiguration -> ok(channel, securityConfiguration.configuration()))
+                    .valid(securityConfiguration -> Responses.ok(channel, securityConfiguration.configuration()))
                     .error((status, toXContent) -> response(channel, status, toXContent))
             );
             return this;
@@ -149,7 +179,7 @@ public interface RequestHandler {
             add(
                 RestRequest.Method.GET,
                 (channel, request, client) -> mapper.apply(request)
-                    .valid(toXContent -> ok(channel, toXContent))
+                    .valid(toXContent -> Responses.ok(channel, toXContent))
                     .error((status, toXContent) -> response(channel, status, toXContent))
             );
             return this;
@@ -166,41 +196,61 @@ public interface RequestHandler {
             }
             switch (method) {
                 case PATCH:
-                    add(
-                        method,
-                        (channel, request, client) -> mapper.apply(request)
-                            .valid(
-                                securityConfiguration -> saveOrUpdateConfigurationHandler.apply(
-                                    client,
-                                    securityConfiguration.configuration(),
-                                    new AbstractApiAction.OnSucessActionListener<>(channel) {
-                                        @Override
-                                        public void onResponse(IndexResponse indexResponse) {
-                                            if (securityConfiguration.maybeEntityName().isPresent()) {
-                                                ok(channel, "'" + securityConfiguration.entityName() + "' updated.");
-                                            } else {
-                                                ok(channel, "Resource updated.");
-                                            }
-                                        }
-                                    }
-                                )
-                            )
-                            .error((status, toXContent) -> response(channel, status, toXContent))
-                    );
-                    break;
-                case PUT:
                     add(method, (channel, request, client) -> mapper.apply(request).valid(securityConfiguration -> {
+                        // Message + status for both the sync response body AND the async
+                        // stored task result must be identical, so we resolve them once
+                        // here based on the loaded configuration state.
+                        final boolean hasEntityName = securityConfiguration.maybeEntityName().isPresent();
+                        final String entityName = hasEntityName ? securityConfiguration.entityName() : null;
+                        final String successMessage = hasEntityName ? "'" + entityName + "' updated." : "Resource updated.";
+                        final RestStatus successStatus = RestStatus.OK;
+                        if (asyncTaskSubmitter.trySubmit(
+                            channel,
+                            request,
+                            client,
+                            securityConfiguration.configuration(),
+                            entityName,
+                            successMessage,
+                            successStatus
+                        )) {
+                            return;
+                        }
                         saveOrUpdateConfigurationHandler.apply(
                             client,
                             securityConfiguration.configuration(),
                             new AbstractApiAction.OnSucessActionListener<>(channel) {
                                 @Override
-                                public void onResponse(IndexResponse response) {
-                                    if (securityConfiguration.entityExists()) {
-                                        ok(channel, "'" + securityConfiguration.entityName() + "' updated.");
-                                    } else {
-                                        created(channel, "'" + securityConfiguration.entityName() + "' created.");
-                                    }
+                                public void onResponse(IndexResponse indexResponse) {
+                                    response(channel, successStatus, Responses.payload(successStatus, successMessage));
+                                }
+                            }
+                        );
+                    }).error((status, toXContent) -> response(channel, status, toXContent)));
+                    break;
+                case PUT:
+                    add(method, (channel, request, client) -> mapper.apply(request).valid(securityConfiguration -> {
+                        final boolean isCreate = !securityConfiguration.entityExists();
+                        final RestStatus successStatus = isCreate ? RestStatus.CREATED : RestStatus.OK;
+                        final String entityName = securityConfiguration.entityName();
+                        final String successMessage = "'" + entityName + "' " + (isCreate ? "created" : "updated") + ".";
+                        if (asyncTaskSubmitter.trySubmit(
+                            channel,
+                            request,
+                            client,
+                            securityConfiguration.configuration(),
+                            entityName,
+                            successMessage,
+                            successStatus
+                        )) {
+                            return;
+                        }
+                        saveOrUpdateConfigurationHandler.apply(
+                            client,
+                            securityConfiguration.configuration(),
+                            new AbstractApiAction.OnSucessActionListener<>(channel) {
+                                @Override
+                                public void onResponse(IndexResponse indexResponse) {
+                                    response(channel, successStatus, Responses.payload(successStatus, successMessage));
                                 }
                             }
                         );
@@ -208,23 +258,32 @@ public interface RequestHandler {
                     break;
                 case DELETE:
                     Objects.requireNonNull(mapper, "onDeleteRequest request handler can't be null");
-                    add(
-                        RestRequest.Method.DELETE,
-                        (channel, request, client) -> mapper.apply(request)
-                            .valid(
-                                securityConfiguration -> saveOrUpdateConfigurationHandler.apply(
-                                    client,
-                                    securityConfiguration.configuration(),
-                                    new AbstractApiAction.OnSucessActionListener<>(channel) {
-                                        @Override
-                                        public void onResponse(IndexResponse response) {
-                                            ok(channel, "'" + securityConfiguration.entityName() + "' deleted.");
-                                        }
-                                    }
-                                )
-                            )
-                            .error((status, toXContent) -> response(channel, status, toXContent))
-                    );
+                    add(RestRequest.Method.DELETE, (channel, request, client) -> mapper.apply(request).valid(securityConfiguration -> {
+                        final String entityName = securityConfiguration.entityName();
+                        final String successMessage = "'" + entityName + "' deleted.";
+                        final RestStatus successStatus = RestStatus.OK;
+                        if (asyncTaskSubmitter.trySubmit(
+                            channel,
+                            request,
+                            client,
+                            securityConfiguration.configuration(),
+                            entityName,
+                            successMessage,
+                            successStatus
+                        )) {
+                            return;
+                        }
+                        saveOrUpdateConfigurationHandler.apply(
+                            client,
+                            securityConfiguration.configuration(),
+                            new AbstractApiAction.OnSucessActionListener<>(channel) {
+                                @Override
+                                public void onResponse(IndexResponse indexResponse) {
+                                    response(channel, successStatus, Responses.payload(successStatus, successMessage));
+                                }
+                            }
+                        );
+                    }).error((status, toXContent) -> response(channel, status, toXContent)));
                     break;
             }
             return this;

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesApiAction.java
@@ -140,6 +140,13 @@ public class RolesApiAction extends AbstractApiAction {
         return CType.ROLES;
     }
 
+    @Override
+    protected boolean supportsAsync() {
+        // Enabled per issue #6337: role writes fan out to every node and are exactly the shape
+        // (index write + cluster reload) that benefits from the task framework.
+        return true;
+    }
+
     private void rolesApiRequestHandlers(RequestHandler.RequestHandlersBuilder requestHandlersBuilder) {
         requestHandlersBuilder.onChangeRequest(Method.PATCH, this::processPatchRequest).override(Method.POST, methodNotImplementedHandler);
     }

--- a/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/RolesMappingApiAction.java
@@ -89,6 +89,11 @@ public class RolesMappingApiAction extends AbstractApiAction {
     }
 
     @Override
+    protected boolean supportsAsync() {
+        return true;
+    }
+
+    @Override
     protected EndpointValidator createEndpointValidator() {
         return new EndpointValidator() {
             @Override

--- a/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
+++ b/src/main/java/org/opensearch/security/dlic/rest/api/TenantsApiAction.java
@@ -98,6 +98,11 @@ public class TenantsApiAction extends AbstractApiAction {
     }
 
     @Override
+    protected boolean supportsAsync() {
+        return true;
+    }
+
+    @Override
     protected EndpointValidator createEndpointValidator() {
         return new EndpointValidator() {
             @Override


### PR DESCRIPTION
### Description
**Category:** Enhancement

Adds support for the standard `wait_for_completion` query parameter to Security configuration write APIs. Callers can now submit a configuration change with `?wait_for_completion=false` and receive an OpenSearch task ID immediately (`{"task":"<nodeId>:<taskId>"}`), then poll the outcome via the standard Tasks API (`GET /_tasks/{task_id}`). Omitting the parameter — or setting it to `true` — preserves the existing synchronous behavior byte-for-byte.

**Why:** Security configuration writes today fan out a cluster-wide reload after the index write, and the caller has to hold the HTTP connection open for the entire lifecycle. If the connection drops there's no way to tell whether the change committed. Every other long-running OpenSearch API (reindex, update-by-query, force-merge, open-index…) solves this via the Tasks framework; Security did not. This change brings Security in line with that convention.

**Old vs new behavior:**

| `wait_for_completion` | Behavior |
|---|---|
| omitted / `true` (default) | Unchanged. Same response body and status code the endpoint returned before this PR. |
| `false` | Update is submitted through the task framework. HTTP 200 with body `{"task":"nodeId:taskId"}` is returned as soon as the task is registered — before the index write or fan-out reload has completed. |

**Task completion boundary.** The task completes only after `ConfigUpdatingActionListener` receives all-node acknowledgements of the reload — exactly the point at which the sync path returns today. Any per-node reload failure surfaces as a task-level error.

**Task result payload.** The stored task result in `.tasks` contains only `{"status":"...","message":"'entity' created."}` — never configuration contents. Standard `_tasks` authorization is therefore sufficient to satisfy the "does not expose Security configuration contents" acceptance criterion; no security-plugin-specific gating on task lookup was added.

**Cancellation.** Deliberately not supported. `SecurityConfigWriteRequest#createTask` returns a plain `Task` rather than a `CancellableTask`, so `POST /_tasks/{id}/_cancel` is rejected by `TransportCancelTasksAction` with `"task [...] doesn't support cancellation"`. Rationale: a mid-fan-out cancel could leave the index write committed but only a subset of nodes reloaded — worse than letting the request run to completion.

### Scope

**In this PR** — the shared plumbing plus opt-in for the 5 endpoints that a Terraform provider calls when provisioning a cluster:

- Roles (`RolesApiAction`)
- Role mappings (`RolesMappingApiAction`)
- Internal users (`InternalUsersApiAction`)
- Tenants (`TenantsApiAction`)
- Audit (`AuditApiAction`)

**Deferred:**
- `ActionGroupsApiAction`, `SecurityConfigApiAction` — same shape (config write + fan-out reload), share the same plumbing, but not called by the Terraform provider. Opt-in is a one-line change per subclass; follow-up PR.
- `AccountApiAction` (self-service password change) — explicitly excluded per feedback in the issue thread; async has near-zero value for an interactive endpoint.
- `AllowlistApiAction`, `NodesDnApiAction`, `RateLimitersApiAction`, `MultiTenancyConfigApiAction` — same pattern, follow-up as demand appears.

**Companion PRs to follow** (separate repositories):
- `opensearch-project/documentation-website` — document the new query parameter, response shape, task lookup.
- `opensearch-project/opensearch-api-specification` — add `wait_for_completion` to the affected endpoint schemas so generated client SDKs pick it up.

### Implementation

**New files (`src/main/java/org/opensearch/security/action/configupdate/`):**

- `SecurityConfigWriteAction` — `ActionType` with name `cluster:admin/opendistro_security/api/write_config`.
- `SecurityConfigWriteRequest` — carries `cType`, serialized config bytes, seqNo/primaryTerm for optimistic concurrency, security index name, task description, success message, and success status. `createTask` returns a plain (non-cancellable) `Task`. `getShouldStoreResult()` returns `true` so `TransportAction.execute` wraps the listener with `TaskResultStoringActionListener` automatically.
- `SecurityConfigWriteResponse` — `ActionResponse` + `ToXContentObject`; body is `{"status":"OK","message":"..."}` matching the sync path exactly. Deliberately does not include configuration contents.
- `TransportSecurityConfigWriteAction` — `HandledTransportAction` that performs the `IndexRequest` and then broadcasts `ConfigUpdateAction`; only completes the listener after all-node ack, mirroring the sync path's `ConfigUpdatingActionListener` chain.

**Modified files:**

- `OpenSearchSecurityPlugin.java` — registers the new transport action.
- `AbstractApiAction.java` — adds `supportsAsync()` hook (default `false`) and a private `maybeSubmitAsTask` helper wired via `withAsyncTaskSubmitter(...)`. Consumes `wait_for_completion` in `prepareRequest` directly (not inside `consumeParameters`) so subclass overrides that don't call `super` still don't reject the parameter as unrecognized.
- `RequestHandler.java` — introduces the `AsyncTaskSubmitter` functional interface and pre-branches `PUT`/`PATCH`/`DELETE` on it. If the endpoint doesn't opt in, `AsyncTaskSubmitter.NEVER` returns `false` and the sync path is unchanged. Response message and status are precomputed once from the loaded configuration state so the sync body and the stored task result are byte-identical.
- 5 endpoint classes — override `supportsAsync()` to return `true`.

**Backwards compatibility.** The pre-branch runs only when the endpoint has opted in *and* `wait_for_completion=false` is explicitly present. The sync response body was refactored to compute `(status, message)` once instead of twice, but produces the same JSON: `{"status":"CREATED","message":"'my_role' created."}` for a new PUT, `{"status":"OK","message":"'my_role' updated."}` for an update, `{"status":"OK","message":"'my_role' deleted."}` for a delete. The public static helper `AbstractApiAction.saveAndUpdateConfigsAsync` is left untouched because `RollbackVersionApiAction` and `ConfigUpgradeApiAction` still depend on its signature.


### Issues Resolved
Closes https://github.com/opensearch-project/security/issues/6337

Is this a backport? **No.** New feature, targets `main`.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? **No** — the transport action's authorization runs through the same REST-admin check the existing sync path uses, at the REST layer, before task submission. No new plugin-specific action name needs a UI-side entry.

### Testing
**New integration test file:** `src/integrationTest/java/org/opensearch/security/api/WaitForCompletionRestApiIntegrationTest.java`

Covers each acceptance criterion in the issue:

- Sync success (parameter omitted, and parameter explicitly set to `true`) — response status and body match the pre-PR behavior.
- Sync failure — invalid body still returns 400 even when `wait_for_completion=false` is requested, because validation runs before task submission (no phantom task IDs for requests that never execute).
- Async success and task lookup — one test per opted-in endpoint (Roles, RolesMapping, InternalUsers, Tenants, Audit): submit with `wait_for_completion=false`, verify the returned task ID follows `<nodeId>:<taskId>` shape, poll `_tasks/{id}?wait_for_completion=true&timeout=30s`, assert `completed=true` and — for Roles and InternalUsers — that the stored task result contains the exact success message the sync path would have returned.
- Task cancellation refused — `POST /_tasks/{id}/_cancel` returns a response whose body contains `"doesn't support cancellation"`.

**Regression coverage:** the existing `RolesRestApiIntegrationTest` and `InternalUsersRestApiIntegrationTest` suites pass unmodified against these changes (17 tests, 0 failures).

**Manual verification** — run against a real multi-node local cluster built from this branch:

| # | Scenario | Expected | Actual |
|---|---|---|---|
| 1 | `PUT /roles/sync_role` (no param) | 201 + `"created"` | `HTTP 201  {"status":"CREATED","message":"'sync_role' created."}` |
| 2 | `PUT /roles/async_role?wait_for_completion=false` | 200 + `{"task":"nodeId:taskId"}` | `HTTP 200  {"task":"WkDLHW0bRzG7OmOx3bpeRg:133"}` |
| 3 | `GET /_tasks/{id}?wait_for_completion=true` | Stored result mirrors sync response | `completed:true, cancellable:false, action:"cluster:admin/opendistro_security/api/write_config", description:"roles/async_role", response:{"status":"CREATED","message":"'async_role' created."}` |
| 4 | `POST /_tasks/{id}/_cancel` | Refused | `caused_by: illegal_argument_exception "task [...] doesn't support cancellation"` |
| 5 | Invalid body + `wait_for_completion=false` | Sync 400, no phantom task | `HTTP 400  {"status":"error","reason":"Invalid configuration","invalid_keys":{"keys":"unknown_field"}}` |
| 6 | Async PUT on internal users | Task ID returned | `HTTP 200  {"task":"...:218"}` |
| 7 | Async PUT on **non**-opted-in endpoint (`actiongroups`) | Parameter silently ignored, sync response | `HTTP 201  {"status":"CREATED","message":"'manual_ag' created."}` |

  The task-manager output in row 3 also confirms `"cancellable":false` at the framework level, so `_tasks/{id}/_cancel` rejection in row 4 comes from
  `TransportCancelTasksAction` rather than any custom check — non-cancellability is a property of the `Task` type, not a plugin-level filter.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
