### PR TITLE
[Backport 2.19] Bump 1password/load-secrets-action to v5.0.1 (security)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -23,7 +23,7 @@ jobs:
           java-version: 21
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Load secret
-        uses: 1password/load-secrets-action@581a835fb51b8e7ec56b71cf2ffddd7e68bb25e0 # v2
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           # Export loaded secrets as environment variables
           export-env: true


### PR DESCRIPTION
Backport of #6412 to `2.19`. The auto-backport failed (cherry-pick conflict), so this was recreated manually to the desired end state.

Relates to https://github.com/opensearch-project/opensearch-build/issues/6440#issuecomment-5349573946

Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>