### PR TITLE
fix(audit): Redact Cookie and other credential headers in audit events

### DIFF
--- a/src/main/java/org/opensearch/security/filter/AuditHeaderUtils.java
+++ b/src/main/java/org/opensearch/security/filter/AuditHeaderUtils.java
@@ -23,14 +23,25 @@ import org.opensearch.security.support.WildcardMatcher;
  */
 public final class AuditHeaderUtils {
 
-    private static final WildcardMatcher AUTHORIZATION_HEADER = WildcardMatcher.from("Authorization").ignoreCase();
+    /**
+     * Request headers that can carry credentials or session identifiers. These are removed from
+     * audit events when {@code exclude_sensitive_headers} is enabled. Matching is case-insensitive.
+     */
+    private static final WildcardMatcher SENSITIVE_HEADERS = WildcardMatcher.from(
+        "Authorization",
+        "Proxy-Authorization",
+        "Cookie",
+        "Set-Cookie",
+        "X-Auth-Token"
+    ).ignoreCase();
 
     private AuditHeaderUtils() {}
 
     /**
      * Returns a filtered copy of the given headers map based on the audit filter config.
-     * If {@code exclude_sensitive_headers} is enabled, strips Authorization (case-insensitive).
-     * Returns an empty map if headers is null or empty.
+     * If {@code exclude_sensitive_headers} is enabled, strips headers that may carry credentials
+     * or session identifiers (Authorization, Proxy-Authorization, Cookie, Set-Cookie, X-Auth-Token),
+     * case-insensitively. Returns an empty map if headers is null or empty.
      */
     public static Map<String, List<String>> filterHeaders(Map<String, List<String>> headers, AuditConfig.Filter filter) {
         if (headers == null || headers.isEmpty()) {
@@ -38,7 +49,7 @@ public final class AuditHeaderUtils {
         }
         Map<String, List<String>> filtered = new HashMap<>(headers);
         if (filter.shouldExcludeSensitiveHeaders()) {
-            filtered.keySet().removeIf(AUTHORIZATION_HEADER);
+            filtered.keySet().removeIf(SENSITIVE_HEADERS);
         }
         return filtered;
     }

--- a/src/test/java/org/opensearch/security/filter/AuditHeaderUtilsTest.java
+++ b/src/test/java/org/opensearch/security/filter/AuditHeaderUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.filter;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.security.auditlog.config.AuditConfig;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+
+public class AuditHeaderUtilsTest {
+
+    private static final Map<String, List<String>> HEADERS = Map.of(
+        "Authorization",
+        List.of("Bearer token"),
+        "Proxy-Authorization",
+        List.of("Basic abc"),
+        "cookie",
+        List.of("session=abc"),
+        "Set-Cookie",
+        List.of("session=abc"),
+        "X-Auth-Token",
+        List.of("abc"),
+        "User-Agent",
+        List.of("curl/8.0")
+    );
+
+    private static AuditConfig.Filter filterWithExcludeSensitiveHeaders(final boolean exclude) {
+        return AuditConfig.Filter.from(
+            Settings.builder().put(ConfigConstants.OPENDISTRO_SECURITY_AUDIT_EXCLUDE_SENSITIVE_HEADERS, exclude).build()
+        );
+    }
+
+    @Test
+    public void stripsSensitiveHeadersCaseInsensitivelyWhenEnabled() {
+        // exclude_sensitive_headers defaults to true
+        final Map<String, List<String>> filtered = AuditHeaderUtils.filterHeaders(HEADERS, AuditConfig.Filter.from(Settings.EMPTY));
+
+        assertThat(filtered, not(hasKey("Authorization")));
+        assertThat(filtered, not(hasKey("Proxy-Authorization")));
+        assertThat(filtered, not(hasKey("cookie")));
+        assertThat(filtered, not(hasKey("Set-Cookie")));
+        assertThat(filtered, not(hasKey("X-Auth-Token")));
+        // non-sensitive headers are retained
+        assertThat(filtered, hasKey("User-Agent"));
+    }
+
+    @Test
+    public void retainsAllHeadersWhenExcludeSensitiveHeadersDisabled() {
+        final Map<String, List<String>> filtered = AuditHeaderUtils.filterHeaders(HEADERS, filterWithExcludeSensitiveHeaders(false));
+
+        assertThat(filtered, hasKey("Authorization"));
+        assertThat(filtered, hasKey("cookie"));
+        assertThat(filtered, hasKey("X-Auth-Token"));
+        assertThat(filtered, hasKey("User-Agent"));
+    }
+
+    @Test
+    public void returnsEmptyMapForNullOrEmptyHeaders() {
+        assertThat(AuditHeaderUtils.filterHeaders(null, AuditConfig.Filter.from(Settings.EMPTY)), anEmptyMap());
+        assertThat(AuditHeaderUtils.filterHeaders(Map.of(), AuditConfig.Filter.from(Settings.EMPTY)), anEmptyMap());
+    }
+}


### PR DESCRIPTION
### Description

`AuditHeaderUtils.filterHeaders` (added in #6304 and used by both `AuditActionFilter` and `AuditTransportInterceptor` for the standalone / SSL-only audit path) only stripped the `Authorization` header when `exclude_sensitive_headers` is enabled. Other headers that commonly carry credentials or session identifiers — `Cookie`, `Set-Cookie`, `Proxy-Authorization`, `X-Auth-Token` — were written verbatim to the audit sink. This was flagged by the PR code analyzer on #6304.

This change broadens the denylist to cover those headers while keeping the existing behavior intact:
- Same `exclude_sensitive_headers` gate (default `true`) — no change when the setting is disabled.
- Same case-insensitive matching.

Only generic, standards-based HTTP auth/session headers are added; nothing vendor-specific.

### Category
Bug fix

### Why these changes are required?
Prevents credentials and session identifiers in request headers from leaking into audit logs on the standalone/SSL-only audit path.

### What is the old behavior before changes and new behavior after changes?
- Old: only `Authorization` was redacted; `Cookie`/`Set-Cookie`/`Proxy-Authorization`/`X-Auth-Token` were logged.
- New: all of the above are redacted when `exclude_sensitive_headers` is enabled.

### Issues
- Resolves #6411 

### Testing
Added `AuditHeaderUtilsTest` covering: sensitive headers stripped case-insensitively when enabled, all headers retained when `exclude_sensitive_headers=false`, and the null/empty guard. `./gradlew test --tests AuditHeaderUtilsTest` passes.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented (javadoc updated)
- [x] Commits are signed per the DCO using `--signoff`

Note for maintainers: this should be backported to `3.8` alongside #6304 (backported via #6370) so it ships with the standalone-audit feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
