### PR TITLE
Support hybrid search with adaptive DLS

### DIFF
--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -89,8 +89,7 @@ public class DlsFilterLevelActionHandler {
         boolean applyDlsFilterToHybridQuery
     ) {
 
-        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
-            || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
+        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
             return true;
         }
 
@@ -177,10 +176,8 @@ public class DlsFilterLevelActionHandler {
         try (StoredContext ctx = threadContext.newStoredContext(true)) {
 
             threadContext.putHeader(
-                applyDlsFilterToHybridQuery
-                    ? ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED
-                    : ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                "true"
+                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+                applyDlsFilterToHybridQuery ? ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE : "true"
             );
 
             try {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.search.BooleanClause;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.ActionRequest;
@@ -50,6 +51,7 @@ import org.opensearch.index.get.GetResult;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.TermsQueryBuilder;
 import org.opensearch.index.seqno.SequenceNumbers;
@@ -310,6 +312,10 @@ public class DlsFilterLevelActionHandler {
             if (ParentChildrenQueryDetector.hasParentOrChildQuery(query)) {
                 throw new OpenSearchSecurityException("Unable to handle filter level DLS for hybrid queries with parent or child clauses");
             }
+            List<QueryBuilder> originalSubqueries = directSubqueries(query);
+            if (originalSubqueries.isEmpty()) {
+                throw new OpenSearchSecurityException("Hybrid query does not expose subqueries for DLS verification");
+            }
             // Hybrid queries must remain top-level, so apply filter level DLS query directly
             QueryBuilder filteredHybridQuery = query.filter(filterLevelQueryBuilder);
             if (filteredHybridQuery == null) {
@@ -317,6 +323,9 @@ public class DlsFilterLevelActionHandler {
             }
             if (!isHybridQuery(filteredHybridQuery)) {
                 throw new OpenSearchSecurityException("Hybrid query was not preserved after applying the DLS filter");
+            }
+            if (!isDlsFilterAppliedToEverySubquery(filteredHybridQuery, filterLevelQueryBuilder, originalSubqueries)) {
+                throw new OpenSearchSecurityException("Hybrid query did not apply the DLS filter to every subquery");
             }
             searchSource.query(filteredHybridQuery);
         } else {
@@ -347,12 +356,62 @@ public class DlsFilterLevelActionHandler {
     /**
      * Neural Search is an optional plugin, so Security identifies its hybrid query through the public query type name
      * instead of depending on its query builder class. {@link QueryBuilder#getName()} is OpenSearch's unique query type
-     * identifier. A query builder registered as {@code hybrid} must honor {@link QueryBuilder#filter(QueryBuilder)} by
-     * applying the supplied filter to every subquery and must expose every subquery through its visitor. Reader-level DLS
-     * remains active whenever this special path is selected, independently of the query builder's filter implementation.
+     * identifier. A query builder registered as {@code hybrid} must expose every execution branch through its visitor.
+     * Security verifies after filtering that the number of branches is unchanged and that each branch preserves its
+     * original query while placing the exact supplied DLS query in a conjunctive boolean filter clause. Reader-level DLS
+     * remains active whenever this special path is selected.
      */
     static boolean isHybridQuery(QueryBuilder query) {
         return query != null && HYBRID_QUERY_NAME.equals(query.getName());
+    }
+
+    private static boolean isDlsFilterAppliedToEverySubquery(
+        QueryBuilder filteredHybridQuery,
+        QueryBuilder filterLevelQueryBuilder,
+        List<QueryBuilder> originalSubqueries
+    ) {
+        List<QueryBuilder> filteredSubqueries = directSubqueries(filteredHybridQuery);
+        if (filteredSubqueries.size() != originalSubqueries.size()) {
+            return false;
+        }
+        for (int i = 0; i < filteredSubqueries.size(); i++) {
+            QueryBuilder originalSubquery = originalSubqueries.get(i);
+            QueryBuilder filteredSubquery = filteredSubqueries.get(i);
+            if (!(filteredSubquery instanceof BoolQueryBuilder boolQuery)
+                || boolQuery.filter().stream().noneMatch(query -> query == filterLevelQueryBuilder)
+                || (filteredSubquery != originalSubquery && boolQuery.must().stream().noneMatch(query -> query == originalSubquery))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static List<QueryBuilder> directSubqueries(QueryBuilder query) {
+        List<QueryBuilder> directSubqueries = new ArrayList<>();
+        query.visit(new DirectSubqueryCollector(directSubqueries, false));
+        return directSubqueries;
+    }
+
+    private static final class DirectSubqueryCollector implements QueryBuilderVisitor {
+        private final List<QueryBuilder> directSubqueries;
+        private final boolean collect;
+
+        private DirectSubqueryCollector(List<QueryBuilder> directSubqueries, boolean collect) {
+            this.directSubqueries = directSubqueries;
+            this.collect = collect;
+        }
+
+        @Override
+        public void accept(QueryBuilder queryBuilder) {
+            if (collect) {
+                directSubqueries.add(queryBuilder);
+            }
+        }
+
+        @Override
+        public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+            return collect ? QueryBuilderVisitor.NO_OP_VISITOR : new DirectSubqueryCollector(directSubqueries, true);
+        }
     }
 
     private boolean handle(GetRequest getRequest, StoredContext ctx) {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -85,10 +85,12 @@ public class DlsFilterLevelActionHandler {
         Client nodeClient,
         ClusterService clusterService,
         IndicesService indicesService,
-        ThreadContext threadContext
+        ThreadContext threadContext,
+        boolean applyDlsFilterToHybridQuery
     ) {
 
-        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
+            || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
             return true;
         }
 
@@ -122,7 +124,8 @@ public class DlsFilterLevelActionHandler {
             nodeClient,
             clusterService,
             indicesService,
-            threadContext
+            threadContext,
+            applyDlsFilterToHybridQuery
         ).handle();
     }
 
@@ -136,6 +139,7 @@ public class DlsFilterLevelActionHandler {
     private final ClusterService clusterService;
     private final IndicesService indicesService;
     private final ThreadContext threadContext;
+    private final boolean applyDlsFilterToHybridQuery;
     private BoolQueryBuilder filterLevelQueryBuilder;
     private DocumentAllowList documentAllowlist;
 
@@ -146,7 +150,8 @@ public class DlsFilterLevelActionHandler {
         Client nodeClient,
         ClusterService clusterService,
         IndicesService indicesService,
-        ThreadContext threadContext
+        ThreadContext threadContext,
+        boolean applyDlsFilterToHybridQuery
     ) {
         this.action = context.getAction();
         this.request = context.getRequest();
@@ -157,6 +162,7 @@ public class DlsFilterLevelActionHandler {
         this.clusterService = clusterService;
         this.indicesService = indicesService;
         this.threadContext = threadContext;
+        this.applyDlsFilterToHybridQuery = applyDlsFilterToHybridQuery;
 
         this.requiresIndexScoping = resolved instanceof ResolvedIndices resolvedIndices
             ? resolvedIndices.local().names().size() != 1
@@ -168,7 +174,9 @@ public class DlsFilterLevelActionHandler {
         try (StoredContext ctx = threadContext.newStoredContext(true)) {
 
             threadContext.putHeader(
-                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+                applyDlsFilterToHybridQuery
+                    ? ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED
+                    : ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
                 log.isDebugEnabled() ? request.toString() : "true"
             );
 
@@ -236,7 +244,7 @@ public class DlsFilterLevelActionHandler {
             }
         }
 
-        applyFilterLevelDls(searchRequest.source(), filterLevelQueryBuilder);
+        applyFilterLevelDls(searchRequest.source(), filterLevelQueryBuilder, applyDlsFilterToHybridQuery);
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override
@@ -263,17 +271,23 @@ public class DlsFilterLevelActionHandler {
     }
 
     /**
-     * Applies the filter level DLS query without wrapping hybrid queries. Hybrid queries must remain top-level.
-     * Their filter method propagates the DLS restriction to every subquery.
+     * Applies the filter level DLS query. When {@code applyDlsFilterToHybridQuery} is true, hybrid queries remain top-level
+     * and their filter method propagates the DLS restriction to every subquery. Reader-level DLS must remain active in
+     * that case to protect search features which do not use the top-level query.
      * @param searchSource
      * @param filterLevelQueryBuilder
+     * @param applyDlsFilterToHybridQuery whether to push the DLS filter into a top-level hybrid query
      */
-    static void applyFilterLevelDls(SearchSourceBuilder searchSource, BoolQueryBuilder filterLevelQueryBuilder) {
+    static void applyFilterLevelDls(
+        SearchSourceBuilder searchSource,
+        BoolQueryBuilder filterLevelQueryBuilder,
+        boolean applyDlsFilterToHybridQuery
+    ) {
         QueryBuilder query = searchSource.query();
         if (query == null) {
             // No query set, apply filter level DLS query directly
             searchSource.query(filterLevelQueryBuilder);
-        } else if (isHybridQuery(query)) {
+        } else if (applyDlsFilterToHybridQuery && isHybridQuery(query)) {
             // Hybrid queries must remain top-level, so apply filter level DLS query directly
             searchSource.query(query.filter(filterLevelQueryBuilder));
         } else {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -71,6 +71,7 @@ import org.opensearch.transport.client.Client;
 
 public class DlsFilterLevelActionHandler {
     private static final Logger log = LogManager.getLogger(DlsFilterLevelActionHandler.class);
+    private static final String HYBRID_QUERY_NAME = "hybrid";
 
     private static final Function<SearchRequest, String> LOCAL_CLUSTER_ALIAS_GETTER = ReflectiveAttributeAccessors.protectedObjectAttr(
         "localClusterAlias",
@@ -227,16 +228,15 @@ public class DlsFilterLevelActionHandler {
             }
         }
 
-        if (searchRequest.source().query() != null) {
-            QueryBuilder query = searchRequest.source().query();
+        QueryBuilder query = searchRequest.source().query();
+        if (query != null) {
             if (ParentChildrenQueryDetector.hasParentOrChildQuery(query)) {
                 listener.onFailure(new OpenSearchSecurityException("Unable to handle filter level DLS for parent or child queries"));
                 return false;
             }
-            filterLevelQueryBuilder.must(query);
         }
 
-        searchRequest.source().query(filterLevelQueryBuilder);
+        applyFilterLevelDls(searchRequest.source(), filterLevelQueryBuilder);
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override
@@ -260,6 +260,31 @@ public class DlsFilterLevelActionHandler {
         });
 
         return false;
+    }
+
+    /**
+     * Applies the filter level DLS query without wrapping hybrid queries. Hybrid queries must remain top-level.
+     * Their filter method propagates the DLS restriction to every subquery.
+     * @param searchSource
+     * @param filterLevelQueryBuilder
+     */
+    static void applyFilterLevelDls(SearchSourceBuilder searchSource, BoolQueryBuilder filterLevelQueryBuilder) {
+        QueryBuilder query = searchSource.query();
+        if (query == null) {
+            // No query set, apply filter level DLS query directly
+            searchSource.query(filterLevelQueryBuilder);
+        } else if (isHybridQuery(query)) {
+            // Hybrid queries must remain top-level, so apply filter level DLS query directly
+            searchSource.query(query.filter(filterLevelQueryBuilder));
+        } else {
+            // Wrap the query in a bool query and apply filter level DLS query to it
+            filterLevelQueryBuilder.must(query);
+            searchSource.query(filterLevelQueryBuilder);
+        }
+    }
+
+    static boolean isHybridQuery(QueryBuilder query) {
+        return query != null && HYBRID_QUERY_NAME.equals(query.getName());
     }
 
     private boolean handle(GetRequest getRequest, StoredContext ctx) {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -177,7 +177,7 @@ public class DlsFilterLevelActionHandler {
                 applyDlsFilterToHybridQuery
                     ? ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED
                     : ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
-                log.isDebugEnabled() ? request.toString() : "true"
+                "true"
             );
 
             try {
@@ -186,7 +186,7 @@ public class DlsFilterLevelActionHandler {
                 }
 
                 if (log.isDebugEnabled()) {
-                    log.debug("Created filterLevelQuery for " + request + ":\n" + filterLevelQueryBuilder);
+                    log.debug("Created filter-level DLS query for request type {}", request.getClass().getSimpleName());
                 }
 
             } catch (Exception e) {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -357,9 +358,9 @@ public class DlsFilterLevelActionHandler {
      * Neural Search is an optional plugin, so Security identifies its hybrid query through the public query type name
      * instead of depending on its query builder class. {@link QueryBuilder#getName()} is OpenSearch's unique query type
      * identifier. A query builder registered as {@code hybrid} must expose every execution branch through its visitor.
-     * Security verifies after filtering that the number of branches is unchanged and that each branch preserves its
-     * original query while placing the exact supplied DLS query in a conjunctive boolean filter clause. Reader-level DLS
-     * remains active whenever this special path is selected.
+     * Security verifies after filtering that the identity-based multiset of branches is unchanged and that each branch
+     * preserves one original query while placing the exact supplied DLS query in a conjunctive boolean filter clause.
+     * Branch order is deliberately ignored. Reader-level DLS remains active whenever this special path is selected.
      */
     static boolean isHybridQuery(QueryBuilder query) {
         return query != null && HYBRID_QUERY_NAME.equals(query.getName());
@@ -374,14 +375,31 @@ public class DlsFilterLevelActionHandler {
         if (filteredSubqueries.size() != originalSubqueries.size()) {
             return false;
         }
-        for (int i = 0; i < filteredSubqueries.size(); i++) {
-            QueryBuilder originalSubquery = originalSubqueries.get(i);
-            QueryBuilder filteredSubquery = filteredSubqueries.get(i);
+
+        Map<QueryBuilder, Integer> unmatchedOriginalSubqueries = new IdentityHashMap<>();
+        originalSubqueries.forEach(originalSubquery -> unmatchedOriginalSubqueries.merge(originalSubquery, 1, Integer::sum));
+        for (QueryBuilder filteredSubquery : filteredSubqueries) {
             if (!(filteredSubquery instanceof BoolQueryBuilder boolQuery)
-                || boolQuery.filter().stream().noneMatch(query -> query == filterLevelQueryBuilder)
-                || (filteredSubquery != originalSubquery && boolQuery.must().stream().noneMatch(query -> query == originalSubquery))) {
+                || boolQuery.filter().stream().noneMatch(query -> query == filterLevelQueryBuilder)) {
                 return false;
             }
+
+            QueryBuilder preservedOriginalSubquery = null;
+            for (Map.Entry<QueryBuilder, Integer> entry : unmatchedOriginalSubqueries.entrySet()) {
+                QueryBuilder originalSubquery = entry.getKey();
+                if (entry.getValue() > 0
+                    && (filteredSubquery == originalSubquery || boolQuery.must().stream().anyMatch(query -> query == originalSubquery))) {
+                    if (preservedOriginalSubquery != null) {
+                        // A filtered branch must not merge multiple original hybrid execution branches.
+                        return false;
+                    }
+                    preservedOriginalSubquery = originalSubquery;
+                }
+            }
+            if (preservedOriginalSubquery == null) {
+                return false;
+            }
+            unmatchedOriginalSubqueries.computeIfPresent(preservedOriginalSubquery, (query, count) -> count - 1);
         }
         return true;
     }

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -304,7 +304,11 @@ public class DlsFilterLevelActionHandler {
             searchSource.query(filterLevelQueryBuilder);
         } else if (applyDlsFilterToHybridQuery && isHybridQuery(query)) {
             // Hybrid queries must remain top-level, so apply filter level DLS query directly
-            searchSource.query(query.filter(filterLevelQueryBuilder));
+            QueryBuilder filteredHybridQuery = query.filter(filterLevelQueryBuilder);
+            if (filteredHybridQuery == null) {
+                throw new OpenSearchSecurityException("Hybrid query returned no query after applying the DLS filter");
+            }
+            searchSource.query(filteredHybridQuery);
         } else {
             // Wrap the query in a bool query and apply filter level DLS query to it
             filterLevelQueryBuilder.must(query);
@@ -312,6 +316,12 @@ public class DlsFilterLevelActionHandler {
         }
     }
 
+    /**
+     * Neural Search is an optional plugin, so Security identifies its hybrid query through the public query type name
+     * instead of depending on its query builder class. {@link QueryBuilder#getName()} is OpenSearch's unique query type
+     * identifier. A query builder registered as {@code hybrid} must honor {@link QueryBuilder#filter(QueryBuilder)} by
+     * applying the supplied filter to every subquery.
+     */
     static boolean isHybridQuery(QueryBuilder query) {
         return query != null && HYBRID_QUERY_NAME.equals(query.getName());
     }

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -171,6 +171,9 @@ public class DlsFilterLevelActionHandler {
 
     private boolean handle() {
 
+        // Snapshot the outer context without clearing the current one. The internal header added below remains active
+        // while nodeClient dispatches the child request and is propagated to local search work; closing the stored
+        // context restores the caller's headers.
         try (StoredContext ctx = threadContext.newStoredContext(true)) {
 
             threadContext.putHeader(
@@ -279,6 +282,8 @@ public class DlsFilterLevelActionHandler {
     static SearchSourceBuilder getOrCreateSearchSource(SearchRequest searchRequest) {
         SearchSourceBuilder searchSource = searchRequest.source();
         if (searchSource == null) {
+            // A source-less search is an implicit match-all. Materialize its source so filter-level DLS can replace that
+            // implicit query with the DLS restriction while retaining SearchSourceBuilder's normal defaults.
             searchSource = SearchSourceBuilder.searchSource();
             searchRequest.source(searchSource);
         }
@@ -303,6 +308,9 @@ public class DlsFilterLevelActionHandler {
             // No query set, apply filter level DLS query directly
             searchSource.query(filterLevelQueryBuilder);
         } else if (applyDlsFilterToHybridQuery && isHybridQuery(query)) {
+            if (ParentChildrenQueryDetector.hasParentOrChildQuery(query)) {
+                throw new OpenSearchSecurityException("Unable to handle filter level DLS for hybrid queries with parent or child clauses");
+            }
             // Hybrid queries must remain top-level, so apply filter level DLS query directly
             QueryBuilder filteredHybridQuery = query.filter(filterLevelQueryBuilder);
             if (filteredHybridQuery == null) {
@@ -320,7 +328,8 @@ public class DlsFilterLevelActionHandler {
      * Neural Search is an optional plugin, so Security identifies its hybrid query through the public query type name
      * instead of depending on its query builder class. {@link QueryBuilder#getName()} is OpenSearch's unique query type
      * identifier. A query builder registered as {@code hybrid} must honor {@link QueryBuilder#filter(QueryBuilder)} by
-     * applying the supplied filter to every subquery.
+     * applying the supplied filter to every subquery and must expose every subquery through its visitor. Reader-level DLS
+     * remains active whenever this special path is selected, independently of the query builder's filter implementation.
      */
     static boolean isHybridQuery(QueryBuilder query) {
         return query != null && HYBRID_QUERY_NAME.equals(query.getName());

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -318,6 +318,9 @@ public class DlsFilterLevelActionHandler {
             if (filteredHybridQuery == null) {
                 throw new OpenSearchSecurityException("Hybrid query returned no query after applying the DLS filter");
             }
+            if (!isHybridQuery(filteredHybridQuery)) {
+                throw new OpenSearchSecurityException("Hybrid query was not preserved after applying the DLS filter");
+            }
             searchSource.query(filteredHybridQuery);
         } else {
             // Wrap the query in a bool query and apply filter level DLS query to it

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -51,6 +51,7 @@ import org.opensearch.index.IndexService;
 import org.opensearch.index.get.GetResult;
 import org.opensearch.index.mapper.MapperService;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
@@ -317,6 +318,9 @@ public class DlsFilterLevelActionHandler {
             if (originalSubqueries.isEmpty()) {
                 throw new OpenSearchSecurityException("Hybrid query does not expose subqueries for DLS verification");
             }
+            Set<BoolQueryBuilder> boolQueriesWithImplicitMinimumShouldMatch = findBoolQueriesWithImplicitMinimumShouldMatch(
+                originalSubqueries
+            );
             // Hybrid queries must remain top-level, so apply filter level DLS query directly
             QueryBuilder filteredHybridQuery = query.filter(filterLevelQueryBuilder);
             if (filteredHybridQuery == null) {
@@ -325,6 +329,7 @@ public class DlsFilterLevelActionHandler {
             if (!isHybridQuery(filteredHybridQuery)) {
                 throw new OpenSearchSecurityException("Hybrid query was not preserved after applying the DLS filter");
             }
+            preserveImplicitMinimumShouldMatch(boolQueriesWithImplicitMinimumShouldMatch, filterLevelQueryBuilder);
             if (!isDlsFilterAppliedToEverySubquery(filteredHybridQuery, filterLevelQueryBuilder, originalSubqueries)) {
                 throw new OpenSearchSecurityException("Hybrid query did not apply the DLS filter to every subquery");
             }
@@ -379,16 +384,10 @@ public class DlsFilterLevelActionHandler {
         Map<QueryBuilder, Integer> unmatchedOriginalSubqueries = new IdentityHashMap<>();
         originalSubqueries.forEach(originalSubquery -> unmatchedOriginalSubqueries.merge(originalSubquery, 1, Integer::sum));
         for (QueryBuilder filteredSubquery : filteredSubqueries) {
-            if (!(filteredSubquery instanceof BoolQueryBuilder boolQuery)
-                || boolQuery.filter().stream().noneMatch(query -> query == filterLevelQueryBuilder)) {
-                return false;
-            }
-
             QueryBuilder preservedOriginalSubquery = null;
             for (Map.Entry<QueryBuilder, Integer> entry : unmatchedOriginalSubqueries.entrySet()) {
                 QueryBuilder originalSubquery = entry.getKey();
-                if (entry.getValue() > 0
-                    && (filteredSubquery == originalSubquery || boolQuery.must().stream().anyMatch(query -> query == originalSubquery))) {
+                if (entry.getValue() > 0 && isDlsFilterAppliedToSubquery(filteredSubquery, originalSubquery, filterLevelQueryBuilder)) {
                     if (preservedOriginalSubquery != null) {
                         // A filtered branch must not merge multiple original hybrid execution branches.
                         return false;
@@ -399,9 +398,76 @@ public class DlsFilterLevelActionHandler {
             if (preservedOriginalSubquery == null) {
                 return false;
             }
+            preserveQueryMetadata(filteredSubquery, preservedOriginalSubquery);
             unmatchedOriginalSubqueries.computeIfPresent(preservedOriginalSubquery, (query, count) -> count - 1);
         }
         return true;
+    }
+
+    private static boolean isDlsFilterAppliedToSubquery(
+        QueryBuilder filteredSubquery,
+        QueryBuilder originalSubquery,
+        QueryBuilder filterLevelQueryBuilder
+    ) {
+        if (filteredSubquery instanceof BoolQueryBuilder boolQuery) {
+            return boolQuery.filter().stream().anyMatch(query -> query == filterLevelQueryBuilder)
+                && (filteredSubquery == originalSubquery || boolQuery.must().stream().anyMatch(query -> query == originalSubquery));
+        }
+        if (filteredSubquery instanceof ConstantScoreQueryBuilder filteredConstantScore
+            && originalSubquery instanceof ConstantScoreQueryBuilder originalConstantScore) {
+            return isDlsFilterAppliedToSubquery(
+                filteredConstantScore.innerQuery(),
+                originalConstantScore.innerQuery(),
+                filterLevelQueryBuilder
+            );
+        }
+        return false;
+    }
+
+    private static Set<BoolQueryBuilder> findBoolQueriesWithImplicitMinimumShouldMatch(List<QueryBuilder> originalSubqueries) {
+        Set<BoolQueryBuilder> boolQueriesWithImplicitMinimumShouldMatch = Collections.newSetFromMap(new IdentityHashMap<>());
+        QueryBuilderVisitor visitor = new QueryBuilderVisitor() {
+            @Override
+            public void accept(QueryBuilder queryBuilder) {
+                if (queryBuilder instanceof BoolQueryBuilder boolQuery
+                    && boolQuery.minimumShouldMatch() == null
+                    && !boolQuery.should().isEmpty()
+                    && boolQuery.must().isEmpty()
+                    && boolQuery.filter().isEmpty()) {
+                    boolQueriesWithImplicitMinimumShouldMatch.add(boolQuery);
+                }
+            }
+
+            @Override
+            public QueryBuilderVisitor getChildVisitor(BooleanClause.Occur occur) {
+                return this;
+            }
+        };
+        originalSubqueries.forEach(queryBuilder -> queryBuilder.visit(visitor));
+        return boolQueriesWithImplicitMinimumShouldMatch;
+    }
+
+    // BoolQueryBuilder.filter mutates the existing query. A filter makes otherwise optional should clauses optional
+    // in Lucene, while a bool query containing only should clauses implicitly requires one should clause to match.
+    private static void preserveImplicitMinimumShouldMatch(
+        Set<BoolQueryBuilder> boolQueriesWithImplicitMinimumShouldMatch,
+        QueryBuilder filterLevelQueryBuilder
+    ) {
+        for (BoolQueryBuilder boolQuery : boolQueriesWithImplicitMinimumShouldMatch) {
+            if (boolQuery.filter().stream().anyMatch(query -> query == filterLevelQueryBuilder)) {
+                boolQuery.minimumShouldMatch(1);
+            }
+        }
+    }
+
+    // ConstantScoreQueryBuilder.filter can return a new builder without copying its boost or query name.
+    private static void preserveQueryMetadata(QueryBuilder filteredSubquery, QueryBuilder originalSubquery) {
+        if (filteredSubquery instanceof ConstantScoreQueryBuilder filteredConstantScore
+            && originalSubquery instanceof ConstantScoreQueryBuilder originalConstantScore) {
+            filteredConstantScore.boost(originalConstantScore.boost());
+            filteredConstantScore.queryName(originalConstantScore.queryName());
+            preserveQueryMetadata(filteredConstantScore.innerQuery(), originalConstantScore.innerQuery());
+        }
     }
 
     private static List<QueryBuilder> directSubqueries(QueryBuilder query) {

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -295,7 +295,7 @@ public class DlsFilterLevelActionHandler {
     /**
      * Applies the filter level DLS query. When {@code applyDlsFilterToHybridQuery} is true, hybrid queries remain top-level
      * and their filter method propagates the DLS restriction to every subquery. Reader-level DLS must remain active in
-     * that case to protect search features which do not use the top-level query.
+     * that case to retain existing DLS behavior for search features which do not use the top-level query.
      * @param searchSource
      * @param filterLevelQueryBuilder
      * @param applyDlsFilterToHybridQuery whether to push the DLS filter into a top-level hybrid query

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -253,7 +253,9 @@ public class DlsFilterLevelActionHandler {
             }
         }
 
-        applyFilterLevelDls(searchSource, filterLevelQueryBuilder, applyDlsFilterToHybridQuery);
+        if (!tryApplyFilterLevelDls(searchSource, filterLevelQueryBuilder, applyDlsFilterToHybridQuery, listener)) {
+            return false;
+        }
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override
@@ -321,6 +323,24 @@ public class DlsFilterLevelActionHandler {
             // Wrap the query in a bool query and apply filter level DLS query to it
             filterLevelQueryBuilder.must(query);
             searchSource.query(filterLevelQueryBuilder);
+        }
+    }
+
+    static boolean tryApplyFilterLevelDls(
+        SearchSourceBuilder searchSource,
+        BoolQueryBuilder filterLevelQueryBuilder,
+        boolean applyDlsFilterToHybridQuery,
+        ActionListener<?> listener
+    ) {
+        try {
+            applyFilterLevelDls(searchSource, filterLevelQueryBuilder, applyDlsFilterToHybridQuery);
+            return true;
+        } catch (Exception e) {
+            log.error("Unable to apply filter-level DLS", e);
+            listener.onFailure(
+                e instanceof OpenSearchSecurityException ? e : new OpenSearchSecurityException("Unable to apply filter-level DLS", e)
+            );
+            return false;
         }
     }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -186,7 +186,12 @@ public class DlsFilterLevelActionHandler {
                 }
 
                 if (log.isDebugEnabled()) {
-                    log.debug("Created filter-level DLS query for request type {}", request.getClass().getSimpleName());
+                    // Do not log the request or query builder: either can contain sensitive request or DLS rule data.
+                    log.debug(
+                        "Created filter-level DLS query for request type {}; index scoping required: {}",
+                        request.getClass().getSimpleName(),
+                        requiresIndexScoping
+                    );
                 }
 
             } catch (Exception e) {
@@ -236,7 +241,8 @@ public class DlsFilterLevelActionHandler {
             }
         }
 
-        QueryBuilder query = searchRequest.source().query();
+        SearchSourceBuilder searchSource = getOrCreateSearchSource(searchRequest);
+        QueryBuilder query = searchSource.query();
         if (query != null) {
             if (ParentChildrenQueryDetector.hasParentOrChildQuery(query)) {
                 listener.onFailure(new OpenSearchSecurityException("Unable to handle filter level DLS for parent or child queries"));
@@ -244,7 +250,7 @@ public class DlsFilterLevelActionHandler {
             }
         }
 
-        applyFilterLevelDls(searchRequest.source(), filterLevelQueryBuilder, applyDlsFilterToHybridQuery);
+        applyFilterLevelDls(searchSource, filterLevelQueryBuilder, applyDlsFilterToHybridQuery);
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override
@@ -268,6 +274,15 @@ public class DlsFilterLevelActionHandler {
         });
 
         return false;
+    }
+
+    static SearchSourceBuilder getOrCreateSearchSource(SearchRequest searchRequest) {
+        SearchSourceBuilder searchSource = searchRequest.source();
+        if (searchSource == null) {
+            searchSource = SearchSourceBuilder.searchSource();
+            searchRequest.source(searchSource);
+        }
+        return searchSource;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -906,13 +906,20 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         return threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY) == Boolean.TRUE;
     }
 
+    private boolean isDlsQueryFilterApplied() {
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
+    }
+
     private boolean applyDlsHere() {
-        if (isSuggest() || isParentChildQuery()) {
+        return shouldApplyDlsToReader(isSuggest(), isParentChildQuery(), isDlsQueryFilterApplied(), getRuntimeActionName());
+    }
+
+    static boolean shouldApplyDlsToReader(boolean suggest, boolean parentChildQuery, boolean dlsQueryFilterApplied, String action) {
+        if (suggest || parentChildQuery || dlsQueryFilterApplied) {
             // we need to apply it here
             return true;
         }
 
-        final String action = getRuntimeActionName();
         assert action != null;
         // we need to apply here if it is not a search request
         // (a get for example)

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -907,7 +907,9 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
     }
 
     private boolean isDlsQueryFilterApplied() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
+        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
+            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+        );
     }
 
     private boolean applyDlsHere() {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsFilterLeafReader.java
@@ -906,14 +906,14 @@ class DlsFlsFilterLeafReader extends SequentialStoredFieldsLeafReader {
         return threadContext.getTransient(ConfigConstants.OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY) == Boolean.TRUE;
     }
 
-    private boolean isDlsQueryFilterApplied() {
+    static boolean isDlsQueryFilterApplied(ThreadContext threadContext) {
         return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
             threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
         );
     }
 
     private boolean applyDlsHere() {
-        return shouldApplyDlsToReader(isSuggest(), isParentChildQuery(), isDlsQueryFilterApplied(), getRuntimeActionName());
+        return shouldApplyDlsToReader(isSuggest(), isParentChildQuery(), isDlsQueryFilterApplied(threadContext), getRuntimeActionName());
     }
 
     static boolean shouldApplyDlsToReader(boolean suggest, boolean parentChildQuery, boolean dlsQueryFilterApplied, String action) {

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -257,13 +257,21 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     doFilterLevelDls = true;
                     log.debug("Doing filter-level DLS due to header");
                 } else {
-                    doFilterLevelDls = dlsRestrictionMap.containsAny(DlsRestriction::containsTermLookupQuery);
+                    doFilterLevelDls = shouldUseFilterLevelDlsInAdaptiveMode(
+                        request,
+                        hasDlsRestrictions,
+                        dlsRestrictionMap.containsAny(DlsRestriction::containsTermLookupQuery)
+                    );
 
                     if (doFilterLevelDls) {
                         setDlsModeHeader(Mode.FILTER_LEVEL);
-                        log.debug("Doing filter-level DLS because the query contains a TLQ");
+                        if (isTopLevelHybridQuery(request)) {
+                            log.debug("Doing filter-level DLS because the search contains a top-level hybrid query");
+                        } else {
+                            log.debug("Doing filter-level DLS because the query contains a TLQ");
+                        }
                     } else {
-                        log.debug("Doing lucene-level DLS because the query does not contain a TLQ");
+                        log.debug("Not using filter-level DLS because it is not required for this request");
                     }
                 }
             }
@@ -431,6 +439,23 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             log.error(e);
             throw e;
         }
+    }
+
+    static boolean shouldUseFilterLevelDlsInAdaptiveMode(
+        ActionRequest request,
+        boolean hasDlsRestrictions,
+        boolean containsTermLookupQuery
+    ) {
+        return hasDlsRestrictions && (containsTermLookupQuery || isTopLevelHybridQuery(request));
+    }
+
+    private static boolean isTopLevelHybridQuery(ActionRequest request) {
+        if (!(request instanceof SearchRequest searchRequest)) {
+            return false;
+        }
+
+        SearchSourceBuilder source = searchRequest.source();
+        return source != null && DlsFilterLevelActionHandler.isHybridQuery(source.query());
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BytesRef;
 
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchSecurityException;
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.RealtimeRequest;
 import org.opensearch.action.admin.indices.shrink.ResizeRequest;
@@ -96,6 +97,7 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_DLS_WRITE
 public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
     private static final String MAP_EXECUTION_HINT = "map";
+    private static final Version HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE = Version.V_3_9_0;
     private static final Logger log = LogManager.getLogger(DlsFlsValveImpl.class);
 
     private final Client nodeClient;
@@ -197,7 +199,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         nodeClient,
                         clusterService,
                         OpenSearchSecurityPlugin.GuiceHolder.getIndicesService(),
-                        threadContext
+                        threadContext,
+                        false
                     );
                 }
             }
@@ -230,11 +233,13 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return true;
             }
 
-            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
+            String filterLevelDlsDone = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+            String dlsQueryFilterApplied = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+            if (filterLevelDlsDone != null || dlsQueryFilterApplied != null) {
                 if (log.isDebugEnabled()) {
                     log.debug(
-                        "DLS is already done for: {}",
-                        threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                        "DLS query handling is already done for: {}",
+                        Objects.requireNonNullElse(filterLevelDlsDone, dlsQueryFilterApplied)
                     );
                 }
 
@@ -243,6 +248,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
             IndexToRuleMap<DlsRestriction> dlsRestrictionMap = null;
             boolean doFilterLevelDls;
+            boolean applyDlsFilterToHybridQuery = false;
 
             if (mode == Mode.FILTER_LEVEL) {
                 doFilterLevelDls = true;
@@ -257,19 +263,20 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     doFilterLevelDls = true;
                     log.debug("Doing filter-level DLS due to header");
                 } else {
-                    doFilterLevelDls = shouldUseFilterLevelDlsInAdaptiveMode(
+                    boolean containsTermLookupQuery = dlsRestrictionMap.containsAny(DlsRestriction::containsTermLookupQuery);
+                    doFilterLevelDls = shouldUseFilterLevelDlsInAdaptiveMode(hasDlsRestrictions, containsTermLookupQuery);
+                    applyDlsFilterToHybridQuery = shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
                         request,
                         hasDlsRestrictions,
-                        dlsRestrictionMap.containsAny(DlsRestriction::containsTermLookupQuery)
+                        containsTermLookupQuery,
+                        isHybridQueryDlsFilterSupported(clusterService.state().nodes().getMinNodeVersion())
                     );
 
                     if (doFilterLevelDls) {
                         setDlsModeHeader(Mode.FILTER_LEVEL);
-                        if (isTopLevelHybridQuery(request)) {
-                            log.debug("Doing filter-level DLS because the search contains a top-level hybrid query");
-                        } else {
-                            log.debug("Doing filter-level DLS because the query contains a TLQ");
-                        }
+                        log.debug("Doing filter-level DLS because the query contains a TLQ");
+                    } else if (applyDlsFilterToHybridQuery) {
+                        log.debug("Applying DLS to the top-level hybrid query while preserving reader-level DLS");
                     } else {
                         log.debug("Not using filter-level DLS because it is not required for this request");
                     }
@@ -277,7 +284,13 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
 
             if (DlsFlsLegacyHeaders.possiblyRequired(clusterService)) {
-                DlsFlsLegacyHeaders.prepare(threadContext, context, config, clusterService.state().metadata(), doFilterLevelDls);
+                DlsFlsLegacyHeaders.prepare(
+                    threadContext,
+                    context,
+                    config,
+                    clusterService.state().metadata(),
+                    doFilterLevelDls && !applyDlsFilterToHybridQuery
+                );
             }
 
             if (request instanceof RealtimeRequest) {
@@ -417,7 +430,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 }
             }
 
-            if (doFilterLevelDls && hasDlsRestrictions) {
+            if ((doFilterLevelDls || applyDlsFilterToHybridQuery) && hasDlsRestrictions) {
                 return DlsFilterLevelActionHandler.handle(
                     context,
                     dlsRestrictionMap,
@@ -425,7 +438,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                     nodeClient,
                     clusterService,
                     OpenSearchSecurityPlugin.GuiceHolder.getIndicesService(),
-                    threadContext
+                    threadContext,
+                    applyDlsFilterToHybridQuery
                 );
             } else {
                 return true;
@@ -441,12 +455,21 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         }
     }
 
-    static boolean shouldUseFilterLevelDlsInAdaptiveMode(
+    static boolean shouldUseFilterLevelDlsInAdaptiveMode(boolean hasDlsRestrictions, boolean containsTermLookupQuery) {
+        return hasDlsRestrictions && containsTermLookupQuery;
+    }
+
+    static boolean shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
         ActionRequest request,
         boolean hasDlsRestrictions,
-        boolean containsTermLookupQuery
+        boolean containsTermLookupQuery,
+        boolean hybridQueryDlsFilterSupported
     ) {
-        return hasDlsRestrictions && (containsTermLookupQuery || isTopLevelHybridQuery(request));
+        return hasDlsRestrictions && !containsTermLookupQuery && hybridQueryDlsFilterSupported && isTopLevelHybridQuery(request);
+    }
+
+    static boolean isHybridQueryDlsFilterSupported(Version minNodeVersion) {
+        return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }
 
     private static boolean isTopLevelHybridQuery(ActionRequest request) {
@@ -468,6 +491,13 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
 
             if (searchContext.suggest() != null) {
+                return;
+            }
+
+            if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
+                // The DLS filter is already present in every hybrid subquery. Reader-level DLS remains active to protect
+                // aggregations, suggestions, and other search features which do not use the top-level query.
+                log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                 return;
             }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -475,7 +475,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }
 
-    private static boolean isLocalOnlyRequest(OptionallyResolvedIndices resolved) {
+    static boolean isLocalOnlyRequest(OptionallyResolvedIndices resolved) {
         return resolved instanceof ResolvedIndices resolvedIndices && resolvedIndices.remote().isEmpty();
     }
 

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -494,13 +494,6 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return;
             }
 
-            if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
-                // The DLS filter is already present in every hybrid subquery. Reader-level DLS remains active to protect
-                // aggregations, suggestions, and other search features which do not use the top-level query.
-                log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
-                return;
-            }
-
             if (dlsFlsBaseContext.isDlsDoneOnFilterLevel() || mode == Mode.FILTER_LEVEL) {
                 // For filter level DLS, the query was already modified to include the DLS restrictions.
                 // Thus, we can exist here early.
@@ -552,6 +545,14 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
 
             if (!dlsRestriction.isUnrestricted()) {
+                if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
+                    // The DLS filter is already present in every hybrid subquery. Reader-level DLS remains active to protect
+                    // aggregations, suggestions, and other search features which do not use the top-level query. This check
+                    // intentionally follows the star-tree safeguard above.
+                    log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
+                    return;
+                }
+
                 if (mode == Mode.ADAPTIVE && dlsRestriction.containsTermLookupQuery()) {
                     // Special case for scroll operations:
                     // Normally, the check dlsFlsBaseContext.isDlsDoneOnFilterLevel() already aborts early if DLS filter level mode

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -235,8 +235,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return true;
             }
 
-            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
-                || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
+            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
                 if (log.isDebugEnabled()) {
                     log.debug("DLS query handling is already done for this request");
                 }
@@ -559,9 +558,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
                     // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // DlsFlsFilterLeafReader sees OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED and retains the existing
-                    // reader-level DLS behavior for aggregations, suggestions, and other paths. This check intentionally
-                    // follows the star-tree safeguard above.
+                    // DlsFlsFilterLeafReader sees the hybrid value on OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE and
+                    // retains the existing reader-level DLS behavior for aggregations, suggestions, and other paths.
+                    // This check intentionally follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;
                 }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -559,9 +559,10 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
-                    // The DLS filter is already present in every hybrid subquery. Reader-level DLS remains active to protect
-                    // aggregations, suggestions, and other search features which do not use the top-level query. This check
-                    // intentionally follows the star-tree safeguard above.
+                    // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
+                    // DlsFlsFilterLeafReader sees OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED and still applies reader-level
+                    // DLS to aggregations, suggestions, and other paths. This check intentionally follows the star-tree
+                    // safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;
                 }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -559,9 +559,9 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             if (!dlsRestriction.isUnrestricted()) {
                 if (dlsFlsBaseContext.isDlsQueryFilterApplied()) {
                     // The top-level hybrid filter already protects hits, so parsed-query rewriting is not needed here.
-                    // DlsFlsFilterLeafReader sees OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED and still applies reader-level
-                    // DLS to aggregations, suggestions, and other paths. This check intentionally follows the star-tree
-                    // safeguard above.
+                    // DlsFlsFilterLeafReader sees OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED and retains the existing
+                    // reader-level DLS behavior for aggregations, suggestions, and other paths. This check intentionally
+                    // follows the star-tree safeguard above.
                     log.trace("handleSearchContext(): DLS is applied to the hybrid query; preserving reader-level DLS");
                     return;
                 }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -282,13 +282,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
 
             if (DlsFlsLegacyHeaders.possiblyRequired(clusterService)) {
-                DlsFlsLegacyHeaders.prepare(
-                    threadContext,
-                    context,
-                    config,
-                    clusterService.state().metadata(),
-                    doFilterLevelDls && !applyDlsFilterToHybridQuery
-                );
+                DlsFlsLegacyHeaders.prepare(threadContext, context, config, clusterService.state().metadata(), doFilterLevelDls);
             }
 
             if (request instanceof RealtimeRequest) {
@@ -471,6 +465,12 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             && isTopLevelHybridQueryWithoutParentChildClauses(request);
     }
 
+    /**
+     * The minimum OpenSearch version is only a lower bound for the Neural Search hybrid-query contract. If a future
+     * Neural Search release changes its {@code filter()} or {@code visit()} behavior, the verification in
+     * {@link DlsFilterLevelActionHandler} rejects the request rather than applying DLS incompletely. Keep the
+     * cross-plugin {@code HybridQueryDlsIT} coverage in sync with that contract.
+     */
     static boolean isHybridQueryDlsFilterSupported(Version minNodeVersion) {
         return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -88,6 +88,7 @@ import org.opensearch.security.support.HeaderHelper;
 import org.opensearch.security.support.SecuritySettings;
 import org.opensearch.security.support.WildcardMatcher;
 import org.opensearch.security.user.User;
+import org.opensearch.security.util.ParentChildrenQueryDetector;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -269,7 +270,8 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                         request,
                         hasDlsRestrictions,
                         containsTermLookupQuery,
-                        isHybridQueryDlsFilterSupported(clusterService.state().nodes().getMinNodeVersion())
+                        isHybridQueryDlsFilterSupported(clusterService.state().nodes().getMinNodeVersion()),
+                        isLocalOnlyRequest(resolved)
                     );
 
                     if (doFilterLevelDls) {
@@ -463,22 +465,33 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         ActionRequest request,
         boolean hasDlsRestrictions,
         boolean containsTermLookupQuery,
-        boolean hybridQueryDlsFilterSupported
+        boolean hybridQueryDlsFilterSupported,
+        boolean localOnlyRequest
     ) {
-        return hasDlsRestrictions && !containsTermLookupQuery && hybridQueryDlsFilterSupported && isTopLevelHybridQuery(request);
+        return hasDlsRestrictions
+            && !containsTermLookupQuery
+            && hybridQueryDlsFilterSupported
+            && localOnlyRequest
+            && isTopLevelHybridQueryWithoutParentChildClauses(request);
     }
 
     static boolean isHybridQueryDlsFilterSupported(Version minNodeVersion) {
         return minNodeVersion != null && minNodeVersion.onOrAfter(HYBRID_QUERY_DLS_FILTER_SUPPORTED_SINCE);
     }
 
-    private static boolean isTopLevelHybridQuery(ActionRequest request) {
+    private static boolean isLocalOnlyRequest(OptionallyResolvedIndices resolved) {
+        return resolved instanceof ResolvedIndices resolvedIndices && resolvedIndices.remote().isEmpty();
+    }
+
+    private static boolean isTopLevelHybridQueryWithoutParentChildClauses(ActionRequest request) {
         if (!(request instanceof SearchRequest searchRequest)) {
             return false;
         }
 
         SearchSourceBuilder source = searchRequest.source();
-        return source != null && DlsFilterLevelActionHandler.isHybridQuery(source.query());
+        return source != null
+            && DlsFilterLevelActionHandler.isHybridQuery(source.query())
+            && !ParentChildrenQueryDetector.hasParentOrChildQuery(source.query());
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -51,6 +51,7 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.query.ParsedQuery;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.reindex.ReindexAction;
 import org.opensearch.script.mustache.RenderSearchTemplateAction;
 import org.opensearch.search.DocValueFormat;
@@ -234,14 +235,10 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
                 return true;
             }
 
-            String filterLevelDlsDone = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
-            String dlsQueryFilterApplied = threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
-            if (filterLevelDlsDone != null || dlsQueryFilterApplied != null) {
+            if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null
+                || threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null) {
                 if (log.isDebugEnabled()) {
-                    log.debug(
-                        "DLS query handling is already done for: {}",
-                        Objects.requireNonNullElse(filterLevelDlsDone, dlsQueryFilterApplied)
-                    );
+                    log.debug("DLS query handling is already done for this request");
                 }
 
                 return true;
@@ -489,9 +486,11 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
         }
 
         SearchSourceBuilder source = searchRequest.source();
-        return source != null
-            && DlsFilterLevelActionHandler.isHybridQuery(source.query())
-            && !ParentChildrenQueryDetector.hasParentOrChildQuery(source.query());
+        if (source == null) {
+            return false;
+        }
+        QueryBuilder query = source.query();
+        return DlsFilterLevelActionHandler.isHybridQuery(query) && !ParentChildrenQueryDetector.hasParentOrChildQuery(query);
     }
 
     @Override

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,11 +64,11 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        if (threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
+    }
+
+    public boolean isDlsQueryFilterApplied() {
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
     }
 
     /**

--- a/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
+++ b/src/main/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContext.java
@@ -64,11 +64,13 @@ public class DlsFlsBaseContext {
     }
 
     public boolean isDlsDoneOnFilterLevel() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null;
+        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE) != null && !isDlsQueryFilterApplied();
     }
 
     public boolean isDlsQueryFilterApplied() {
-        return threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED) != null;
+        return ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
+            threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+        );
     }
 
     /**

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,6 +72,8 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
+    public static final String OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
+        + "dls_query_filter_applied";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,7 +72,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
-    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = "hybrid_query";
+    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "hybrid_query";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -72,8 +72,7 @@ public class ConfigConstants {
     public static final String OPENDISTRO_SECURITY_DOC_ALLOWLIST_TRANSIENT = OPENDISTRO_SECURITY_CONFIG_PREFIX + "doc_allowlist_t";
 
     public static final String OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE = OPENDISTRO_SECURITY_CONFIG_PREFIX + "filter_level_dls_done";
-    public static final String OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED = OPENDISTRO_SECURITY_CONFIG_PREFIX
-        + "dls_query_filter_applied";
+    public static final String OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE = "hybrid_query";
     public static final String OPENDISTRO_SECURITY_CONTAIN_PARENT_CHILD_QUERY = OPENDISTRO_SECURITY_CONFIG_PREFIX + "is_parent_child_query";
 
     public static final String OPENDISTRO_SECURITY_DLS_QUERY_CCS = OPENDISTRO_SECURITY_CONFIG_PREFIX + "dls_query_ccs";

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -222,13 +222,12 @@ public class SecurityInterceptor {
             boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
                 && !clusterInfoHolder.hasNode(connection.getNode());
 
-            if (isSearchAction
-                && isDestinationOutsideLocalCluster
+            if (isDestinationOutsideLocalCluster
                 && ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
                     headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
                 )) {
-                // The top-level query filter is only valid within the coordinating cluster. Strip its marker from any
-                // unrecognized destination even if RemoteClusterService does not currently report CCS as enabled.
+                // The top-level query filter is only valid within the coordinating cluster. Strip its marker from every
+                // action sent to an unrecognized destination, even if RemoteClusterService does not report CCS as enabled.
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
             }
 

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -202,7 +202,6 @@ public class SecurityInterceptor {
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
-                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER)
                             || k.equals(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS)
@@ -231,7 +230,6 @@ public class SecurityInterceptor {
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
-                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER);
             }

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -218,7 +218,7 @@ public class SecurityInterceptor {
                 dlsFlsLegacyHeaders.performHeaderDecoration(connection, request, headerMap);
             }
 
-            if (OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled()
+            if (isCrossClusterSearchEnabled()
                 && clusterInfoHolder.isInitialized()
                 && (action.equals(ClusterSearchShardsAction.NAME) || action.equals(SearchAction.NAME))
                 && !clusterInfoHolder.hasNode(connection.getNode())) {
@@ -234,7 +234,7 @@ public class SecurityInterceptor {
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER);
             }
 
-            if (OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled()
+            if (isCrossClusterSearchEnabled()
                 && clusterInfoHolder.isInitialized()
                 && !action.startsWith("internal:")
                 && !action.equals(ClusterSearchShardsAction.NAME)
@@ -256,7 +256,7 @@ public class SecurityInterceptor {
             }
 
             if (StringUtils.isNotEmpty(injectedRolesValidationString)
-                && OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled()
+                && isCrossClusterSearchEnabled()
                 && !clusterInfoHolder.hasNode(connection.getNode())
                 && getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_INJECTED_ROLES_VALIDATION_HEADER) == null) {
                 // Sending roles validation for only cross cluster requests
@@ -287,6 +287,10 @@ public class SecurityInterceptor {
 
             sender.sendRequest(connection, action, request, options, restoringHandler);
         }
+    }
+
+    boolean isCrossClusterSearchEnabled() {
+        return OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService().isCrossClusterSearchEnabled();
     }
 
     private void ensureCorrectHeaders(

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -202,6 +202,7 @@ public class SecurityInterceptor {
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                            || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER)
                             || k.equals(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER)
                             || k.equals(ConfigConstants.OPENSEARCH_SECURITY_REQUEST_HEADERS)
@@ -230,6 +231,7 @@ public class SecurityInterceptor {
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FLS_FIELDS_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER);
                 headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER);
             }

--- a/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
+++ b/src/main/java/org/opensearch/security/transport/SecurityInterceptor.java
@@ -218,10 +218,21 @@ public class SecurityInterceptor {
                 dlsFlsLegacyHeaders.performHeaderDecoration(connection, request, headerMap);
             }
 
-            if (isCrossClusterSearchEnabled()
-                && clusterInfoHolder.isInitialized()
-                && (action.equals(ClusterSearchShardsAction.NAME) || action.equals(SearchAction.NAME))
-                && !clusterInfoHolder.hasNode(connection.getNode())) {
+            boolean isSearchAction = action.equals(ClusterSearchShardsAction.NAME) || action.equals(SearchAction.NAME);
+            boolean isDestinationOutsideLocalCluster = clusterInfoHolder.isInitialized()
+                && !clusterInfoHolder.hasNode(connection.getNode());
+
+            if (isSearchAction
+                && isDestinationOutsideLocalCluster
+                && ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE.equals(
+                    headerMap.get(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE)
+                )) {
+                // The top-level query filter is only valid within the coordinating cluster. Strip its marker from any
+                // unrecognized destination even if RemoteClusterService does not currently report CCS as enabled.
+                headerMap.remove(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+            }
+
+            if (isCrossClusterSearchEnabled() && isSearchAction && isDestinationOutsideLocalCluster) {
                 if (isDebugEnabled) {
                     log.debug("remove dls/fls/mf because we sent a ccs request to a remote cluster");
                 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +39,7 @@ public class DlsFilterLevelActionHandlerTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         when(hybridQuery.filter(dlsQuery)).thenReturn(hybridQuery);
 
-        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
 
         assertThat(searchSource.query(), sameInstance(hybridQuery));
         assertThat(dlsQuery.must(), empty());
@@ -56,7 +57,7 @@ public class DlsFilterLevelActionHandlerTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
 
-        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
 
         assertThat(searchSource.query(), sameInstance(filteredHybridQuery));
         verify(hybridQuery).filter(dlsQuery);
@@ -68,7 +69,7 @@ public class DlsFilterLevelActionHandlerTest {
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(originalQuery);
 
-        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, false);
 
         assertThat(searchSource.query(), sameInstance(dlsQuery));
         assertThat(dlsQuery.must(), contains(sameInstance(originalQuery)));
@@ -80,11 +81,26 @@ public class DlsFilterLevelActionHandlerTest {
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource();
 
-        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, false);
 
         assertThat(searchSource.query(), sameInstance(dlsQuery));
         assertThat(dlsQuery.must(), empty());
         assertThat(dlsQuery.should(), hasSize(1));
+    }
+
+    @Test
+    public void wrapsHybridQueryWhenReaderLevelDlsIsNotPreserved() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, false);
+
+        assertThat(searchSource.query(), sameInstance(dlsQuery));
+        assertThat(dlsQuery.must(), contains(sameInstance(hybridQuery)));
+        verify(hybridQuery, never()).filter(dlsQuery);
     }
 
     private static BoolQueryBuilder createDlsQuery() {

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.configuration;
+
+import org.junit.Test;
+
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DlsFilterLevelActionHandlerTest {
+
+    @Test
+    public void appliesDlsAsFilterToTopLevelHybridQuery() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(dlsQuery)).thenReturn(hybridQuery);
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+        assertThat(dlsQuery.must(), empty());
+        assertThat(dlsQuery.should(), hasSize(1));
+        verify(hybridQuery).filter(dlsQuery);
+    }
+
+    @Test
+    public void usesQueryReturnedByHybridFilter() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+
+        assertThat(searchSource.query(), sameInstance(filteredHybridQuery));
+        verify(hybridQuery).filter(dlsQuery);
+    }
+
+    @Test
+    public void wrapsNonHybridQueryWithDlsQuery() {
+        QueryBuilder originalQuery = QueryBuilders.matchAllQuery();
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(originalQuery);
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+
+        assertThat(searchSource.query(), sameInstance(dlsQuery));
+        assertThat(dlsQuery.must(), contains(sameInstance(originalQuery)));
+        assertThat(dlsQuery.should(), hasSize(1));
+    }
+
+    @Test
+    public void usesDlsQueryWhenSearchHasNoQuery() {
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource();
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery);
+
+        assertThat(searchSource.query(), sameInstance(dlsQuery));
+        assertThat(dlsQuery.must(), empty());
+        assertThat(dlsQuery.should(), hasSize(1));
+    }
+
+    private static BoolQueryBuilder createDlsQuery() {
+        return QueryBuilders.boolQuery().minimumShouldMatch(1).should(QueryBuilders.termQuery("tenant", "allowed"));
+    }
+}

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -59,11 +59,16 @@ public class DlsFilterLevelActionHandlerTest {
     @Test
     public void appliesDlsAsFilterToTopLevelHybridQuery() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder originalSubquery = QueryBuilders.boolQuery().must(QueryBuilders.matchAllQuery());
+        QueryBuilder[] subqueries = { originalSubquery };
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        when(hybridQuery.filter(dlsQuery)).thenReturn(hybridQuery);
+        stubHybridQuery(hybridQuery, subqueries);
+        when(hybridQuery.filter(dlsQuery)).thenAnswer(invocation -> {
+            subqueries[0] = originalSubquery.filter(dlsQuery);
+            return hybridQuery;
+        });
 
         DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
 
@@ -77,11 +82,13 @@ public class DlsFilterLevelActionHandlerTest {
     public void usesQueryReturnedByHybridFilter() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        when(filteredHybridQuery.getName()).thenReturn("hybrid");
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, firstSubquery.filter(dlsQuery), secondSubquery.filter(dlsQuery));
         when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
 
         DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
@@ -91,12 +98,96 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
-    public void failsClosedWhenHybridFilterReturnsNull() {
+    public void failsClosedWhenHybridFilterDoesNotReachEverySubquery() {
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, firstSubquery.filter(dlsQuery), secondSubquery);
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterDropsSubquery() {
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, firstSubquery.filter(dlsQuery));
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridNameDoesNotExposeSubqueries() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
 
         when(hybridQuery.getName()).thenReturn("hybrid");
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query does not expose subqueries for DLS verification"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+        verify(hybridQuery, never()).filter(dlsQuery);
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterIsOnlyOptional() {
+        QueryBuilder originalSubquery = QueryBuilders.matchAllQuery();
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        BoolQueryBuilder unsafeFilteredSubquery = QueryBuilders.boolQuery().should(originalSubquery).should(dlsQuery);
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, originalSubquery);
+        stubHybridQuery(filteredHybridQuery, unsafeFilteredSubquery);
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterReturnsNull() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, QueryBuilders.matchAllQuery());
         when(hybridQuery.filter(dlsQuery)).thenReturn(null);
 
         OpenSearchSecurityException exception = assertThrows(
@@ -115,7 +206,7 @@ public class DlsFilterLevelActionHandlerTest {
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
+        stubHybridQuery(hybridQuery, QueryBuilders.matchAllQuery());
         when(nonHybridQuery.getName()).thenReturn("bool");
         when(hybridQuery.filter(dlsQuery)).thenReturn(nonHybridQuery);
 
@@ -136,7 +227,7 @@ public class DlsFilterLevelActionHandlerTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
+        stubHybridQuery(hybridQuery, QueryBuilders.matchAllQuery());
         when(hybridQuery.filter(dlsQuery)).thenReturn(null);
 
         boolean applied = DlsFilterLevelActionHandler.tryApplyFilterLevelDls(searchSource, dlsQuery, true, listener);
@@ -160,7 +251,7 @@ public class DlsFilterLevelActionHandlerTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
+        stubHybridQuery(hybridQuery, QueryBuilders.matchAllQuery());
         when(hybridQuery.filter(dlsQuery)).thenThrow(failure);
 
         boolean applied = DlsFilterLevelActionHandler.tryApplyFilterLevelDls(searchSource, dlsQuery, true, listener);
@@ -313,6 +404,8 @@ public class DlsFilterLevelActionHandlerTest {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        QueryBuilder originalSubquery = QueryBuilders.matchAllQuery();
+        QueryBuilder[] filteredSubqueries = new QueryBuilder[1];
         SearchRequest searchRequest = new SearchRequest("index").source(SearchSourceBuilder.searchSource().query(hybridQuery));
         DocumentPrivileges.RenderedDlsQuery renderedDlsQuery = mock(DocumentPrivileges.RenderedDlsQuery.class);
         DlsRestriction dlsRestriction = new DlsRestriction(List.of(renderedDlsQuery));
@@ -323,9 +416,12 @@ public class DlsFilterLevelActionHandlerTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        when(filteredHybridQuery.getName()).thenReturn("hybrid");
-        when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(filteredHybridQuery);
+        stubHybridQuery(hybridQuery, originalSubquery);
+        stubHybridQuery(filteredHybridQuery, filteredSubqueries);
+        when(hybridQuery.filter(any(QueryBuilder.class))).thenAnswer(invocation -> {
+            filteredSubqueries[0] = originalSubquery.filter(invocation.getArgument(0));
+            return filteredHybridQuery;
+        });
         when(renderedDlsQuery.getQueryBuilder()).thenReturn(QueryBuilders.termQuery("tenant", "allowed"));
         when(context.getAction()).thenReturn("indices:data/read/search");
         when(context.getRequest()).thenReturn(searchRequest);
@@ -379,7 +475,7 @@ public class DlsFilterLevelActionHandlerTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
 
-        when(hybridQuery.getName()).thenReturn("hybrid");
+        stubHybridQuery(hybridQuery, QueryBuilders.matchAllQuery());
         when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(null);
         when(renderedDlsQuery.getQueryBuilder()).thenReturn(QueryBuilders.termQuery("tenant", "allowed"));
         when(context.getAction()).thenReturn("indices:data/read/search");
@@ -437,6 +533,19 @@ public class DlsFilterLevelActionHandlerTest {
 
     private static BoolQueryBuilder createDlsQuery() {
         return QueryBuilders.boolQuery().minimumShouldMatch(1).should(QueryBuilders.termQuery("tenant", "allowed"));
+    }
+
+    private static void stubHybridQuery(QueryBuilder hybridQuery, QueryBuilder... subqueries) {
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        doAnswer(invocation -> {
+            QueryBuilderVisitor visitor = invocation.getArgument(0);
+            visitor.accept(hybridQuery);
+            QueryBuilderVisitor subqueryVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
+            for (QueryBuilder subquery : subqueries) {
+                subquery.visit(subqueryVisitor);
+            }
+            return null;
+        }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
     }
 
     private static void assertDlsMarkerPreventsReentry(String value) {

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -77,6 +77,18 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
+    public void wrapsNonHybridQueryEvenWhenHybridFilterFlagIsSet() {
+        QueryBuilder originalQuery = QueryBuilders.matchAllQuery();
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(originalQuery);
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
+
+        assertThat(searchSource.query(), sameInstance(dlsQuery));
+        assertThat(dlsQuery.must(), contains(sameInstance(originalQuery)));
+    }
+
+    @Test
     public void usesDlsQueryWhenSearchHasNoQuery() {
         BoolQueryBuilder dlsQuery = createDlsQuery();
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource();

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -228,12 +228,12 @@ public class DlsFilterLevelActionHandlerTest {
 
     @Test
     public void filterLevelDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+        assertDlsMarkerPreventsReentry("true");
     }
 
     @Test
     public void hybridQueryDlsMarkerPreventsReentry() {
-        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
     }
 
     @Test
@@ -266,9 +266,9 @@ public class DlsFilterLevelActionHandlerTest {
         return QueryBuilders.boolQuery().minimumShouldMatch(1).should(QueryBuilders.termQuery("tenant", "allowed"));
     }
 
-    private static void assertDlsMarkerPreventsReentry(String header) {
+    private static void assertDlsMarkerPreventsReentry(String value) {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(header, "true");
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
 
         boolean result = DlsFilterLevelActionHandler.handle(null, null, null, null, null, null, threadContext, false);
 

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -11,11 +11,20 @@
 
 package org.opensearch.security.configuration;
 
+import java.util.List;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.apache.lucene.search.BooleanClause;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
@@ -25,7 +34,11 @@ import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
+import org.opensearch.security.privileges.dlsfls.DlsRestriction;
+import org.opensearch.security.privileges.dlsfls.DocumentPrivileges;
+import org.opensearch.security.privileges.dlsfls.IndexToRuleMap;
 import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -139,6 +152,31 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
+    public void wrapsUnexpectedHybridFilterFailureForActionListener() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+        IllegalStateException failure = new IllegalStateException("filter failed");
+        @SuppressWarnings("unchecked")
+        ActionListener<Object> listener = mock(ActionListener.class);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(dlsQuery)).thenThrow(failure);
+
+        boolean applied = DlsFilterLevelActionHandler.tryApplyFilterLevelDls(searchSource, dlsQuery, true, listener);
+
+        assertThat(applied, is(false));
+        verify(listener).onFailure(
+            org.mockito.ArgumentMatchers.argThat(
+                exception -> exception instanceof OpenSearchSecurityException
+                    && exception.getMessage().equals("Unable to apply filter-level DLS")
+                    && exception.getCause() == failure
+            )
+        );
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
     public void failsClosedWhenHybridQueryContainsParentChildClause() {
         QueryBuilder parentChildQuery = mock(QueryBuilder.class);
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
@@ -234,6 +272,141 @@ public class DlsFilterLevelActionHandlerTest {
     @Test
     public void hybridQueryDlsMarkerPreventsReentry() {
         assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+    }
+
+    @Test
+    public void scopesFilterLevelCompletionStateToChildRequest() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        SearchRequest searchRequest = new SearchRequest("index");
+        ResolvedIndices resolved = ResolvedIndices.of("index");
+        @SuppressWarnings("unchecked")
+        IndexToRuleMap<DlsRestriction> restrictions = mock(IndexToRuleMap.class);
+        ClusterService clusterService = mock(ClusterService.class);
+
+        when(context.getAction()).thenReturn("indices:data/read/search");
+        when(context.getRequest()).thenReturn(searchRequest);
+        when(context.getResolvedIndices()).thenReturn(resolved);
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        when(restrictions.getIndexMap()).thenAnswer(invocation -> {
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is("true"));
+            return ImmutableMap.of();
+        });
+
+        boolean result = DlsFilterLevelActionHandler.handle(
+            context,
+            restrictions,
+            mock(ActionListener.class),
+            mock(Client.class),
+            clusterService,
+            null,
+            threadContext,
+            false
+        );
+
+        assertThat(result, is(true));
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+    }
+
+    @Test
+    public void dispatchesHybridSearchWithHybridCompletionState() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        SearchRequest searchRequest = new SearchRequest("index").source(SearchSourceBuilder.searchSource().query(hybridQuery));
+        DocumentPrivileges.RenderedDlsQuery renderedDlsQuery = mock(DocumentPrivileges.RenderedDlsQuery.class);
+        DlsRestriction dlsRestriction = new DlsRestriction(List.of(renderedDlsQuery));
+        IndexToRuleMap<DlsRestriction> restrictions = new IndexToRuleMap<>(ImmutableMap.of("index", dlsRestriction));
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        Client nodeClient = mock(Client.class);
+        @SuppressWarnings("unchecked")
+        ActionListener<Object> listener = mock(ActionListener.class);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(filteredHybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(filteredHybridQuery);
+        when(renderedDlsQuery.getQueryBuilder()).thenReturn(QueryBuilders.termQuery("tenant", "allowed"));
+        when(context.getAction()).thenReturn("indices:data/read/search");
+        when(context.getRequest()).thenReturn(searchRequest);
+        when(context.getResolvedIndices()).thenReturn(ResolvedIndices.of("index"));
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+        doAnswer(invocation -> {
+            assertThat(
+                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
+                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE)
+            );
+            return null;
+        }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
+
+        org.apache.logging.log4j.core.Logger logger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(
+            DlsFilterLevelActionHandler.class
+        );
+        Level previousLevel = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        try {
+            boolean result = DlsFilterLevelActionHandler.handle(
+                context,
+                restrictions,
+                listener,
+                nodeClient,
+                clusterService,
+                null,
+                threadContext,
+                true
+            );
+
+            assertThat(result, is(false));
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+            assertThat(searchRequest.source().query(), sameInstance(filteredHybridQuery));
+            verify(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
+        } finally {
+            logger.setLevel(previousLevel);
+        }
+    }
+
+    @Test
+    public void reportsHybridFilterFailureFromHandler() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        SearchRequest searchRequest = new SearchRequest("index").source(SearchSourceBuilder.searchSource().query(hybridQuery));
+        DocumentPrivileges.RenderedDlsQuery renderedDlsQuery = mock(DocumentPrivileges.RenderedDlsQuery.class);
+        DlsRestriction dlsRestriction = new DlsRestriction(List.of(renderedDlsQuery));
+        IndexToRuleMap<DlsRestriction> restrictions = new IndexToRuleMap<>(ImmutableMap.of("index", dlsRestriction));
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        ClusterService clusterService = mock(ClusterService.class);
+        Client nodeClient = mock(Client.class);
+        @SuppressWarnings("unchecked")
+        ActionListener<Object> listener = mock(ActionListener.class);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(null);
+        when(renderedDlsQuery.getQueryBuilder()).thenReturn(QueryBuilders.termQuery("tenant", "allowed"));
+        when(context.getAction()).thenReturn("indices:data/read/search");
+        when(context.getRequest()).thenReturn(searchRequest);
+        when(context.getResolvedIndices()).thenReturn(ResolvedIndices.of("index"));
+        when(clusterService.state()).thenReturn(mock(ClusterState.class));
+
+        boolean result = DlsFilterLevelActionHandler.handle(
+            context,
+            restrictions,
+            listener,
+            nodeClient,
+            clusterService,
+            null,
+            threadContext,
+            true
+        );
+
+        assertThat(result, is(false));
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+        verify(listener).onFailure(
+            org.mockito.ArgumentMatchers.argThat(
+                exception -> exception instanceof OpenSearchSecurityException
+                    && exception.getMessage().equals("Hybrid query returned no query after applying the DLS filter")
+            )
+        );
+        verify(nodeClient, never()).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -98,6 +98,24 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
+    public void acceptsFilteredHybridSubqueriesInDifferentOrder() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, secondSubquery.filter(dlsQuery), firstSubquery.filter(dlsQuery));
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
+
+        assertThat(searchSource.query(), sameInstance(filteredHybridQuery));
+    }
+
+    @Test
     public void failsClosedWhenHybridFilterDoesNotReachEverySubquery() {
         QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
         QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
@@ -142,6 +160,51 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
+    public void failsClosedWhenHybridFilterDuplicatesOneSubquery() {
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, firstSubquery.filter(dlsQuery), firstSubquery.filter(dlsQuery));
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterMergesOriginalSubqueries() {
+        QueryBuilder firstSubquery = QueryBuilders.termQuery("signal", "first");
+        QueryBuilder secondSubquery = QueryBuilders.termQuery("signal", "second");
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        BoolQueryBuilder mergedSubquery = QueryBuilders.boolQuery().must(firstSubquery).must(secondSubquery).filter(dlsQuery);
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, firstSubquery, secondSubquery);
+        stubHybridQuery(filteredHybridQuery, mergedSubquery, firstSubquery.filter(dlsQuery));
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
     public void failsClosedWhenHybridNameDoesNotExposeSubqueries() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         BoolQueryBuilder dlsQuery = createDlsQuery();
@@ -170,6 +233,30 @@ public class DlsFilterLevelActionHandlerTest {
 
         stubHybridQuery(hybridQuery, originalSubquery);
         stubHybridQuery(filteredHybridQuery, unsafeFilteredSubquery);
+        when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query did not apply the DLS filter to every subquery"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterUsesDifferentFilter() {
+        QueryBuilder originalSubquery = QueryBuilders.matchAllQuery();
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        BoolQueryBuilder wrongFilteredSubquery = QueryBuilders.boolQuery()
+            .must(originalSubquery)
+            .filter(QueryBuilders.termQuery("tenant", "other"));
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, originalSubquery);
+        stubHybridQuery(filteredHybridQuery, wrongFilteredSubquery);
         when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
 
         OpenSearchSecurityException exception = assertThrows(

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -68,6 +68,7 @@ public class DlsFilterLevelActionHandlerTest {
         SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
 
         when(hybridQuery.getName()).thenReturn("hybrid");
+        when(filteredHybridQuery.getName()).thenReturn("hybrid");
         when(hybridQuery.filter(dlsQuery)).thenReturn(filteredHybridQuery);
 
         DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
@@ -91,6 +92,26 @@ public class DlsFilterLevelActionHandlerTest {
         );
 
         assertThat(exception.getMessage(), is("Hybrid query returned no query after applying the DLS filter"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterReturnsNonHybridQuery() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder nonHybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(nonHybridQuery.getName()).thenReturn("bool");
+        when(hybridQuery.filter(dlsQuery)).thenReturn(nonHybridQuery);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query was not preserved after applying the DLS filter"));
         assertThat(searchSource.query(), sameInstance(hybridQuery));
     }
 

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -13,6 +13,7 @@ package org.opensearch.security.configuration;
 
 import org.junit.Test;
 
+import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
@@ -23,7 +24,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -62,6 +65,24 @@ public class DlsFilterLevelActionHandlerTest {
 
         assertThat(searchSource.query(), sameInstance(filteredHybridQuery));
         verify(hybridQuery).filter(dlsQuery);
+    }
+
+    @Test
+    public void failsClosedWhenHybridFilterReturnsNull() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(dlsQuery)).thenReturn(null);
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Hybrid query returned no query after applying the DLS filter"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -18,6 +18,7 @@ import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
@@ -90,6 +91,29 @@ public class DlsFilterLevelActionHandlerTest {
         );
 
         assertThat(exception.getMessage(), is("Hybrid query returned no query after applying the DLS filter"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void reportsHybridFilterFailureToActionListener() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+        @SuppressWarnings("unchecked")
+        ActionListener<Object> listener = mock(ActionListener.class);
+
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(dlsQuery)).thenReturn(null);
+
+        boolean applied = DlsFilterLevelActionHandler.tryApplyFilterLevelDls(searchSource, dlsQuery, true, listener);
+
+        assertThat(applied, is(false));
+        verify(listener).onFailure(
+            org.mockito.ArgumentMatchers.argThat(
+                exception -> exception instanceof OpenSearchSecurityException
+                    && exception.getMessage().equals("Hybrid query returned no query after applying the DLS filter")
+            )
+        );
         assertThat(searchSource.query(), sameInstance(hybridQuery));
     }
 

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -11,12 +11,14 @@
 
 package org.opensearch.security.configuration;
 
+import org.apache.lucene.search.BooleanClause;
 import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -27,6 +29,8 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -83,6 +87,32 @@ public class DlsFilterLevelActionHandlerTest {
 
         assertThat(exception.getMessage(), is("Hybrid query returned no query after applying the DLS filter"));
         assertThat(searchSource.query(), sameInstance(hybridQuery));
+    }
+
+    @Test
+    public void failsClosedWhenHybridQueryContainsParentChildClause() {
+        QueryBuilder parentChildQuery = mock(QueryBuilder.class);
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        when(parentChildQuery.getWriteableName()).thenReturn("has_child");
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        doAnswer(invocation -> {
+            QueryBuilderVisitor visitor = invocation.getArgument(0);
+            visitor.accept(hybridQuery);
+            visitor.getChildVisitor(BooleanClause.Occur.MUST).accept(parentChildQuery);
+            return null;
+        }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
+
+        OpenSearchSecurityException exception = assertThrows(
+            OpenSearchSecurityException.class,
+            () -> DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true)
+        );
+
+        assertThat(exception.getMessage(), is("Unable to handle filter level DLS for hybrid queries with parent or child clauses"));
+        assertThat(searchSource.query(), sameInstance(hybridQuery));
+        verify(hybridQuery, never()).filter(dlsQuery);
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -16,11 +16,15 @@ import org.junit.Test;
 
 import org.opensearch.OpenSearchSecurityException;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.security.privileges.PrivilegesEvaluationContext;
+import org.opensearch.security.support.ConfigConstants;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -167,6 +171,38 @@ public class DlsFilterLevelActionHandlerTest {
     }
 
     @Test
+    public void preservesExistingSearchSource() {
+        SearchSourceBuilder existingSearchSource = SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery());
+        SearchRequest searchRequest = new SearchRequest().source(existingSearchSource);
+
+        SearchSourceBuilder searchSource = DlsFilterLevelActionHandler.getOrCreateSearchSource(searchRequest);
+
+        assertThat(searchSource, sameInstance(existingSearchSource));
+        assertThat(searchRequest.source(), sameInstance(existingSearchSource));
+    }
+
+    @Test
+    public void filterLevelDlsMarkerPreventsReentry() {
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+    }
+
+    @Test
+    public void hybridQueryDlsMarkerPreventsReentry() {
+        assertDlsMarkerPreventsReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+    }
+
+    @Test
+    public void unmarkedClusterActionUsesNormalDispatchChecks() {
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        when(context.getAction()).thenReturn("cluster:test");
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+        boolean result = DlsFilterLevelActionHandler.handle(context, null, null, null, null, null, threadContext, false);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
     public void wrapsHybridQueryWhenReaderLevelDlsIsNotPreserved() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         BoolQueryBuilder dlsQuery = createDlsQuery();
@@ -183,5 +219,14 @@ public class DlsFilterLevelActionHandlerTest {
 
     private static BoolQueryBuilder createDlsQuery() {
         return QueryBuilders.boolQuery().minimumShouldMatch(1).should(QueryBuilders.termQuery("tenant", "allowed"));
+    }
+
+    private static void assertDlsMarkerPreventsReentry(String header) {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader(header, "true");
+
+        boolean result = DlsFilterLevelActionHandler.handle(null, null, null, null, null, null, threadContext, false);
+
+        assertThat(result, is(true));
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -13,6 +13,7 @@ package org.opensearch.security.configuration;
 
 import org.junit.Test;
 
+import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
@@ -95,6 +96,20 @@ public class DlsFilterLevelActionHandlerTest {
 
         DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, false);
 
+        assertThat(searchSource.query(), sameInstance(dlsQuery));
+        assertThat(dlsQuery.must(), empty());
+        assertThat(dlsQuery.should(), hasSize(1));
+    }
+
+    @Test
+    public void createsSearchSourceAndAppliesDlsWhenSearchHasNoSource() {
+        SearchRequest searchRequest = new SearchRequest();
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+
+        SearchSourceBuilder searchSource = DlsFilterLevelActionHandler.getOrCreateSearchSource(searchRequest);
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, false);
+
+        assertThat(searchRequest.source(), sameInstance(searchSource));
         assertThat(searchSource.query(), sameInstance(dlsQuery));
         assertThat(dlsQuery.must(), empty());
         assertThat(dlsQuery.should(), hasSize(1));

--- a/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFilterLevelActionHandlerTest.java
@@ -29,6 +29,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryBuilders;
@@ -76,6 +77,52 @@ public class DlsFilterLevelActionHandlerTest {
         assertThat(dlsQuery.must(), empty());
         assertThat(dlsQuery.should(), hasSize(1));
         verify(hybridQuery).filter(dlsQuery);
+    }
+
+    @Test
+    public void preservesImplicitMinimumShouldMatchWhenFilteringHybridBoolSubquery() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        BoolQueryBuilder originalSubquery = QueryBuilders.boolQuery().should(QueryBuilders.termQuery("signal", "first"));
+        QueryBuilder[] subqueries = { originalSubquery };
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, subqueries);
+        when(hybridQuery.filter(dlsQuery)).thenAnswer(invocation -> {
+            subqueries[0] = originalSubquery.filter(dlsQuery);
+            return hybridQuery;
+        });
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
+
+        assertThat(originalSubquery.minimumShouldMatch(), is("1"));
+        assertThat(originalSubquery.filter(), contains(sameInstance(dlsQuery)));
+    }
+
+    @Test
+    public void preservesConstantScoreHybridSubqueryWhenFiltering() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        ConstantScoreQueryBuilder originalSubquery = QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("signal", "first"));
+        originalSubquery.boost(2.0f);
+        originalSubquery.queryName("original-constant-score");
+        QueryBuilder[] subqueries = { originalSubquery };
+        BoolQueryBuilder dlsQuery = createDlsQuery();
+        SearchSourceBuilder searchSource = SearchSourceBuilder.searchSource().query(hybridQuery);
+
+        stubHybridQuery(hybridQuery, subqueries);
+        when(hybridQuery.filter(dlsQuery)).thenAnswer(invocation -> {
+            subqueries[0] = originalSubquery.filter(dlsQuery);
+            return hybridQuery;
+        });
+
+        DlsFilterLevelActionHandler.applyFilterLevelDls(searchSource, dlsQuery, true);
+
+        ConstantScoreQueryBuilder filteredSubquery = (ConstantScoreQueryBuilder) subqueries[0];
+        BoolQueryBuilder filteredInnerQuery = (BoolQueryBuilder) filteredSubquery.innerQuery();
+        assertThat(filteredSubquery.boost(), is(2.0f));
+        assertThat(filteredSubquery.queryName(), is("original-constant-score"));
+        assertThat(filteredInnerQuery.must(), contains(sameInstance(originalSubquery.innerQuery())));
+        assertThat(filteredInnerQuery.filter(), contains(sameInstance(dlsQuery)));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -10,6 +10,10 @@ package org.opensearch.security.configuration;
 
 import org.junit.Test;
 
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.support.ConfigConstants;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
@@ -17,6 +21,22 @@ import static org.junit.Assert.assertThrows;
 public class DlsFlsFilterLeafReaderTest {
 
     private static final String SEARCH_ACTION = "indices:data/read/search[phase/query]";
+
+    @Test
+    public void identifiesHybridQueryDlsCompletionState() {
+        ThreadContext unmarkedContext = new ThreadContext(Settings.EMPTY);
+        ThreadContext filterLevelContext = new ThreadContext(Settings.EMPTY);
+        filterLevelContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
+        ThreadContext hybridContext = new ThreadContext(Settings.EMPTY);
+        hybridContext.putHeader(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+
+        assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(unmarkedContext), is(false));
+        assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(filterLevelContext), is(false));
+        assertThat(DlsFlsFilterLeafReader.isDlsQueryFilterApplied(hybridContext), is(true));
+    }
 
     @Test
     public void appliesDlsToReaderWhenHybridQueryFilterWasApplied() {

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file to be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.security.configuration;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class DlsFlsFilterLeafReaderTest {
+
+    private static final String SEARCH_ACTION = "indices:data/read/search[phase/query]";
+
+    @Test
+    public void appliesDlsToReaderWhenHybridQueryFilterWasApplied() {
+        assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, false, true, SEARCH_ACTION), is(true));
+    }
+
+    @Test
+    public void doesNotApplyDlsToReaderForRegularSearch() {
+        assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, false, false, SEARCH_ACTION), is(false));
+    }
+
+    @Test
+    public void appliesDlsToReaderForSuggestAndParentChildSearches() {
+        assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(true, false, false, SEARCH_ACTION), is(true));
+        assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, true, false, SEARCH_ACTION), is(true));
+    }
+
+    @Test
+    public void appliesDlsToReaderForNonSearchActions() {
+        assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, false, false, "indices:data/read/get"), is(true));
+    }
+}

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsFilterLeafReaderTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 public class DlsFlsFilterLeafReaderTest {
 
@@ -36,5 +37,10 @@ public class DlsFlsFilterLeafReaderTest {
     @Test
     public void appliesDlsToReaderForNonSearchActions() {
         assertThat(DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, false, false, "indices:data/read/get"), is(true));
+    }
+
+    @Test
+    public void rejectsMissingActionWhenReaderDlsIsNotOtherwiseRequired() {
+        assertThrows(AssertionError.class, () -> DlsFlsFilterLeafReader.shouldApplyDlsToReader(false, false, false, null));
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -13,10 +13,10 @@ package org.opensearch.security.configuration;
 
 import org.junit.Test;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.index.query.QueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -27,44 +27,51 @@ import static org.mockito.Mockito.when;
 public class DlsFlsValveImplTest {
 
     @Test
-    public void usesFilterLevelDlsForTopLevelHybridQueryInAdaptiveMode() {
+    public void appliesDlsFilterToTopLevelHybridQueryInAdaptiveMode() {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
 
         assertThat(result, is(true));
     }
 
     @Test
     public void usesFilterLevelDlsForTermLookupQueryInAdaptiveMode() {
-        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()));
-
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, true);
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(true, true);
 
         assertThat(result, is(true));
     }
 
     @Test
-    public void usesLuceneLevelDlsForRegularQueryInAdaptiveMode() {
-        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()));
+    public void doesNotApplyHybridQueryFilterForTermLookupQuery() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void usesLuceneLevelDlsForRegularQueryInAdaptiveMode() {
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(true, false);
 
         assertThat(result, is(false));
     }
 
     @Test
     public void usesLuceneLevelDlsWhenSearchHasNoSourceInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(new SearchRequest(), true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true);
 
         assertThat(result, is(false));
     }
 
     @Test
     public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(mock(ActionRequest.class), true, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(mock(ActionRequest.class), true, false, true);
 
         assertThat(result, is(false));
     }
@@ -75,8 +82,26 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, false, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true);
 
         assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotApplyHybridQueryFilterWhenClusterContainsOlderNode() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
+
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void hybridQueryDlsFilterRequiresOpenSearchThreeNineOnEveryNode() {
+        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(null), is(false));
+        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_8_0), is(false));
+        assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_9_0), is(true));
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -47,6 +47,7 @@ import org.opensearch.search.internal.SearchContext;
 import org.opensearch.search.startree.StarTreeQueryContext;
 import org.opensearch.security.privileges.PrivilegesEvaluationContext;
 import org.opensearch.security.privileges.dlsfls.DlsFlsBaseContext;
+import org.opensearch.security.privileges.dlsfls.DlsFlsLegacyHeaders;
 import org.opensearch.security.privileges.dlsfls.DlsFlsProcessedConfig;
 import org.opensearch.security.privileges.dlsfls.DlsRestriction;
 import org.opensearch.security.privileges.dlsfls.DocumentPrivileges;
@@ -61,7 +62,9 @@ import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -306,10 +309,46 @@ public class DlsFlsValveImplTest {
         invokeAdaptiveDlsValve(new BoolQueryBuilder(), null, true);
     }
 
-    private static void invokeAdaptiveDlsValve(QueryBuilder query, QueryBuilder expectedQuery, boolean expectedResult) throws Exception {
+    @Test
+    public void preparesLegacyHeadersForFilterLevelDls() throws Exception {
+        ThreadContext threadContext = invokeAdaptiveDlsValve(
+            new BoolQueryBuilder(),
+            null,
+            false,
+            Version.V_2_19_0,
+            DlsFlsValveImpl.Mode.FILTER_LEVEL.name(),
+            "true"
+        );
+
+        assertThat(threadContext.getTransient(DlsFlsLegacyHeaders.TRANSIENT_HEADER), instanceOf(DlsFlsLegacyHeaders.class));
+    }
+
+    private static ThreadContext invokeAdaptiveDlsValve(QueryBuilder query, QueryBuilder expectedQuery, boolean expectedResult)
+        throws Exception {
+        return invokeAdaptiveDlsValve(
+            query,
+            expectedQuery,
+            expectedResult,
+            Version.V_3_9_0,
+            null,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
+    }
+
+    private static ThreadContext invokeAdaptiveDlsValve(
+        QueryBuilder query,
+        QueryBuilder expectedQuery,
+        boolean expectedResult,
+        Version minNodeVersion,
+        String dlsModeHeader,
+        String expectedCompletionMarker
+    ) throws Exception {
         String index = "index";
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
+        if (dlsModeHeader != null) {
+            threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER, dlsModeHeader);
+        }
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
@@ -335,8 +374,22 @@ public class DlsFlsValveImplTest {
         when(documentPrivileges.getRestrictions(context, resolved.local().names(clusterState))).thenReturn(restrictions);
         FieldPrivileges fieldPrivileges = mock(FieldPrivileges.class);
         when(fieldPrivileges.isUnrestricted(context, resolved)).thenReturn(true);
+        when(
+            fieldPrivileges.getRestrictions(
+                org.mockito.ArgumentMatchers.eq(context),
+                org.mockito.ArgumentMatchers.eq(Metadata.EMPTY_METADATA.indices().keySet()),
+                org.mockito.ArgumentMatchers.nullable(FieldPrivileges.FlsRule.class)
+            )
+        ).thenReturn(IndexToRuleMap.unrestricted());
         FieldMasking fieldMasking = mock(FieldMasking.class);
         when(fieldMasking.isUnrestricted(context, resolved)).thenReturn(true);
+        when(
+            fieldMasking.getRestrictions(
+                org.mockito.ArgumentMatchers.eq(context),
+                org.mockito.ArgumentMatchers.eq(Metadata.EMPTY_METADATA.indices().keySet()),
+                org.mockito.ArgumentMatchers.nullable(FieldMasking.FieldMaskingRule.class)
+            )
+        ).thenReturn(IndexToRuleMap.unrestricted());
         DlsFlsProcessedConfig config = mock(DlsFlsProcessedConfig.class);
         when(config.getDocumentPrivileges()).thenReturn(documentPrivileges);
         when(config.getFieldPrivileges()).thenReturn(fieldPrivileges);
@@ -345,7 +398,7 @@ public class DlsFlsValveImplTest {
         when(baseContext.config()).thenReturn(config);
 
         DiscoveryNodes nodes = mock(DiscoveryNodes.class);
-        when(nodes.getMinNodeVersion()).thenReturn(Version.V_3_9_0);
+        when(nodes.getMinNodeVersion()).thenReturn(minNodeVersion);
         when(clusterState.nodes()).thenReturn(nodes);
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(clusterState);
@@ -356,10 +409,7 @@ public class DlsFlsValveImplTest {
         @SuppressWarnings("unchecked")
         ActionListener<Object> listener = mock(ActionListener.class);
         doAnswer(invocation -> {
-            assertThat(
-                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
-                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE)
-            );
+            assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is(expectedCompletionMarker));
             return null;
         }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
         DlsFlsValveImpl valve = new DlsFlsValveImpl(
@@ -385,9 +435,14 @@ public class DlsFlsValveImplTest {
             );
         } else {
             verify(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
-            assertThat(searchRequest.source().query(), sameInstance(expectedQuery));
+            if (expectedQuery != null) {
+                assertThat(searchRequest.source().query(), sameInstance(expectedQuery));
+            } else {
+                assertThat(searchRequest.source().query(), not(sameInstance(query)));
+            }
         }
         assertThat(result, is(expectedResult));
+        return threadContext;
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -16,12 +16,36 @@ import org.junit.Test;
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.shard.IndexShard;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.search.internal.SearchContext;
+import org.opensearch.search.startree.StarTreeQueryContext;
+import org.opensearch.security.privileges.PrivilegesEvaluationContext;
+import org.opensearch.security.privileges.dlsfls.DlsFlsBaseContext;
+import org.opensearch.security.privileges.dlsfls.DlsFlsProcessedConfig;
+import org.opensearch.security.privileges.dlsfls.DlsRestriction;
+import org.opensearch.security.privileges.dlsfls.DocumentPrivileges;
+import org.opensearch.security.privileges.dlsfls.FieldMasking;
+import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
+import org.opensearch.security.resources.ResourcePluginInfo;
+import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DlsFlsValveImplTest {
@@ -103,5 +127,61 @@ public class DlsFlsValveImplTest {
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(null), is(false));
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_8_0), is(false));
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_9_0), is(true));
+    }
+
+    @Test
+    public void disablesStarTreeBeforeSkippingHybridQueryWrapping() throws Exception {
+        String index = "index";
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        DlsFlsBaseContext baseContext = mock(DlsFlsBaseContext.class);
+        when(baseContext.isDlsQueryFilterApplied()).thenReturn(true);
+        PrivilegesEvaluationContext privilegesEvaluationContext = mock(PrivilegesEvaluationContext.class);
+        when(baseContext.getPrivilegesEvaluationContext()).thenReturn(privilegesEvaluationContext);
+
+        DlsRestriction dlsRestriction = mock(DlsRestriction.class);
+        DocumentPrivileges documentPrivileges = mock(DocumentPrivileges.class);
+        when(documentPrivileges.getRestriction(privilegesEvaluationContext, index)).thenReturn(dlsRestriction);
+        DlsFlsProcessedConfig config = mock(DlsFlsProcessedConfig.class);
+        when(config.getDocumentPrivileges()).thenReturn(documentPrivileges);
+        when(config.getFieldPrivileges()).thenReturn(mock(FieldPrivileges.class));
+        when(config.getFieldMasking()).thenReturn(mock(FieldMasking.class));
+        when(baseContext.config()).thenReturn(config);
+
+        SearchContext searchContext = mock(SearchContext.class);
+        IndexMetadata indexMetadata = IndexMetadata.builder(index)
+            .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_VERSION_CREATED.getKey(), Version.CURRENT))
+            .numberOfShards(1)
+            .numberOfReplicas(0)
+            .build();
+        IndexSettings indexSettings = new IndexSettings(indexMetadata, Settings.EMPTY);
+        IndexShard indexShard = mock(IndexShard.class);
+        when(indexShard.indexSettings()).thenReturn(indexSettings);
+        when(searchContext.indexShard()).thenReturn(indexShard);
+        QueryShardContext queryShardContext = mock(QueryShardContext.class);
+        when(queryShardContext.getStarTreeQueryContext()).thenReturn(mock(StarTreeQueryContext.class));
+        when(searchContext.getQueryShardContext()).thenReturn(queryShardContext);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        @SuppressWarnings("unchecked")
+        OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting = mock(OpensearchDynamicSetting.class);
+        DlsFlsValveImpl valve = new DlsFlsValveImpl(
+            Settings.EMPTY,
+            mock(Client.class),
+            clusterService,
+            NamedXContentRegistry.EMPTY,
+            threadPool,
+            baseContext,
+            mock(AdminDNs.class),
+            mock(ResourcePluginInfo.class),
+            resourceSharingEnabledSetting
+        );
+
+        valve.handleSearchContext(searchContext, threadPool);
+
+        verify(queryShardContext).setStarTreeQueryContext(null);
+        verify(dlsRestriction, never()).toBooleanQueryBuilder(any(), any());
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -23,6 +23,7 @@ import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -43,6 +44,7 @@ import org.opensearch.transport.client.Client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -56,7 +58,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
 
         assertThat(result, is(true));
     }
@@ -74,7 +76,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, true, true, true);
 
         assertThat(result, is(false));
     }
@@ -88,14 +90,20 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void usesLuceneLevelDlsWhenSearchHasNoSourceInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(new SearchRequest(), true, false, true, true);
 
         assertThat(result, is(false));
     }
 
     @Test
     public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(mock(ActionRequest.class), true, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
+            mock(ActionRequest.class),
+            true,
+            false,
+            true,
+            true
+        );
 
         assertThat(result, is(false));
     }
@@ -106,7 +114,7 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, false, false, true, true);
 
         assertThat(result, is(false));
     }
@@ -117,7 +125,36 @@ public class DlsFlsValveImplTest {
         when(hybridQuery.getName()).thenReturn("hybrid");
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
-        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false);
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, false, true);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotApplyHybridQueryFilterForCrossClusterSearch() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
+
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotApplyHybridQueryFilterForParentChildQuery() {
+        QueryBuilder parentChildQuery = mock(QueryBuilder.class);
+        when(parentChildQuery.getWriteableName()).thenReturn("has_child");
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        doAnswer(invocation -> {
+            QueryBuilderVisitor visitor = invocation.getArgument(0);
+            visitor.accept(parentChildQuery);
+            return null;
+        }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
+
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
 
         assertThat(result, is(false));
     }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
+import org.apache.lucene.search.BooleanClause;
 import org.junit.Test;
 
 import org.opensearch.Version;
@@ -40,6 +41,7 @@ import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
+import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.index.query.QueryShardContext;
 import org.opensearch.index.shard.IndexShard;
 import org.opensearch.search.builder.SearchSourceBuilder;
@@ -297,9 +299,14 @@ public class DlsFlsValveImplTest {
     public void routesEligibleHybridQueriesThroughFilterLevelDls() throws Exception {
         QueryBuilder hybridQuery = mock(QueryBuilder.class);
         QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
-        when(hybridQuery.getName()).thenReturn("hybrid");
-        when(filteredHybridQuery.getName()).thenReturn("hybrid");
-        when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(filteredHybridQuery);
+        QueryBuilder originalSubquery = QueryBuilders.matchAllQuery();
+        QueryBuilder[] filteredSubqueries = new QueryBuilder[1];
+        stubHybridQuery(hybridQuery, originalSubquery);
+        stubHybridQuery(filteredHybridQuery, filteredSubqueries);
+        when(hybridQuery.filter(any(QueryBuilder.class))).thenAnswer(invocation -> {
+            filteredSubqueries[0] = originalSubquery.filter(invocation.getArgument(0));
+            return filteredHybridQuery;
+        });
 
         invokeAdaptiveDlsValve(hybridQuery, filteredHybridQuery, false);
     }
@@ -499,5 +506,18 @@ public class DlsFlsValveImplTest {
 
         verify(queryShardContext).setStarTreeQueryContext(null);
         verify(dlsRestriction, never()).toBooleanQueryBuilder(any(), any());
+    }
+
+    private static void stubHybridQuery(QueryBuilder hybridQuery, QueryBuilder... subqueries) {
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        doAnswer(invocation -> {
+            QueryBuilderVisitor visitor = invocation.getArgument(0);
+            visitor.accept(hybridQuery);
+            QueryBuilderVisitor subqueryVisitor = visitor.getChildVisitor(BooleanClause.Occur.MUST);
+            for (QueryBuilder subquery : subqueries) {
+                subquery.visit(subqueryVisitor);
+            }
+            return null;
+        }).when(hybridQuery).visit(any(QueryBuilderVisitor.class));
     }
 }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -102,17 +102,17 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void hybridQueryDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
     }
 
     @Test
     public void filterLevelDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+        assertDlsMarkerPreventsValveReentry("true");
     }
 
-    private static void assertDlsMarkerPreventsValveReentry(String header) throws Exception {
+    private static void assertDlsMarkerPreventsValveReentry(String value) throws Exception {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
-        threadContext.putHeader(header, "true");
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, value);
         threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
         ThreadPool threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(threadContext);

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -22,6 +22,7 @@ import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexSettings;
+import org.opensearch.index.query.BoolQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilderVisitor;
 import org.opensearch.index.query.QueryShardContext;
@@ -96,6 +97,15 @@ public class DlsFlsValveImplTest {
     }
 
     @Test
+    public void usesLuceneLevelDlsWhenSearchSourceHasNoQueryInAdaptiveMode() {
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource());
+
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
     public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
         boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(
             mock(ActionRequest.class),
@@ -137,6 +147,18 @@ public class DlsFlsValveImplTest {
         SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
 
         boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotApplyHybridQueryFilterWhenHybridQueryIsNotTopLevel() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        BoolQueryBuilder outerQuery = new BoolQueryBuilder().must(hybridQuery);
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(outerQuery));
+
+        boolean result = DlsFlsValveImpl.shouldApplyDlsFilterToHybridQueryInAdaptiveMode(searchRequest, true, false, true, true);
 
         assertThat(result, is(false));
     }

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.configuration;
+
+import org.junit.Test;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DlsFlsValveImplTest {
+
+    @Test
+    public void usesFilterLevelDlsForTopLevelHybridQueryInAdaptiveMode() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
+
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, false);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void usesFilterLevelDlsForTermLookupQueryInAdaptiveMode() {
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()));
+
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, true);
+
+        assertThat(result, is(true));
+    }
+
+    @Test
+    public void usesLuceneLevelDlsForRegularQueryInAdaptiveMode() {
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(QueryBuilders.matchAllQuery()));
+
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, true, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void usesLuceneLevelDlsWhenSearchHasNoSourceInAdaptiveMode() {
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(new SearchRequest(), true, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void usesLuceneLevelDlsForNonSearchRequestInAdaptiveMode() {
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(mock(ActionRequest.class), true, false);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotSelectDlsModeForHybridQueryWithoutDlsRestrictions() {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        SearchRequest searchRequest = new SearchRequest().source(SearchSourceBuilder.searchSource().query(hybridQuery));
+
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(searchRequest, false, false);
+
+        assertThat(result, is(false));
+    }
+}

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -11,13 +11,26 @@
 
 package org.opensearch.security.configuration;
 
+import java.util.Map;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
 import org.junit.Test;
 
 import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
+import org.opensearch.action.OriginalIndices;
 import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.metadata.OptionallyResolvedIndices;
+import org.opensearch.cluster.metadata.ResolvedIndices;
+import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
@@ -39,6 +52,7 @@ import org.opensearch.security.privileges.dlsfls.DlsRestriction;
 import org.opensearch.security.privileges.dlsfls.DocumentPrivileges;
 import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
+import org.opensearch.security.privileges.dlsfls.IndexToRuleMap;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.setting.OpensearchDynamicSetting;
 import org.opensearch.security.support.ConfigConstants;
@@ -48,6 +62,7 @@ import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -102,7 +117,14 @@ public class DlsFlsValveImplTest {
 
     @Test
     public void hybridQueryDlsMarkerPreventsValveReentry() throws Exception {
-        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+        org.apache.logging.log4j.core.Logger logger = (org.apache.logging.log4j.core.Logger) LogManager.getLogger(DlsFlsValveImpl.class);
+        Level previousLevel = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        try {
+            assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE);
+        } finally {
+            logger.setLevel(previousLevel);
+        }
     }
 
     @Test
@@ -255,6 +277,117 @@ public class DlsFlsValveImplTest {
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(null), is(false));
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_8_0), is(false));
         assertThat(DlsFlsValveImpl.isHybridQueryDlsFilterSupported(Version.V_3_9_0), is(true));
+    }
+
+    @Test
+    public void appliesHybridQueryDlsOnlyToLocalIndices() {
+        ResolvedIndices localIndices = ResolvedIndices.of("index");
+        OriginalIndices originalIndices = new OriginalIndices(new String[] { "remote-index" }, IndicesOptions.strictExpandOpen());
+        ResolvedIndices remoteIndices = localIndices.withRemoteIndices(Map.of("remote", originalIndices));
+
+        assertThat(DlsFlsValveImpl.isLocalOnlyRequest(localIndices), is(true));
+        assertThat(DlsFlsValveImpl.isLocalOnlyRequest(remoteIndices), is(false));
+        assertThat(DlsFlsValveImpl.isLocalOnlyRequest(mock(OptionallyResolvedIndices.class)), is(false));
+    }
+
+    @Test
+    public void routesEligibleHybridQueriesThroughFilterLevelDls() throws Exception {
+        QueryBuilder hybridQuery = mock(QueryBuilder.class);
+        QueryBuilder filteredHybridQuery = mock(QueryBuilder.class);
+        when(hybridQuery.getName()).thenReturn("hybrid");
+        when(filteredHybridQuery.getName()).thenReturn("hybrid");
+        when(hybridQuery.filter(any(QueryBuilder.class))).thenReturn(filteredHybridQuery);
+
+        invokeAdaptiveDlsValve(hybridQuery, filteredHybridQuery, false);
+    }
+
+    @Test
+    public void keepsRegularQueriesAtLuceneLevelDls() throws Exception {
+        invokeAdaptiveDlsValve(new BoolQueryBuilder(), null, true);
+    }
+
+    private static void invokeAdaptiveDlsValve(QueryBuilder query, QueryBuilder expectedQuery, boolean expectedResult) throws Exception {
+        String index = "index";
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        SearchRequest searchRequest = new SearchRequest(index).source(SearchSourceBuilder.searchSource().query(query));
+        ResolvedIndices resolved = ResolvedIndices.of(index);
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        when(context.getAction()).thenReturn("indices:data/read/search");
+        when(context.getRequest()).thenReturn(searchRequest);
+        when(context.getResolvedIndices()).thenReturn(resolved);
+        when(context.clusterState()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(Metadata.EMPTY_METADATA);
+
+        DocumentPrivileges.RenderedDlsQuery renderedDlsQuery = mock(DocumentPrivileges.RenderedDlsQuery.class);
+        when(renderedDlsQuery.getQueryBuilder()).thenReturn(new BoolQueryBuilder());
+        DlsRestriction dlsRestriction = mock(DlsRestriction.class);
+        when(dlsRestriction.getQueries()).thenReturn(ImmutableList.of(renderedDlsQuery));
+        when(dlsRestriction.isUnrestricted()).thenReturn(false);
+        when(dlsRestriction.containsTermLookupQuery()).thenReturn(false);
+        IndexToRuleMap<DlsRestriction> restrictions = new IndexToRuleMap<>(ImmutableMap.of(index, dlsRestriction));
+        DocumentPrivileges documentPrivileges = mock(DocumentPrivileges.class);
+        when(documentPrivileges.isUnrestricted(context, resolved)).thenReturn(false);
+        when(documentPrivileges.getRestrictions(context, resolved.local().names(clusterState))).thenReturn(restrictions);
+        FieldPrivileges fieldPrivileges = mock(FieldPrivileges.class);
+        when(fieldPrivileges.isUnrestricted(context, resolved)).thenReturn(true);
+        FieldMasking fieldMasking = mock(FieldMasking.class);
+        when(fieldMasking.isUnrestricted(context, resolved)).thenReturn(true);
+        DlsFlsProcessedConfig config = mock(DlsFlsProcessedConfig.class);
+        when(config.getDocumentPrivileges()).thenReturn(documentPrivileges);
+        when(config.getFieldPrivileges()).thenReturn(fieldPrivileges);
+        when(config.getFieldMasking()).thenReturn(fieldMasking);
+        DlsFlsBaseContext baseContext = mock(DlsFlsBaseContext.class);
+        when(baseContext.config()).thenReturn(config);
+
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(nodes.getMinNodeVersion()).thenReturn(Version.V_3_9_0);
+        when(clusterState.nodes()).thenReturn(nodes);
+        ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        @SuppressWarnings("unchecked")
+        OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting = mock(OpensearchDynamicSetting.class);
+        when(resourceSharingEnabledSetting.getDynamicSettingValue()).thenReturn(false);
+        Client nodeClient = mock(Client.class);
+        @SuppressWarnings("unchecked")
+        ActionListener<Object> listener = mock(ActionListener.class);
+        doAnswer(invocation -> {
+            assertThat(
+                threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
+                is(ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE)
+            );
+            return null;
+        }).when(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
+        DlsFlsValveImpl valve = new DlsFlsValveImpl(
+            Settings.EMPTY,
+            nodeClient,
+            clusterService,
+            NamedXContentRegistry.EMPTY,
+            threadPool,
+            baseContext,
+            mock(AdminDNs.class),
+            mock(ResourcePluginInfo.class),
+            resourceSharingEnabledSetting
+        );
+
+        boolean result = valve.invoke(context, listener);
+
+        assertThat(threadContext.getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE), is((String) null));
+        if (expectedResult) {
+            assertThat(searchRequest.source().query(), sameInstance(query));
+            verify(nodeClient, never()).search(
+                any(SearchRequest.class),
+                org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any()
+            );
+        } else {
+            verify(nodeClient).search(any(SearchRequest.class), org.mockito.ArgumentMatchers.<ActionListener<SearchResponse>>any());
+            assertThat(searchRequest.source().query(), sameInstance(expectedQuery));
+        }
+        assertThat(result, is(expectedResult));
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -17,9 +17,11 @@ import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.OptionallyResolvedIndices;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -39,6 +41,8 @@ import org.opensearch.security.privileges.dlsfls.FieldMasking;
 import org.opensearch.security.privileges.dlsfls.FieldPrivileges;
 import org.opensearch.security.resources.ResourcePluginInfo;
 import org.opensearch.security.setting.OpensearchDynamicSetting;
+import org.opensearch.security.support.ConfigConstants;
+import org.opensearch.security.user.User;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -87,6 +91,71 @@ public class DlsFlsValveImplTest {
         boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(true, false);
 
         assertThat(result, is(false));
+    }
+
+    @Test
+    public void doesNotUseFilterLevelDlsWithoutDlsRestrictions() {
+        boolean result = DlsFlsValveImpl.shouldUseFilterLevelDlsInAdaptiveMode(false, true);
+
+        assertThat(result, is(false));
+    }
+
+    @Test
+    public void hybridQueryDlsMarkerPreventsValveReentry() throws Exception {
+        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED);
+    }
+
+    @Test
+    public void filterLevelDlsMarkerPreventsValveReentry() throws Exception {
+        assertDlsMarkerPreventsValveReentry(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE);
+    }
+
+    private static void assertDlsMarkerPreventsValveReentry(String header) throws Exception {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        threadContext.putHeader(header, "true");
+        threadContext.putTransient(ConfigConstants.OPENDISTRO_SECURITY_USER, new User("test-user"));
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+
+        PrivilegesEvaluationContext context = mock(PrivilegesEvaluationContext.class);
+        OptionallyResolvedIndices resolved = mock(OptionallyResolvedIndices.class);
+        when(context.getAction()).thenReturn("indices:data/read/search[phase/query]");
+        when(context.getRequest()).thenReturn(new SearchRequest());
+        when(context.getResolvedIndices()).thenReturn(resolved);
+
+        DocumentPrivileges documentPrivileges = mock(DocumentPrivileges.class);
+        when(documentPrivileges.isUnrestricted(context, resolved)).thenReturn(false);
+        FieldPrivileges fieldPrivileges = mock(FieldPrivileges.class);
+        when(fieldPrivileges.isUnrestricted(context, resolved)).thenReturn(true);
+        FieldMasking fieldMasking = mock(FieldMasking.class);
+        when(fieldMasking.isUnrestricted(context, resolved)).thenReturn(true);
+        DlsFlsProcessedConfig config = mock(DlsFlsProcessedConfig.class);
+        when(config.getDocumentPrivileges()).thenReturn(documentPrivileges);
+        when(config.getFieldPrivileges()).thenReturn(fieldPrivileges);
+        when(config.getFieldMasking()).thenReturn(fieldMasking);
+        DlsFlsBaseContext baseContext = mock(DlsFlsBaseContext.class);
+        when(baseContext.config()).thenReturn(config);
+
+        ClusterService clusterService = mock(ClusterService.class);
+        @SuppressWarnings("unchecked")
+        OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting = mock(OpensearchDynamicSetting.class);
+        when(resourceSharingEnabledSetting.getDynamicSettingValue()).thenReturn(false);
+        DlsFlsValveImpl valve = new DlsFlsValveImpl(
+            Settings.EMPTY,
+            mock(Client.class),
+            clusterService,
+            NamedXContentRegistry.EMPTY,
+            threadPool,
+            baseContext,
+            mock(AdminDNs.class),
+            mock(ResourcePluginInfo.class),
+            resourceSharingEnabledSetting
+        );
+
+        boolean result = valve.invoke(context, mock(ActionListener.class));
+
+        assertThat(result, is(true));
+        verify(clusterService, never()).state();
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
+++ b/src/test/java/org/opensearch/security/configuration/DlsFlsValveImplTest.java
@@ -330,6 +330,20 @@ public class DlsFlsValveImplTest {
         assertThat(threadContext.getTransient(DlsFlsLegacyHeaders.TRANSIENT_HEADER), instanceOf(DlsFlsLegacyHeaders.class));
     }
 
+    @Test
+    public void doesNotApplyFilterLevelDlsWhenOnlyFlsIsRestricted() throws Exception {
+        invokeAdaptiveDlsValve(
+            new BoolQueryBuilder(),
+            null,
+            true,
+            Version.V_3_9_0,
+            DlsFlsValveImpl.Mode.FILTER_LEVEL.name(),
+            null,
+            false,
+            true
+        );
+    }
+
     private static ThreadContext invokeAdaptiveDlsValve(QueryBuilder query, QueryBuilder expectedQuery, boolean expectedResult)
         throws Exception {
         return invokeAdaptiveDlsValve(
@@ -349,6 +363,28 @@ public class DlsFlsValveImplTest {
         Version minNodeVersion,
         String dlsModeHeader,
         String expectedCompletionMarker
+    ) throws Exception {
+        return invokeAdaptiveDlsValve(
+            query,
+            expectedQuery,
+            expectedResult,
+            minNodeVersion,
+            dlsModeHeader,
+            expectedCompletionMarker,
+            true,
+            false
+        );
+    }
+
+    private static ThreadContext invokeAdaptiveDlsValve(
+        QueryBuilder query,
+        QueryBuilder expectedQuery,
+        boolean expectedResult,
+        Version minNodeVersion,
+        String dlsModeHeader,
+        String expectedCompletionMarker,
+        boolean hasDlsRestrictions,
+        boolean hasFlsRestrictions
     ) throws Exception {
         String index = "index";
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
@@ -377,10 +413,10 @@ public class DlsFlsValveImplTest {
         when(dlsRestriction.containsTermLookupQuery()).thenReturn(false);
         IndexToRuleMap<DlsRestriction> restrictions = new IndexToRuleMap<>(ImmutableMap.of(index, dlsRestriction));
         DocumentPrivileges documentPrivileges = mock(DocumentPrivileges.class);
-        when(documentPrivileges.isUnrestricted(context, resolved)).thenReturn(false);
+        when(documentPrivileges.isUnrestricted(context, resolved)).thenReturn(!hasDlsRestrictions);
         when(documentPrivileges.getRestrictions(context, resolved.local().names(clusterState))).thenReturn(restrictions);
         FieldPrivileges fieldPrivileges = mock(FieldPrivileges.class);
-        when(fieldPrivileges.isUnrestricted(context, resolved)).thenReturn(true);
+        when(fieldPrivileges.isUnrestricted(context, resolved)).thenReturn(!hasFlsRestrictions);
         when(
             fieldPrivileges.getRestrictions(
                 org.mockito.ArgumentMatchers.eq(context),

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -30,7 +30,10 @@ public class DlsFlsBaseContextTest {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
 
-        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+        threadContext.putHeader(
+            ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+            ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+        );
 
         assertThat(context.isDlsQueryFilterApplied(), is(true));
         assertThat(context.isDlsDoneOnFilterLevel(), is(false));

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+package org.opensearch.security.privileges.dlsfls;
+
+import org.junit.Test;
+
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.security.configuration.AdminDNs;
+import org.opensearch.security.privileges.PrivilegesConfiguration;
+import org.opensearch.security.support.ConfigConstants;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class DlsFlsBaseContextTest {
+
+    @Test
+    public void hybridQueryFilterDoesNotMarkReaderLevelDlsAsDone() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
+
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+
+        assertThat(context.isDlsQueryFilterApplied(), is(true));
+        assertThat(context.isDlsDoneOnFilterLevel(), is(false));
+    }
+}

--- a/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
+++ b/src/test/java/org/opensearch/security/privileges/dlsfls/DlsFlsBaseContextTest.java
@@ -35,4 +35,15 @@ public class DlsFlsBaseContextTest {
         assertThat(context.isDlsQueryFilterApplied(), is(true));
         assertThat(context.isDlsDoneOnFilterLevel(), is(false));
     }
+
+    @Test
+    public void filterLevelDlsMarkerDoesNotMarkHybridQueryFilterAsApplied() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        DlsFlsBaseContext context = new DlsFlsBaseContext(mock(PrivilegesConfiguration.class), threadContext, mock(AdminDNs.class));
+
+        threadContext.putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "true");
+
+        assertThat(context.isDlsDoneOnFilterLevel(), is(true));
+        assertThat(context.isDlsQueryFilterApplied(), is(false));
+    }
 }

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -452,8 +452,6 @@ public class SecurityInterceptorTests {
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER, "fake masked field header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER, "fake doc allowlist header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "fake filter level dls header");
-        threadPool.getThreadContext()
-            .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "fake dls query filter applied header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER, "fake dls mode header");
         threadPool.getThreadContext()
             .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER, "fake dls filter header");
@@ -468,10 +466,10 @@ public class SecurityInterceptorTests {
     }
 
     @Test
-    public void testDlsQueryFilterAppliedHeaderIsCopiedToLocalNodes() {
+    public void testHybridQueryDlsStateIsCopiedToLocalNodes() {
         enableCrossClusterSearch();
-        String headerValue = "hybrid DLS query filter applied";
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
+        String headerValue = ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE;
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, headerValue);
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
         when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
@@ -486,7 +484,7 @@ public class SecurityInterceptorTests {
                 TransportResponseHandler<T> handler
             ) {
                 assertThat(
-                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED),
+                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE),
                     is(headerValue)
                 );
                 senderLatch.get().countDown();
@@ -498,9 +496,13 @@ public class SecurityInterceptorTests {
     }
 
     @Test
-    public void testDlsQueryFilterAppliedHeaderIsRemovedForRemoteCluster() {
+    public void testHybridQueryDlsStateIsRemovedForRemoteCluster() {
         enableCrossClusterSearch();
-        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+        threadPool.getThreadContext()
+            .putHeader(
+                ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
+                ConfigConstants.OPENDISTRO_SECURITY_HYBRID_QUERY_DLS_DONE
+            );
         when(clusterInfoHolder.isInitialized()).thenReturn(true);
         when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
 
@@ -513,7 +515,7 @@ public class SecurityInterceptorTests {
                 TransportRequestOptions options,
                 TransportResponseHandler<T> handler
             ) {
-                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED));
+                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE));
                 senderLatch.get().countDown();
             }
         };

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -8,6 +8,7 @@
 
 package org.opensearch.security.transport;
 
+import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -24,6 +25,7 @@ import org.junit.Test;
 import org.opensearch.Version;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.search.PitService;
+import org.opensearch.action.search.SearchAction;
 import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.service.ClusterService;
@@ -48,6 +50,7 @@ import org.opensearch.security.user.UserFactory;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.Transport.Connection;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportInterceptor.AsyncSender;
@@ -308,6 +311,19 @@ public class SecurityInterceptorTests {
         senderLatch.set(new CountDownLatch(1));
     }
 
+    private void enableCrossClusterSearch() {
+        try {
+            RemoteClusterService remoteClusterService = OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService();
+            Field remoteClustersField = RemoteClusterService.class.getDeclaredField("remoteClusters");
+            remoteClustersField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> remoteClusters = (Map<String, Object>) remoteClustersField.get(remoteClusterService);
+            remoteClusters.put("test-remote-cluster", new Object());
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("Could not configure the test remote cluster", e);
+        }
+    }
+
     @Test
     public void testSendRequestDecorateLocalConnection() {
 
@@ -452,9 +468,13 @@ public class SecurityInterceptorTests {
     }
 
     @Test
-    public void testDlsQueryFilterAppliedHeaderIsCopied() {
+    public void testDlsQueryFilterAppliedHeaderIsCopiedToLocalNodes() {
+        enableCrossClusterSearch();
         String headerValue = "hybrid DLS query filter applied";
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
+        when(clusterInfoHolder.isInitialized()).thenReturn(true);
+        when(clusterInfoHolder.hasNode(localNode)).thenReturn(true);
+        when(clusterInfoHolder.hasNode(otherNode)).thenReturn(true);
 
         AsyncSender headerVerifyingSender = new AsyncSender() {
             @Override
@@ -473,7 +493,32 @@ public class SecurityInterceptorTests {
             }
         };
 
-        completableRequestDecorate(headerVerifyingSender, connection1, action, request, options, handler, localNode);
+        completableRequestDecorate(headerVerifyingSender, connection1, SearchAction.NAME, request, options, handler, localNode);
+        completableRequestDecorate(headerVerifyingSender, connection2, SearchAction.NAME, request, options, handler, localNode);
+    }
+
+    @Test
+    public void testDlsQueryFilterAppliedHeaderIsRemovedForRemoteCluster() {
+        enableCrossClusterSearch();
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "true");
+        when(clusterInfoHolder.isInitialized()).thenReturn(true);
+        when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
+
+        AsyncSender headerVerifyingSender = new AsyncSender() {
+            @Override
+            public <T extends TransportResponse> void sendRequest(
+                Connection connection,
+                String action,
+                TransportRequest request,
+                TransportRequestOptions options,
+                TransportResponseHandler<T> handler
+            ) {
+                assertNull(threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED));
+                senderLatch.get().countDown();
+            }
+        };
+
+        completableRequestDecorate(headerVerifyingSender, connection3, SearchAction.NAME, request, options, handler, localNode);
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -514,6 +514,15 @@ public class SecurityInterceptorTests {
     @Test
     public void testHybridQueryDlsStateIsRemovedForRemoteCluster() {
         enableCrossClusterSearch();
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode();
+    }
+
+    @Test
+    public void testHybridQueryDlsStateIsRemovedWhenCrossClusterSearchIsDisabled() {
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode();
+    }
+
+    private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode() {
         threadPool.getThreadContext()
             .putHeader(
                 ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -8,7 +8,6 @@
 
 package org.opensearch.security.transport;
 
-import java.lang.reflect.Field;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -50,7 +49,6 @@ import org.opensearch.security.user.UserFactory;
 import org.opensearch.telemetry.tracing.noop.NoopTracer;
 import org.opensearch.test.transport.MockTransport;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.transport.RemoteClusterService;
 import org.opensearch.transport.Transport.Connection;
 import org.opensearch.transport.TransportException;
 import org.opensearch.transport.TransportInterceptor.AsyncSender;
@@ -137,6 +135,7 @@ public class SecurityInterceptorTests {
     private AsyncSender jdkSerializedSender;
     private AsyncSender customSerializedSender;
     private AtomicReference<CountDownLatch> senderLatch = new AtomicReference<>(new CountDownLatch(1));
+    private boolean crossClusterSearchEnabled;
 
     @Before
     public void setup() {
@@ -148,6 +147,7 @@ public class SecurityInterceptorTests {
             .put("request.headers.default", "1")
             .build();
         threadPool = new ThreadPool(settings);
+        crossClusterSearchEnabled = false;
         securityInterceptor = new SecurityInterceptor(
             settings,
             threadPool,
@@ -162,7 +162,12 @@ public class SecurityInterceptorTests {
             () -> true,
             new UserFactory.Simple(),
             new RemoteClusterIdentityPolicy(false)
-        );
+        ) {
+            @Override
+            boolean isCrossClusterSearchEnabled() {
+                return crossClusterSearchEnabled;
+            }
+        };
 
         clusterName = ClusterName.DEFAULT;
         when(clusterService.getClusterName()).thenReturn(clusterName);
@@ -312,16 +317,27 @@ public class SecurityInterceptorTests {
     }
 
     private void enableCrossClusterSearch() {
-        try {
-            RemoteClusterService remoteClusterService = OpenSearchSecurityPlugin.GuiceHolder.getRemoteClusterService();
-            Field remoteClustersField = RemoteClusterService.class.getDeclaredField("remoteClusters");
-            remoteClustersField.setAccessible(true);
-            @SuppressWarnings("unchecked")
-            Map<String, Object> remoteClusters = (Map<String, Object>) remoteClustersField.get(remoteClusterService);
-            remoteClusters.put("test-remote-cluster", new Object());
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("Could not configure the test remote cluster", e);
-        }
+        crossClusterSearchEnabled = true;
+    }
+
+    @Test
+    public void testCrossClusterSearchStatusUsesRemoteClusterService() {
+        SecurityInterceptor interceptor = new SecurityInterceptor(
+            settings,
+            threadPool,
+            backendRegistry,
+            auditLog,
+            principalExtractor,
+            requestEvalProvider,
+            clusterService,
+            sslExceptionHandler,
+            clusterInfoHolder,
+            sslConfig,
+            () -> true,
+            new UserFactory.Simple()
+        );
+
+        assertFalse(interceptor.isCrossClusterSearchEnabled());
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -508,21 +508,34 @@ public class SecurityInterceptorTests {
         };
 
         completableRequestDecorate(headerVerifyingSender, connection1, SearchAction.NAME, request, options, handler, localNode);
-        completableRequestDecorate(headerVerifyingSender, connection2, SearchAction.NAME, request, options, handler, localNode);
+        completableRequestDecorate(headerVerifyingSender, connection2, "internal:hybrid-follow-up", request, options, handler, localNode);
     }
 
     @Test
     public void testHybridQueryDlsStateIsRemovedForRemoteCluster() {
         enableCrossClusterSearch();
-        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode();
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(SearchAction.NAME);
     }
 
     @Test
     public void testHybridQueryDlsStateIsRemovedWhenCrossClusterSearchIsDisabled() {
-        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode();
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(SearchAction.NAME);
     }
 
-    private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode() {
+    @Test
+    public void testHybridQueryDlsStateIsRemovedForNonSearchAction() {
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode("internal:hybrid-follow-up");
+    }
+
+    @Test
+    public void testUnrecognizedNonSearchDestinationWithoutHybridMarkerUsesNormalHeaders() {
+        when(clusterInfoHolder.isInitialized()).thenReturn(true);
+        when(clusterInfoHolder.hasNode(remoteNode)).thenReturn(false);
+
+        completableRequestDecorate(jdkSerializedSender, connection3, action, request, options, handler, localNode);
+    }
+
+    private void assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(String action) {
         threadPool.getThreadContext()
             .putHeader(
                 ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE,
@@ -545,7 +558,7 @@ public class SecurityInterceptorTests {
             }
         };
 
-        completableRequestDecorate(headerVerifyingSender, connection3, SearchAction.NAME, request, options, handler, localNode);
+        completableRequestDecorate(headerVerifyingSender, connection3, action, request, options, handler, localNode);
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -335,7 +335,8 @@ public class SecurityInterceptorTests {
             clusterInfoHolder,
             sslConfig,
             () -> true,
-            new UserFactory.Simple()
+            new UserFactory.Simple(),
+            new RemoteClusterIdentityPolicy(false)
         );
 
         assertFalse(interceptor.isCrossClusterSearchEnabled());

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -436,6 +436,8 @@ public class SecurityInterceptorTests {
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_MASKED_FIELD_HEADER, "fake masked field header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DOC_ALLOWLIST_HEADER, "fake doc allowlist header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_FILTER_LEVEL_DLS_DONE, "fake filter level dls header");
+        threadPool.getThreadContext()
+            .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, "fake dls query filter applied header");
         threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_MODE_HEADER, "fake dls mode header");
         threadPool.getThreadContext()
             .putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_FILTER_LEVEL_QUERY_HEADER, "fake dls filter header");
@@ -447,6 +449,31 @@ public class SecurityInterceptorTests {
 
         // this is a local request
         completableRequestDecorate(sender, connection1, action, request, options, handler, localNode);
+    }
+
+    @Test
+    public void testDlsQueryFilterAppliedHeaderIsCopied() {
+        String headerValue = "hybrid DLS query filter applied";
+        threadPool.getThreadContext().putHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED, headerValue);
+
+        AsyncSender headerVerifyingSender = new AsyncSender() {
+            @Override
+            public <T extends TransportResponse> void sendRequest(
+                Connection connection,
+                String action,
+                TransportRequest request,
+                TransportRequestOptions options,
+                TransportResponseHandler<T> handler
+            ) {
+                assertThat(
+                    threadPool.getThreadContext().getHeader(ConfigConstants.OPENDISTRO_SECURITY_DLS_QUERY_FILTER_APPLIED),
+                    is(headerValue)
+                );
+                senderLatch.get().countDown();
+            }
+        };
+
+        completableRequestDecorate(headerVerifyingSender, connection1, action, request, options, handler, localNode);
     }
 
     @Test

--- a/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
+++ b/src/test/java/org/opensearch/security/transport/SecurityInterceptorTests.java
@@ -22,6 +22,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.opensearch.Version;
+import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsAction;
 import org.opensearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.opensearch.action.search.PitService;
 import org.opensearch.action.search.SearchAction;
@@ -515,6 +516,11 @@ public class SecurityInterceptorTests {
     public void testHybridQueryDlsStateIsRemovedForRemoteCluster() {
         enableCrossClusterSearch();
         assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(SearchAction.NAME);
+    }
+
+    @Test
+    public void testHybridQueryDlsStateIsRemovedForClusterSearchShardsAction() {
+        assertHybridQueryDlsStateIsRemovedForUnrecognizedNode(ClusterSearchShardsAction.NAME);
     }
 
     @Test


### PR DESCRIPTION
### Description

* Category: Bug fix

Hybrid search requests can fail when they are executed by a user with Document-Level Security (DLS). Neural Search requires a `HybridQuery` to remain the top-level Lucene query, while the Security plugin can wrap the user query in `BooleanQuery` and `ConstantScoreQuery` objects when enforcing DLS. Neural Search then rejects the query or fails while casting the wrapper to `HybridQuery`.

The original report also observed inconsistent behavior: adding a suggestion could make an otherwise equivalent request succeed because it selected a different DLS path.

#### Old behavior

In adaptive DLS mode, a top-level hybrid query could be wrapped by the Security plugin. This changed the query shape expected by Neural Search and could cause every shard to fail with errors such as:

* `hybrid query must be a top level query and cannot be wrapped into other queries`
* `BooleanQuery` or `ConstantScoreQuery` cannot be cast to `HybridQuery`

#### New behavior

For supported top-level hybrid requests in adaptive mode, the Security plugin now:

* Detects the hybrid query without adding a compile-time dependency on Neural Search.
* Applies the DLS query through `QueryBuilder.filter(...)`, preserving the hybrid query as the top-level query and propagating DLS into every hybrid subquery.
* Uses a separate internal marker so reader-level DLS remains active for global aggregations and other search paths that do not rely solely on the top-level query.
* Propagates that marker between nodes in the local cluster and removes it before cross-cluster search requests.
* Retains the existing star-tree safeguard before skipping query wrapping.

Non-hybrid queries and unsupported hybrid configurations continue through their existing DLS paths.

#### Supported scope

The special hybrid handling is enabled only when all of these conditions are true:

* DLS mode is `adaptive`.
* The request has DLS restrictions.
* The user query is a top-level `hybrid` query.
* The DLS rule does not contain a term-lookup query.
* The hybrid query contains no parent/child query clauses.
* The request targets only the local cluster.
* Every node in the cluster runs OpenSearch 3.9 or newer.

Within that scope, the fix supports:

* Single or multiple hybrid subqueries.
* Existing hybrid filters, which are composed with the DLS filter.
* DLS-filtered hits.
* Global aggregations protected by reader-level DLS.
* Searches containing suggestions.
* Multi-node local clusters.

#### Not supported by this change

The special handling is intentionally not enabled for:

* Explicit `filter_level` DLS mode.
* Explicit `lucene_level` DLS mode.
* Adaptive mode when the DLS rule contains a term-lookup query.
* Hybrid queries nested beneath another query.
* Hybrid queries containing parent/child clauses.
* Cross-cluster search.
* Mixed-version clusters containing a node older than OpenSearch 3.9.

These cases retain their existing DLS behavior and are not claimed to be compatible with hybrid search by this PR.

This change introduces no new setting, permission, REST API, or dependency on the Neural Search plugin.

### Issues Resolved

Addresses:

* https://github.com/opensearch-project/neural-search/issues/1303
* Original transferred issue: https://github.com/opensearch-project/ml-commons/issues/3815
* Original community report: https://forum.opensearch.org/t/hybrid-search-not-working-with-document-level-security/24239

Related prior work:

* https://github.com/opensearch-project/neural-search/pull/1432

Neural Search PR #1432 added support for recognizing and reconstructing the Security DLS wrapper shape available at the time. This PR complements that work on the Security side by avoiding the outer wrapper for supported hybrid requests.

This is not a backport.

These changes introduce no new permissions and require no Security Dashboards companion PR.

### Testing

#### Security plugin unit tests

Added focused coverage for:

* Adaptive-mode selection and the DLS, version, and local-cluster gates.
* Requests without a source or query, non-search requests, and non-hybrid queries.
* Nested hybrid queries, parent/child clauses, and term-lookup DLS rules.
* Applying DLS through the hybrid filter method and composing an existing hybrid filter.
* Preserving reader-level DLS and protecting global aggregations.
* Retaining the star-tree safeguard.
* Propagating the internal marker to another local node and removing it before a remote-cluster request.

Executed:

```bash
./gradlew test \
  --tests org.opensearch.security.configuration.DlsFlsFilterLeafReaderTest \
  --tests org.opensearch.security.configuration.DlsFilterLevelActionHandlerTest \
  --tests org.opensearch.security.configuration.DlsFlsValveImplTest \
  --tests org.opensearch.security.privileges.dlsfls.DlsFlsBaseContextTest \
  --tests org.opensearch.security.transport.SecurityInterceptorTests
```

Result: passed.

```bash
./gradlew :precommit
```

Result: passed.

The Security plugin bundle was also built successfully.

#### Cross-plugin integration testing

Published the Security plugin ZIP to Maven Local:

```bash
cd /path/to/opensearch-security
./gradlew publishPluginZipPublicationToMavenLocal
```

Then ran the companion Neural Search test on a three-node cluster:

```bash
cd /path/to/neural-search
./gradlew :integTest \
  --tests org.opensearch.neuralsearch.query.HybridQueryDlsIT \
  -x spotlessApply \
  -Dsecurity.enabled=true \
  -PnumNodes=3 \
  --refresh-dependencies
```

Result: passed.

The test verifies the unrestricted administrator baseline, DLS-filtered hits, DLS-protected global aggregation counts and buckets, a suggestion-bearing request with an allowed-document suggestion, composition with an existing hybrid filter, a single-clause hybrid query, no duplicate hits, and no failed shards.

Running the same test with the unmodified Security plugin reproduced the original top-level `BooleanQuery`/`HybridQuery` failure.

The companion integration coverage is available in [opensearch-project/neural-search#1957](https://github.com/opensearch-project/neural-search/pull/1957). That draft depends on this Security PR and should merge only after this fix is available to the Neural Search integration-test build.

### Check List

- [x] New functionality includes testing
- [x] New functionality has been documented — behavior and support boundaries are documented above and in code comments; no user-facing setting or API is introduced
- [x] New Roles/Permissions have a corresponding security dashboards plugin PR — N/A, no roles or permissions were added
- [x] API changes companion pull request created — N/A, no API changes were made
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
