### PR TITLE
Replace RestHighLevelClient with OpenSearch Java Client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -534,6 +534,8 @@ configurations {
             // For org.opensearch.plugin:transport-grpc
             force "com.google.guava:failureaccess:1.0.3"
             force "org.scala-lang:scala3-library_3:3.9.0"
+
+            force "jakarta.json:jakarta.json-api:2.1.3"
         }
     }
 }
@@ -632,6 +634,7 @@ allprojects {
                 }
                 integrationTestImplementation "io.projectreactor.netty:reactor-netty-core:${versions.reactor_netty}"
                 integrationTestImplementation "io.projectreactor.netty:reactor-netty-http:${versions.reactor_netty}"
+                integrationTestImplementation 'org.opensearch.client:opensearch-java:3.10.0'
             }
         }
     }
@@ -823,6 +826,7 @@ dependencies {
     testCompileOnly 'org.apiguardian:apiguardian-api:1.1.2'
 
     testImplementation libs.springframework.beans
+    testImplementation 'org.opensearch.client:opensearch-java:3.10.0'
 
     testRuntimeOnly(libs.springframework.core) {
         exclude(group: 'org.springframework', module: 'spring-jcl')

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -97,6 +97,7 @@ configurations {
             force "io.netty:netty-transport:${versions.netty}"
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
 
+            force "jakarta.json:jakarta.json-api:2.1.3"
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
+++ b/src/integrationTest/java/org/opensearch/security/CrossClusterSearchTests.java
@@ -22,21 +22,20 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
-import org.opensearch.test.framework.cluster.SearchRequestFactory;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.security.Song.ARTIST_FIRST;
 import static org.opensearch.security.Song.FIELD_ARTIST;
@@ -51,15 +50,14 @@ import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.security.Song.TITLE_MAGNUM_OPUS;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitDoesNotContainField;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitDoesNotContainField;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 
 /**
 * This is a parameterized test so that one test class is used to test security plugin behaviour when <code>ccsMinimizeRoundtrips</code>
@@ -75,6 +73,7 @@ public class CrossClusterSearchTests {
 
     public static final String REMOTE_CLUSTER_NAME = "ccsRemote";
     public static final String REMOTE_SONG_INDEX = REMOTE_CLUSTER_NAME + ":" + SONG_INDEX_NAME;
+    public static final String REMOTE_PROHIBITED_SONG_INDEX = REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME;
 
     public static final String SONG_ID_1R = "remote-00001";
     public static final String SONG_ID_2L = "local-00002";
@@ -127,6 +126,12 @@ public class CrossClusterSearchTests {
 
     public static final String LIMITED_USER_INDEX_NAME = "user-" + LIMITED_USER.getName() + "-" + LIMITED_USER.getAttribute(TYPE_ATTRIBUTE);
     public static final String ADMIN_USER_INDEX_NAME = "user-" + ADMIN_USER.getName() + "-" + ADMIN_USER.getAttribute(TYPE_ATTRIBUTE);
+    public static final String REMOTE_LIMITED_USER_INDEX = REMOTE_CLUSTER_NAME
+        + ":"
+        + "user-"
+        + LIMITED_USER.getName()
+        + "-"
+        + LIMITED_USER.getAttribute(TYPE_ATTRIBUTE);
 
     private static final TestCertificates TEST_CERTIFICATES = new TestCertificates();
 
@@ -187,73 +192,74 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldFindDocumentOnRemoteCluster_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(2));
-            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
-            assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
+            assertThat(response, searchHitsContainDocumentWithId(0, REMOTE_SONG_INDEX, SONG_ID_1R));
+            assertThat(response, searchHitsContainDocumentWithId(1, REMOTE_SONG_INDEX, SONG_ID_6R));
         }
     }
 
-    private SearchRequest searchAll(String indexName) {
-        SearchRequest searchRequest = SearchRequestFactory.searchAll(indexName);
-        searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
-        return searchRequest;
+    private SearchRequest searchAll(String indexName, String... indexNames) {
+        return SearchRequest.of(
+            b -> b.index(indexName, indexNames)
+                .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
+                .query(QueryBuilders.matchAll().build().toQuery())
+        );
     }
 
     @Test
     public void shouldFindDocumentOnRemoteCluster_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll("*" + ":" + SONG_INDEX_NAME);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             // only remote documents are found
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(2));
-            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
-            assertThat(response, searchHitsContainDocumentWithId(1, SONG_INDEX_NAME, SONG_ID_6R));
+            assertThat(response, searchHitsContainDocumentWithId(0, REMOTE_SONG_INDEX, SONG_ID_1R));
+            assertThat(response, searchHitsContainDocumentWithId(1, REMOTE_SONG_INDEX, SONG_ID_6R));
         }
     }
 
     @Test
     public void shouldSearchForDocumentOnRemoteClustersWhenStarIsUsedAsClusterName_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll("*" + ":" + PROHIBITED_SONG_INDEX_NAME);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            SearchRequest searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
-            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX, SONG_INDEX_NAME);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(3));
             assertThat(
                 response,
                 searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_1R),
                     Pair.of(SONG_INDEX_NAME, SONG_ID_2L),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R)
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_6R)
                 )
             );
         }
@@ -261,41 +267,39 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfLocalAccess() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            var searchRequest = SearchRequestFactory.searchAll(REMOTE_SONG_INDEX, PROHIBITED_SONG_INDEX_NAME);
-            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX, PROHIBITED_SONG_INDEX_NAME);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentOnBothClustersWhenIndexOnBothClusterArePointedOut_negativeLackOfRemoteAccess() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             String remoteIndex = REMOTE_CLUSTER_NAME + ":" + PROHIBITED_SONG_INDEX_NAME;
-            SearchRequest searchRequest = SearchRequestFactory.searchAll(remoteIndex, SONG_INDEX_NAME);
-            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+            SearchRequest searchRequest = searchAll(remoteIndex, SONG_INDEX_NAME);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchViaAllAliasOnRemoteCluster_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
             assertThat(
                 response,
                 searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_1R),
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_6R),
+                    Pair.of(REMOTE_PROHIBITED_SONG_INDEX, SONG_ID_3R),
+                    Pair.of(REMOTE_LIMITED_USER_INDEX, SONG_ID_5R)
                 )
             );
         }
@@ -303,29 +307,29 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldSearchViaAllAliasOnRemoteCluster_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":_all");
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(4));
             assertThat(
                 response,
                 searchHitsContainDocumentsInAnyOrder(
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_1R),
-                    Pair.of(SONG_INDEX_NAME, SONG_ID_6R),
-                    Pair.of(PROHIBITED_SONG_INDEX_NAME, SONG_ID_3R),
-                    Pair.of(LIMITED_USER_INDEX_NAME, SONG_ID_5R)
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_1R),
+                    Pair.of(REMOTE_SONG_INDEX, SONG_ID_6R),
+                    Pair.of(REMOTE_PROHIBITED_SONG_INDEX, SONG_ID_3R),
+                    Pair.of(REMOTE_LIMITED_USER_INDEX, SONG_ID_5R)
                 )
             );
         }
@@ -333,19 +337,19 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldSearchAllIndexOnRemoteClusterWhenStarIsUsedAsIndexName_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":*");
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldResolveUserNameExpressionInRoleIndexPattern_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + LIMITED_USER_INDEX_NAME);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, numberOfTotalHitsIsEqualTo(1));
         }
@@ -353,75 +357,82 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldResolveUserNameExpressionInRoleIndexPattern_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":" + ADMIN_USER_INDEX_NAME);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchInIndexWithPrefix_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":song*");
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(2));
             assertThat(
                 response,
-                searchHitsContainDocumentsInAnyOrder(Pair.of(SONG_INDEX_NAME, SONG_ID_1R), Pair.of(SONG_INDEX_NAME, SONG_ID_6R))
+                searchHitsContainDocumentsInAnyOrder(Pair.of(REMOTE_SONG_INDEX, SONG_ID_1R), Pair.of(REMOTE_SONG_INDEX, SONG_ID_6R))
             );
         }
     }
 
     @Test
     public void shouldSearchInIndexWithPrefix_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchAll(REMOTE_CLUSTER_NAME + ":prohibited*");
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseRock() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_ROCK)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DLS_USER_ROCK)) {
             SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             // searching for all documents, so is it important that result contain only one document with id SONG_ID_1
             // and document with SONG_ID_6 is excluded from result set by DLS
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(1));
-            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_1R));
+            assertThat(response, searchHitsContainDocumentWithId(0, REMOTE_SONG_INDEX, SONG_ID_1R));
         }
     }
 
     @Test
     public void shouldEvaluateDocumentLevelSecurityRulesOnRemoteClusterOnSearchRequest_caseJazz() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DLS_USER_JAZZ)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DLS_USER_JAZZ)) {
             SearchRequest searchRequest = searchAll(REMOTE_SONG_INDEX);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             // searching for all documents, so is it important that result contain only one document with id SONG_ID_6
             // and document with SONG_ID_1 is excluded from result set by DLS
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(1));
-            assertThat(response, searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, SONG_ID_6R));
+            assertThat(response, searchHitsContainDocumentWithId(0, REMOTE_SONG_INDEX, SONG_ID_6R));
         }
+    }
+
+    private SearchRequest queryStringQueryRequest(String indexName, String queryString) {
+        return SearchRequest.of(
+            b -> b.index(indexName)
+                .ccsMinimizeRoundtrips(ccsMinimizeRoundtrips)
+                .query(QueryBuilders.queryString().query(queryString).build().toQuery())
+        );
     }
 
     @Test
     public void shouldHaveAccessOnlyToSpecificField() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_INCLUDE_TITLE_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(FLS_INCLUDE_TITLE_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
-            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(1));
@@ -436,11 +447,10 @@ public class CrossClusterSearchTests {
 
     @Test
     public void shouldLackAccessToSpecificField() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(FLS_EXCLUDE_LYRICS_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(FLS_EXCLUDE_LYRICS_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(REMOTE_SONG_INDEX, QUERY_TITLE_MAGNUM_OPUS);
-            searchRequest.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
 
-            SearchResponse response = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(1));

--- a/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsIntegrationTests.java
@@ -11,7 +11,6 @@ package org.opensearch.security;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -24,20 +23,22 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
-import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.get.MultiGetItemResponse;
-import org.opensearch.action.get.MultiGetRequest;
-import org.opensearch.action.get.MultiGetResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.AvgAggregate;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.MgetRequest;
+import org.opensearch.client.opensearch.core.MgetResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.get.GetResult;
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
 import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.aggregations.Aggregation;
-import org.opensearch.search.aggregations.metrics.ParsedAvg;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.transport.client.Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -48,7 +49,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.security.Song.ARTIST_FIRST;
 import static org.opensearch.security.Song.ARTIST_NO;
 import static org.opensearch.security.Song.ARTIST_STRING;
@@ -61,14 +61,14 @@ import static org.opensearch.security.Song.QUERY_TITLE_NEXT_SONG;
 import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.averageAggregationRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.searchRequestWithSort;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containDocument;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containAggregationWithNameAndType;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
+import static org.opensearch.test.framework.client.SearchRequestFactory.averageAggregationRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.searchRequestWithSort;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containAggregationWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
 
 public class DlsIntegrationTests {
 
@@ -405,9 +405,9 @@ public class DlsIntegrationTests {
     @Test
     public void testShouldSearchAll() throws IOException {
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_ALL_USER)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
@@ -419,15 +419,15 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
             assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_NO));
         }
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_FIRST_AND_SECOND_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_FIRST_AND_SECOND_USER)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
@@ -439,7 +439,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -450,16 +450,16 @@ public class DlsIntegrationTests {
     @Test
     public void testShouldSearchI1_S2I2_S3() throws IOException {
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_STRING)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
             assertThat(searchResponse, searchHitContainsFieldWithValue(0, FIELD_ARTIST, ARTIST_STRING));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -470,12 +470,12 @@ public class DlsIntegrationTests {
     public void testShouldSearchI1_S3I1_S6I2_S2() throws IOException {
 
         try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+            CloseableOpenSearchClient client = cluster.getClient(
                 READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE
             )
         ) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
@@ -483,7 +483,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_UNKNOWN));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -493,13 +493,9 @@ public class DlsIntegrationTests {
 
     public void testShouldSearchI1_S1I1_S3I2_S2I2_S4() throws IOException {
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
@@ -507,7 +503,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_FIRST));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
@@ -518,9 +514,9 @@ public class DlsIntegrationTests {
 
     public void testShouldSearchStarsLessThanThree() throws IOException {
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
@@ -528,7 +524,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(1, FIELD_ARTIST, ARTIST_STRING));
 
             searchRequest = searchRequestWithSort(SECOND_INDEX_NAME);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(2));
@@ -541,9 +537,9 @@ public class DlsIntegrationTests {
     public void testSearchForAllDocumentsWithIndexPattern() throws IOException {
 
         // DLS
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_ALL_USER)) {
             SearchRequest searchRequest = searchRequestWithSort("*".concat(FIRST_INDEX_NAME));
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
@@ -555,7 +551,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
 
             searchRequest = searchRequestWithSort("*".concat(SECOND_INDEX_NAME));
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -566,9 +562,9 @@ public class DlsIntegrationTests {
     @Test
     public void testSearchForAllDocumentsWithAlias() throws IOException {
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_ALL_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_ALL_USER)) {
             SearchRequest searchRequest = searchRequestWithSort(FIRST_INDEX_ALIAS);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(6));
@@ -580,7 +576,7 @@ public class DlsIntegrationTests {
             assertThat(searchResponse, searchHitContainsFieldWithValue(5, FIELD_ARTIST, ARTIST_UNKNOWN));
 
             searchRequest = searchRequestWithSort("*".concat(SECOND_INDEX_NAME));
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -595,119 +591,107 @@ public class DlsIntegrationTests {
     public void testAggregateAndComputeStarRatings() throws IOException {
 
         // DLS
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_MATCHES_ARTIST_FIRST)) {
             String aggregationName = "averageStars";
             Song song = FIRST_INDEX_SONGS_BY_ID.get(FIND_ID_OF_SONG_WITH_ARTIST.apply(FIRST_INDEX_SONGS_BY_ID, ARTIST_TWINS));
 
             SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-            assertThat(((ParsedAvg) actualAggregation).getValue(), is(song.getStars() * 1.0));
+            Aggregate actualAggregation = searchResponse.aggregations().get(aggregationName);
+            assertThat(actualAggregation._get(), instanceOf(AvgAggregate.class));
+            assertThat(((AvgAggregate) actualAggregation._get()).value(), is(song.getStars() * 1.0d));
         }
         try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+            CloseableOpenSearchClient client = cluster.getClient(
                 READ_WHERE_FIELD_ARTIST_MATCHES_ARTIST_TWINS_OR_FIELD_STARS_GREATER_THAN_FIVE
             )
         ) {
+
             String aggregationName = "averageStars";
             SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-            assertThat(((ParsedAvg) actualAggregation).getValue(), is(4.5));
+            Aggregate actualAggregation = searchResponse.aggregations().get(aggregationName);
+            assertThat(actualAggregation._get(), instanceOf(AvgAggregate.class));
+            assertThat(((AvgAggregate) actualAggregation._get()).value(), is(4.5d));
         }
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(READ_WHERE_STARS_LESS_THAN_THREE)) {
             String aggregationName = "averageStars";
             SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-            assertThat(((ParsedAvg) actualAggregation).getValue(), is(1.5));
+            Aggregate actualAggregation = searchResponse.aggregations().get(aggregationName);
+            assertThat(actualAggregation._get(), instanceOf(AvgAggregate.class));
+            assertThat(((AvgAggregate) actualAggregation._get()).value(), is(1.5d));
         }
     }
 
     @Test
     public void testGetDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
-        GetRequest findExistingDoc = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
-        GetRequest findNonExistingDoc = new GetRequest(FIRST_INDEX_NAME, "RANDOM_INDEX");
+        GetRequest findExistingDoc = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
+        GetRequest findNonExistingDoc = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id("RANDOM_INDEX"));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
-            assertGetForDLSRestrictions(restHighLevelClient, findExistingDoc, findNonExistingDoc);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
+            assertGetForDLSRestrictions(client, findExistingDoc, findNonExistingDoc);
         }
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_STARS_TERM_QUERY)) {
-            assertGetForDLSRestrictions(restHighLevelClient, findExistingDoc, findNonExistingDoc);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_STARS_TERM_QUERY)) {
+            assertGetForDLSRestrictions(client, findExistingDoc, findNonExistingDoc);
         }
     }
 
-    private void assertGetForDLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        GetRequest findExistingDoc,
-        GetRequest findNonExistingDoc
-    ) throws IOException, Exception {
-        GetResponse response = restHighLevelClient.get(findExistingDoc, DEFAULT);
+    private void assertGetForDLSRestrictions(OpenSearchClient client, GetRequest findExistingDoc, GetRequest findNonExistingDoc)
+        throws IOException, Exception {
+        GetResponse<?> response = client.get(findExistingDoc, Map.class);
         assertThat(response, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        response = restHighLevelClient.get(findNonExistingDoc, DEFAULT);
-        assertThat(response.isExists(), equalTo(false));
+        response = client.get(findNonExistingDoc, Map.class);
+        assertThat(response.found(), equalTo(false));
     }
 
     @Test
     public void testMultiGetDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
-            assertMGetForDLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
+            assertMGetForDLSRestrictions(client, multiGetRequest);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_STARS_TERM_QUERY)) {
-            assertMGetForDLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_STARS_TERM_QUERY)) {
+            assertMGetForDLSRestrictions(client, multiGetRequest);
         }
     }
 
-    private void assertMGetForDLSRestrictions(RestHighLevelClient restHighLevelClient, MultiGetRequest multiGetRequest) throws IOException,
-        Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+    private void assertMGetForDLSRestrictions(OpenSearchClient client, MgetRequest multiGetRequest) throws IOException, Exception {
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        List<GetResult<?>> getResponses = multiGetResponse.docs().stream().map(MultiGetResponseItem::result).collect(Collectors.toList());
         assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
         assertThat(getResponses, not(hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2))));
     }
 
     @Test
     public void testSearchDocumentWithBoolOrTermDLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
-            assertSearchForDLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_ARTIST_BOOL_QUERY)) {
+            assertSearchForDLSRestrictions(client, searchRequest);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_STARS_TERM_QUERY)) {
-            assertSearchForDLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_STARS_TERM_QUERY)) {
+            assertSearchForDLSRestrictions(client, searchRequest);
         }
     }
 
     @SuppressWarnings("unchecked")
-    private void assertSearchForDLSRestrictions(RestHighLevelClient restHighLevelClient, SearchRequest searchRequest) throws IOException,
-        Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+    private void assertSearchForDLSRestrictions(OpenSearchClient client, SearchRequest searchRequest) throws IOException, Exception {
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
         assertThat(searchResponse, searchHitsContainDocumentsInAnyOrder(Pair.of(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
@@ -715,50 +699,36 @@ public class DlsIntegrationTests {
 
     @Test
     public void testGetDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
-        GetRequest findExistingDoc = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
-        GetRequest findNonExistingDoc = new GetRequest(FIRST_INDEX_NAME, "RANDOM_INDEX");
+        GetRequest findExistingDoc = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
+        GetRequest findNonExistingDoc = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id("RANDOM_INDEX"));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY
-            )
-        ) {
-            assertGetForDLSRestrictions(restHighLevelClient, findExistingDoc, findNonExistingDoc);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY)) {
+            assertGetForDLSRestrictions(client, findExistingDoc, findNonExistingDoc);
         }
     }
 
     @Test
     public void testMultiGetDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY
-            )
-        ) {
-            assertMGetForDLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY)) {
+            assertMGetForDLSRestrictions(client, multiGetRequest);
         }
     }
 
     @Test
     public void testSearchDocumentWithBoolAndTermDLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY
-            )
-        ) {
-            assertSearchForDLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_MATCH_ARTIST_BOOL_QUERY_MATCH_STARS_TERM_QUERY)) {
+            assertSearchForDLSRestrictions(client, searchRequest);
         }
     }
 
     public void testOverlappingRoleUnionSearchFiltering() throws Exception {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NON_SENSITIVE_ONLY)) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_NON_SENSITIVE_ONLY)) {
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 4);
 
@@ -774,20 +744,16 @@ public class DlsIntegrationTests {
             );
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOW_ALL)) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOW_ALL)) {
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 10);
         }
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_UNION_OF_OVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_ALLOW_ALL
-            )
-        ) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_UNION_OF_OVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_ALLOW_ALL)) {
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 10);
 
@@ -804,9 +770,9 @@ public class DlsIntegrationTests {
     @Test
     @SuppressWarnings("unchecked")
     public void testNonOverlappingRoleUnionSearchFiltering() throws Exception {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NON_SENSITIVE_ONLY)) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_NON_SENSITIVE_ONLY)) {
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 4);
 
@@ -822,9 +788,9 @@ public class DlsIntegrationTests {
             );
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_MATCH_HISTORY_GENRE_ONLY)) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_MATCH_HISTORY_GENRE_ONLY)) {
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 5);
 
@@ -841,12 +807,13 @@ public class DlsIntegrationTests {
         }
 
         try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
+            CloseableOpenSearchClient client = cluster.getClient(
                 USER_UNION_OF_NONOVERLAPPING_ROLES_NON_SENSITIVE_ONLY_AND_HISTORY_GENRE_ONLY
             )
         ) {
-            SearchRequest searchRequest = new SearchRequest(UNION_TEST_INDEX_NAME);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(UNION_TEST_INDEX_NAME));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchResponseHitsEqualTo(searchResponse, 9);
 
@@ -866,7 +833,7 @@ public class DlsIntegrationTests {
         }
     }
 
-    private void assertSearchResponseHitsEqualTo(SearchResponse searchResponse, int hits) throws Exception {
+    private void assertSearchResponseHitsEqualTo(SearchResponse<?> searchResponse, int hits) throws Exception {
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(hits));
     }

--- a/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
+++ b/src/integrationTest/java/org/opensearch/security/DoNotFailOnForbiddenTests.java
@@ -9,57 +9,57 @@
 */
 package org.opensearch.security;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
-import org.hamcrest.Matchers;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.opensearch.action.get.MultiGetItemResponse;
-import org.opensearch.action.get.MultiGetRequest;
-import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.search.MultiSearchRequest;
-import org.opensearch.action.search.MultiSearchResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchScrollRequest;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.cat.AliasesResponse;
+import org.opensearch.client.opensearch.cat.IndicesResponse;
+import org.opensearch.client.opensearch.cat.aliases.AliasesRecord;
+import org.opensearch.client.opensearch.cat.indices.IndicesRecord;
+import org.opensearch.client.opensearch.core.FieldCapsRequest;
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+import org.opensearch.client.opensearch.core.MgetRequest;
+import org.opensearch.client.opensearch.core.MgetResponse;
+import org.opensearch.client.opensearch.core.MsearchRequest;
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+import org.opensearch.client.opensearch.core.msearch.MultisearchBody;
+import org.opensearch.client.opensearch.core.msearch.MultisearchHeader;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.transport.client.Client;
 
 import static org.apache.http.HttpStatus.SC_CREATED;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.security.Song.FIELD_STARS;
 import static org.opensearch.security.Song.FIELD_TITLE;
@@ -71,23 +71,23 @@ import static org.opensearch.security.Song.TITLE_MAGNUM_OPUS;
 import static org.opensearch.security.Song.TITLE_NEXT_SONG;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.averageAggregationRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.getSearchScrollRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.searchRequestWithScroll;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.statsAggregationRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.averageAggregationRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.getSearchScrollRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.queryStringQueryRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.searchRequestWithScroll;
+import static org.opensearch.test.framework.client.SearchRequestFactory.statsAggregationRequest;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containDocument;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containOnlyDocumentId;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.documentContainField;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containAggregationWithNameAndType;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containNotEmptyScrollingId;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfHitsInPageIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.containOnlyDocumentId;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.documentContainField;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containAggregationWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containNotEmptyScrollingId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfHitsInPageIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 
 public class DoNotFailOnForbiddenTests {
 
@@ -181,19 +181,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldPerformSimpleSearch_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(
                 new String[] { MARVELOUS_SONGS, HORRIBLE_SONGS },
                 QUERY_TITLE_MAGNUM_OPUS
             );
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
         }
     }
 
-    private static void assertThatContainOneSong(SearchResponse searchResponse, String documentId, String title) {
+    private static void assertThatContainOneSong(SearchResponse<?> searchResponse, String documentId, String title) {
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
         assertThat(searchResponse, searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, documentId));
@@ -202,19 +202,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldPerformSimpleSearch_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentsViaIndexPattern_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
         }
@@ -222,19 +222,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldSearchForDocumentsViaIndexPattern_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(HORRIBLE_SONGS, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(BOTH_INDEX_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
         }
@@ -242,19 +242,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldSearchForDocumentsViaAll_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThatContainOneSong(searchResponse, ID_1, TITLE_MAGNUM_OPUS);
         }
@@ -262,10 +262,10 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldSearchForDocumentsViaAll_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_POISON);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(0));
@@ -274,124 +274,142 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldMGetDocument_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            MultiGetRequest request = new MultiGetRequest().add(MARVELOUS_SONGS, ID_1).add(MARVELOUS_SONGS, ID_4);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            MgetRequest request = MgetRequest.of(
+                r -> r.docs(d -> d.index(MARVELOUS_SONGS).id(ID_1)).docs(d -> d.index(MARVELOUS_SONGS).id(ID_4))
+            );
 
-            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+            MgetResponse<?> response = client.mget(request, Map.class);
 
-            MultiGetItemResponse[] responses = response.getResponses();
-            assertThat(responses, arrayWithSize(2));
-            MultiGetItemResponse firstResult = responses[0];
-            MultiGetItemResponse secondResult = responses[1];
-            assertThat(firstResult.getFailure(), nullValue());
-            assertThat(secondResult.getFailure(), nullValue());
+            var responses = response.docs();
+            assertThat(responses, iterableWithSize(2));
+            MultiGetResponseItem<?> firstResult = responses.get(0);
+            MultiGetResponseItem<?> secondResult = responses.get(1);
+            assertThat(firstResult.isResult(), is(true));
+            assertThat(secondResult.isResult(), is(true));
             assertThat(
-                firstResult.getResponse(),
+                firstResult.result(),
                 allOf(containDocument(MARVELOUS_SONGS, ID_1), documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
             );
-            assertThat(secondResult.getResponse(), containOnlyDocumentId(MARVELOUS_SONGS, ID_4));
+            assertThat(secondResult.result(), containOnlyDocumentId(MARVELOUS_SONGS, ID_4));
         }
     }
 
     @Test
     public void shouldMGetDocument_partial() throws Exception {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            MultiGetRequest request = new MultiGetRequest().add(MARVELOUS_SONGS, ID_1).add(HORRIBLE_SONGS, ID_4);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            MgetRequest request = MgetRequest.of(
+                r -> r.docs(d -> d.index(MARVELOUS_SONGS).id(ID_1)).docs(d -> d.index(HORRIBLE_SONGS).id(ID_4))
+            );
 
-            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+            MgetResponse<?> response = client.mget(request, Map.class);
 
-            MultiGetItemResponse[] responses = response.getResponses();
-            assertThat(responses, arrayWithSize(2));
-            MultiGetItemResponse firstResult = responses[0];
-            MultiGetItemResponse secondResult = responses[1];
-            assertThat(firstResult.getFailure(), nullValue());
+            var responses = response.docs();
+            assertThat(responses, iterableWithSize(2));
+            MultiGetResponseItem<?> firstResult = responses.get(0);
+            MultiGetResponseItem<?> secondResult = responses.get(1);
+            assertThat(firstResult.isResult(), is(true));
             assertThat(
-                firstResult.getResponse(),
+                firstResult.result(),
                 allOf(containDocument(MARVELOUS_SONGS, ID_1), documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
             );
-            assertThat(secondResult.getFailure().getMessage(), containsString("no permissions for [indices:data/read/mget[shard]]"));
+            assertThat(secondResult.failure().error().reason(), containsString("no permissions for [indices:data/read/mget[shard]]"));
         }
     }
 
     @Test
     public void shouldMGetDocument_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            MultiGetRequest request = new MultiGetRequest().add(HORRIBLE_SONGS, ID_4);
-            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
-            MultiGetItemResponse[] responses = response.getResponses();
-            assertThat(responses, arrayWithSize(1));
-            MultiGetItemResponse firstResult = responses[0];
-            assertThat(firstResult.getFailure().getMessage(), containsString("no permissions for [indices:data/read/mget[shard]]"));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            MgetRequest request = MgetRequest.of(r -> r.index(HORRIBLE_SONGS).ids(ID_4));
+            MgetResponse<?> response = client.mget(request, Map.class);
+            var responses = response.docs();
+            assertThat(responses, iterableWithSize(1));
+            MultiGetResponseItem<?> firstResult = responses.get(0);
+            assertThat(firstResult.failure().error().reason(), containsString("no permissions for [indices:data/read/mget[shard]]"));
         }
     }
 
     @Test
     public void shouldMSearchDocument_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            MultiSearchRequest request = new MultiSearchRequest();
-            request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_MAGNUM_OPUS));
-            request.add(queryStringQueryRequest(BOTH_INDEX_PATTERN, QUERY_TITLE_NEXT_SONG));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            MsearchRequest request = MsearchRequest.of(
+                r -> r.searches(
+                    s -> s.header(MultisearchHeader.of(h -> h.index(BOTH_INDEX_PATTERN)))
+                        .body(
+                            MultisearchBody.of(b -> b.query(QueryBuilders.queryString().query(QUERY_TITLE_MAGNUM_OPUS).build().toQuery()))
+                        )
+                )
+                    .searches(
+                        s -> s.header(MultisearchHeader.of(h -> h.index(BOTH_INDEX_PATTERN)))
+                            .body(
+                                MultisearchBody.of(b -> b.query(QueryBuilders.queryString().query(QUERY_TITLE_NEXT_SONG).build().toQuery()))
+                            )
+                    )
+            );
 
-            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+            MsearchResponse<?> response = client.msearch(request, Map.class);
+            var responses = response.responses();
+            assertThat(responses, iterableWithSize(2));
+            assertThat(responses.get(0).isResult(), is(true));
+            assertThat(responses.get(1).isResult(), is(true));
 
-            MultiSearchResponse.Item[] responses = response.getResponses();
-            assertThat(responses, Matchers.arrayWithSize(2));
-            assertThat(responses[0].getFailure(), nullValue());
-            assertThat(responses[1].getFailure(), nullValue());
-
-            assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-            assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_1));
-            assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-            assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_3));
+            assertThat(responses.get(0).result(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(responses.get(0).result(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_1));
+            assertThat(responses.get(1).result(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+            assertThat(responses.get(1).result(), searchHitsContainDocumentWithId(0, MARVELOUS_SONGS, ID_3));
         }
     }
 
     @Test
     public void shouldMSearchDocument_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            MultiSearchRequest request = new MultiSearchRequest();
-            request.add(queryStringQueryRequest(FORBIDDEN_INDEX_ALIAS, QUERY_TITLE_POISON));
-            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
-            MultiSearchResponse.Item[] responses = response.getResponses();
-            assertThat(responses, Matchers.arrayWithSize(1));
-            assertThat(responses[0].getFailure().getMessage(), containsString("no permissions for [indices:data/read/search]"));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            MsearchRequest request = MsearchRequest.of(
+                r -> r.searches(
+                    s -> s.header(MultisearchHeader.of(f -> f.index(FORBIDDEN_INDEX_ALIAS)))
+                        .body(MultisearchBody.of(b -> b.query(QueryBuilders.queryString().query(QUERY_TITLE_POISON).build().toQuery())))
+                )
+            );
+            MsearchResponse<?> response = client.msearch(request, Map.class);
+            var responses = response.responses();
+            assertThat(responses, iterableWithSize(1));
+            assertThat(responses.get(0).failure().error().reason(), containsString("no permissions for [indices:data/read/search]"));
         }
     }
 
     @Test
     public void shouldGetFieldCapabilities_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(MARVELOUS_SONGS, HORRIBLE_SONGS).fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.index(MARVELOUS_SONGS, HORRIBLE_SONGS).fields(FIELD_TITLE));
 
-            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+            FieldCapsResponse response = client.fieldCaps(request);
 
-            assertThat(response.get(), aMapWithSize(1));
-            assertThat(response.getIndices(), arrayWithSize(1));
-            assertThat(response.getField(FIELD_TITLE), hasKey("text"));
-            assertThat(response.getIndices(), arrayContainingInAnyOrder(MARVELOUS_SONGS));
+            assertThat(response.fields(), aMapWithSize(1));
+            assertThat(response.indices(), iterableWithSize(1));
+            assertThat(response.fields().get(FIELD_TITLE), hasKey("text"));
+            assertThat(response.indices(), containsInAnyOrder(MARVELOUS_SONGS));
         }
     }
 
     @Test
     public void shouldGetFieldCapabilities_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(HORRIBLE_SONGS).fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.index(HORRIBLE_SONGS).fields(FIELD_TITLE));
 
-            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.fieldCaps(request), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldScrollOverSearchResults_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchRequestWithScroll(BOTH_INDEX_PATTERN, 2);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containNotEmptyScrollingId());
 
-            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            ScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
 
-            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            SearchResponse<?> scrollResponse = client.scroll(scrollRequest, Map.class);
             assertThat(scrollResponse, isSuccessfulSearchResponse());
             assertThat(scrollResponse, containNotEmptyScrollingId());
             assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
@@ -401,19 +419,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldScrollOverSearchResults_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             SearchRequest searchRequest = searchRequestWithScroll(HORRIBLE_SONGS, 2);
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldPerformAggregation_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             final String aggregationName = "averageStars";
             SearchRequest searchRequest = averageAggregationRequest(BOTH_INDEX_PATTERN, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
@@ -422,21 +440,21 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldPerformAggregation_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             final String aggregationName = "averageStars";
             SearchRequest searchRequest = averageAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldPerformStatAggregation_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             final String aggregationName = "statsStars";
             SearchRequest searchRequest = statsAggregationRequest(BOTH_INDEX_ALIAS, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
@@ -445,23 +463,19 @@ public class DoNotFailOnForbiddenTests {
 
     @Test
     public void shouldPerformStatAggregation_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
             final String aggregationName = "statsStars";
             SearchRequest searchRequest = statsAggregationRequest(HORRIBLE_SONGS, aggregationName, FIELD_STARS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldPerformCatIndices_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            Request getIndicesRequest = new Request("GET", "/_cat/indices");
-            // High level client doesn't support _cat/_indices API
-            Response getIndicesResponse = restHighLevelClient.getLowLevelClient().performRequest(getIndicesRequest);
-            List<String> indexes = new BufferedReader(
-                new InputStreamReader(getIndicesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
-            ).lines().collect(Collectors.toList());
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            IndicesResponse getIndicesResponse = client.cat().indices();
+            List<String> indexes = getIndicesResponse.valueBody().stream().map(IndicesRecord::index).toList();
 
             assertThat(indexes.size(), equalTo(1));
             assertThat(indexes.get(0), containsString("marvelous_songs"));
@@ -471,30 +485,21 @@ public class DoNotFailOnForbiddenTests {
     @Test
     public void shouldPerformCatAliases_positive() throws IOException {
         // DNFOF works for limited access user
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_USER)) {
-            Request getAliasesRequest = new Request("GET", "/_cat/aliases");
-            Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
-            List<String> aliases = new BufferedReader(
-                new InputStreamReader(getAliasesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
-            ).lines().collect(Collectors.toList());
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_USER)) {
+            AliasesResponse getAliasesResponse = client.cat().aliases();
+            List<String> aliases = getAliasesResponse.valueBody().stream().map(AliasesRecord::index).sorted().toList();
 
             // Does not fail on forbidden, but alias response only contains index which user has access to
-            assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));
             assertThat(aliases.size(), equalTo(1));
-            assertThat(aliases.get(0), containsString("marvelous_songs"));
-            assertThat(aliases.get(0), not(containsString("horrible_songs")));
+            assertThat(aliases, hasItem(containsString("marvelous_songs")));
+            assertThat(aliases, not(hasItem(containsString("horrible_songs"))));
 
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            Request getAliasesRequest = new Request("GET", "/_cat/aliases");
-            Response getAliasesResponse = restHighLevelClient.getLowLevelClient().performRequest(getAliasesRequest);
-            List<String> aliases = new BufferedReader(
-                new InputStreamReader(getAliasesResponse.getEntity().getContent(), StandardCharsets.UTF_8)
-            ).lines().collect(Collectors.toList());
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
+            AliasesResponse getAliasesResponse = client.cat().aliases();
+            List<String> aliases = getAliasesResponse.valueBody().stream().map(AliasesRecord::index).sorted().toList();
 
-            // Admin has access to all
-            assertThat(getAliasesResponse.getStatusLine().getStatusCode(), equalTo(200));
             // Aliases have one entry for each index
             // This response is [(both-indices: marvelous_songs), (both-indices: horrible_songs), (forbidden-index: horrible_songs)]
             assertThat(aliases.size(), equalTo(3));

--- a/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
+++ b/src/integrationTest/java/org/opensearch/security/FlsAndFieldMaskingTests.java
@@ -10,7 +10,6 @@
 package org.opensearch.security;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -28,36 +27,38 @@ import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.get.MultiGetItemResponse;
-import org.opensearch.action.get.MultiGetRequest;
-import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
-import org.opensearch.action.search.MultiSearchRequest;
-import org.opensearch.action.search.MultiSearchResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchScrollRequest;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.AvgAggregate;
+import org.opensearch.client.opensearch.core.FieldCapsRequest;
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.MgetRequest;
+import org.opensearch.client.opensearch.core.MgetResponse;
+import org.opensearch.client.opensearch.core.MsearchRequest;
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.index.mapper.SourceFieldMapper;
 import org.opensearch.index.mapper.size.SizeFieldMapper;
-import org.opensearch.index.query.MatchAllQueryBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.plugin.mapper.MapperSizePlugin;
-import org.opensearch.search.aggregations.Aggregation;
-import org.opensearch.search.aggregations.metrics.ParsedAvg;
-import org.opensearch.search.builder.SearchSourceBuilder;
-import org.opensearch.search.sort.SortOrder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.log.LogsRule;
+import org.opensearch.test.framework.matcher.client.GetResponseMatchers;
+import org.opensearch.test.framework.matcher.client.MultiGetResponseItemMatchers;
+import org.opensearch.test.framework.matcher.client.MultiSearchResponseItemMatchers;
 import org.opensearch.transport.client.Client;
 
 import static org.apache.http.HttpStatus.SC_OK;
@@ -73,7 +74,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.security.Song.ARTIST_FIRST;
 import static org.opensearch.security.Song.ARTIST_STRING;
 import static org.opensearch.security.Song.ARTIST_TWINS;
@@ -87,28 +87,28 @@ import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.security.Song.TITLE_NEXT_SONG;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.averageAggregationRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.getSearchScrollRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryByIdsRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.searchRequestWithScroll;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.containsExactlyIndices;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.containsFieldWithNameAndType;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.numberOfFieldsIsEqualTo;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containDocument;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.documentContainField;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.documentDoesNotContainField;
-import static org.opensearch.test.framework.matcher.MultiGetResponseMatchers.isSuccessfulMultiGetResponse;
-import static org.opensearch.test.framework.matcher.MultiGetResponseMatchers.numberOfGetItemResponsesIsEqualTo;
-import static org.opensearch.test.framework.matcher.MultiSearchResponseMatchers.isSuccessfulMultiSearchResponse;
-import static org.opensearch.test.framework.matcher.MultiSearchResponseMatchers.numberOfSearchItemResponsesIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containAggregationWithNameAndType;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containNotEmptyScrollingId;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitDoesContainField;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitDoesNotContainField;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.client.SearchRequestFactory.averageAggregationRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.getSearchScrollRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.queryByIdsRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.searchRequestWithScroll;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.containsExactlyIndices;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.containsFieldWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.numberOfFieldsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.documentContainField;
+import static org.opensearch.test.framework.matcher.client.GetResultMatchers.documentDoesNotContainField;
+import static org.opensearch.test.framework.matcher.client.MultiGetResponseMatchers.isSuccessfulMultiGetResponse;
+import static org.opensearch.test.framework.matcher.client.MultiGetResponseMatchers.numberOfGetItemResponsesIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.MultiSearchResponseMatchers.isSuccessfulMultiSearchResponse;
+import static org.opensearch.test.framework.matcher.client.MultiSearchResponseMatchers.numberOfSearchItemResponsesIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containAggregationWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containNotEmptyScrollingId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitDoesContainField;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitDoesNotContainField;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
 
 public class FlsAndFieldMaskingTests {
 
@@ -445,87 +445,90 @@ public class FlsAndFieldMaskingTests {
             QueryBuilders.queryStringQuery(String.format("%s:%s", FIELD_ARTIST, SONGS[0].getArtist()))
         );
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(user)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(user)) {
             // search
-            SearchResponse searchResponse = restHighLevelClient.search(new SearchRequest(indexName), DEFAULT);
+            SearchResponse<?> searchResponse = client.search(SearchRequest.of(r -> r.index(indexName)), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
             // search with index pattern
-            searchResponse = restHighLevelClient.search(new SearchRequest("*".concat(indexName)), DEFAULT);
+            searchResponse = client.search(SearchRequest.of(r -> r.index("*".concat(indexName))), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
             // search via alias
-            searchResponse = restHighLevelClient.search(new SearchRequest(indexAlias), DEFAULT);
+            searchResponse = client.search(SearchRequest.of(r -> r.index(indexAlias)), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
             // search via filtered alias
-            searchResponse = restHighLevelClient.search(new SearchRequest(indexFilteredAlias), DEFAULT);
+            searchResponse = client.search(SearchRequest.of(r -> r.index(indexFilteredAlias)), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
             // search via all indices alias
-            searchResponse = restHighLevelClient.search(new SearchRequest(ALL_INDICES_ALIAS), DEFAULT);
+            searchResponse = client.search(SearchRequest.of(r -> r.index(ALL_INDICES_ALIAS)), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
             // scroll
-            searchResponse = restHighLevelClient.search(searchRequestWithScroll(indexName, 1), DEFAULT);
+            searchResponse = client.search(searchRequestWithScroll(indexName, 1), Map.class);
 
             assertSearchHitsDoNotContainField(searchResponse, FIELD_STARS);
 
-            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
-            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            ScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            SearchResponse<?> scrollResponse = client.scroll(scrollRequest, Map.class);
 
             assertSearchHitsDoNotContainField(scrollResponse, FIELD_STARS);
 
             // aggregate data and compute avg
             String aggregationName = "averageStars";
-            searchResponse = restHighLevelClient.search(averageAggregationRequest(indexName, aggregationName, FIELD_STARS), DEFAULT);
+            searchResponse = client.search(averageAggregationRequest(indexName, aggregationName, FIELD_STARS), Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-            assertThat(((ParsedAvg) actualAggregation).getValue(), is(Double.POSITIVE_INFINITY)); // user cannot see the STARS field
+            Aggregate actualAggregation = searchResponse.aggregations().get(aggregationName);
+            assertThat(actualAggregation._get(), instanceOf(AvgAggregate.class));
+            assertThat(actualAggregation.avg().value(), is(nullValue())); // user cannot see the STARS field
 
             // get document
-            GetResponse getResponse = restHighLevelClient.get(new GetRequest(indexName, docIds.get(0)), DEFAULT);
+            GetResponse<?> getResponse = client.get(GetRequest.of(r -> r.index(indexName).id(docIds.get(0))), Map.class);
 
             assertThat(getResponse, documentDoesNotContainField(FIELD_STARS));
 
             // multi get
             for (String index : List.of(indexName, indexAlias)) {
-                MultiGetRequest multiGetRequest = new MultiGetRequest();
-                docIds.forEach(id -> multiGetRequest.add(new MultiGetRequest.Item(index, id)));
+                MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(index).ids(docIds));
+                MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
 
-                MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-
-                List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-                    .map(MultiGetItemResponse::getResponse)
-                    .collect(Collectors.toList());
-                assertThat(getResponses, everyItem(documentDoesNotContainField(FIELD_STARS)));
+                var getResponses = multiGetResponse.docs();
+                assertThat(getResponses, everyItem(MultiGetResponseItemMatchers.documentDoesNotContainField(FIELD_STARS)));
             }
 
             // multi search
             for (String index : List.of(indexName, indexAlias)) {
-                MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
-                docIds.forEach(id -> multiSearchRequest.add(queryByIdsRequest(index, id)));
-                MultiSearchResponse multiSearchResponse = restHighLevelClient.msearch(multiSearchRequest, DEFAULT);
+                MsearchRequest multiSearchRequest = MsearchRequest.of(
+                    r -> r.searches(
+                        s -> s.header(h -> h.index(index))
+                            .body(
+                                b -> b.query(
+                                    org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.ids().values(docIds).build().toQuery()
+                                )
+                            )
+                    )
+                );
+                MsearchResponse<?> multiSearchResponse = client.msearch(multiSearchRequest, Map.class);
 
                 assertThat(multiSearchResponse, isSuccessfulMultiSearchResponse());
-                List<MultiSearchResponse.Item> itemResponses = List.of(multiSearchResponse.getResponses());
-                itemResponses.forEach(item -> assertSearchHitsDoNotContainField(item.getResponse(), FIELD_STARS));
+                var itemResponses = multiSearchResponse.responses();
+                itemResponses.forEach(item -> assertSearchHitsDoNotContainField(item.result(), FIELD_STARS));
             }
 
             // field capabilities
-            FieldCapabilitiesResponse fieldCapsResponse = restHighLevelClient.fieldCaps(
-                new FieldCapabilitiesRequest().indices(indexName).fields(FIELD_TITLE, FIELD_STARS),
-                DEFAULT
+            FieldCapsResponse fieldCapsResponse = client.fieldCaps(
+                FieldCapsRequest.of(r -> r.index(indexName).fields(FIELD_TITLE, FIELD_STARS))
             );
-            assertThat(fieldCapsResponse.getField(FIELD_STARS), nullValue());
+            assertThat(fieldCapsResponse.fields().get(FIELD_STARS), nullValue());
         }
     }
 
@@ -570,31 +573,29 @@ public class FlsAndFieldMaskingTests {
         return user;
     }
 
-    private static void assertSearchHitsDoNotContainField(SearchResponse response, String excludedField) {
+    private static void assertSearchHitsDoNotContainField(SearchResponse<?> response, String excludedField) {
         assertThat(response, isSuccessfulSearchResponse());
-        assertThat(response.getHits().getHits().length, greaterThan(0));
-        IntStream.range(0, response.getHits().getHits().length)
-            .boxed()
+        assertThat(response.hits().hits().size(), greaterThan(0));
+        IntStream.range(0, response.hits().hits().size())
             .forEach(index -> assertThat(response, searchHitDoesNotContainField(index, excludedField)));
     }
 
-    private static void assertSearchHitsDoContainField(SearchResponse response, String includedField) {
+    private static void assertSearchHitsDoContainField(SearchResponse<?> response, String includedField) {
         assertThat(response, isSuccessfulSearchResponse());
-        assertThat(response.getHits().getHits().length, greaterThan(0));
-        IntStream.range(0, response.getHits().getHits().length)
-            .boxed()
+        assertThat(response.hits().hits().size(), greaterThan(0));
+        IntStream.range(0, response.hits().hits().size())
             .forEach(index -> assertThat(response, searchHitDoesContainField(index, includedField)));
     }
 
     @Test
     public void searchForDocuments() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String songId = FIRST_INDEX_ID_SONG_1;
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
             SearchRequest searchRequest = queryByIdsRequest(FIRST_INDEX_NAME, songId);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -608,7 +609,7 @@ public class FlsAndFieldMaskingTests {
             song = SECOND_INDEX_SONGS_BY_ID.get(songId);
 
             searchRequest = queryByIdsRequest(SECOND_INDEX_NAME, songId);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -623,12 +624,12 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void searchForDocumentsWithIndexPattern() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String songId = FIRST_INDEX_ID_SONG_2;
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
             SearchRequest searchRequest = queryByIdsRequest("*".concat(FIRST_INDEX_NAME), songId);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -642,7 +643,7 @@ public class FlsAndFieldMaskingTests {
             song = SECOND_INDEX_SONGS_BY_ID.get(songId);
 
             searchRequest = queryByIdsRequest("*".concat(SECOND_INDEX_NAME), songId);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -657,12 +658,12 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void searchForDocumentsViaAlias() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String songId = FIRST_INDEX_ID_SONG_3;
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
             SearchRequest searchRequest = queryByIdsRequest(FIRST_INDEX_ALIAS, songId);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -676,7 +677,7 @@ public class FlsAndFieldMaskingTests {
             song = SECOND_INDEX_SONGS_BY_ID.get(songId);
 
             searchRequest = queryByIdsRequest("*".concat(SECOND_INDEX_ALIAS), songId);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -691,12 +692,12 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void searchForDocumentsViaFilteredAlias() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String songId = FIND_ID_OF_SONG_WITH_TITLE.apply(FIRST_INDEX_SONGS_BY_ID, TITLE_NEXT_SONG);
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
-            SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_ALIAS_FILTERED_BY_NEXT_SONG_TITLE));
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -711,12 +712,12 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void searchForDocumentsViaAllIndicesAlias() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ALL_INDICES_MASKED_TITLE_ARTIST_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(ALL_INDICES_MASKED_TITLE_ARTIST_READER)) {
             String songId = FIRST_INDEX_ID_SONG_4;
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
             SearchRequest searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -730,7 +731,7 @@ public class FlsAndFieldMaskingTests {
             song = SECOND_INDEX_SONGS_BY_ID.get(songId);
 
             searchRequest = queryByIdsRequest(ALL_INDICES_ALIAS, songId);
-            searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -745,20 +746,19 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void scrollOverSearchResults() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String songId = FIRST_INDEX_SONGS_BY_ID.firstKey();
             Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
 
             SearchRequest searchRequest = searchRequestWithScroll(FIRST_INDEX_NAME, 1);
-            searchRequest.source().sort("_id", SortOrder.ASC);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containNotEmptyScrollingId());
 
-            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            ScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
 
-            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            SearchResponse<?> scrollResponse = client.scroll(scrollRequest, Map.class);
             assertThat(scrollResponse, isSuccessfulSearchResponse());
             assertThat(scrollResponse, containNotEmptyScrollingId());
             assertThat(searchResponse, searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, songId));
@@ -772,7 +772,7 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void aggregateDataAndComputeAverage() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             String aggregationName = "averageStars";
             Double expectedValue = FIRST_INDEX_SONGS_BY_ID.values()
                 .stream()
@@ -781,46 +781,50 @@ public class FlsAndFieldMaskingTests {
                 .orElseThrow(() -> new RuntimeException("Cannot compute average stars - list of docs is empty"));
             SearchRequest searchRequest = averageAggregationRequest(FIRST_INDEX_NAME, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
-            Aggregation actualAggregation = searchResponse.getAggregations().get(aggregationName);
-            assertThat(actualAggregation, instanceOf(ParsedAvg.class));
-            assertThat(((ParsedAvg) actualAggregation).getValue(), is(expectedValue));
+            Aggregate actualAggregation = searchResponse.aggregations().get(aggregationName);
+            assertThat(actualAggregation._get(), instanceOf(AvgAggregate.class));
+            assertThat(actualAggregation.avg().value(), is(expectedValue));
         }
     }
 
     @Test
     public void getDocument() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-            String songId = FIRST_INDEX_ID_SONG_4;
-            Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
-            GetResponse response = restHighLevelClient.get(new GetRequest(FIRST_INDEX_NAME, songId), DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
+            {
+                String songId = FIRST_INDEX_ID_SONG_4;
+                Song song = FIRST_INDEX_SONGS_BY_ID.get(songId);
+                GetResponse<?> response = client.get(GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(songId)), Map.class);
 
-            assertThat(response, containDocument(FIRST_INDEX_NAME, songId));
-            assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
-            assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-            assertThat(response, documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
-            assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+                assertThat(response, containDocument(FIRST_INDEX_NAME, songId));
+                assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
+                assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+                assertThat(response, documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(song.getArtist())));
+                assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+            }
 
-            songId = SECOND_INDEX_ID_SONG_1;
-            song = SECOND_INDEX_SONGS_BY_ID.get(songId);
-            response = restHighLevelClient.get(new GetRequest(SECOND_INDEX_NAME, songId), DEFAULT);
+            {
+                String songId = SECOND_INDEX_ID_SONG_1;
+                Song song = SECOND_INDEX_SONGS_BY_ID.get(songId);
+                GetResponse<?> response = client.get(GetRequest.of(r -> r.index(SECOND_INDEX_NAME).id(songId)), Map.class);
 
-            assertThat(response, containDocument(SECOND_INDEX_NAME, songId));
-            assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
-            assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
-            assertThat(response, documentContainField(FIELD_ARTIST, song.getArtist()));
-            assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+                assertThat(response, containDocument(SECOND_INDEX_NAME, songId));
+                assertThat(response, documentContainField(FIELD_TITLE, song.getTitle()));
+                assertThat(response, documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(song.getLyrics())));
+                assertThat(response, documentContainField(FIELD_ARTIST, song.getArtist()));
+                assertThat(response, documentContainField(FIELD_STARS, song.getStars()));
+            }
         }
     }
 
     @Test
     public void multiGetDocuments() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             List<List<String>> indicesToCheck = List.of(
                 List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
                 List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
@@ -831,33 +835,36 @@ public class FlsAndFieldMaskingTests {
             Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
 
             for (List<String> indices : indicesToCheck) {
-                MultiGetRequest request = new MultiGetRequest();
-                request.add(new MultiGetRequest.Item(indices.get(0), firstSongId));
-                request.add(new MultiGetRequest.Item(indices.get(1), secondSongId));
-                MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+                MgetRequest request = MgetRequest.of(
+                    r -> r.docs(d -> d.index(indices.get(0)).id(firstSongId)).docs(d -> d.index(indices.get(1)).id(secondSongId))
+                );
+                MgetResponse<?> response = client.mget(request, Map.class);
 
                 assertThat(response, isSuccessfulMultiGetResponse());
                 assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
 
-                MultiGetItemResponse[] responses = response.getResponses();
+                var responses = response.docs();
                 assertThat(
-                    responses[0].getResponse(),
+                    responses.get(0),
                     allOf(
-                        containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1),
-                        documentContainField(FIELD_TITLE, firstSong.getTitle()),
-                        documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
-                        documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
-                        documentContainField(FIELD_STARS, firstSong.getStars())
+                        MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_TITLE, firstSong.getTitle()),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_STARS, firstSong.getStars())
                     )
                 );
                 assertThat(
-                    responses[1].getResponse(),
+                    responses.get(1),
                     allOf(
-                        containDocument(SECOND_INDEX_NAME, secondSongId),
-                        documentContainField(FIELD_TITLE, secondSong.getTitle()),
-                        documentContainField(FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
-                        documentContainField(FIELD_ARTIST, secondSong.getArtist()),
-                        documentContainField(FIELD_STARS, secondSong.getStars())
+                        MultiGetResponseItemMatchers.containDocument(SECOND_INDEX_NAME, secondSongId),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_TITLE, secondSong.getTitle()),
+                        MultiGetResponseItemMatchers.documentContainField(
+                            FIELD_LYRICS,
+                            VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())
+                        ),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_ARTIST, secondSong.getArtist()),
+                        MultiGetResponseItemMatchers.documentContainField(FIELD_STARS, secondSong.getStars())
                     )
                 );
             }
@@ -867,7 +874,7 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void multiSearchDocuments() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
             List<List<String>> indicesToCheck = List.of(
                 List.of(FIRST_INDEX_NAME, SECOND_INDEX_NAME),
                 List.of(FIRST_INDEX_ALIAS, SECOND_INDEX_ALIAS)
@@ -878,34 +885,68 @@ public class FlsAndFieldMaskingTests {
             Song secondSong = SECOND_INDEX_SONGS_BY_ID.get(secondSongId);
 
             for (List<String> indices : indicesToCheck) {
-                MultiSearchRequest request = new MultiSearchRequest();
-                request.add(queryByIdsRequest(indices.get(0), firstSongId));
-                request.add(queryByIdsRequest(indices.get(1), secondSongId));
-                MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+                MsearchRequest request = MsearchRequest.of(
+                    r -> r.searches(
+                        s -> s.header(h -> h.index(indices.get(0)))
+                            .body(
+                                b -> b.query(
+                                    org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.ids()
+                                        .values(firstSongId)
+                                        .build()
+                                        .toQuery()
+                                )
+                            )
+                    )
+                        .searches(
+                            s -> s.header(h -> h.index(indices.get(1)))
+                                .body(
+                                    b -> b.query(
+                                        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.ids()
+                                            .values(secondSongId)
+                                            .build()
+                                            .toQuery()
+                                    )
+                                )
+                        )
+                );
+
+                MsearchResponse<?> response = client.msearch(request, Map.class);
 
                 assertThat(response, isSuccessfulMultiSearchResponse());
                 assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
 
-                MultiSearchResponse.Item[] responses = response.getResponses();
+                var responses = response.responses();
 
                 assertThat(
-                    responses[0].getResponse(),
+                    responses.get(0),
                     allOf(
-                        searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, firstSongId),
-                        searchHitContainsFieldWithValue(0, FIELD_TITLE, firstSong.getTitle()),
-                        searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())),
-                        searchHitContainsFieldWithValue(0, FIELD_ARTIST, VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())),
-                        searchHitContainsFieldWithValue(0, FIELD_STARS, firstSong.getStars())
+                        MultiSearchResponseItemMatchers.searchHitsContainDocumentWithId(0, FIRST_INDEX_NAME, firstSongId),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(0, FIELD_TITLE, firstSong.getTitle()),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(
+                            0,
+                            FIELD_LYRICS,
+                            VALUE_TO_MASKED_VALUE.apply(firstSong.getLyrics())
+                        ),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(
+                            0,
+                            FIELD_ARTIST,
+                            VALUE_TO_MASKED_VALUE.apply(firstSong.getArtist())
+                        ),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(0, FIELD_STARS, firstSong.getStars())
                     )
                 );
                 assertThat(
-                    responses[1].getResponse(),
+                    responses.get(1),
                     allOf(
-                        searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, secondSongId),
-                        searchHitContainsFieldWithValue(0, FIELD_TITLE, secondSong.getTitle()),
-                        searchHitContainsFieldWithValue(0, FIELD_LYRICS, VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())),
-                        searchHitContainsFieldWithValue(0, FIELD_ARTIST, secondSong.getArtist()),
-                        searchHitContainsFieldWithValue(0, FIELD_STARS, secondSong.getStars())
+                        MultiSearchResponseItemMatchers.searchHitsContainDocumentWithId(0, SECOND_INDEX_NAME, secondSongId),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(0, FIELD_TITLE, secondSong.getTitle()),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(
+                            0,
+                            FIELD_LYRICS,
+                            VALUE_TO_MASKED_VALUE.apply(secondSong.getLyrics())
+                        ),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(0, FIELD_ARTIST, secondSong.getArtist()),
+                        MultiSearchResponseItemMatchers.searchHitContainsFieldWithValue(0, FIELD_STARS, secondSong.getStars())
                     )
                 );
             }
@@ -915,10 +956,9 @@ public class FlsAndFieldMaskingTests {
     @Test
     public void getFieldCapabilities() throws IOException {
         // FIELD MASKING
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(MASKED_ARTIST_LYRICS_READER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(FIRST_INDEX_NAME)
-                .fields(FIELD_ARTIST, FIELD_TITLE, FIELD_LYRICS);
-            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(MASKED_ARTIST_LYRICS_READER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.index(FIRST_INDEX_NAME).fields(FIELD_ARTIST, FIELD_TITLE, FIELD_LYRICS));
+            FieldCapsResponse response = client.fieldCaps(request);
 
             assertThat(response, containsExactlyIndices(FIRST_INDEX_NAME));
             assertThat(response, numberOfFieldsIsEqualTo(3));
@@ -930,43 +970,43 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertGetForFLSRestrictions(restHighLevelClient, getRequest, true);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_FLS)) {
+            assertGetForFLSRestrictions(client, getRequest, true);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertGetForFLSRestrictions(restHighLevelClient, getRequest, false);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_NO_FIELD_TITLE_FLS)) {
+            assertGetForFLSRestrictions(client, getRequest, false);
         }
     }
 
-    private void assertGetForFLSRestrictions(RestHighLevelClient restHighLevelClient, GetRequest getRequest, boolean shouldShowFieldTitle)
+    private void assertGetForFLSRestrictions(OpenSearchClient client, GetRequest getRequest, boolean shouldShowFieldTitle)
         throws IOException, Exception {
         // if shouldShowFieldTitle == true, we check that only the title field is fetched; if shouldShowFieldTitle == false, we check that
         // only the title field is
         // ignored
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
 
-        Matcher<GetResponse> containsTitleField = documentContainField(
+        Matcher<GetResponse<?>> containsTitleField = GetResponseMatchers.documentContainField(
             FIELD_TITLE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle()
         );
-        Matcher<GetResponse> containsArtistField = documentContainField(
+        Matcher<GetResponse<?>> containsArtistField = GetResponseMatchers.documentContainField(
             FIELD_ARTIST,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
         );
-        Matcher<GetResponse> containsLyricsField = documentContainField(
+        Matcher<GetResponse<?>> containsLyricsField = GetResponseMatchers.documentContainField(
             FIELD_LYRICS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
         );
-        Matcher<GetResponse> containsStarsField = documentContainField(
+        Matcher<GetResponse<?>> containsStarsField = GetResponseMatchers.documentContainField(
             FIELD_STARS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
         );
-        Matcher<GetResponse> containsGenreField = documentContainField(
+        Matcher<GetResponse<?>> containsGenreField = GetResponseMatchers.documentContainField(
             FIELD_GENRE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
         );
@@ -980,72 +1020,65 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertMGetForFLSRestrictions(restHighLevelClient, multiGetRequest, true);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_FLS)) {
+            assertMGetForFLSRestrictions(client, multiGetRequest, true);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertMGetForFLSRestrictions(restHighLevelClient, multiGetRequest, false);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_NO_FIELD_TITLE_FLS)) {
+            assertMGetForFLSRestrictions(client, multiGetRequest, false);
         }
     }
 
-    private void assertMGetForFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest,
-        boolean shouldShowFieldTitle
-    ) throws IOException, Exception {
+    private void assertMGetForFLSRestrictions(OpenSearchClient client, MgetRequest multiGetRequest, boolean shouldShowFieldTitle)
+        throws IOException, Exception {
         // if shouldShowFieldTitle == true, we check that only the title field is fetched; if shouldShowFieldTitle == false, we check that
         // only the title field is
         // ignored
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
 
-        Matcher<GetResponse> documentOneContainsTitleField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentOneContainsTitleField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_TITLE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle()
         );
-        Matcher<GetResponse> documentOneContainsArtistField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentOneContainsArtistField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_ARTIST,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
         );
-        Matcher<GetResponse> documentOneContainsLyricsField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentOneContainsLyricsField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_LYRICS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
         );
-        Matcher<GetResponse> documentOneContainsStarsField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentOneContainsStarsField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_STARS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
         );
-        Matcher<GetResponse> documentOneContainsGenreField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentOneContainsGenreField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_GENRE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
         );
-        Matcher<GetResponse> documentTwoContainsTitleField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentTwoContainsTitleField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_TITLE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle()
         );
-        Matcher<GetResponse> documentTwoContainsArtistField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentTwoContainsArtistField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_ARTIST,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
         );
-        Matcher<GetResponse> documentTwoContainsLyricsField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentTwoContainsLyricsField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_LYRICS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
         );
-        Matcher<GetResponse> documentTwoContainsStarsField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentTwoContainsStarsField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_STARS,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
         );
-        Matcher<GetResponse> documentTwoContainsGenreField = documentContainField(
+        Matcher<MultiGetResponseItem<?>> documentTwoContainsGenreField = MultiGetResponseItemMatchers.documentContainField(
             FIELD_GENRE,
             FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
         );
@@ -1094,26 +1127,23 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testSearchDocumentWithWithNoTitleFieldOrOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_FLS)) {
-            assertSearchForFLSRestrictions(restHighLevelClient, searchRequest, true);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_FLS)) {
+            assertSearchForFLSRestrictions(client, searchRequest, true);
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_NO_FIELD_TITLE_FLS)) {
-            assertSearchForFLSRestrictions(restHighLevelClient, searchRequest, false);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_NO_FIELD_TITLE_FLS)) {
+            assertSearchForFLSRestrictions(client, searchRequest, false);
         }
     }
 
-    private void assertSearchForFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        SearchRequest searchRequest,
-        boolean shouldShowFieldTitle
-    ) throws IOException, Exception {
+    private void assertSearchForFLSRestrictions(OpenSearchClient client, SearchRequest searchRequest, boolean shouldShowFieldTitle)
+        throws IOException, Exception {
         // if shouldShowFieldTitle == true, we check that only the title field is fetched; if shouldShowFieldTitle == false, we check that
         // only the title field is
         // ignored
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1154,16 +1184,16 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithTitleFieldMaskingRestriction() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_MASKED)) {
-            assertProperGetResponsesForTitleFieldMaskingRestriction(restHighLevelClient, getRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperGetResponsesForTitleFieldMaskingRestriction(client, getRequest);
         }
     }
 
-    private void assertProperGetResponsesForTitleFieldMaskingRestriction(RestHighLevelClient restHighLevelClient, GetRequest getRequest)
-        throws IOException, Exception {
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+    private void assertProperGetResponsesForTitleFieldMaskingRestriction(OpenSearchClient client, GetRequest getRequest) throws IOException,
+        Exception {
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         assertThat(
@@ -1178,30 +1208,24 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithTitleFieldMaskingRestriction() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_MASKED)) {
-            assertProperMultiGetResponseForTitleFieldMaskingRestriction(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperMultiGetResponseForTitleFieldMaskingRestriction(client, multiGetRequest);
         }
     }
 
-    private void assertProperMultiGetResponseForTitleFieldMaskingRestriction(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest
-    ) throws IOException, Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+    private void assertProperMultiGetResponseForTitleFieldMaskingRestriction(OpenSearchClient client, MgetRequest multiGetRequest)
+        throws IOException, Exception {
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
         assertThat(
             getResponses,
             hasItem(
-                documentContainField(
+                MultiGetResponseItemMatchers.documentContainField(
                     FIELD_TITLE,
                     VALUE_TO_MASKED_VALUE.apply(FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())
                 )
@@ -1210,7 +1234,7 @@ public class FlsAndFieldMaskingTests {
         assertThat(
             getResponses,
             hasItem(
-                documentContainField(
+                MultiGetResponseItemMatchers.documentContainField(
                     FIELD_TITLE,
                     VALUE_TO_MASKED_VALUE.apply(FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle())
                 )
@@ -1218,40 +1242,90 @@ public class FlsAndFieldMaskingTests {
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
+                )
+            )
         );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre())));
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
+                )
+            )
+        );
     }
 
     @Test
     public void testSearchDocumentWithTitleFieldMaskingRestriction() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ONLY_FIELD_TITLE_MASKED)) {
-            assertProperSearchResponseForTitleFieldMaskingRestriction(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperSearchResponseForTitleFieldMaskingRestriction(client, searchRequest);
         }
     }
 
-    private void assertProperSearchResponseForTitleFieldMaskingRestriction(
-        RestHighLevelClient restHighLevelClient,
-        SearchRequest searchRequest
-    ) throws IOException, Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+    private void assertProperSearchResponseForTitleFieldMaskingRestriction(OpenSearchClient client, SearchRequest searchRequest)
+        throws IOException, Exception {
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1269,16 +1343,16 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
-            assertProperGetResponsesForOnlyAndNoTitleFLSRestrictions(restHighLevelClient, getRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
+            assertProperGetResponsesForOnlyAndNoTitleFLSRestrictions(client, getRequest);
         }
     }
 
-    private void assertProperGetResponsesForOnlyAndNoTitleFLSRestrictions(RestHighLevelClient restHighLevelClient, GetRequest getRequest)
+    private void assertProperGetResponsesForOnlyAndNoTitleFLSRestrictions(OpenSearchClient client, GetRequest getRequest)
         throws IOException, Exception {
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
 
@@ -1292,72 +1366,130 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
-            assertProperMultiGetResponseForOnlyAndNoTitleFLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
+            assertProperMultiGetResponseForOnlyAndNoTitleFLSRestrictions(client, multiGetRequest);
         }
     }
 
-    private void assertProperMultiGetResponseForOnlyAndNoTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest
-    ) throws IOException, Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+    private void assertProperMultiGetResponseForOnlyAndNoTitleFLSRestrictions(OpenSearchClient client, MgetRequest multiGetRequest)
+        throws IOException, Exception {
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
 
         // since the roles are overlapping, the role with less permissions is the only one that is used- which is no title
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()))
-        );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre())));
-        assertThat(
-            getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle())))
-        );
-        assertThat(
-            getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
+                )
+            )
         );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre())));
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle()
+                    )
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
+                )
+            )
+        );
     }
 
     @Test
     public void testSearchDocumentWithWithNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
-            assertProperSearchResponseForOnlyAndNoTitleFLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_AND_NO_FIELD_TITLE_FLS)) {
+            assertProperSearchResponseForOnlyAndNoTitleFLSRestrictions(client, searchRequest);
         }
     }
 
-    private void assertProperSearchResponseForOnlyAndNoTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        SearchRequest searchRequest
-    ) throws IOException, Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+    private void assertProperSearchResponseForOnlyAndNoTitleFLSRestrictions(OpenSearchClient client, SearchRequest searchRequest)
+        throws IOException, Exception {
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1374,20 +1506,16 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithTitleFieldMaskingAndOnlyTitleFLSRestrictions() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperGetResponsesForTitleFieldMaskingAndOnlyTitleFLSRestrictions(restHighLevelClient, getRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperGetResponsesForTitleFieldMaskingAndOnlyTitleFLSRestrictions(client, getRequest);
         }
     }
 
-    private void assertProperGetResponsesForTitleFieldMaskingAndOnlyTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        GetRequest getRequest
-    ) throws IOException, Exception {
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+    private void assertProperGetResponsesForTitleFieldMaskingAndOnlyTitleFLSRestrictions(OpenSearchClient client, GetRequest getRequest)
+        throws IOException, Exception {
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         assertThat(
@@ -1402,32 +1530,26 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithTitleFieldMaskingAndOnlyTitleFLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperMultiGetResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperMultiGetResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(client, multiGetRequest);
         }
     }
 
     private void assertProperMultiGetResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest
+        OpenSearchClient client,
+        MgetRequest multiGetRequest
     ) throws IOException, Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
         assertThat(
             getResponses,
             hasItem(
-                documentContainField(
+                MultiGetResponseItemMatchers.documentContainField(
                     FIELD_TITLE,
                     VALUE_TO_MASKED_VALUE.apply(FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())
                 )
@@ -1436,7 +1558,7 @@ public class FlsAndFieldMaskingTests {
         assertThat(
             getResponses,
             hasItem(
-                documentContainField(
+                MultiGetResponseItemMatchers.documentContainField(
                     FIELD_TITLE,
                     VALUE_TO_MASKED_VALUE.apply(FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle())
                 )
@@ -1444,54 +1566,108 @@ public class FlsAndFieldMaskingTests {
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_ARTIST,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_ARTIST,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_LYRICS,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_LYRICS,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_STARS,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_STARS,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_GENRE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_GENRE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
+                    )
+                )
+            )
         );
     }
 
     @Test
     public void testSearchDocumentWithTitleFieldMaskingAndOnlyTitleFLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperSearchResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_ONLY_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperSearchResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(client, searchRequest);
         }
     }
 
     private void assertProperSearchResponseForTitleFieldMaskingAndOnlyTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
+        OpenSearchClient client,
         SearchRequest searchRequest
     ) throws IOException, Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1509,20 +1685,16 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithTitleFieldMaskingAndNoTitleFLSRestrictions() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperGetResponsesForTitleFieldMaskingAndNoTitleFLSRestrictions(restHighLevelClient, getRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperGetResponsesForTitleFieldMaskingAndNoTitleFLSRestrictions(client, getRequest);
         }
     }
 
-    private void assertProperGetResponsesForTitleFieldMaskingAndNoTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        GetRequest getRequest
-    ) throws IOException, Exception {
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+    private void assertProperGetResponsesForTitleFieldMaskingAndNoTitleFLSRestrictions(OpenSearchClient client, GetRequest getRequest)
+        throws IOException, Exception {
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
         assertThat(getResponse, not(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())));
@@ -1534,74 +1706,132 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithTitleFieldMaskingAndNoTitleFLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(restHighLevelClient, multiGetRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(client, multiGetRequest);
         }
     }
 
     private void assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest
+        OpenSearchClient client,
+        MgetRequest multiGetRequest
     ) throws IOException, Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
+                )
+            )
         );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre())));
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
+                )
+            )
+        );
     }
 
     @Test
     public void testSearchDocumentWithTitleFieldMaskingAndNoTitleFLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)
-        ) {
-            assertProperSearchResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(restHighLevelClient, searchRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_BOTH_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperSearchResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(client, searchRequest);
         }
     }
 
     private void assertProperSearchResponseForTitleFieldMaskingAndNoTitleFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
+        OpenSearchClient client,
         SearchRequest searchRequest
     ) throws IOException, Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1616,22 +1846,18 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testGetDocumentWithTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        GetRequest getRequest = new GetRequest(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1);
+        GetRequest getRequest = GetRequest.of(r -> r.index(FIRST_INDEX_NAME).id(FIRST_INDEX_ID_SONG_1));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
-            )
-        ) {
-            assertProperGetResponsesForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(restHighLevelClient, getRequest);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperGetResponsesForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(client, getRequest);
         }
     }
 
     private void assertProperGetResponsesForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
+        OpenSearchClient client,
         GetRequest getRequest
     ) throws IOException, Exception {
-        GetResponse getResponse = restHighLevelClient.get(getRequest, DEFAULT);
+        GetResponse<?> getResponse = client.get(getRequest, Map.class);
 
         assertThat(getResponse, containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
 
@@ -1646,87 +1872,135 @@ public class FlsAndFieldMaskingTests {
 
     @Test
     public void testMultiGetDocumentWithTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        MultiGetRequest multiGetRequest = new MultiGetRequest();
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1));
-        multiGetRequest.add(new MultiGetRequest.Item(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2));
+        MgetRequest multiGetRequest = MgetRequest.of(r -> r.index(FIRST_INDEX_NAME).ids(FIRST_INDEX_ID_SONG_1, FIRST_INDEX_ID_SONG_2));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
-            )
-        ) {
-            assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
-                restHighLevelClient,
-                multiGetRequest
-            );
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(client, multiGetRequest);
         }
     }
 
     private void assertProperMultiGetResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
-        MultiGetRequest multiGetRequest
+        OpenSearchClient client,
+        MgetRequest multiGetRequest
     ) throws IOException, Exception {
-        MultiGetResponse multiGetResponse = restHighLevelClient.mget(multiGetRequest, DEFAULT);
-        List<GetResponse> getResponses = Arrays.stream(multiGetResponse.getResponses())
-            .map(MultiGetItemResponse::getResponse)
-            .collect(Collectors.toList());
+        MgetResponse<?> multiGetResponse = client.mget(multiGetRequest, Map.class);
+        var getResponses = multiGetResponse.docs();
 
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
-        assertThat(getResponses, hasItem(containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_1)));
+        assertThat(getResponses, hasItem(MultiGetResponseItemMatchers.containDocument(FIRST_INDEX_NAME, FIRST_INDEX_ID_SONG_2)));
 
         // since the roles are overlapping, the role with less permissions is the only one that is used- which is no title, and since there
         // is no title the masking role has no effect
         assertThat(
             getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle())))
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getTitle()
+                    )
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getArtist()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()))
-        );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre())));
-        assertThat(
-            getResponses,
-            not(hasItem(documentContainField(FIELD_TITLE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle())))
-        );
-        assertThat(
-            getResponses,
-            hasItem(documentContainField(FIELD_ARTIST, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getLyrics()
+                )
+            )
         );
         assertThat(
             getResponses,
-            hasItem(documentContainField(FIELD_LYRICS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()))
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getStars()
+                )
+            )
         );
-        assertThat(getResponses, hasItem(documentContainField(FIELD_STARS, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars())));
-        assertThat(getResponses, hasItem(documentContainField(FIELD_GENRE, FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre())));
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_1).getGenre()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            not(
+                hasItem(
+                    MultiGetResponseItemMatchers.documentContainField(
+                        FIELD_TITLE,
+                        FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getTitle()
+                    )
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_ARTIST,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getArtist()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_LYRICS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getLyrics()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_STARS,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getStars()
+                )
+            )
+        );
+        assertThat(
+            getResponses,
+            hasItem(
+                MultiGetResponseItemMatchers.documentContainField(
+                    FIELD_GENRE,
+                    FIRST_INDEX_SONGS_BY_ID.get(FIRST_INDEX_ID_SONG_2).getGenre()
+                )
+            )
+        );
     }
 
     @Test
     public void testSearchDocumentWithTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions() throws IOException, Exception {
-        SearchRequest searchRequest = new SearchRequest(FIRST_INDEX_NAME);
+        SearchRequest searchRequest = SearchRequest.of(r -> r.index(FIRST_INDEX_NAME));
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED
-            )
-        ) {
-            assertProperSearchResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
-                restHighLevelClient,
-                searchRequest
-            );
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALL_ONLY_AND_NO_FIELD_TITLE_FLS_ONLY_FIELD_TITLE_MASKED)) {
+            assertProperSearchResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(client, searchRequest);
         }
     }
 
     private void assertProperSearchResponseForTitleFieldMaskingAndNoTitleFieldAndOnlyTitleFieldFLSRestrictions(
-        RestHighLevelClient restHighLevelClient,
+        OpenSearchClient client,
         SearchRequest searchRequest
     ) throws IOException, Exception {
-        SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
         assertThat(searchResponse, isSuccessfulSearchResponse());
         assertThat(searchResponse, numberOfTotalHitsIsEqualTo(4));
@@ -1747,17 +2021,19 @@ public class FlsAndFieldMaskingTests {
         String indexName = "fls_includes_index";
         List<String> docIds = createIndexWithDocs(indexName, SONGS[0], SONGS[1]);
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_FLS_INCLUDE_STARS)) {
-            SearchRequest searchRequest = new SearchRequest(indexName);
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            MatchAllQueryBuilder matchAllQueryBuilder = QueryBuilders.matchAllQuery();
-            searchSourceBuilder.storedFields(List.of(SizeFieldMapper.NAME, SourceFieldMapper.NAME));
-            searchSourceBuilder.query(matchAllQueryBuilder);
-            searchRequest.source(searchSourceBuilder);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_FLS_INCLUDE_STARS)) {
+            SearchRequest searchRequest = SearchRequest.of(
+                r -> r.index(indexName)
+                    .storedFields(SizeFieldMapper.NAME, SourceFieldMapper.NAME)
+                    .query(org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.matchAll().build().toQuery())
+            );
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchHitsDoContainField(searchResponse, FIELD_STARS);
-            assertThat(searchResponse.toString(), containsString(SizeFieldMapper.NAME));
+            assertThat(
+                searchResponse.hits().hits().stream().map(Hit::metaFields).flatMap(f -> f.keySet().stream()).toList(),
+                hasItem(SizeFieldMapper.NAME)
+            );
             assertSearchHitsDoNotContainField(searchResponse, FIELD_ARTIST);
         }
     }
@@ -1773,17 +2049,19 @@ public class FlsAndFieldMaskingTests {
             logsRule.assertThatContainExactly(indexName + " was closed. Setting metadataFields to empty. Closed index is not searchable.");
         }
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_FLS_INCLUDE_STARS)) {
-            SearchRequest searchRequest = new SearchRequest(indexName);
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            MatchAllQueryBuilder matchAllQueryBuilder = QueryBuilders.matchAllQuery();
-            searchSourceBuilder.storedFields(List.of(SizeFieldMapper.NAME, SourceFieldMapper.NAME));
-            searchSourceBuilder.query(matchAllQueryBuilder);
-            searchRequest.source(searchSourceBuilder);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_FLS_INCLUDE_STARS)) {
+            SearchRequest searchRequest = SearchRequest.of(
+                r -> r.index(indexName)
+                    .storedFields(SizeFieldMapper.NAME, SourceFieldMapper.NAME)
+                    .query(org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.matchAll().build().toQuery())
+            );
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertSearchHitsDoContainField(searchResponse, FIELD_STARS);
-            assertThat(searchResponse.toString(), containsString(SizeFieldMapper.NAME));
+            assertThat(
+                searchResponse.hits().hits().stream().map(Hit::metaFields).flatMap(f -> f.keySet().stream()).toList(),
+                hasItem(SizeFieldMapper.NAME)
+            );
             assertSearchHitsDoNotContainField(searchResponse, FIELD_ARTIST);
         }
     }

--- a/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/PointInTimeOperationTest.java
@@ -10,6 +10,8 @@
 package org.opensearch.security;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Before;
@@ -19,20 +21,20 @@ import org.junit.Test;
 
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.search.CreatePitRequest;
-import org.opensearch.action.search.CreatePitResponse;
-import org.opensearch.action.search.DeletePitRequest;
-import org.opensearch.action.search.DeletePitResponse;
-import org.opensearch.action.search.GetAllPitNodesResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.common.unit.TimeValue;
-import org.opensearch.search.builder.PointInTimeBuilder;
-import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch.core.CreatePitRequest;
+import org.opensearch.client.opensearch.core.CreatePitResponse;
+import org.opensearch.client.opensearch.core.DeleteAllPitsResponse;
+import org.opensearch.client.opensearch.core.DeletePitRequest;
+import org.opensearch.client.opensearch.core.DeletePitResponse;
+import org.opensearch.client.opensearch.core.GetAllPitsResponse;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Pit;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.transport.client.Client;
@@ -40,20 +42,21 @@ import org.opensearch.transport.client.Client;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.core.rest.RestStatus.OK;
 import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.PitResponseMatchers.deleteResponseContainsExactlyPitWithIds;
-import static org.opensearch.test.framework.matcher.PitResponseMatchers.getAllResponseContainsExactlyPitWithIds;
-import static org.opensearch.test.framework.matcher.PitResponseMatchers.isSuccessfulCreatePitResponse;
-import static org.opensearch.test.framework.matcher.PitResponseMatchers.isSuccessfulDeletePitResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.deletePitsResponseContainsExactlyPitWithIds;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.deleteResponseContainsExactlyPitWithIds;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.getAllResponseContainsExactlyPitWithIds;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.isSuccessfulCreatePitResponse;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.isSuccessfulDeletePitResponse;
+import static org.opensearch.test.framework.matcher.client.PitResponseMatchers.isSuccessfulDeletePitsResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentsInAnyOrder;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 
 public class PointInTimeOperationTest {
 
@@ -128,8 +131,8 @@ public class PointInTimeOperationTest {
 
     @Before
     public void cleanUpPits() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            restHighLevelClient.deleteAllPits(DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
+            client.deleteAllPits();
         }
     }
 
@@ -142,10 +145,12 @@ public class PointInTimeOperationTest {
 
     @Test
     public void createPit_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_SONG_INDEX);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = CreatePitRequest.of(
+                r -> r.keepAlive(Time.of(t -> t.time("30m"))).allowPartialPitCreation(false).index(FIRST_SONG_INDEX)
+            );
 
-            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = client.createPit(createPitRequest);
 
             assertThat(createPitResponse, isSuccessfulCreatePitResponse());
         }
@@ -153,10 +158,12 @@ public class PointInTimeOperationTest {
 
     @Test
     public void createPitWithIndexAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, FIRST_INDEX_ALIAS);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = CreatePitRequest.of(
+                r -> r.keepAlive(Time.of(t -> t.time("30m"))).allowPartialPitCreation(false).index(FIRST_INDEX_ALIAS)
+            );
 
-            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = client.createPit(createPitRequest);
 
             assertThat(createPitResponse, isSuccessfulCreatePitResponse());
         }
@@ -164,29 +171,33 @@ public class PointInTimeOperationTest {
 
     @Test
     public void createPit_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_SONG_INDEX);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = CreatePitRequest.of(
+                r -> r.keepAlive(Time.of(t -> t.time("30m"))).allowPartialPitCreation(false).index(SECOND_SONG_INDEX)
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.createPit(createPitRequest), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void createPitWithIndexAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, SECOND_INDEX_ALIAS);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            CreatePitRequest createPitRequest = CreatePitRequest.of(
+                r -> r.keepAlive(Time.of(t -> t.time("30m"))).allowPartialPitCreation(false).index(SECOND_INDEX_ALIAS)
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.createPit(createPitRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.createPit(createPitRequest), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void listAllPits_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(POINT_IN_TIME_USER)) {
             String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
             String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
 
-            GetAllPitNodesResponse getAllPitsResponse = restHighLevelClient.getAllPits(DEFAULT);
+            GetAllPitsResponse getAllPitsResponse = client.getAllPits();
 
             assertThat(getAllPitsResponse, getAllResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
         }
@@ -194,17 +205,17 @@ public class PointInTimeOperationTest {
 
     @Test
     public void listAllPits_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            assertThatThrownBy(() -> restHighLevelClient.getAllPits(DEFAULT), statusException(FORBIDDEN));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            assertThatThrownBy(() -> client.getAllPits(), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void deletePit_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
 
-            DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
+            DeletePitResponse deletePitResponse = client.deletePit(DeletePitRequest.of(r -> r.pitId(existingPitId)));
             assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
             assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
         }
@@ -212,10 +223,10 @@ public class PointInTimeOperationTest {
 
     @Test
     public void deletePitCreatedWithIndexAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
 
-            DeletePitResponse deletePitResponse = restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT);
+            DeletePitResponse deletePitResponse = client.deletePit(DeletePitRequest.of(r -> r.pitId(existingPitId)));
             assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
             assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(existingPitId));
         }
@@ -223,56 +234,49 @@ public class PointInTimeOperationTest {
 
     @Test
     public void deletePit_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
 
-            assertThatThrownBy(
-                () -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT),
-                statusException(FORBIDDEN)
-            );
+            assertThatThrownBy(() -> client.deletePit(DeletePitRequest.of(r -> r.pitId(existingPitId))), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void deletePitCreatedWithIndexAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
 
-            assertThatThrownBy(
-                () -> restHighLevelClient.deletePit(new DeletePitRequest(existingPitId), DEFAULT),
-                statusException(FORBIDDEN)
-            );
+            assertThatThrownBy(() -> client.deletePit(DeletePitRequest.of(r -> r.pitId(existingPitId))), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void deleteAllPits_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(POINT_IN_TIME_USER)) {
             String firstIndexPit = createPitForIndices(FIRST_SONG_INDEX);
             String secondIndexPit = createPitForIndices(SECOND_SONG_INDEX);
 
-            DeletePitResponse deletePitResponse = restHighLevelClient.deleteAllPits(DEFAULT);
-            assertThat(deletePitResponse, isSuccessfulDeletePitResponse());
-            assertThat(deletePitResponse, deleteResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
+            DeleteAllPitsResponse deletePitResponse = client.deleteAllPits();
+            assertThat(deletePitResponse, isSuccessfulDeletePitsResponse());
+            assertThat(deletePitResponse, deletePitsResponseContainsExactlyPitWithIds(firstIndexPit, secondIndexPit));
         }
     }
 
     @Test
     public void deleteAllPits_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
-            assertThatThrownBy(() -> restHighLevelClient.deleteAllPits(DEFAULT), statusException(FORBIDDEN));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
+            assertThatThrownBy(() -> client.deleteAllPits(), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void searchWithPit_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(FIRST_SONG_INDEX);
 
-            SearchRequest searchRequest = new SearchRequest();
-            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = SearchRequest.of(r -> r.pit(Pit.of(p -> p.id(existingPitId))));
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(
                 searchResponse,
@@ -287,13 +291,12 @@ public class PointInTimeOperationTest {
 
     @Test
     public void searchWithPitCreatedWithIndexAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(FIRST_INDEX_ALIAS);
 
-            SearchRequest searchRequest = new SearchRequest();
-            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = SearchRequest.of(r -> r.pit(Pit.of(p -> p.id(existingPitId))));
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(
                 searchResponse,
@@ -308,25 +311,23 @@ public class PointInTimeOperationTest {
 
     @Test
     public void searchWithPit_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(SECOND_SONG_INDEX);
 
-            SearchRequest searchRequest = new SearchRequest();
-            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = SearchRequest.of(r -> r.pit(Pit.of(p -> p.id(existingPitId))));
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void searchWithPitCreatedWithIndexAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_POINT_IN_TIME_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_POINT_IN_TIME_USER)) {
             String existingPitId = createPitForIndices(SECOND_INDEX_ALIAS);
 
-            SearchRequest searchRequest = new SearchRequest();
-            searchRequest.source(new SearchSourceBuilder().pointInTimeBuilder(new PointInTimeBuilder(existingPitId)));
+            SearchRequest searchRequest = SearchRequest.of(r -> r.pit(Pit.of(p -> p.id(existingPitId))));
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
@@ -396,13 +397,15 @@ public class PointInTimeOperationTest {
     * Creates PIT for given indices. Returns PIT id.
     */
     private String createPitForIndices(String... indices) throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            CreatePitRequest createPitRequest = new CreatePitRequest(TimeValue.timeValueMinutes(30), false, indices);
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
+            CreatePitRequest createPitRequest = CreatePitRequest.of(
+                r -> r.keepAlive(Time.of(t -> t.time("30m"))).allowPartialPitCreation(false).index(Arrays.asList(indices))
+            );
 
-            CreatePitResponse createPitResponse = restHighLevelClient.createPit(createPitRequest, DEFAULT);
+            CreatePitResponse createPitResponse = client.createPit(createPitRequest);
 
             assertThat(createPitResponse, isSuccessfulCreatePitResponse());
-            return createPitResponse.getId();
+            return createPitResponse.pitId();
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SearchOperationTest.java
@@ -27,72 +27,80 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
-import org.opensearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
-import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.opensearch.action.admin.indices.alias.Alias;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions;
-import org.opensearch.action.admin.indices.cache.clear.ClearIndicesCacheRequest;
-import org.opensearch.action.admin.indices.cache.clear.ClearIndicesCacheResponse;
-import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsRequest;
-import org.opensearch.action.admin.indices.open.OpenIndexRequest;
-import org.opensearch.action.admin.indices.open.OpenIndexResponse;
-import org.opensearch.action.admin.indices.settings.get.GetSettingsRequest;
-import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
-import org.opensearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.opensearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesRequest;
 import org.opensearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
-import org.opensearch.action.bulk.BulkRequest;
-import org.opensearch.action.bulk.BulkResponse;
-import org.opensearch.action.delete.DeleteRequest;
-import org.opensearch.action.delete.DeleteResponse;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesRequest;
-import org.opensearch.action.fieldcaps.FieldCapabilitiesResponse;
-import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
-import org.opensearch.action.get.MultiGetItemResponse;
-import org.opensearch.action.get.MultiGetRequest;
-import org.opensearch.action.get.MultiGetRequest.Item;
-import org.opensearch.action.get.MultiGetResponse;
-import org.opensearch.action.index.IndexRequest;
-import org.opensearch.action.search.MultiSearchRequest;
-import org.opensearch.action.search.MultiSearchResponse;
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.action.search.SearchScrollRequest;
-import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.client.core.CountRequest;
-import org.opensearch.client.indices.CloseIndexRequest;
-import org.opensearch.client.indices.CloseIndexResponse;
-import org.opensearch.client.indices.CreateIndexRequest;
-import org.opensearch.client.indices.CreateIndexResponse;
-import org.opensearch.client.indices.GetIndexRequest;
-import org.opensearch.client.indices.GetIndexResponse;
-import org.opensearch.client.indices.GetMappingsRequest;
-import org.opensearch.client.indices.GetMappingsResponse;
-import org.opensearch.client.indices.PutIndexTemplateRequest;
-import org.opensearch.client.indices.PutMappingRequest;
-import org.opensearch.client.indices.ResizeRequest;
-import org.opensearch.client.indices.ResizeResponse;
-import org.opensearch.cluster.health.ClusterHealthStatus;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.HealthStatus;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.mapping.Property;
+import org.opensearch.client.opensearch.cluster.HealthRequest;
+import org.opensearch.client.opensearch.cluster.HealthResponse;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.CountRequest;
+import org.opensearch.client.opensearch.core.DeleteRequest;
+import org.opensearch.client.opensearch.core.DeleteResponse;
+import org.opensearch.client.opensearch.core.FieldCapsRequest;
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
+import org.opensearch.client.opensearch.core.IndexRequest;
+import org.opensearch.client.opensearch.core.MgetRequest;
+import org.opensearch.client.opensearch.core.MgetResponse;
+import org.opensearch.client.opensearch.core.MsearchRequest;
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.UpdateRequest;
+import org.opensearch.client.opensearch.core.UpdateResponse;
+import org.opensearch.client.opensearch.indices.Alias;
+import org.opensearch.client.opensearch.indices.ClearCacheRequest;
+import org.opensearch.client.opensearch.indices.ClearCacheResponse;
+import org.opensearch.client.opensearch.indices.CloneIndexRequest;
+import org.opensearch.client.opensearch.indices.CloneIndexResponse;
+import org.opensearch.client.opensearch.indices.CloseIndexRequest;
+import org.opensearch.client.opensearch.indices.CloseIndexResponse;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.CreateIndexResponse;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteTemplateRequest;
+import org.opensearch.client.opensearch.indices.ExistsRequest;
+import org.opensearch.client.opensearch.indices.GetIndexRequest;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.client.opensearch.indices.GetIndicesSettingsRequest;
+import org.opensearch.client.opensearch.indices.GetIndicesSettingsResponse;
+import org.opensearch.client.opensearch.indices.GetMappingRequest;
+import org.opensearch.client.opensearch.indices.GetMappingResponse;
+import org.opensearch.client.opensearch.indices.IndexSettings;
+import org.opensearch.client.opensearch.indices.OpenRequest;
+import org.opensearch.client.opensearch.indices.OpenResponse;
+import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
+import org.opensearch.client.opensearch.indices.PutMappingRequest;
+import org.opensearch.client.opensearch.indices.PutTemplateRequest;
+import org.opensearch.client.opensearch.indices.ShrinkRequest;
+import org.opensearch.client.opensearch.indices.ShrinkResponse;
+import org.opensearch.client.opensearch.indices.SplitRequest;
+import org.opensearch.client.opensearch.indices.SplitResponse;
+import org.opensearch.client.opensearch.indices.UpdateAliasesRequest;
+import org.opensearch.client.opensearch.indices.update_aliases.AddAction;
+import org.opensearch.client.opensearch.indices.update_aliases.RemoveAction;
+import org.opensearch.client.opensearch.indices.update_aliases.RemoveIndexAction;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
+import org.opensearch.client.transport.endpoints.BooleanResponse;
 import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexTemplateMetadata;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.core.rest.RestStatus;
-import org.opensearch.index.query.BoolQueryBuilder;
-import org.opensearch.index.query.MatchQueryBuilder;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.index.reindex.BulkByScrollResponse;
-import org.opensearch.index.reindex.ReindexRequest;
 import org.opensearch.repositories.RepositoryMissingException;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.security.auditlog.AuditLog;
 import org.opensearch.test.framework.AuditCompliance;
 import org.opensearch.test.framework.AuditConfiguration;
@@ -102,29 +110,24 @@ import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.audit.AuditLogsRule;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
+import org.opensearch.test.framework.matcher.client.GetResultMatchers;
 import org.opensearch.transport.client.Client;
 import org.opensearch.transport.client.ClusterAdminClient;
 import org.opensearch.transport.client.IndicesAdminClient;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
-import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.REMOVE;
-import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.REMOVE_INDEX;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
-import static org.opensearch.core.rest.RestStatus.ACCEPTED;
 import static org.opensearch.core.rest.RestStatus.BAD_REQUEST;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
-import static org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR;
 import static org.opensearch.rest.RestRequest.Method.DELETE;
 import static org.opensearch.rest.RestRequest.Method.GET;
 import static org.opensearch.rest.RestRequest.Method.POST;
@@ -147,14 +150,11 @@ import static org.opensearch.test.framework.audit.AuditMessagePredicate.auditPre
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.grantedPrivilege;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.missingPrivilege;
 import static org.opensearch.test.framework.audit.AuditMessagePredicate.userAuthenticated;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.averageAggregationRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.getSearchScrollRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.searchRequestWithScroll;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.statsAggregationRequest;
-import static org.opensearch.test.framework.matcher.BulkResponseMatchers.bulkResponseContainExceptions;
-import static org.opensearch.test.framework.matcher.BulkResponseMatchers.failureBulkResponse;
-import static org.opensearch.test.framework.matcher.BulkResponseMatchers.successBulkResponse;
+import static org.opensearch.test.framework.client.SearchRequestFactory.averageAggregationRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.getSearchScrollRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.queryStringQueryRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.searchRequestWithScroll;
+import static org.opensearch.test.framework.client.SearchRequestFactory.statsAggregationRequest;
 import static org.opensearch.test.framework.matcher.ClusterMatchers.aliasExists;
 import static org.opensearch.test.framework.matcher.ClusterMatchers.clusterContainSuccessSnapshot;
 import static org.opensearch.test.framework.matcher.ClusterMatchers.clusterContainTemplate;
@@ -167,35 +167,40 @@ import static org.opensearch.test.framework.matcher.ClusterMatchers.indexMapping
 import static org.opensearch.test.framework.matcher.ClusterMatchers.indexSettingsContainValues;
 import static org.opensearch.test.framework.matcher.ClusterMatchers.indexStateIsEqualTo;
 import static org.opensearch.test.framework.matcher.ClusterMatchers.snapshotInClusterDoesNotExists;
-import static org.opensearch.test.framework.matcher.DeleteResponseMatchers.isSuccessfulDeleteResponse;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.containsExactlyIndices;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.containsFieldWithNameAndType;
-import static org.opensearch.test.framework.matcher.FieldCapabilitiesResponseMatchers.numberOfFieldsIsEqualTo;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containDocument;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.documentContainField;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.getIndexResponseContainsIndices;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.getMappingsResponseContainsIndices;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.getSettingsResponseContainsIndices;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.isSuccessfulClearIndicesCacheResponse;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.isSuccessfulCloseIndexResponse;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.isSuccessfulCreateIndexResponse;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.isSuccessfulOpenIndexResponse;
-import static org.opensearch.test.framework.matcher.IndexResponseMatchers.isSuccessfulResizeResponse;
-import static org.opensearch.test.framework.matcher.MultiGetResponseMatchers.isSuccessfulMultiGetResponse;
-import static org.opensearch.test.framework.matcher.MultiGetResponseMatchers.numberOfGetItemResponsesIsEqualTo;
-import static org.opensearch.test.framework.matcher.MultiSearchResponseMatchers.isSuccessfulMultiSearchResponse;
-import static org.opensearch.test.framework.matcher.MultiSearchResponseMatchers.numberOfSearchItemResponsesIsEqualTo;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.errorMessageContain;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containAggregationWithNameAndType;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.containNotEmptyScrollingId;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfHitsInPageIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
-import static org.opensearch.test.framework.matcher.UpdateResponseMatchers.isSuccessfulUpdateResponse;
+import static org.opensearch.test.framework.matcher.client.BulkResponseMatchers.bulkResponseContainExceptions;
+import static org.opensearch.test.framework.matcher.client.BulkResponseMatchers.failureBulkResponse;
+import static org.opensearch.test.framework.matcher.client.BulkResponseMatchers.successBulkResponse;
+import static org.opensearch.test.framework.matcher.client.DeleteResponseMatchers.isSuccessfulDeleteResponse;
+import static org.opensearch.test.framework.matcher.client.ErrorCauseMatchers.errorType;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.containsExactlyIndices;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.containsFieldWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.FieldCapsResponseMatchers.numberOfFieldsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.GetResponseMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.client.GetResponseMatchers.documentContainField;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.getIndexResponseContainsIndices;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.getMappingsResponseContainsIndices;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.getSettingsResponseContainsIndices;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulClearIndicesCacheResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulCloneResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulCloseIndexResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulCreateIndexResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulOpenIndexResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulResizeResponse;
+import static org.opensearch.test.framework.matcher.client.IndexResponseMatchers.isSuccessfulSplitResponse;
+import static org.opensearch.test.framework.matcher.client.MultiGetResponseMatchers.isSuccessfulMultiGetResponse;
+import static org.opensearch.test.framework.matcher.client.MultiGetResponseMatchers.numberOfGetItemResponsesIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.MultiSearchResponseMatchers.isSuccessfulMultiSearchResponse;
+import static org.opensearch.test.framework.matcher.client.MultiSearchResponseMatchers.numberOfSearchItemResponsesIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containAggregationWithNameAndType;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.containNotEmptyScrollingId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfHitsInPageIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
+import static org.opensearch.test.framework.matcher.client.UpdateResponseMatchers.isSuccessfulUpdateResponse;
 
 public class SearchOperationTest {
 
@@ -399,10 +404,18 @@ public class SearchOperationTest {
                     new IndicesAliasesRequest().addAliasAction(new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(SONG_LYRICS_ALIAS))
                 )
                 .actionGet();
-            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S2).source(SONGS[1].asMap()))
-                .actionGet();
-            client.index(new IndexRequest().setRefreshPolicy(IMMEDIATE).index(SONG_INDEX_NAME).id(ID_S3).source(SONGS[2].asMap()))
-                .actionGet();
+            client.index(
+                new org.opensearch.action.index.IndexRequest().setRefreshPolicy(IMMEDIATE)
+                    .index(SONG_INDEX_NAME)
+                    .id(ID_S2)
+                    .source(SONGS[1].asMap())
+            ).actionGet();
+            client.index(
+                new org.opensearch.action.index.IndexRequest().setRefreshPolicy(IMMEDIATE)
+                    .index(SONG_INDEX_NAME)
+                    .id(ID_S3)
+                    .source(SONGS[2].asMap())
+            ).actionGet();
 
             client.prepareIndex(PROHIBITED_SONG_INDEX_NAME).setId(ID_P4).setSource(SONGS[3].asMap()).setRefreshPolicy(IMMEDIATE).get();
             client.admin()
@@ -426,7 +439,7 @@ public class SearchOperationTest {
                 UNDELETABLE_TEMPLATE_NAME
             );
             createTemplateRequest.patterns(List.of("pattern-does-not-match-to-any-index"));
-            createTemplateRequest.alias(new Alias(ALIAS_FROM_UNDELETABLE_TEMPLATE));
+            createTemplateRequest.alias(new org.opensearch.action.admin.indices.alias.Alias(ALIAS_FROM_UNDELETABLE_TEMPLATE));
             client.admin().indices().putTemplate(createTemplateRequest).actionGet();
 
             client.admin()
@@ -458,7 +471,8 @@ public class SearchOperationTest {
             IndicesExistsRequest indicesExistsRequest = new IndicesExistsRequest(indexToBeDeleted);
             var indicesExistsResponse = indices.exists(indicesExistsRequest).get();
             if (indicesExistsResponse.isExists()) {
-                DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexToBeDeleted);
+                org.opensearch.action.admin.indices.delete.DeleteIndexRequest deleteIndexRequest =
+                    new org.opensearch.action.admin.indices.delete.DeleteIndexRequest(indexToBeDeleted);
                 indices.delete(deleteIndexRequest).actionGet();
                 Awaitility.await().ignoreExceptions().until(() -> !indices.exists(indicesExistsRequest).get().isExists());
             }
@@ -495,10 +509,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldSearchForDocuments_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -511,10 +525,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldSearchForDocuments_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -522,10 +536,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldSearchForDocumentsViaAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(SONG_LYRICS_ALIAS, QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -538,10 +552,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldSearchForDocumentsViaAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(PROHIBITED_SONG_ALIAS, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(
             userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics_index_alias/_search")
@@ -551,10 +565,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchSongViaMultiIndexAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_NEXT_SONG);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -567,10 +581,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchSongViaMultiIndexAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(COLLECTIVE_INDEX_ALIAS, QUERY_TITLE_POISON);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/collective-index-alias/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -578,10 +592,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchAllIndexes_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -594,10 +608,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchAllIndexes_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest(QUERY_TITLE_MAGNUM_OPUS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -605,10 +619,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchSongIndexesWithAsterisk_prohibitedSongIndex_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_POISON);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -621,10 +635,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchSongIndexesWithAsterisk_singIndex_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -637,10 +651,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAbleToSearchSongIndexesWithAsterisk_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("*" + SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/*song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -648,16 +662,30 @@ public class SearchOperationTest {
 
     @Test
     public void shouldFindSongUsingDslQuery_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SearchRequest searchRequest = new SearchRequest(SONG_INDEX_NAME);
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-            boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "f.+"));
-            boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_MAGNUM_OPUS));
-            searchSourceBuilder.query(boolQueryBuilder);
-            searchRequest.source(searchSourceBuilder);
-
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = SearchRequest.of(
+                r -> r.index(SONG_INDEX_NAME)
+                    .query(
+                        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.bool()
+                            .filter(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.regexp()
+                                    .field(FIELD_ARTIST)
+                                    .value("f.+")
+                                    .build()
+                                    .toQuery()
+                            )
+                            .filter(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.match()
+                                    .field(FIELD_TITLE)
+                                    .query(FieldValue.of(TITLE_MAGNUM_OPUS))
+                                    .build()
+                                    .toQuery()
+                            )
+                            .build()
+                            .toQuery()
+                    )
+            );
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -670,16 +698,31 @@ public class SearchOperationTest {
 
     @Test
     public void shouldFindSongUsingDslQuery_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SearchRequest searchRequest = new SearchRequest(PROHIBITED_SONG_INDEX_NAME);
-            SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
-            BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-            boolQueryBuilder.filter(QueryBuilders.regexpQuery(FIELD_ARTIST, "n.+"));
-            boolQueryBuilder.filter(new MatchQueryBuilder(FIELD_TITLE, TITLE_POISON));
-            searchSourceBuilder.query(boolQueryBuilder);
-            searchRequest.source(searchSourceBuilder);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SearchRequest searchRequest = SearchRequest.of(
+                r -> r.index(PROHIBITED_SONG_INDEX_NAME)
+                    .query(
+                        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.bool()
+                            .filter(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.regexp()
+                                    .field(FIELD_ARTIST)
+                                    .value("n.+")
+                                    .build()
+                                    .toQuery()
+                            )
+                            .filter(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.match()
+                                    .field(FIELD_TITLE)
+                                    .query(FieldValue.of(TITLE_POISON))
+                                    .build()
+                                    .toQuery()
+                            )
+                            .build()
+                            .toQuery()
+                    )
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -687,10 +730,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldPerformSearchWithAllIndexAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -703,10 +746,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldPerformSearchWithAllIndexAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = queryStringQueryRequest("_all", QUERY_TITLE_MAGNUM_OPUS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_all/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -714,15 +757,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldScrollOverSearchResults_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containNotEmptyScrollingId());
 
-            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            ScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
 
-            SearchResponse scrollResponse = restHighLevelClient.scroll(scrollRequest, DEFAULT);
+            SearchResponse<?> scrollResponse = client.scroll(scrollRequest, Map.class);
             assertThat(scrollResponse, isSuccessfulSearchResponse());
             assertThat(scrollResponse, containNotEmptyScrollingId());
             assertThat(scrollResponse, numberOfTotalHitsIsEqualTo(3));
@@ -736,15 +779,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldScrollOverSearchResults_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
             SearchRequest searchRequest = searchRequestWithScroll(SONG_INDEX_NAME, 2);
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containNotEmptyScrollingId());
 
-            SearchScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
+            ScrollRequest scrollRequest = getSearchScrollRequest(searchResponse);
 
-            assertThatThrownBy(() -> restHighLevelClient.scroll(scrollRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.scroll(scrollRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(DOUBLE_READER_USER, "SearchRequest"));
@@ -754,8 +797,8 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetDocument_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            GetResponse response = restHighLevelClient.get(new GetRequest(SONG_INDEX_NAME, ID_S1), DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            GetResponse<?> response = client.get(GetRequest.of(r -> r.index(SONG_INDEX_NAME).id(ID_S1)), Map.class);
 
             assertThat(response, containDocument(SONG_INDEX_NAME, ID_S1));
             assertThat(response, documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS));
@@ -766,9 +809,9 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetDocument_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            GetRequest getRequest = new GetRequest(PROHIBITED_SONG_INDEX_NAME, ID_P4);
-            assertThatThrownBy(() -> restHighLevelClient.get(getRequest, DEFAULT), statusException(FORBIDDEN));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            GetRequest getRequest = GetRequest.of(r -> r.index(PROHIBITED_SONG_INDEX_NAME).id(ID_P4));
+            assertThatThrownBy(() -> client.get(getRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_doc/4"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "GetRequest"));
@@ -776,61 +819,63 @@ public class SearchOperationTest {
 
     @Test
     public void shouldPerformMultiGetDocuments_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            MultiGetRequest request = new MultiGetRequest();
-            request.add(new Item(SONG_INDEX_NAME, ID_S1));
-            request.add(new Item(SONG_INDEX_NAME, ID_S2));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            MgetRequest request = MgetRequest.of(r -> r.index(SONG_INDEX_NAME).ids(ID_S1, ID_S2));
 
-            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+            MgetResponse<?> response = client.mget(request, Map.class);
 
             assertThat(response, is(notNullValue()));
             assertThat(response, isSuccessfulMultiGetResponse());
             assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
 
-            MultiGetItemResponse[] responses = response.getResponses();
+            var responses = response.docs();
             assertThat(
-                responses[0].getResponse(),
-                allOf(containDocument(SONG_INDEX_NAME, ID_S1), documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS))
+                responses.get(0).result(),
+                allOf(
+                    GetResultMatchers.containDocument(SONG_INDEX_NAME, ID_S1),
+                    GetResultMatchers.documentContainField(FIELD_TITLE, TITLE_MAGNUM_OPUS)
+                )
             );
             assertThat(
-                responses[1].getResponse(),
-                allOf(containDocument(SONG_INDEX_NAME, ID_S2), documentContainField(FIELD_TITLE, TITLE_SONG_1_PLUS_1))
+                responses.get(1).result(),
+                allOf(
+                    GetResultMatchers.containDocument(SONG_INDEX_NAME, ID_S2),
+                    GetResultMatchers.documentContainField(FIELD_TITLE, TITLE_SONG_1_PLUS_1)
+                )
             );
         }
-        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/song_lyrics/_mget"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetShardRequest"));
     }
 
     @Test
     public void shouldPerformMultiGetDocuments_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-            MultiGetRequest request = new MultiGetRequest();
-            request.add(new Item(SONG_INDEX_NAME, ID_S1));
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
+            MgetRequest request = MgetRequest.of(r -> r.index(SONG_INDEX_NAME).ids(ID_S1));
 
-            assertThatThrownBy(() -> restHighLevelClient.mget(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.mget(request, Map.class), statusException(FORBIDDEN));
         }
-        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_mget"));
+        auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/song_lyrics/_mget"));
         auditLogsRule.assertExactlyOne(missingPrivilege(DOUBLE_READER_USER, "MultiGetRequest"));
     }
 
     @Test
     public void shouldPerformMultiGetDocuments_partiallyPositive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            MultiGetRequest request = new MultiGetRequest();
-            request.add(new Item(SONG_INDEX_NAME, ID_S1));
-            request.add(new Item(PROHIBITED_SONG_INDEX_NAME, ID_P4));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            MgetRequest request = MgetRequest.of(
+                r -> r.docs(d -> d.index(SONG_INDEX_NAME).id(ID_S1)).docs(d -> d.index(PROHIBITED_SONG_INDEX_NAME).id(ID_P4))
+            );
 
-            MultiGetResponse response = restHighLevelClient.mget(request, DEFAULT);
+            MgetResponse<?> response = client.mget(request, Map.class);
 
             assertThat(request, notNullValue());
             assertThat(response, not(isSuccessfulMultiGetResponse()));
             assertThat(response, numberOfGetItemResponsesIsEqualTo(2));
 
-            MultiGetItemResponse[] responses = response.getResponses();
-            assertThat(responses, arrayContaining(hasProperty("failure", nullValue()), hasProperty("failure", notNullValue())));
-            assertThat(responses[1].getFailure().getFailure(), statusException(INTERNAL_SERVER_ERROR));
-            assertThat(responses[1].getFailure().getFailure(), errorMessageContain("security_exception"));
+            var responses = response.docs();
+            // assertThat(responses, arrayContaining(hasProperty("failure", nullValue()), hasProperty("failure", notNullValue())));
+            assertThat(responses.get(1).failure().error().type(), equalTo("security_exception"));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_mget"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiGetRequest"));
@@ -840,23 +885,44 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAllowedToPerformMulitSearch_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            MultiSearchRequest request = new MultiSearchRequest();
-            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            MsearchRequest request = MsearchRequest.of(
+                r -> r.searches(
+                    s -> s.header(h -> h.index(SONG_INDEX_NAME))
+                        .body(
+                            b -> b.query(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                    .query(QUERY_TITLE_MAGNUM_OPUS)
+                                    .build()
+                                    .toQuery()
+                            )
+                        )
+                )
+                    .searches(
+                        s -> s.header(h -> h.index(SONG_INDEX_NAME))
+                            .body(
+                                b -> b.query(
+                                    org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                        .query(QUERY_TITLE_NEXT_SONG)
+                                        .build()
+                                        .toQuery()
+                                )
+                            )
+                    )
+            );
 
-            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+            MsearchResponse<?> response = client.msearch(request, Map.class);
 
             assertThat(response, notNullValue());
             assertThat(response, isSuccessfulMultiSearchResponse());
             assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
 
-            MultiSearchResponse.Item[] responses = response.getResponses();
+            var responses = response.responses();
 
-            assertThat(responses[0].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
-            assertThat(responses[0].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
-            assertThat(responses[1].getResponse(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
-            assertThat(responses[1].getResponse(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
+            assertThat(responses.get(0).result(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_MAGNUM_OPUS));
+            assertThat(responses.get(0).result(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S1));
+            assertThat(responses.get(1).result(), searchHitContainsFieldWithValue(0, FIELD_TITLE, TITLE_NEXT_SONG));
+            assertThat(responses.get(1).result(), searchHitsContainDocumentWithId(0, SONG_INDEX_NAME, ID_S3));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
@@ -865,22 +931,42 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAllowedToPerformMulitSearch_partiallyPositive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            MultiSearchRequest request = new MultiSearchRequest();
-            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-            request.add(queryStringQueryRequest(PROHIBITED_SONG_INDEX_NAME, QUERY_TITLE_POISON));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            MsearchRequest request = MsearchRequest.of(
+                r -> r.searches(
+                    s -> s.header(h -> h.index(SONG_INDEX_NAME))
+                        .body(
+                            b -> b.query(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                    .query(QUERY_TITLE_MAGNUM_OPUS)
+                                    .build()
+                                    .toQuery()
+                            )
+                        )
+                )
+                    .searches(
+                        s -> s.header(h -> h.index(PROHIBITED_SONG_INDEX_NAME))
+                            .body(
+                                b -> b.query(
+                                    org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                        .query(QUERY_TITLE_POISON)
+                                        .build()
+                                        .toQuery()
+                                )
+                            )
+                    )
+            );
 
-            MultiSearchResponse response = restHighLevelClient.msearch(request, DEFAULT);
+            MsearchResponse<?> response = client.msearch(request, Map.class);
 
             assertThat(response, notNullValue());
             assertThat(response, not(isSuccessfulMultiSearchResponse()));
             assertThat(response, numberOfSearchItemResponsesIsEqualTo(2));
 
-            MultiSearchResponse.Item[] responses = response.getResponses();
-            assertThat(responses[0].getFailure(), nullValue());
-            assertThat(responses[1].getFailure(), statusException(INTERNAL_SERVER_ERROR));
-            assertThat(responses[1].getFailure(), errorMessageContain("security_exception"));
-            assertThat(responses[1].getResponse(), nullValue());
+            var responses = response.responses();
+            assertThat(responses.get(0).isFailure(), equalTo(false));
+            assertThat(responses.get(1).isFailure(), equalTo(true));
+            assertThat(responses.get(1).failure().error().type(), containsString("security_exception"));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_msearch"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(LIMITED_READ_USER, "MultiSearchRequest"));
@@ -890,12 +976,34 @@ public class SearchOperationTest {
 
     @Test
     public void shouldBeAllowedToPerformMulitSearch_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(DOUBLE_READER_USER)) {
-            MultiSearchRequest request = new MultiSearchRequest();
-            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS));
-            request.add(queryStringQueryRequest(SONG_INDEX_NAME, QUERY_TITLE_NEXT_SONG));
+        try (CloseableOpenSearchClient client = cluster.getClient(DOUBLE_READER_USER)) {
 
-            assertThatThrownBy(() -> restHighLevelClient.msearch(request, DEFAULT), statusException(FORBIDDEN));
+            MsearchRequest request = MsearchRequest.of(
+                r -> r.searches(
+                    s -> s.header(h -> h.index(SONG_INDEX_NAME))
+                        .body(
+                            b -> b.query(
+                                org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                    .query(QUERY_TITLE_MAGNUM_OPUS)
+                                    .build()
+                                    .toQuery()
+                            )
+                        )
+                )
+                    .searches(
+                        s -> s.header(h -> h.index(SONG_INDEX_NAME))
+                            .body(
+                                b -> b.query(
+                                    org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.queryString()
+                                        .query(QUERY_TITLE_NEXT_SONG)
+                                        .build()
+                                        .toQuery()
+                                )
+                            )
+                    )
+            );
+
+            assertThatThrownBy(() -> client.msearch(request, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(DOUBLE_READER_USER).withRestRequest(POST, "/_msearch"));
         auditLogsRule.assertAtLeast(1, missingPrivilege(DOUBLE_READER_USER, "MultiSearchRequest"));
@@ -903,11 +1011,11 @@ public class SearchOperationTest {
 
     @Test
     public void shouldAggregateDataAndComputeAverage_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             final String aggregationName = "averageStars";
             SearchRequest searchRequest = averageAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "avg"));
@@ -918,10 +1026,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldAggregateDataAndComputeAverage_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = averageAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "averageStars", FIELD_STARS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest").withIndex(PROHIBITED_SONG_INDEX_NAME));
@@ -929,11 +1037,11 @@ public class SearchOperationTest {
 
     @Test
     public void shouldPerformStatAggregation_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             final String aggregationName = "statsStars";
             SearchRequest searchRequest = statsAggregationRequest(SONG_INDEX_NAME, aggregationName, FIELD_STARS);
 
-            SearchResponse searchResponse = restHighLevelClient.search(searchRequest, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(searchRequest, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, containAggregationWithNameAndType(aggregationName, "stats"));
@@ -944,10 +1052,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldPerformStatAggregation_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
             SearchRequest searchRequest = statsAggregationRequest(PROHIBITED_SONG_INDEX_NAME, "statsStars", FIELD_STARS);
 
-            assertThatThrownBy(() -> restHighLevelClient.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/prohibited_song_lyrics/_search"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "SearchRequest"));
@@ -955,13 +1063,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldIndexDocumentInBulkRequest_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
 
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+
+            BulkResponse response = client.bulk(bulkRequest);
 
             assertThat(response, successBulkResponse());
             assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one"));
@@ -981,18 +1091,16 @@ public class SearchOperationTest {
 
     @Test
     public void shouldIndexDocumentInBulkRequest_partiallyPositive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-            assertThat(
-                response,
-                bulkResponseContainExceptions(0, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
             );
+
+            BulkResponse response = client.bulk(bulkRequest);
+
+            assertThat(response, bulkResponseContainExceptions(0, errorType(equalTo("security_exception"))));
             assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, "two"));
             assertThat(
                 internalClient,
@@ -1009,22 +1117,16 @@ public class SearchOperationTest {
 
     @Test
     public void shouldIndexDocumentInBulkRequest_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-            assertThat(
-                response,
-                allOf(
-                    failureBulkResponse(),
-                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
-                )
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
             );
+
+            BulkResponse response = client.bulk(bulkRequest);
+
+            assertThat(response, allOf(failureBulkResponse(), bulkResponseContainExceptions(errorType(equalTo("security_exception")))));
             assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "one")));
             assertThat(internalClient, not(clusterContainsDocument(SONG_INDEX_NAME, "two")));
         }
@@ -1035,18 +1137,24 @@ public class SearchOperationTest {
 
     @Test
     public void shouldUpdateDocumentsInBulk_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
             final String titleOne = "shape of my mind";
             final String titleTwo = "forgiven";
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
-            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
-            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "two").doc(Map.of(FIELD_TITLE, titleTwo)));
 
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+            client.bulk(bulkRequest);
+
+            bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.update(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(Map.of(FIELD_TITLE, titleOne))))
+                    .operations(op -> op.update(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(Map.of(FIELD_TITLE, titleTwo))))
+                    .refresh(Refresh.True)
+            );
+
+            BulkResponse response = client.bulk(bulkRequest);
 
             assertThat(response, successBulkResponse());
             assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
@@ -1060,21 +1168,23 @@ public class SearchOperationTest {
 
     @Test
     public void shouldUpdateDocumentsInBulk_partiallyPositive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
             final String titleOne = "shape of my mind";
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
-            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new UpdateRequest(WRITE_SONG_INDEX_NAME, "one").doc(Map.of(FIELD_TITLE, titleOne)));
-            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
-
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-            assertThat(
-                response,
-                bulkResponseContainExceptions(1, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .refresh(Refresh.True)
             );
+            client.bulk(bulkRequest);
+
+            bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.update(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(Map.of(FIELD_TITLE, titleOne))))
+                    .operations(op -> op.update(i -> i.index(SONG_INDEX_NAME).id(ID_S2).document(Map.of(FIELD_TITLE, "forgiven"))))
+                    .refresh(Refresh.True)
+            );
+
+            BulkResponse response = client.bulk(bulkRequest);
+
+            assertThat(response, bulkResponseContainExceptions(1, errorType(equalTo("security_exception"))));
             assertThat(internalClient, clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "one", FIELD_TITLE, titleOne));
             assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
         }
@@ -1088,21 +1198,18 @@ public class SearchOperationTest {
 
     @Test
     public void shouldUpdateDocumentsInBulk_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S1).doc(Map.of(FIELD_TITLE, "shape of my mind")));
-            bulkRequest.add(new UpdateRequest(SONG_INDEX_NAME, ID_S2).doc(Map.of(FIELD_TITLE, "forgiven")));
-
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-            assertThat(
-                response,
-                allOf(
-                    failureBulkResponse(),
-                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(
+                    op -> op.update(i -> i.index(SONG_INDEX_NAME).id(ID_S1).document(Map.of(FIELD_TITLE, "shape of my mind")))
                 )
+                    .operations(op -> op.update(i -> i.index(SONG_INDEX_NAME).id(ID_S2).document(Map.of(FIELD_TITLE, "forgiven"))))
+                    .refresh(Refresh.True)
             );
+
+            BulkResponse response = client.bulk(bulkRequest);
+
+            assertThat(response, allOf(failureBulkResponse(), bulkResponseContainExceptions(errorType(equalTo("security_exception")))));
             assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S1, FIELD_TITLE, TITLE_MAGNUM_OPUS));
             assertThat(internalClient, clusterContainsDocumentWithFieldValue(SONG_INDEX_NAME, ID_S2, FIELD_TITLE, TITLE_SONG_1_PLUS_1));
         }
@@ -1117,18 +1224,23 @@ public class SearchOperationTest {
         Settings sourceIndexSettings = Settings.builder().put("index.number_of_replicas", 2).put("index.number_of_shards", 2).build();
         IndexOperationsHelper.createIndex(cluster, WRITE_SONG_INDEX_NAME, sourceIndexSettings);
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("three").source(SONGS[2].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("four").source(SONGS[3].asMap()));
-            assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
-            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
-            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "three"));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("three").document(SONGS[2].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("four").document(SONGS[3].asMap())))
+                    .refresh(Refresh.True)
+            );
+            assertThat(client.bulk(bulkRequest), successBulkResponse());
 
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.delete(i -> i.index(WRITE_SONG_INDEX_NAME).id("one")))
+                    .operations(op -> op.delete(i -> i.index(WRITE_SONG_INDEX_NAME).id("three")))
+                    .refresh(Refresh.True)
+            );
+
+            BulkResponse response = client.bulk(bulkRequest);
 
             assertThat(response, successBulkResponse());
             assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
@@ -1151,22 +1263,24 @@ public class SearchOperationTest {
         Settings indexSettings = Settings.builder().put("index.number_of_replicas", 0).put("index.number_of_shards", 1).build();
         IndexOperationsHelper.createIndex(cluster, WRITE_SONG_INDEX_NAME, indexSettings);
 
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("one").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("two").source(SONGS[1].asMap()));
-            assertThat(restHighLevelClient.bulk(bulkRequest, DEFAULT), successBulkResponse());
-            bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "one"));
-            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("one").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("two").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+            assertThat(client.bulk(bulkRequest), successBulkResponse());
 
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.delete(i -> i.index(WRITE_SONG_INDEX_NAME).id("one")))
+                    .operations(op -> op.delete(i -> i.index(SONG_INDEX_NAME).id(ID_S3)))
+                    .refresh(Refresh.True)
+            );
+
+            BulkResponse response = client.bulk(bulkRequest);
             assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, "one")));
 
-            assertThat(
-                response,
-                bulkResponseContainExceptions(1, allOf(statusException(INTERNAL_SERVER_ERROR), errorMessageContain("security_exception")))
-            );
+            assertThat(response, bulkResponseContainExceptions(1, errorType(equalTo(("security_exception")))));
             assertThat(
                 internalClient,
                 clusterContainsDocumentWithFieldValue(WRITE_SONG_INDEX_NAME, "two", FIELD_TITLE, TITLE_SONG_1_PLUS_1)
@@ -1181,21 +1295,16 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteDocumentInBulk_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(IMMEDIATE);
-            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S1));
-            bulkRequest.add(new DeleteRequest(SONG_INDEX_NAME, ID_S3));
-
-            BulkResponse response = restHighLevelClient.bulk(bulkRequest, DEFAULT);
-
-            assertThat(
-                response,
-                allOf(
-                    failureBulkResponse(),
-                    bulkResponseContainExceptions(statusException(INTERNAL_SERVER_ERROR)),
-                    bulkResponseContainExceptions(errorMessageContain("security_exception"))
-                )
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.delete(i -> i.index(SONG_INDEX_NAME).id(ID_S1)))
+                    .operations(op -> op.delete(i -> i.index(SONG_INDEX_NAME).id(ID_S3)))
+                    .refresh(Refresh.True)
             );
+
+            BulkResponse response = client.bulk(bulkRequest);
+
+            assertThat(response, allOf(failureBulkResponse(), bulkResponseContainExceptions(errorType(equalTo(("security_exception"))))));
             assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S1));
             assertThat(internalClient, clusterContainsDocument(SONG_INDEX_NAME, ID_S3));
         }
@@ -1207,14 +1316,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldReindexDocuments_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(WRITE_SONG_INDEX_NAME);
+        try (CloseableOpenSearchClient client = cluster.getClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = ReindexRequest.of(
+                r -> r.source(s -> s.index(SONG_INDEX_NAME)).dest(d -> d.index(WRITE_SONG_INDEX_NAME))
+            );
 
-            BulkByScrollResponse response = restHighLevelClient.reindex(reindexRequest, DEFAULT);
+            ReindexResponse response = client.reindex(reindexRequest);
 
             assertThat(response, notNullValue());
-            assertThat(response.getBulkFailures(), empty());
-            assertThat(response.getSearchFailures(), empty());
+            assertThat(response.failures(), empty());
             assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S1));
             assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S2));
             assertThat(internalClient, clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_S3));
@@ -1232,11 +1342,12 @@ public class SearchOperationTest {
 
     @Test
     public void shouldReindexDocuments_negativeSource() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME)
-                .setDestIndex(WRITE_SONG_INDEX_NAME);
+        try (CloseableOpenSearchClient client = cluster.getClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = ReindexRequest.of(
+                r -> r.source(s -> s.index(PROHIBITED_SONG_INDEX_NAME)).dest(d -> d.index(WRITE_SONG_INDEX_NAME))
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.reindex(reindexRequest), statusException(FORBIDDEN));
             assertThat(internalClient, not(clusterContainsDocument(WRITE_SONG_INDEX_NAME, ID_P4)));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
@@ -1246,10 +1357,12 @@ public class SearchOperationTest {
 
     @Test
     public void shouldReindexDocuments_negativeDestination() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(SONG_INDEX_NAME).setDestIndex(PROHIBITED_SONG_INDEX_NAME);
+        try (CloseableOpenSearchClient client = cluster.getClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = ReindexRequest.of(
+                r -> r.source(s -> s.index(SONG_INDEX_NAME)).dest(d -> d.index(PROHIBITED_SONG_INDEX_NAME))
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.reindex(reindexRequest), statusException(FORBIDDEN));
             assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S1)));
             assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S2)));
             assertThat(internalClient, not(clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_S3)));
@@ -1264,10 +1377,12 @@ public class SearchOperationTest {
 
     @Test
     public void shouldReindexDocuments_negativeSourceAndDestination() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(REINDEXING_USER)) {
-            ReindexRequest reindexRequest = new ReindexRequest().setSourceIndices(PROHIBITED_SONG_INDEX_NAME).setDestIndex(SONG_INDEX_NAME);
+        try (CloseableOpenSearchClient client = cluster.getClient(REINDEXING_USER)) {
+            ReindexRequest reindexRequest = ReindexRequest.of(
+                r -> r.source(s -> s.index(PROHIBITED_SONG_INDEX_NAME)).dest(d -> d.index(SONG_INDEX_NAME))
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.reindex(reindexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.reindex(reindexRequest), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(REINDEXING_USER).withRestRequest(POST, "/_reindex"));
         auditLogsRule.assertExactlyOne(grantedPrivilege(REINDEXING_USER, "ReindexRequest"));
@@ -1278,13 +1393,15 @@ public class SearchOperationTest {
     public void shouldUpdateDocument_positive() throws IOException {
         String newField = "newField";
         String newValue = "newValue";
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-            UpdateRequest updateRequest = new UpdateRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, DOCUMENT_TO_UPDATE_ID).doc(
-                newField,
-                newValue
-            ).setRefreshPolicy(IMMEDIATE);
+        try (CloseableOpenSearchClient client = cluster.getClient(UPDATE_DELETE_USER)) {
+            UpdateRequest<Map, ?> updateRequest = UpdateRequest.of(
+                r -> r.index(UPDATE_DELETE_OPERATION_INDEX_NAME)
+                    .id(DOCUMENT_TO_UPDATE_ID)
+                    .doc(Map.of(newField, newValue))
+                    .refresh(Refresh.True)
+            );
 
-            UpdateResponse response = restHighLevelClient.update(updateRequest, DEFAULT);
+            UpdateResponse<?> response = client.update(updateRequest, Map.class);
 
             assertThat(response, isSuccessfulUpdateResponse());
             assertThat(
@@ -1298,11 +1415,11 @@ public class SearchOperationTest {
     public void shouldUpdateDocument_negative() throws IOException {
         String newField = "newField";
         String newValue = "newValue";
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-            UpdateRequest updateRequest = new UpdateRequest(PROHIBITED_SONG_INDEX_NAME, DOCUMENT_TO_UPDATE_ID).doc(newField, newValue)
-                .setRefreshPolicy(IMMEDIATE);
-
-            assertThatThrownBy(() -> restHighLevelClient.update(updateRequest, DEFAULT), statusException(FORBIDDEN));
+        try (CloseableOpenSearchClient client = cluster.getClient(UPDATE_DELETE_USER)) {
+            UpdateRequest<Map, ?> updateRequest = UpdateRequest.of(
+                r -> r.index(PROHIBITED_SONG_INDEX_NAME).id(DOCUMENT_TO_UPDATE_ID).doc(Map.of(newField, newValue)).refresh(Refresh.True)
+            );
+            assertThatThrownBy(() -> client.update(updateRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 
@@ -1311,14 +1428,18 @@ public class SearchOperationTest {
         String docId = "shouldDeleteDocument_positive";
         try (Client client = cluster.getInternalNodeClient()) {
             client.index(
-                new IndexRequest(UPDATE_DELETE_OPERATION_INDEX_NAME).id(docId).source("field", "value").setRefreshPolicy(IMMEDIATE)
+                new org.opensearch.action.index.IndexRequest(UPDATE_DELETE_OPERATION_INDEX_NAME).id(docId)
+                    .source("field", "value")
+                    .setRefreshPolicy(IMMEDIATE)
             ).actionGet();
             assertThat(internalClient, clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId));
         }
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-            DeleteRequest deleteRequest = new DeleteRequest(UPDATE_DELETE_OPERATION_INDEX_NAME, docId).setRefreshPolicy(IMMEDIATE);
+        try (CloseableOpenSearchClient client = cluster.getClient(UPDATE_DELETE_USER)) {
+            DeleteRequest deleteRequest = DeleteRequest.of(
+                r -> r.index(UPDATE_DELETE_OPERATION_INDEX_NAME).id(docId).refresh(Refresh.True)
+            );
 
-            DeleteResponse response = restHighLevelClient.delete(deleteRequest, DEFAULT);
+            DeleteResponse response = client.delete(deleteRequest);
 
             assertThat(response, isSuccessfulDeleteResponse());
             assertThat(internalClient, not(clusterContainsDocument(UPDATE_DELETE_OPERATION_INDEX_NAME, docId)));
@@ -1327,23 +1448,24 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteDocument_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(UPDATE_DELETE_USER)) {
-            DeleteRequest deleteRequest = new DeleteRequest(PROHIBITED_SONG_INDEX_NAME, ID_S1).setRefreshPolicy(IMMEDIATE);
+        try (CloseableOpenSearchClient client = cluster.getClient(UPDATE_DELETE_USER)) {
+            DeleteRequest deleteRequest = DeleteRequest.of(r -> r.index(PROHIBITED_SONG_INDEX_NAME).id(ID_S1).refresh(Refresh.True));
 
-            assertThatThrownBy(() -> restHighLevelClient.delete(deleteRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.delete(deleteRequest), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldCreateAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            UpdateAliasesRequest indicesAliasesRequest = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.add(AddAction.of(add -> add.index(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME))))
+            );
 
-            var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
+            var response = client.indices().updateAliases(indicesAliasesRequest);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
@@ -1353,14 +1475,12 @@ public class SearchOperationTest {
 
     @Test
     public void shouldCreateAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            AliasActions aliasAction = new AliasActions(ADD).indices(PROHIBITED_SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-            assertThatThrownBy(
-                () -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT),
-                statusException(FORBIDDEN)
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            UpdateAliasesRequest indicesAliasesRequest = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.add(AddAction.of(add -> add.index(PROHIBITED_SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME))))
             );
+
+            assertThatThrownBy(() -> client.indices().updateAliases(indicesAliasesRequest), statusException(FORBIDDEN));
 
             assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_P4)));
         }
@@ -1370,17 +1490,20 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteAlias_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            AliasActions aliasAction = new AliasActions(ADD).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
-            restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
-            aliasAction = new AliasActions(REMOVE).indices(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME);
-            indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            UpdateAliasesRequest indicesAliasesRequest = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.add(AddAction.of(add -> add.index(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME))))
+            );
 
-            var response = restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT);
+            client.indices().updateAliases(indicesAliasesRequest);
+            indicesAliasesRequest = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.remove(RemoveAction.of(add -> add.index(SONG_INDEX_NAME).alias(TEMPORARY_ALIAS_NAME))))
+            );
+
+            var response = client.indices().updateAliases(indicesAliasesRequest);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, not(clusterContainsDocument(TEMPORARY_ALIAS_NAME, ID_S1)));
         }
         auditLogsRule.assertExactly(2, userAuthenticated(LIMITED_READ_USER).withRestRequest(POST, "/_aliases"));
@@ -1390,14 +1513,12 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteAlias_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            AliasActions aliasAction = new AliasActions(REMOVE).indices(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS);
-            IndicesAliasesRequest indicesAliasesRequest = new IndicesAliasesRequest().addAliasAction(aliasAction);
-
-            assertThatThrownBy(
-                () -> restHighLevelClient.indices().updateAliases(indicesAliasesRequest, DEFAULT),
-                statusException(FORBIDDEN)
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            UpdateAliasesRequest indicesAliasesRequest = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.remove(RemoveAction.of(add -> add.index(PROHIBITED_SONG_INDEX_NAME).alias(PROHIBITED_SONG_ALIAS))))
             );
+
+            assertThatThrownBy(() -> client.indices().updateAliases(indicesAliasesRequest), statusException(FORBIDDEN));
 
             assertThat(internalClient, clusterContainsDocument(PROHIBITED_SONG_INDEX_NAME, ID_P4));
         }
@@ -1407,21 +1528,24 @@ public class SearchOperationTest {
 
     @Test
     public void shouldCreateIndexTemplate_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            PutTemplateRequest request = PutTemplateRequest.of(
+                r -> r.name(MUSICAL_INDEX_TEMPLATE)
+                    .indexPatterns(TEMPLATE_INDEX_PREFIX)
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, Alias.builder().build())
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, Alias.builder().build())
+            );
 
-            var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
+            var response = client.indices().putTemplate(request);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
             String documentId = "0001";
-            IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId)
-                .source(SONGS[0].asMap())
-                .setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.index(indexRequest, DEFAULT);
+            IndexRequest<?> indexRequest = IndexRequest.of(
+                r -> r.index(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId).document(SONGS[0].asMap()).refresh(Refresh.True)
+            );
+            client.index(indexRequest);
             assertThat(internalClient, clusterContainsDocument(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ, documentId));
             assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId));
             assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, documentId));
@@ -1438,12 +1562,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldCreateIndexTemplate_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            PutTemplateRequest request = PutTemplateRequest.of(
+                r -> r.name(MUSICAL_INDEX_TEMPLATE)
+                    .indexPatterns(TEMPLATE_INDEX_PREFIX)
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, Alias.builder().build())
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, Alias.builder().build())
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().putTemplate(request), statusException(FORBIDDEN));
             assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE)));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(PUT, "/_template/musical-index-template"));
@@ -1452,16 +1579,17 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteTemplate_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX));
-            restHighLevelClient.indices().putTemplate(request, DEFAULT);
-            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
-            DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            PutTemplateRequest request = PutTemplateRequest.of(r -> r.name(MUSICAL_INDEX_TEMPLATE).indexPatterns(TEMPLATE_INDEX_PREFIX));
 
-            var response = restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT);
+            client.indices().putTemplate(request);
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+            DeleteTemplateRequest deleteRequest = DeleteTemplateRequest.of(r -> r.name(MUSICAL_INDEX_TEMPLATE));
+
+            var response = client.indices().deleteTemplate(deleteRequest);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, not(clusterContainTemplate(MUSICAL_INDEX_TEMPLATE)));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_template/musical-index-template"));
@@ -1473,10 +1601,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteTemplate_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            DeleteTemplateRequest deleteRequest = DeleteTemplateRequest.of(r -> r.name(UNDELETABLE_TEMPLATE_NAME));
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().deleteTemplate(deleteRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().deleteTemplate(deleteRequest), statusException(FORBIDDEN));
 
             assertThat(internalClient, clusterContainTemplate(UNDELETABLE_TEMPLATE_NAME));
         }
@@ -1488,24 +1616,33 @@ public class SearchOperationTest {
 
     @Test
     public void shouldUpdateTemplate_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            PutIndexTemplateRequest request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002));
-            restHighLevelClient.indices().putTemplate(request, DEFAULT);
-            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
-            request = new PutIndexTemplateRequest(MUSICAL_INDEX_TEMPLATE).patterns(List.of(TEMPLATE_INDEX_PREFIX))
-                .alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            PutTemplateRequest request = PutTemplateRequest.of(
+                r -> r.name(MUSICAL_INDEX_TEMPLATE)
+                    .indexPatterns(TEMPLATE_INDEX_PREFIX)
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, Alias.builder().build())
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0002, Alias.builder().build())
+            );
 
-            var response = restHighLevelClient.indices().putTemplate(request, DEFAULT);
+            client.indices().putTemplate(request);
+            assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
+
+            request = PutTemplateRequest.of(
+                r -> r.name(MUSICAL_INDEX_TEMPLATE)
+                    .indexPatterns(TEMPLATE_INDEX_PREFIX)
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003, Alias.builder().build())
+            );
+
+            var response = client.indices().putTemplate(request);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             String documentId = "000one";
-            IndexRequest indexRequest = new IndexRequest(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId)
-                .source(SONGS[0].asMap())
-                .setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.index(indexRequest, DEFAULT);
+            IndexRequest<?> indexRequest = IndexRequest.of(
+                r -> r.index(INDEX_NAME_SONG_TRANSCRIPTION_JAZZ).id(documentId).document(SONGS[0].asMap()).refresh(Refresh.True)
+            );
+
+            client.index(indexRequest);
             assertThat(internalClient, clusterContainTemplate(MUSICAL_INDEX_TEMPLATE));
             assertThat(internalClient, clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003, documentId));
             assertThat(internalClient, not(clusterContainsDocument(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0001, documentId)));
@@ -1523,12 +1660,14 @@ public class SearchOperationTest {
 
     @Test
     public void shouldUpdateTemplate_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            PutIndexTemplateRequest request = new PutIndexTemplateRequest(UNDELETABLE_TEMPLATE_NAME).patterns(
-                List.of(TEMPLATE_INDEX_PREFIX)
-            ).alias(new Alias(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003));
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            PutTemplateRequest request = PutTemplateRequest.of(
+                r -> r.name(UNDELETABLE_TEMPLATE_NAME)
+                    .indexPatterns(TEMPLATE_INDEX_PREFIX)
+                    .aliases(ALIAS_USED_IN_MUSICAL_INDEX_TEMPLATE_0003, Alias.builder().build())
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().putTemplate(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().putTemplate(request), statusException(FORBIDDEN));
             assertThat(internalClient, clusterContainTemplateWithAlias(UNDELETABLE_TEMPLATE_NAME, ALIAS_FROM_UNDELETABLE_TEMPLATE));
             assertThat(
                 internalClient,
@@ -1541,10 +1680,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetFieldCapabilitiesForAllIndexes_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.fields(FIELD_TITLE));
 
-            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+            FieldCapsResponse response = client.fieldCaps(request);
 
             assertThat(response, notNullValue());
             assertThat(response, containsExactlyIndices(SONG_INDEX_NAME, PROHIBITED_SONG_INDEX_NAME, UPDATE_DELETE_OPERATION_INDEX_NAME));
@@ -1558,10 +1697,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetFieldCapabilitiesForAllIndexes_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.fields(FIELD_TITLE));
 
-            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.fieldCaps(request), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/_field_caps"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
@@ -1569,10 +1708,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetFieldCapabilitiesForParticularIndex_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(SONG_INDEX_NAME).fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.index(SONG_INDEX_NAME).fields(FIELD_TITLE));
 
-            FieldCapabilitiesResponse response = restHighLevelClient.fieldCaps(request, DEFAULT);
+            FieldCapsResponse response = client.fieldCaps(request);
 
             assertThat(response, notNullValue());
             assertThat(response, containsExactlyIndices(SONG_INDEX_NAME));
@@ -1586,10 +1725,10 @@ public class SearchOperationTest {
 
     @Test
     public void shouldGetFieldCapabilitiesForParticularIndex_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            FieldCapabilitiesRequest request = new FieldCapabilitiesRequest().indices(PROHIBITED_SONG_INDEX_NAME).fields(FIELD_TITLE);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            FieldCapsRequest request = FieldCapsRequest.of(r -> r.index(PROHIBITED_SONG_INDEX_NAME).fields(FIELD_TITLE));
 
-            assertThatThrownBy(() -> restHighLevelClient.fieldCaps(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.fieldCaps(request), statusException(FORBIDDEN));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_READ_USER).withRestRequest(GET, "/prohibited_song_lyrics/_field_caps"));
         auditLogsRule.assertExactlyOne(missingPrivilege(LIMITED_READ_USER, "FieldCapabilitiesRequest"));
@@ -1597,14 +1736,14 @@ public class SearchOperationTest {
 
     @Test
     public void shouldCreateSnapshotRepository_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             String snapshotDirPath = cluster.getSnapshotDirPath();
 
             var response = steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotDirPath, "fs");
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
@@ -1613,8 +1752,8 @@ public class SearchOperationTest {
 
     @Test
     public void shouldCreateSnapshotRepository_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             String snapshotDirPath = cluster.getSnapshotDirPath();
 
             assertThatThrownBy(
@@ -1629,15 +1768,15 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteSnapshotRepository_positive() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
             assertThat(internalClient, clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME));
 
             var response = steps.deleteSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME);
 
             assertThat(response, notNullValue());
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, not(clusterContainsSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME)));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
@@ -1650,8 +1789,8 @@ public class SearchOperationTest {
 
     @Test
     public void shouldDeleteSnapshotRepository_negative() throws IOException {
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
 
             assertThatThrownBy(() -> steps.deleteSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME), statusException(FORBIDDEN));
             assertThat(internalClient, clusterContainsSnapshotRepository(UNUSED_SNAPSHOT_REPOSITORY_NAME));
@@ -1666,14 +1805,14 @@ public class SearchOperationTest {
     public void shouldCreateSnapshot_positive() throws IOException {
         final String snapshotName = "snapshot-positive-test";
         long snapshotGetCount;
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
 
             CreateSnapshotResponse response = steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
 
             assertThat(response, notNullValue());
-            assertThat(response.status(), equalTo(RestStatus.ACCEPTED));
+            assertThat(response.accepted(), equalTo(true));
             snapshotGetCount = steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
             assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
         }
@@ -1694,8 +1833,8 @@ public class SearchOperationTest {
     @Test
     public void shouldCreateSnapshot_negative() throws IOException {
         final String snapshotName = "snapshot-negative-test";
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
 
             assertThatThrownBy(
                 () -> steps.createSnapshot(UNUSED_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME),
@@ -1714,16 +1853,16 @@ public class SearchOperationTest {
     public void shouldDeleteSnapshot_positive() throws IOException {
         String snapshotName = "delete-snapshot-positive";
         long snapshotGetCount;
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
-            restHighLevelClient.snapshot();
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
+            client.snapshot();
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
             steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
             snapshotGetCount = steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
 
             var response = steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
 
-            assertThat(response.isAcknowledged(), equalTo(true));
+            assertThat(response.acknowledged(), equalTo(true));
             assertThat(internalClient, snapshotInClusterDoesNotExists(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
         }
         auditLogsRule.assertExactlyOne(userAuthenticated(LIMITED_WRITE_USER).withRestRequest(PUT, "/_snapshot/test-snapshot-repository"));
@@ -1747,14 +1886,14 @@ public class SearchOperationTest {
     public void shouldDeleteSnapshot_negative() throws IOException {
         String snapshotName = "delete-snapshot-negative";
         long snapshotGetCount;
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
             steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, SONG_INDEX_NAME);
             snapshotGetCount = steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
         }
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             assertThatThrownBy(() -> steps.deleteSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName), statusException(FORBIDDEN));
 
             assertThat(internalClient, clusterContainSuccessSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName));
@@ -1781,17 +1920,19 @@ public class SearchOperationTest {
         final String snapshotName = "restore-snapshot-positive";
         long snapshotGetCount;
         AtomicInteger restoredCount = new AtomicInteger();
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             // 1. create some documents
             Settings indexSettings = Settings.builder().put("index.number_of_replicas", 0).put("index.number_of_shards", 1).build();
             IndexOperationsHelper.createIndex(cluster, WRITE_SONG_INDEX_NAME, indexSettings);
 
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Eins").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Zwei").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+
+            client.bulk(bulkRequest);
 
             // 2. create snapshot repository
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
@@ -1803,28 +1944,29 @@ public class SearchOperationTest {
             snapshotGetCount = steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
 
             // 5. introduce some changes
-            bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Drei").source(SONGS[2].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Vier").source(SONGS[3].asMap()));
-            bulkRequest.add(new DeleteRequest(WRITE_SONG_INDEX_NAME, "Eins"));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Drei").document(SONGS[2].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Vier").document(SONGS[3].asMap())))
+                    .operations(op -> op.delete(i -> i.index(WRITE_SONG_INDEX_NAME).id("Eins")))
+                    .refresh(Refresh.True)
+            );
+            client.bulk(bulkRequest);
 
             // 6. restore the snapshot
             var response = steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1");
 
             assertThat(response, notNullValue());
-            assertThat(response.status(), equalTo(ACCEPTED));
+            assertThat(response.accepted(), equalTo(true));
 
             // 7. wait until snapshot is restored
-            CountRequest countRequest = new CountRequest(RESTORED_SONG_INDEX_NAME);
+            CountRequest countRequest = CountRequest.of(r -> r.index(RESTORED_SONG_INDEX_NAME));
             Awaitility.await()
                 .ignoreExceptions()
                 .pollInterval(100, TimeUnit.MILLISECONDS)
                 .alias("Index contains proper number of documents restored from snapshot.")
                 .until(() -> {
                     restoredCount.incrementAndGet();
-                    return restHighLevelClient.count(countRequest, DEFAULT).getCount() == 2;
+                    return client.count(countRequest).count() == 2;
                 });
 
             // 8. verify that document are present in restored index
@@ -1874,15 +2016,16 @@ public class SearchOperationTest {
         long snapshotGetCount;
         Settings indexSettings = Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build();
         IndexOperationsHelper.createIndex(cluster, WRITE_SONG_INDEX_NAME, indexSettings);
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
 
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+            SnapshotSteps steps = new SnapshotSteps(client);
             // 1. create some documents
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Eins").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Zwei").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+            client.bulk(bulkRequest);
 
             // 2. create snapshot repository
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
@@ -1939,14 +2082,15 @@ public class SearchOperationTest {
         long snapshotGetCount;
         Settings indexSettings = Settings.builder().put("index.number_of_shards", 1).put("index.number_of_replicas", 0).build();
         IndexOperationsHelper.createIndex(cluster, WRITE_SONG_INDEX_NAME, indexSettings);
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_WRITE_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_WRITE_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             // 1. create some documents
-            BulkRequest bulkRequest = new BulkRequest();
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Eins").source(SONGS[0].asMap()));
-            bulkRequest.add(new IndexRequest(WRITE_SONG_INDEX_NAME).id("Zwei").source(SONGS[1].asMap()));
-            bulkRequest.setRefreshPolicy(IMMEDIATE);
-            restHighLevelClient.bulk(bulkRequest, DEFAULT);
+            BulkRequest bulkRequest = BulkRequest.of(
+                r -> r.operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Eins").document(SONGS[0].asMap())))
+                    .operations(op -> op.index(i -> i.index(WRITE_SONG_INDEX_NAME).id("Zwei").document(SONGS[1].asMap())))
+                    .refresh(Refresh.True)
+            );
+            client.bulk(bulkRequest);
 
             // 2. create snapshot repository
             steps.createSnapshotRepository(TEST_SNAPSHOT_REPOSITORY_NAME, cluster.getSnapshotDirPath(), "fs");
@@ -1958,8 +2102,8 @@ public class SearchOperationTest {
             snapshotGetCount = steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName);
         }
         // 5. restore the snapshot
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             assertThatThrownBy(
                 () -> steps.restoreSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, snapshotName, "(.+)", "restored_$1"),
                 statusException(FORBIDDEN)
@@ -2002,13 +2146,9 @@ public class SearchOperationTest {
     // required permissions: "indices:admin/create"
     public void createIndex_positive() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_positive");
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
-            CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            CreateIndexRequest createIndexRequest = CreateIndexRequest.of(r -> r.index(indexName));
+            CreateIndexResponse createIndexResponse = client.indices().create(createIndexRequest);
 
             assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
             assertThat(cluster, indexExists(indexName));
@@ -2018,14 +2158,10 @@ public class SearchOperationTest {
     @Test
     public void createIndex_negative() throws IOException {
         String indexName = "create_index_negative";
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            CreateIndexRequest createIndexRequest = CreateIndexRequest.of(r -> r.index(indexName));
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().create(createIndexRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(indexName)));
         }
     }
@@ -2034,14 +2170,10 @@ public class SearchOperationTest {
     // required permissions: "indices:admin/get"
     public void checkIfIndexExists_positive() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("index_exists_positive");
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            boolean exists = restHighLevelClient.indices().exists(new GetIndexRequest(indexName), DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            BooleanResponse exists = client.indices().exists(ExistsRequest.of(r -> r.index(indexName)));
 
-            assertThat(exists, is(false));
+            assertThat(exists.value(), is(false));
         }
     }
 
@@ -2049,22 +2181,17 @@ public class SearchOperationTest {
     public void checkIfIndexExists_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "index_exists_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().exists(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().exists(ExistsRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .exists(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().exists(ExistsRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(() -> restHighLevelClient.indices().exists(new GetIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().exists(ExistsRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2074,15 +2201,11 @@ public class SearchOperationTest {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexName);
-            var response = restHighLevelClient.indices().delete(deleteIndexRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            DeleteIndexRequest deleteIndexRequest = DeleteIndexRequest.of(r -> r.index(indexName));
+            var response = client.indices().delete(deleteIndexRequest);
 
-            assertThat(response.isAcknowledged(), is(true));
+            assertThat(response.acknowledged(), is(true));
             assertThat(cluster, not(indexExists(indexName)));
         }
     }
@@ -2091,25 +2214,17 @@ public class SearchOperationTest {
     public void deleteIndex_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "delete_index_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().delete(new DeleteIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().delete(DeleteIndexRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .delete(new DeleteIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().delete(DeleteIndexRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(
-                () -> restHighLevelClient.indices().delete(new DeleteIndexRequest("*"), DEFAULT),
-                statusException(FORBIDDEN)
-            );
+            assertThatThrownBy(() -> client.indices().delete(DeleteIndexRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2118,16 +2233,14 @@ public class SearchOperationTest {
     public void shouldDeleteIndexByAliasRequest_positive() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("delete_index_by_alias_request_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            UpdateAliasesRequest request = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.removeIndex(RemoveIndexAction.of(add -> add.index(indexName))))
+            );
 
-            var response = restHighLevelClient.indices().updateAliases(request, DEFAULT);
+            var response = client.indices().updateAliases(request);
 
-            assertThat(response.isAcknowledged(), is(true));
+            assertThat(response.acknowledged(), is(true));
             assertThat(cluster, not(indexExists(indexName)));
         }
         auditLogsRule.assertExactlyOne(
@@ -2146,14 +2259,11 @@ public class SearchOperationTest {
     @Test
     public void shouldDeleteIndexByAliasRequest_negative() throws IOException {
         String indexName = "delete_index_by_alias_request_negative";
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            IndicesAliasesRequest request = new IndicesAliasesRequest().addAliasAction(new AliasActions(REMOVE_INDEX).indices(indexName));
-
-            assertThatThrownBy(() -> restHighLevelClient.indices().updateAliases(request, DEFAULT), statusException(FORBIDDEN));
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            UpdateAliasesRequest request = UpdateAliasesRequest.of(
+                r -> r.actions(a -> a.removeIndex(RemoveIndexAction.of(add -> add.index(indexName))))
+            );
+            assertThatThrownBy(() -> client.indices().updateAliases(request), statusException(FORBIDDEN));
         }
     }
 
@@ -2163,13 +2273,9 @@ public class SearchOperationTest {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            GetIndexRequest getIndexRequest = new GetIndexRequest(indexName);
-            GetIndexResponse response = restHighLevelClient.indices().get(getIndexRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            GetIndexRequest getIndexRequest = GetIndexRequest.of(r -> r.index(indexName));
+            GetIndexResponse response = client.indices().get(getIndexRequest);
 
             assertThat(response, getIndexResponseContainsIndices(indexName));
         }
@@ -2179,21 +2285,17 @@ public class SearchOperationTest {
     public void getIndex_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "get_index_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().get(GetIndexRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().get(new GetIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().get(GetIndexRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(() -> restHighLevelClient.indices().get(new GetIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().get(GetIndexRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2203,13 +2305,9 @@ public class SearchOperationTest {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("close_index_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            CloseIndexRequest closeIndexRequest = new CloseIndexRequest(indexName);
-            CloseIndexResponse response = restHighLevelClient.indices().close(closeIndexRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            CloseIndexRequest closeIndexRequest = CloseIndexRequest.of(r -> r.index(indexName));
+            CloseIndexResponse response = client.indices().close(closeIndexRequest);
 
             assertThat(response, isSuccessfulCloseIndexResponse());
             assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.CLOSE));
@@ -2220,22 +2318,17 @@ public class SearchOperationTest {
     public void closeIndex_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "close_index_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().close(new CloseIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().close(CloseIndexRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .close(new CloseIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().close(CloseIndexRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(() -> restHighLevelClient.indices().close(new CloseIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().close(CloseIndexRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2246,13 +2339,9 @@ public class SearchOperationTest {
         IndexOperationsHelper.createIndex(cluster, indexName);
         IndexOperationsHelper.closeIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            OpenIndexRequest closeIndexRequest = new OpenIndexRequest(indexName);
-            OpenIndexResponse response = restHighLevelClient.indices().open(closeIndexRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            OpenRequest closeIndexRequest = OpenRequest.of(r -> r.index(indexName));
+            OpenResponse response = client.indices().open(closeIndexRequest);
 
             assertThat(response, isSuccessfulOpenIndexResponse());
             assertThat(cluster, indexStateIsEqualTo(indexName, IndexMetadata.State.OPEN));
@@ -2263,22 +2352,17 @@ public class SearchOperationTest {
     public void openIndex_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "open_index_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().open(new OpenIndexRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().open(OpenRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .open(new OpenIndexRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().open(OpenRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(() -> restHighLevelClient.indices().open(new OpenIndexRequest("*"), DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().open(OpenRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2294,24 +2378,22 @@ public class SearchOperationTest {
             .build();
         IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ClusterHealthResponse healthResponse = restHighLevelClient.cluster()
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            HealthResponse healthResponse = client.cluster()
                 .health(
-                    new ClusterHealthRequest(sourceIndexName).waitForNoRelocatingShards(true)
-                        .waitForActiveShards(4)
-                        .waitForNoInitializingShards(true)
-                        .waitForGreenStatus(),
-                    DEFAULT
+                    HealthRequest.of(
+                        r -> r.index(sourceIndexName)
+                            .waitForNoRelocatingShards(true)
+                            .waitForActiveShards(s -> s.count(4))
+                            .waitForNoInitializingShards(true)
+                            .waitForStatus(HealthStatus.Green)
+                    )
                 );
 
-            assertThat(healthResponse.getStatus(), is(ClusterHealthStatus.GREEN));
+            assertThat(healthResponse.status(), is(HealthStatus.Green));
 
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            ResizeResponse response = restHighLevelClient.indices().shrink(resizeRequest, DEFAULT);
+            ShrinkRequest resizeRequest = ShrinkRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
+            ShrinkResponse response = client.indices().shrink(resizeRequest);
 
             assertThat(response, isSuccessfulResizeResponse(targetIndexName));
             assertThat(cluster, indexExists(targetIndexName));
@@ -2320,33 +2402,26 @@ public class SearchOperationTest {
 
     @Test
     public void shrinkIndex_negative() throws IOException {
-        // user cannot access target index
-        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_source");
-        String targetIndexName = "shrink_index_negative_target";
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access target index
+            String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_source");
+            String targetIndexName = "shrink_index_negative_target";
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            ShrinkRequest resizeRequest = ShrinkRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
+
+            assertThatThrownBy(() -> client.indices().shrink(resizeRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
 
-        // user cannot access source index
-        sourceIndexName = "shrink_index_negative_source";
-        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_target");
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access source index
+            String sourceIndexName = "shrink_index_negative_source";
+            String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("shrink_index_negative_target");
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            ShrinkRequest resizeRequest = ShrinkRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().shrink(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().shrink(resizeRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
     }
@@ -2359,52 +2434,40 @@ public class SearchOperationTest {
         String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_positive_target");
         IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            ResizeResponse response = restHighLevelClient.indices().clone(resizeRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            CloneIndexRequest cloneRequest = CloneIndexRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
+            CloneIndexResponse response = client.indices().clone(cloneRequest);
 
-            assertThat(response, isSuccessfulResizeResponse(targetIndexName));
+            assertThat(response, isSuccessfulCloneResponse(targetIndexName));
             assertThat(cluster, indexExists(targetIndexName));
 
             // can't clone the same index twice, target already exists
-            ResizeRequest repeatResizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            assertThatThrownBy(() -> restHighLevelClient.indices().clone(repeatResizeRequest, DEFAULT), statusException(BAD_REQUEST));
+            CloneIndexRequest repeatCloneRequest = CloneIndexRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
+            assertThatThrownBy(() -> client.indices().clone(repeatCloneRequest), statusException(BAD_REQUEST));
         }
     }
 
     @Test
     public void cloneIndex_negative() throws IOException {
-        // user cannot access target index
-        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_source");
-        String targetIndexName = "clone_index_negative_target";
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access target index
+            String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_source");
+            String targetIndexName = "clone_index_negative_target";
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            CloneIndexRequest cloneRequest = CloneIndexRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().clone(cloneRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
 
-        // user cannot access source index
-        sourceIndexName = "clone_index_negative_source";
-        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_target");
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access source index
+            String sourceIndexName = "clone_index_negative_source";
+            String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clone_index_negative_target");
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
+            CloneIndexRequest cloneRequest = CloneIndexRequest.of(r -> r.target(targetIndexName).index(sourceIndexName));
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().clone(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().clone(cloneRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
     }
@@ -2417,51 +2480,43 @@ public class SearchOperationTest {
         String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_positive_target");
         IndexOperationsHelper.createIndex(cluster, sourceIndexName, sourceIndexSettings);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
-            ResizeResponse response = restHighLevelClient.indices().split(resizeRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            SplitRequest resizeRequest = SplitRequest.of(
+                r -> r.target(targetIndexName).index(sourceIndexName).settings("index.number_of_shards", JsonData.of(2))
+            );
+            SplitResponse response = client.indices().split(resizeRequest);
 
-            assertThat(response, isSuccessfulResizeResponse(targetIndexName));
+            assertThat(response, isSuccessfulSplitResponse(targetIndexName));
             assertThat(cluster, indexExists(targetIndexName));
         }
     }
 
     @Test
     public void splitIndex_negative() throws IOException {
-        // user cannot access target index
-        String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_source");
-        String targetIndexName = "split_index_negative_target";
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access target index
+            String sourceIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_source");
+            String targetIndexName = "split_index_negative_target";
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            SplitRequest resizeRequest = SplitRequest.of(
+                r -> r.target(targetIndexName).index(sourceIndexName).settings("index.number_of_shards", JsonData.of(2))
+            );
+
+            assertThatThrownBy(() -> client.indices().split(resizeRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
 
-        // user cannot access source index
-        sourceIndexName = "split_index_negative_source";
-        targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_target");
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            // user cannot access source index
+            String sourceIndexName = "split_index_negative_source";
+            String targetIndexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("split_index_negative_target");
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ResizeRequest resizeRequest = new ResizeRequest(targetIndexName, sourceIndexName);
-            resizeRequest.setSettings(Settings.builder().put("index.number_of_shards", 2).build());
+            SplitRequest resizeRequest = SplitRequest.of(
+                r -> r.target(targetIndexName).index(sourceIndexName).settings("index.number_of_shards", JsonData.of(2))
+            );
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().split(resizeRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().split(resizeRequest), statusException(FORBIDDEN));
             assertThat(cluster, not(indexExists(targetIndexName)));
         }
     }
@@ -2472,13 +2527,9 @@ public class SearchOperationTest {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("get_index_settings_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            GetSettingsRequest getSettingsRequest = new GetSettingsRequest().indices(indexName);
-            GetSettingsResponse response = restHighLevelClient.indices().getSettings(getSettingsRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            GetIndicesSettingsRequest getSettingsRequest = GetIndicesSettingsRequest.of(r -> r.index(indexName));
+            GetIndicesSettingsResponse response = client.indices().getSettings(getSettingsRequest);
 
             assertThat(response, getSettingsResponseContainsIndices(indexName));
         }
@@ -2488,23 +2539,19 @@ public class SearchOperationTest {
     public void getIndexSettings_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "get_index_settings_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().getSettings(GetIndicesSettingsRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .getSettings(new GetSettingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices()
+                    .getSettings(GetIndicesSettingsRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().getSettings(new GetSettingsRequest().indices("*"), DEFAULT),
+                () -> client.indices().getSettings(GetIndicesSettingsRequest.of(r -> r.index("*"))),
                 statusException(FORBIDDEN)
             );
         }
@@ -2515,19 +2562,17 @@ public class SearchOperationTest {
     public void updateIndexSettings_positive() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("update_index_settings_positive");
         Settings initialSettings = Settings.builder().put("index.number_of_replicas", "2").build();
-        Settings updatedSettings = Settings.builder().put("index.number_of_replicas", "4").build();
+        IndexSettings updatedSettings = IndexSettings.of(s -> s.numberOfReplicas(4));
         IndexOperationsHelper.createIndex(cluster, indexName, initialSettings);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(indexName).settings(updatedSettings);
-            var response = restHighLevelClient.indices().putSettings(updateSettingsRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            PutIndicesSettingsRequest updateSettingsRequest = PutIndicesSettingsRequest.of(
+                r -> r.index(indexName).settings(updatedSettings)
+            );
+            var response = client.indices().putSettings(updateSettingsRequest);
 
-            assertThat(response.isAcknowledged(), is(true));
-            assertThat(cluster, indexSettingsContainValues(indexName, updatedSettings));
+            assertThat(response.acknowledged(), is(true));
+            assertThat(cluster, indexSettingsContainValues(indexName, Settings.builder().put("index.number_of_replicas", "4").build()));
         }
     }
 
@@ -2535,28 +2580,25 @@ public class SearchOperationTest {
     public void updateIndexSettings_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "update_index_settings_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        Settings settingsToUpdate = Settings.builder().put("index.number_of_replicas", 2).build();
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        IndexSettings settingsToUpdate = IndexSettings.of(s -> s.numberOfReplicas(2));
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .putSettings(new UpdateSettingsRequest(indexThatUserHasNoAccessTo).settings(settingsToUpdate), DEFAULT),
+                () -> client.indices()
+                    .putSettings(PutIndicesSettingsRequest.of(r -> r.index(indexThatUserHasNoAccessTo).settings(settingsToUpdate))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
+                () -> client.indices()
                     .putSettings(
-                        new UpdateSettingsRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).settings(settingsToUpdate),
-                        DEFAULT
+                        PutIndicesSettingsRequest.of(
+                            r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).settings(settingsToUpdate)
+                        )
                     ),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().putSettings(new UpdateSettingsRequest("*").settings(settingsToUpdate), DEFAULT),
+                () -> client.indices().putSettings(PutIndicesSettingsRequest.of(r -> r.index("*").settings(settingsToUpdate))),
                 statusException(FORBIDDEN)
             );
         }
@@ -2569,15 +2611,13 @@ public class SearchOperationTest {
         Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            PutMappingRequest putMappingRequest = new PutMappingRequest(indexName).source(indexMapping);
-            var response = restHighLevelClient.indices().putMapping(putMappingRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            PutMappingRequest putMappingRequest = PutMappingRequest.of(
+                r -> r.index(indexName).properties("message", Property.of(p -> p.text(t -> t)))
+            );
+            var response = client.indices().putMapping(putMappingRequest);
 
-            assertThat(response.isAcknowledged(), is(true));
+            assertThat(response.acknowledged(), is(true));
             assertThat(cluster, indexMappingIsEqualTo(indexName, indexMapping));
         }
     }
@@ -2586,25 +2626,29 @@ public class SearchOperationTest {
     public void createIndexMappings_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "create_index_mappings_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        Map<String, Object> indexMapping = Map.of("properties", Map.of("message", Map.of("type", "text")));
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .putMapping(new PutMappingRequest(indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
+                () -> client.indices()
+                    .putMapping(
+                        PutMappingRequest.of(
+                            r -> r.index(indexThatUserHasNoAccessTo).properties("message", Property.of(p -> p.text(t -> t)))
+                        )
+                    ),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .putMapping(new PutMappingRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo).source(indexMapping), DEFAULT),
+                () -> client.indices()
+                    .putMapping(
+                        PutMappingRequest.of(
+                            r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo)
+                                .properties("message", Property.of(p -> p.text(t -> t)))
+                        )
+                    ),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().putMapping(new PutMappingRequest("*").source(indexMapping), DEFAULT),
+                () -> client.indices()
+                    .putMapping(PutMappingRequest.of(r -> r.index("*").properties("message", Property.of(p -> p.text(t -> t))))),
                 statusException(FORBIDDEN)
             );
         }
@@ -2618,13 +2662,9 @@ public class SearchOperationTest {
         IndexOperationsHelper.createIndex(cluster, indexName);
         IndexOperationsHelper.createMapping(cluster, indexName, indexMapping);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(indexName);
-            GetMappingsResponse response = restHighLevelClient.indices().getMapping(getMappingsRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            GetMappingRequest getMappingsRequest = GetMappingRequest.of(r -> r.index(indexName));
+            GetMappingResponse response = client.indices().getMapping(getMappingsRequest);
 
             assertThat(response, getMappingsResponseContainsIndices(indexName));
         }
@@ -2634,25 +2674,17 @@ public class SearchOperationTest {
     public void getIndexMappings_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "get_index_mappings_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().getMapping(GetMappingRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .getMapping(new GetMappingsRequest().indices(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().getMapping(GetMappingRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(
-                () -> restHighLevelClient.indices().getMapping(new GetMappingsRequest().indices("*"), DEFAULT),
-                statusException(FORBIDDEN)
-            );
+            assertThatThrownBy(() -> client.indices().getMapping(GetMappingRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2662,13 +2694,9 @@ public class SearchOperationTest {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("clear_index_cache_positive");
         IndexOperationsHelper.createIndex(cluster, indexName);
 
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            ClearIndicesCacheRequest clearIndicesCacheRequest = new ClearIndicesCacheRequest(indexName);
-            ClearIndicesCacheResponse response = restHighLevelClient.indices().clearCache(clearIndicesCacheRequest, DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            ClearCacheRequest clearIndicesCacheRequest = ClearCacheRequest.of(r -> r.index(indexName));
+            ClearCacheResponse response = client.indices().clearCache(clearIndicesCacheRequest);
 
             assertThat(response, isSuccessfulClearIndicesCacheResponse());
         }
@@ -2678,25 +2706,17 @@ public class SearchOperationTest {
     public void clearIndexCache_negative() throws IOException {
         String indexThatUserHasNoAccessTo = "clear_index_cache_negative";
         String indexThatUserHasAccessTo = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat(indexThatUserHasNoAccessTo);
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
 
             assertThatThrownBy(
-                () -> restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest(indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().clearCache(ClearCacheRequest.of(r -> r.index(indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
             assertThatThrownBy(
-                () -> restHighLevelClient.indices()
-                    .clearCache(new ClearIndicesCacheRequest(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo), DEFAULT),
+                () -> client.indices().clearCache(ClearCacheRequest.of(r -> r.index(indexThatUserHasAccessTo, indexThatUserHasNoAccessTo))),
                 statusException(FORBIDDEN)
             );
-            assertThatThrownBy(
-                () -> restHighLevelClient.indices().clearCache(new ClearIndicesCacheRequest("*"), DEFAULT),
-                statusException(FORBIDDEN)
-            );
+            assertThatThrownBy(() -> client.indices().clearCache(ClearCacheRequest.of(r -> r.index("*"))), statusException(FORBIDDEN));
         }
     }
 
@@ -2704,16 +2724,12 @@ public class SearchOperationTest {
     // required permissions: "indices:admin/create", "indices:admin/aliases"
     public void shouldCreateIndexWithAlias_positive() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_positive");
-        try (
-            RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(
-                USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES
-            )
-        ) {
-            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).alias(
-                new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE)
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_PERFORM_INDEX_OPERATIONS_ON_SELECTED_INDICES)) {
+            CreateIndexRequest createIndexRequest = CreateIndexRequest.of(
+                r -> r.index(indexName).aliases(ALIAS_CREATE_INDEX_WITH_ALIAS_POSITIVE, Alias.builder().build())
             );
 
-            CreateIndexResponse createIndexResponse = restHighLevelClient.indices().create(createIndexRequest, DEFAULT);
+            CreateIndexResponse createIndexResponse = client.indices().create(createIndexRequest);
 
             assertThat(createIndexResponse, isSuccessfulCreateIndexResponse(indexName));
             assertThat(cluster, indexExists(indexName));
@@ -2738,12 +2754,12 @@ public class SearchOperationTest {
     @Test
     public void shouldCreateIndexWithAlias_negative() throws IOException {
         String indexName = INDICES_ON_WHICH_USER_CAN_PERFORM_INDEX_OPERATIONS_PREFIX.concat("create_index_with_alias_negative");
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(USER_ALLOWED_TO_CREATE_INDEX)) {
-            CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).alias(
-                new Alias(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE)
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_ALLOWED_TO_CREATE_INDEX)) {
+            CreateIndexRequest createIndexRequest = CreateIndexRequest.of(
+                r -> r.index(indexName).aliases(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE, Alias.builder().build())
             );
 
-            assertThatThrownBy(() -> restHighLevelClient.indices().create(createIndexRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.indices().create(createIndexRequest), statusException(FORBIDDEN));
 
             assertThat(internalClient, not(aliasExists(ALIAS_CREATE_INDEX_WITH_ALIAS_NEGATIVE)));
         }

--- a/src/integrationTest/java/org/opensearch/security/SecurityIndexSnapshotRestoreTests.java
+++ b/src/integrationTest/java/org/opensearch/security/SecurityIndexSnapshotRestoreTests.java
@@ -22,7 +22,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
 import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
 import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
@@ -30,12 +29,10 @@ import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResp
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest;
-import org.opensearch.client.RequestOptions;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.security.api.AbstractApiIntegrationTest;
@@ -49,6 +46,7 @@ import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
 import org.opensearch.test.framework.cluster.LocalOpenSearchCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.transport.client.Client;
 
@@ -63,7 +61,9 @@ import static org.opensearch.security.support.ConfigConstants.SECURITY_RESTAPI_R
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
 import static org.opensearch.test.framework.TestSecurityConfig.User.USER_ADMIN;
-import static org.opensearch.test.framework.matcher.GetResponseMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
+import static org.opensearch.test.framework.matcher.client.GetResponseMatchers.containDocument;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -139,14 +139,14 @@ public class SecurityIndexSnapshotRestoreTests extends AbstractApiIntegrationTes
     @Test
     public void testSecurityCacheReloadAfterRestore() throws Exception {
         // 1. Read data in custom index with LIMITED_READ_USER_1
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER_1)) {
-            GetResponse response = restHighLevelClient.get(new GetRequest(TEST_INDEX_NAME, DOC_ID), RequestOptions.DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER_1)) {
+            GetResponse<?> response = client.get(GetRequest.of(r -> r.index(TEST_INDEX_NAME).id(DOC_ID)), Map.class);
             assertThat(response, containDocument(TEST_INDEX_NAME, DOC_ID));
         }
 
         // 2. Create snapshot of security index
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(ADMIN_USER)) {
-            SnapshotSteps steps = new SnapshotSteps(restHighLevelClient);
+        try (CloseableOpenSearchClient client = cluster.getClient(ADMIN_USER)) {
+            SnapshotSteps steps = new SnapshotSteps(client);
             steps.createSnapshot(TEST_SNAPSHOT_REPOSITORY_NAME, "test-snap", securityIndex);
             steps.waitForSnapshotCreation(TEST_SNAPSHOT_REPOSITORY_NAME, "test-snap");
         }
@@ -159,8 +159,8 @@ public class SecurityIndexSnapshotRestoreTests extends AbstractApiIntegrationTes
         }
 
         // 4. Read data in custom index with LIMITED_READ_USER_2
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER_2)) {
-            GetResponse response = restHighLevelClient.get(new GetRequest(TEST_INDEX_NAME, DOC_ID), RequestOptions.DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER_2)) {
+            GetResponse<?> response = client.get(GetRequest.of(r -> r.index(TEST_INDEX_NAME).id(DOC_ID)), Map.class);
             assertThat(response, containDocument(TEST_INDEX_NAME, DOC_ID));
         }
 
@@ -183,16 +183,17 @@ public class SecurityIndexSnapshotRestoreTests extends AbstractApiIntegrationTes
         }
 
         // 7. Read data in custom index with LIMITED_READ_USER_1 because it was in snapshot
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER_1)) {
-            GetResponse response = restHighLevelClient.get(new GetRequest(TEST_INDEX_NAME, DOC_ID), RequestOptions.DEFAULT);
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER_1)) {
+            GetResponse<?> response = client.get(GetRequest.of(r -> r.index(TEST_INDEX_NAME).id(DOC_ID)), Map.class);
             assertThat(response, containDocument(TEST_INDEX_NAME, DOC_ID));
         }
 
         // 8. Should get 401 error to read custom index with LIMITED_READ_USER_2 because it was not in snapshot
-        try (RestHighLevelClient restHighLevelClient = cluster.getRestHighLevelClient(LIMITED_READ_USER_2)) {
-            restHighLevelClient.get(new GetRequest(TEST_INDEX_NAME, DOC_ID), RequestOptions.DEFAULT);
-        } catch (OpenSearchStatusException exception) {
-            assertEquals(RestStatus.UNAUTHORIZED, exception.status());  // Verify it's a 401
+        try (CloseableOpenSearchClient client = cluster.getClient(LIMITED_READ_USER_2)) {
+            assertThatThrownBy(
+                () -> client.get(GetRequest.of(r -> r.index(TEST_INDEX_NAME).id(DOC_ID)), Map.class),
+                statusException(RestStatus.UNAUTHORIZED)
+            );
         }
 
         // 9. Verify all nodes have reloaded the security configuration by directly checking ConfigurationRepository

--- a/src/integrationTest/java/org/opensearch/security/SnapshotSteps.java
+++ b/src/integrationTest/java/org/opensearch/security/SnapshotSteps.java
@@ -10,56 +10,56 @@
 package org.opensearch.security;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.awaitility.Awaitility;
 
-import org.opensearch.action.admin.cluster.repositories.delete.DeleteRepositoryRequest;
-import org.opensearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
-import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
-import org.opensearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.opensearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
-import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
-import org.opensearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
-import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
-import org.opensearch.action.admin.cluster.snapshots.restore.RestoreSnapshotResponse;
-import org.opensearch.client.RestHighLevelClient;
-import org.opensearch.client.SnapshotClient;
-import org.opensearch.snapshots.SnapshotInfo;
-import org.opensearch.snapshots.SnapshotState;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.snapshot.CreateRepositoryRequest;
+import org.opensearch.client.opensearch.snapshot.CreateRepositoryResponse;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
+import org.opensearch.client.opensearch.snapshot.DeleteRepositoryRequest;
+import org.opensearch.client.opensearch.snapshot.DeleteRepositoryResponse;
+import org.opensearch.client.opensearch.snapshot.DeleteSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.DeleteSnapshotResponse;
+import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
+import org.opensearch.client.opensearch.snapshot.OpenSearchSnapshotClient;
+import org.opensearch.client.opensearch.snapshot.RestoreSnapshotRequest;
+import org.opensearch.client.opensearch.snapshot.RestoreSnapshotResponse;
+import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
 
 import static java.util.Objects.requireNonNull;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 
 class SnapshotSteps {
 
-    private final SnapshotClient snapshotClient;
+    private final OpenSearchSnapshotClient snapshotClient;
 
-    public SnapshotSteps(RestHighLevelClient restHighLevelClient) {
-        this.snapshotClient = requireNonNull(restHighLevelClient, "Rest high level client is required.").snapshot();
+    public SnapshotSteps(OpenSearchClient client) {
+        this.snapshotClient = requireNonNull(client, "Rest high level client is required.").snapshot();
     }
 
-    public org.opensearch.action.support.clustermanager.AcknowledgedResponse createSnapshotRepository(
-        String repositoryName,
-        String snapshotDirPath,
-        String type
-    ) throws IOException {
-        PutRepositoryRequest createRepositoryRequest = new PutRepositoryRequest().name(repositoryName)
-            .type(type)
-            .settings(Map.of("location", snapshotDirPath));
-        return snapshotClient.createRepository(createRepositoryRequest, DEFAULT);
+    public CreateRepositoryResponse createSnapshotRepository(String repositoryName, String snapshotDirPath, String type)
+        throws IOException {
+        CreateRepositoryRequest createRepositoryRequest = CreateRepositoryRequest.of(
+            r -> r.name(repositoryName).type(type).settings(s -> s.location(snapshotDirPath))
+        );
+        return snapshotClient.createRepository(createRepositoryRequest);
     }
 
     public CreateSnapshotResponse createSnapshot(String repositoryName, String snapshotName, String... indices) throws IOException {
-        CreateSnapshotRequest createSnapshotRequest = new CreateSnapshotRequest(repositoryName, snapshotName).indices(indices);
-        return snapshotClient.create(createSnapshotRequest, DEFAULT);
+        CreateSnapshotRequest createSnapshotRequest = CreateSnapshotRequest.of(
+            r -> r.repository(repositoryName).snapshot(snapshotName).indices(Arrays.asList(indices))
+        );
+        return snapshotClient.create(createSnapshotRequest);
     }
 
     public int waitForSnapshotCreation(String repositoryName, String snapshotName) {
         AtomicInteger count = new AtomicInteger();
-        GetSnapshotsRequest getSnapshotsRequest = new GetSnapshotsRequest(repositoryName, new String[] { snapshotName });
+        GetSnapshotRequest getSnapshotsRequest = GetSnapshotRequest.of(r -> r.repository(repositoryName).snapshot(snapshotName));
         Awaitility.await()
             .pollDelay(250, TimeUnit.MILLISECONDS)
             .pollInterval(2, TimeUnit.SECONDS)
@@ -67,22 +67,20 @@ class SnapshotSteps {
             .ignoreExceptions()
             .until(() -> {
                 count.incrementAndGet();
-                GetSnapshotsResponse snapshotsResponse = snapshotClient.get(getSnapshotsRequest, DEFAULT);
-                SnapshotInfo snapshotInfo = snapshotsResponse.getSnapshots().get(0);
-                return SnapshotState.SUCCESS.equals(snapshotInfo.state());
+                GetSnapshotResponse snapshotsResponse = snapshotClient.get(getSnapshotsRequest);
+                SnapshotInfo snapshotInfo = snapshotsResponse.snapshots().get(0);
+                return "SUCCESS".equals(snapshotInfo.state());
             });
         return count.get();
     }
 
-    public org.opensearch.action.support.clustermanager.AcknowledgedResponse deleteSnapshotRepository(String repositoryName)
-        throws IOException {
-        DeleteRepositoryRequest request = new DeleteRepositoryRequest(repositoryName);
-        return snapshotClient.deleteRepository(request, DEFAULT);
+    public DeleteRepositoryResponse deleteSnapshotRepository(String repositoryName) throws IOException {
+        DeleteRepositoryRequest request = DeleteRepositoryRequest.of(r -> r.name(repositoryName));
+        return snapshotClient.deleteRepository(request);
     }
 
-    public org.opensearch.action.support.clustermanager.AcknowledgedResponse deleteSnapshot(String repositoryName, String snapshotName)
-        throws IOException {
-        return snapshotClient.delete(new DeleteSnapshotRequest(repositoryName, snapshotName), DEFAULT);
+    public DeleteSnapshotResponse deleteSnapshot(String repositoryName, String snapshotName) throws IOException {
+        return snapshotClient.delete(DeleteSnapshotRequest.of(r -> r.repository(repositoryName).snapshot(snapshotName)));
     }
 
     public RestoreSnapshotResponse restoreSnapshot(
@@ -91,9 +89,9 @@ class SnapshotSteps {
         String renamePattern,
         String renameReplacement
     ) throws IOException {
-        RestoreSnapshotRequest restoreSnapshotRequest = new RestoreSnapshotRequest(repositoryName, snapshotName).renamePattern(
-            renamePattern
-        ).renameReplacement(renameReplacement);
-        return snapshotClient.restore(restoreSnapshotRequest, DEFAULT);
+        RestoreSnapshotRequest restoreSnapshotRequest = RestoreSnapshotRequest.of(
+            r -> r.repository(repositoryName).snapshot(snapshotName).renamePattern(renamePattern).renameReplacement(renameReplacement)
+        );
+        return snapshotClient.restore(restoreSnapshotRequest);
     }
 }

--- a/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
+++ b/src/integrationTest/java/org/opensearch/security/http/JwtAuthenticationTests.java
@@ -22,14 +22,14 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.test.framework.JwtConfigBuilder;
 import org.opensearch.test.framework.TestSecurityConfig;
 import org.opensearch.test.framework.TestSecurityConfig.Role;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.test.framework.log.LogsRule;
@@ -45,7 +45,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.security.Song.FIELD_TITLE;
 import static org.opensearch.security.Song.QUERY_TITLE_MAGNUM_OPUS;
@@ -54,13 +53,13 @@ import static org.opensearch.security.Song.TITLE_MAGNUM_OPUS;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.BASIC_AUTH_DOMAIN_ORDER;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.queryStringQueryRequest;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitContainsFieldWithValue;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitContainsFieldWithValue;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 
 public class JwtAuthenticationTests {
 
@@ -254,10 +253,10 @@ public class JwtAuthenticationTests {
         String[] roles = { ROLE_VP };
         Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, QA_DEPARTMENT);
         Header header = tokenFactory1.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))) {
+        try (CloseableOpenSearchClient client = cluster.getClient(List.of(header))) {
             SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
 
-            SearchResponse response = client.search(searchRequest, DEFAULT);
+            SearchResponse<?> response = client.search(searchRequest, Map.class);
 
             assertThat(response, isSuccessfulSearchResponse());
             assertThat(response, numberOfTotalHitsIsEqualTo(1));
@@ -271,10 +270,10 @@ public class JwtAuthenticationTests {
         String[] roles = { ROLE_VP };
         Map<String, Object> additionalClaims = Map.of(CLAIM_DEPARTMENT, "department-without-access-to-qa-song-index");
         Header header = tokenFactory1.generateValidTokenWithCustomClaims(USER_SUPERHERO, roles, additionalClaims);
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(List.of(header))) {
+        try (CloseableOpenSearchClient client = cluster.getClient(List.of(header))) {
             SearchRequest searchRequest = queryStringQueryRequest(QA_SONG_INDEX_NAME, QUERY_TITLE_MAGNUM_OPUS);
 
-            assertThatThrownBy(() -> client.search(searchRequest, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(searchRequest, Map.class), statusException(FORBIDDEN));
         }
     }
 

--- a/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/http/LdapTlsAuthenticationTest.java
@@ -20,9 +20,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.test.framework.AuthorizationBackend;
 import org.opensearch.test.framework.AuthzDomain;
 import org.opensearch.test.framework.LdapAuthenticationConfigBuilder;
@@ -36,6 +35,7 @@ import org.opensearch.test.framework.TestSecurityConfig.User;
 import org.opensearch.test.framework.certificate.TestCertificates;
 import org.opensearch.test.framework.cluster.ClusterManager;
 import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.test.framework.cluster.OpenSearchClientProvider.CloseableOpenSearchClient;
 import org.opensearch.test.framework.cluster.TestRestClient;
 import org.opensearch.test.framework.cluster.TestRestClient.HttpResponse;
 import org.opensearch.test.framework.ldap.EmbeddedLDAPServer;
@@ -49,7 +49,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.client.RequestOptions.DEFAULT;
 import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
 import static org.opensearch.security.Song.SONGS;
 import static org.opensearch.security.http.DirectoryInformationTrees.CN_GROUP_ADMIN;
@@ -74,12 +73,12 @@ import static org.opensearch.security.http.DirectoryInformationTrees.USER_SPOCK;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
 import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.BASIC_AUTH_DOMAIN_ORDER;
 import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
-import static org.opensearch.test.framework.cluster.SearchRequestFactory.queryStringQueryRequest;
+import static org.opensearch.test.framework.client.SearchRequestFactory.queryStringQueryRequest;
 import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
-import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
-import static org.opensearch.test.framework.matcher.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.searchHitsContainDocumentWithId;
+import static org.opensearch.test.framework.matcher.client.TransportExceptionMatchers.statusException;
 
 /**
 * Test uses plain TLS connection between OpenSearch and LDAP server.
@@ -277,10 +276,10 @@ public class LdapTlsAuthenticationTest {
 
     @Test
     public void shouldPerformAuthorizationAgainstLdapToAccessIndex_positive() throws IOException {
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_KIRK, PASSWORD_KIRK)) {
             SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
 
-            SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(request, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -290,19 +289,19 @@ public class LdapTlsAuthenticationTest {
 
     @Test
     public void shouldPerformAuthorizationAgainstLdapToAccessIndex_negative() throws IOException {
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_LEONARD, PASSWORD_LEONARD)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_LEONARD, PASSWORD_LEONARD)) {
             SearchRequest request = queryStringQueryRequest(SONG_INDEX_NAME, "*");
 
-            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(request, Map.class), statusException(FORBIDDEN));
         }
     }
 
     @Test
     public void shouldResolveUserAttributesLoadedFromLdap_positive() throws IOException {
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_SPOCK, PASSWORD_SPOCK)) {
             SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
 
-            SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(request, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -312,10 +311,10 @@ public class LdapTlsAuthenticationTest {
 
     @Test
     public void shouldResolveUserAttributesLoadedFromLdap_negative() throws IOException {
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_SPOCK, PASSWORD_SPOCK)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_SPOCK, PASSWORD_SPOCK)) {
             SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
 
-            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(request, Map.class), statusException(FORBIDDEN));
         }
     }
 
@@ -386,10 +385,10 @@ public class LdapTlsAuthenticationTest {
     @Test
     public void shouldAccessImpersonatedUserPersonalIndex_positive() throws IOException {
         BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
             SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_SPOCK, "*");
 
-            SearchResponse searchResponse = client.search(request, DEFAULT);
+            SearchResponse<?> searchResponse = client.search(request, Map.class);
 
             assertThat(searchResponse, isSuccessfulSearchResponse());
             assertThat(searchResponse, numberOfTotalHitsIsEqualTo(1));
@@ -400,10 +399,10 @@ public class LdapTlsAuthenticationTest {
     @Test
     public void shouldAccessImpersonatedUserPersonalIndex_negative() throws IOException {
         BasicHeader impersonateHeader = new BasicHeader(HEADER_NAME_IMPERSONATE, USER_SPOCK);
-        try (RestHighLevelClient client = cluster.getRestHighLevelClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
+        try (CloseableOpenSearchClient client = cluster.getClient(USER_KIRK, PASSWORD_KIRK, impersonateHeader)) {
             SearchRequest request = queryStringQueryRequest(PERSONAL_INDEX_NAME_KIRK, "*");
 
-            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+            assertThatThrownBy(() -> client.search(request, Map.class), statusException(FORBIDDEN));
         }
     }
 }

--- a/src/integrationTest/java/org/opensearch/test/framework/client/SearchRequestFactory.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/client/SearchRequestFactory.java
@@ -1,0 +1,80 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.client;
+
+import java.util.Arrays;
+
+import org.opensearch.client.opensearch._types.FieldSort;
+import org.opensearch.client.opensearch._types.SortOptions;
+import org.opensearch.client.opensearch._types.SortOrder;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.ScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+public final class SearchRequestFactory {
+    private SearchRequestFactory() {
+
+    }
+
+    public static SearchRequest searchRequestWithSort(String indexName) {
+        return SearchRequest.of(
+            r -> r.index(indexName).sort(SortOptions.of(s -> s.field(FieldSort.of(f -> f.field("_id").order(SortOrder.Asc)))))
+        );
+    }
+
+    public static SearchRequest averageAggregationRequest(String indexName, String aggregationName, String fieldName) {
+        return SearchRequest.of(
+            r -> r.index(indexName).size(0).aggregations(aggregationName, Aggregation.of(a -> a.avg(v -> v.field(fieldName))))
+        );
+    }
+
+    public static SearchRequest statsAggregationRequest(String indexName, String aggregationName, String fieldName) {
+        return SearchRequest.of(
+            r -> r.index(indexName).size(0).aggregations(aggregationName, Aggregation.of(a -> a.stats(v -> v.field(fieldName))))
+        );
+    }
+
+    public static SearchRequest queryStringQueryRequest(String[] indicesNames, String queryString) {
+        return SearchRequest.of(
+            r -> r.index(Arrays.asList(indicesNames)).query(QueryBuilders.queryString().query(queryString).build().toQuery())
+        );
+    }
+
+    public static SearchRequest queryStringQueryRequest(String queryString) {
+        return SearchRequest.of(r -> r.query(QueryBuilders.queryString().query(queryString).build().toQuery()));
+    }
+
+    public static SearchRequest queryStringQueryRequest(String indexName, String queryString) {
+        return SearchRequest.of(r -> r.index(indexName).query(QueryBuilders.queryString().query(queryString).build().toQuery()));
+    }
+
+    public static SearchRequest searchRequestWithScroll(String indexName, int pageSize) {
+        return SearchRequest.of(
+            r -> r.index(indexName)
+                .scroll(Time.of(t -> t.time("1m")))
+                .query(QueryBuilders.matchAll().build().toQuery())
+                .size(pageSize)
+                .sort(SortOptions.of(s -> s.field(FieldSort.of(f -> f.field("_id").order(SortOrder.Asc)))))
+        );
+    }
+
+    public static ScrollRequest getSearchScrollRequest(SearchResponse<?> searchResponse) {
+        return ScrollRequest.of(r -> r.scrollId(searchResponse.scrollId()).scroll(Time.of(t -> t.time("1m"))));
+    }
+
+    public static SearchRequest queryByIdsRequest(String indexName, String... ids) {
+        return SearchRequest.of(
+            r -> r.index(Arrays.asList(indexName)).query(QueryBuilders.ids().values(Arrays.asList(ids)).build().toQuery())
+        );
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/cluster/OpenSearchClientProvider.java
@@ -29,6 +29,7 @@
 package org.opensearch.test.framework.cluster;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
@@ -39,13 +40,13 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.hc.client5.http.auth.AuthScope;
@@ -56,20 +57,29 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBu
 import org.apache.hc.client5.http.nio.AsyncClientConnectionManager;
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 
-import org.opensearch.client.RestClient;
-import org.opensearch.client.RestClientBuilder;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson3.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.core.FieldCapsRequest;
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+import org.opensearch.client.opensearch.generic.Bodies;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Requests.JsonBodyBuilder;
+import org.opensearch.client.opensearch.generic.Response;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.opensearch.client.util.ApiTypeHelper;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.support.PemKeyReader;
 import org.opensearch.test.framework.certificate.CertificateData;
 import org.opensearch.test.framework.certificate.TestCertificates;
 
+import jakarta.json.stream.JsonGenerator;
 import reactor.netty.http.HttpProtocol;
 
 import static org.opensearch.security.ssl.util.SSLConfigConstants.DEFAULT_STORE_TYPE;
@@ -119,8 +129,60 @@ public interface OpenSearchClientProvider {
         return getRestClient(getTestCertificates().getAdminCertificateData());
     }
 
-    default RestHighLevelClient getRestHighLevelClient(String username, String password, Header... headers) {
-        return getRestHighLevelClient(new UserCredentialsHolder() {
+    static final class CloseableOpenSearchClient extends OpenSearchClient implements AutoCloseable {
+        public CloseableOpenSearchClient(OpenSearchTransport transport) {
+            super(transport);
+        }
+
+        @Override
+        public FieldCapsResponse fieldCaps(FieldCapsRequest request) throws IOException, OpenSearchException {
+            // Awaits https://github.com/opensearch-project/opensearch-java/issues/1792
+            final JsonpMapper jsonpMapper = _transport().jsonpMapper();
+
+            final FieldCapsRequest r = FieldCapsRequest.builder()
+                .fields(ApiTypeHelper.undefinedList())
+                .index(request.index())
+                .indexFilter(request.indexFilter())
+                .build();
+
+            String indexPrefix = "";
+            if (request.index().size() == 1) {
+                indexPrefix = "/" + request.index().get(0);
+            }
+
+            JsonBodyBuilder builder = Requests.builder()
+                .endpoint(indexPrefix + "/_field_caps")
+                .method("GET")
+                .query(Map.of("fields", request.fields().stream().collect(Collectors.joining(","))));
+
+            try (StringWriter writer = new StringWriter()) {
+                try (JsonGenerator generator = jsonpMapper.jsonProvider().createGenerator(writer)) {
+                    r.serialize(generator, jsonpMapper);
+                }
+                builder = builder.body(Bodies.json(writer.toString()));
+            }
+
+            final Response resp = generic().execute(builder.build());
+            return resp.getBody()
+                .map(body -> Bodies.json(body, FieldCapsResponse._DESERIALIZER, jsonpMapper))
+                .orElseThrow(() -> new IOException("Response body is required"));
+        }
+
+        @Override
+        public void close() throws IOException {
+            ForkJoinPool.commonPool().submit(() -> {
+                // Do the closing of the restClient asynchronously, as it might cause a 5 second delay
+                try {
+                    _transport().close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    default CloseableOpenSearchClient getClient(String username, String password, Header... headers) {
+        return getClient(new UserCredentialsHolder() {
             @Override
             public String getName() {
                 return username;
@@ -133,11 +195,11 @@ public interface OpenSearchClientProvider {
         }, Arrays.asList(headers));
     }
 
-    default RestHighLevelClient getRestHighLevelClient(UserCredentialsHolder user) {
-        return getRestHighLevelClient(user, Collections.emptySet());
+    default CloseableOpenSearchClient getClient(UserCredentialsHolder user) {
+        return getClient(user, Collections.emptySet());
     }
 
-    default RestHighLevelClient getRestHighLevelClient(UserCredentialsHolder user, Collection<? extends Header> defaultHeaders) {
+    default CloseableOpenSearchClient getClient(UserCredentialsHolder user, Collection<? extends Header> defaultHeaders) {
 
         BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(
@@ -145,29 +207,19 @@ public interface OpenSearchClientProvider {
             new UsernamePasswordCredentials(user.getName(), user.getPassword().toCharArray())
         );
 
-        return getRestHighLevelClient(credentialsProvider, defaultHeaders);
+        return getClient(credentialsProvider, defaultHeaders);
     }
 
-    default RestHighLevelClient getRestHighLevelClient(Collection<? extends Header> defaultHeaders) {
-        return getRestHighLevelClient((BasicCredentialsProvider) null, defaultHeaders);
+    default CloseableOpenSearchClient getClient(Collection<? extends Header> defaultHeaders) {
+        return getClient((BasicCredentialsProvider) null, defaultHeaders);
     }
 
-    default RestHighLevelClient getRestHighLevelClient(
-        BasicCredentialsProvider credentialsProvider,
-        Collection<? extends Header> defaultHeaders
-    ) {
-        RestClientBuilder.HttpClientConfigCallback configCallback = httpClientBuilder -> {
+    default CloseableOpenSearchClient getClient(BasicCredentialsProvider credentialsProvider, Collection<? extends Header> defaultHeaders) {
+        ApacheHttpClient5TransportBuilder.HttpClientConfigCallback configCallback = httpClientBuilder -> {
             TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
                 .setSslContext(getSSLContext())
                 .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
-                .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
-                    @Override
-                    public TlsDetails create(final SSLEngine sslEngine) {
-                        return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
-                    }
-                })
-                .build();
+                .buildAsync();
 
             final AsyncClientConnectionManager cm = PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
 
@@ -181,20 +233,11 @@ public interface OpenSearchClientProvider {
         };
 
         InetSocketAddress httpAddress = getHttpAddress();
-        RestClientBuilder builder = RestClient.builder(new HttpHost("https", httpAddress.getHostString(), httpAddress.getPort()))
-            .setHttpClientConfigCallback(configCallback);
+        ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(
+            new HttpHost("https", httpAddress.getHostString(), httpAddress.getPort())
+        ).setHttpClientConfigCallback(configCallback);
 
-        return new RestHighLevelClient(builder.build(), (restClient) -> {
-            ForkJoinPool.commonPool().submit(() -> {
-                // Do the closing of the restClient asynchronously, as it might cause a 5 second delay
-                try {
-                    restClient.close();
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }, Collections.emptyList()) {
-        };
+        return new CloseableOpenSearchClient(builder.setMapper(new JacksonJsonpMapper()).build());
     }
 
     default CloseableHttpClient getClosableHttpClient(String[] supportedCipherSuit) {

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseContainExceptionsAtIndexMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseContainExceptionsAtIndexMatcher.java
@@ -1,0 +1,72 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class BulkResponseContainExceptionsAtIndexMatcher extends TypeSafeDiagnosingMatcher<BulkResponse> {
+
+    private final int errorIndex;
+    private final Matcher<ErrorCause> exceptionMatcher;
+
+    public BulkResponseContainExceptionsAtIndexMatcher(int errorIndex, Matcher<ErrorCause> exceptionMatcher) {
+        this.errorIndex = errorIndex;
+        this.exceptionMatcher = requireNonNull(exceptionMatcher, "Exception matcher is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(BulkResponse response, Description mismatchDescription) {
+        if (response.errors() == false) {
+            mismatchDescription.appendText("received successful bulk response what is not expected.");
+            return false;
+        }
+        List<BulkResponseItem> items = response.items();
+        if ((items == null) || (items.isEmpty() == true) || (errorIndex >= items.size())) {
+            mismatchDescription.appendText("bulk response does not contain item with index ").appendValue(errorIndex);
+            return false;
+        }
+        BulkResponseItem item = items.get(errorIndex);
+        if (item == null) {
+            mismatchDescription.appendText("bulk item response with index ").appendValue(errorIndex).appendText(" is null.");
+            return false;
+        }
+        ErrorCause failure = item.error();
+        if (failure == null) {
+            mismatchDescription.appendText("bulk response item with index ")
+                .appendValue(errorIndex)
+                .appendText(" does not contain failure");
+            return false;
+        }
+        if (exceptionMatcher.matches(failure) == false) {
+            mismatchDescription.appendText("bulk response item with index ")
+                .appendValue(errorIndex)
+                .appendText(" contains incorrect exception which is ")
+                .appendValue(failure);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("bulk response should contain exceptions which indicate failure");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseContainExceptionsMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseContainExceptionsMatcher.java
@@ -1,0 +1,69 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.List;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class BulkResponseContainExceptionsMatcher extends TypeSafeDiagnosingMatcher<BulkResponse> {
+
+    private final Matcher<ErrorCause> exceptionMatcher;
+
+    public BulkResponseContainExceptionsMatcher(Matcher<ErrorCause> exceptionMatcher) {
+        this.exceptionMatcher = requireNonNull(exceptionMatcher, "Exception matcher is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(BulkResponse response, Description mismatchDescription) {
+        if (response.errors() == false) {
+            mismatchDescription.appendText("received successful bulk response what is not expected.");
+            return false;
+        }
+        List<BulkResponseItem> items = response.items();
+        if ((items == null) || (items.isEmpty())) {
+            mismatchDescription.appendText("bulk response does not contain items ").appendValue(items);
+            return false;
+        }
+        for (int i = 0; i < items.size(); ++i) {
+            BulkResponseItem item = items.get(i);
+            if (item == null) {
+                mismatchDescription.appendText("bulk item response with index ").appendValue(i).appendText(" is null.");
+                return false;
+            }
+            ErrorCause failure = item.error();
+            if (failure == null) {
+                mismatchDescription.appendText("bulk response item with index ").appendValue(i).appendText(" does not contain failure");
+                return false;
+            }
+            if (exceptionMatcher.matches(failure) == false) {
+                mismatchDescription.appendText("bulk response item with index ")
+                    .appendValue(i)
+                    .appendText(" contains incorrect exception which is ")
+                    .appendValue(failure);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("bulk response should contain exceptions which indicate failure");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/BulkResponseMatchers.java
@@ -1,0 +1,38 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch.core.BulkResponse;
+
+public class BulkResponseMatchers {
+
+    private BulkResponseMatchers() {
+
+    }
+
+    public static Matcher<BulkResponse> successBulkResponse() {
+        return new SuccessBulkResponseMatcher();
+    }
+
+    public static Matcher<BulkResponse> failureBulkResponse() {
+        return new FailureBulkResponseMatcher();
+    }
+
+    public static Matcher<BulkResponse> bulkResponseContainExceptions(Matcher<ErrorCause> exceptionMatcher) {
+        return new BulkResponseContainExceptionsMatcher(exceptionMatcher);
+    }
+
+    public static Matcher<BulkResponse> bulkResponseContainExceptions(int index, Matcher<ErrorCause> exceptionMatcher) {
+        return new BulkResponseContainExceptionsAtIndexMatcher(index, exceptionMatcher);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainNotEmptyScrollingIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainNotEmptyScrollingIdMatcher.java
@@ -1,0 +1,34 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+class ContainNotEmptyScrollingIdMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        String scrollId = searchResponse.scrollId();
+        if (StringUtils.isEmpty(scrollId)) {
+            mismatchDescription.appendText("scrolling id is null or empty");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search response should contain scrolling id.");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsAggregationWithNameAndTypeMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsAggregationWithNameAndTypeMatcher.java
@@ -1,0 +1,58 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class ContainsAggregationWithNameAndTypeMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final String expectedAggregationName;
+    private final String expectedAggregationType;
+
+    public ContainsAggregationWithNameAndTypeMatcher(String expectedAggregationName, String expectedAggregationType) {
+        this.expectedAggregationName = requireNonNull(expectedAggregationName, "Aggregation name is required");
+        this.expectedAggregationType = requireNonNull(expectedAggregationType, "Expected aggregation type is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> response, Description mismatchDescription) {
+        Map<String, Aggregate> aggregations = response.aggregations();
+        if (aggregations == null) {
+            mismatchDescription.appendText("search response does not contain aggregations");
+            return false;
+        }
+        Aggregate aggregation = aggregations.get(expectedAggregationName);
+        if (aggregation == null) {
+            mismatchDescription.appendText("Response does not contain aggregation with name ").appendValue(expectedAggregationName);
+            return false;
+        }
+        if (expectedAggregationType.equals(aggregation._kind().jsonValue()) == false) {
+            mismatchDescription.appendText("Aggregation contain incorrect type which is ").appendValue(aggregation._kind().jsonValue());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search response should contains aggregation results with name ")
+            .appendValue(expectedAggregationName)
+            .appendText(" and type ")
+            .appendValue(expectedAggregationType);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsExactlyIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsExactlyIndicesMatcher.java
@@ -1,0 +1,46 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+
+import static java.util.Objects.isNull;
+
+class ContainsExactlyIndicesMatcher extends TypeSafeDiagnosingMatcher<FieldCapsResponse> {
+
+    private final Set<String> expectedIndices;
+
+    ContainsExactlyIndicesMatcher(String... expectedIndices) {
+        if (isNull(expectedIndices) || expectedIndices.length == 0) {
+            throw new IllegalArgumentException("expectedIndices cannot be null or empty");
+        }
+        this.expectedIndices = Set.of(expectedIndices);
+    }
+
+    @Override
+    protected boolean matchesSafely(FieldCapsResponse response, Description mismatchDescription) {
+        if (!expectedIndices.equals(new HashSet<>(response.indices()))) {
+            mismatchDescription.appendText("Actual indices: ").appendValue(response.indices());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response contains indices: ").appendValue(expectedIndices);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsFieldWithTypeMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ContainsFieldWithTypeMatcher.java
@@ -1,0 +1,55 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+import org.opensearch.client.opensearch.core.field_caps.FieldCapability;
+
+import static java.util.Objects.requireNonNull;
+
+class ContainsFieldWithTypeMatcher extends TypeSafeDiagnosingMatcher<FieldCapsResponse> {
+
+    private final String expectedFieldName;
+    private final String expectedFieldType;
+
+    ContainsFieldWithTypeMatcher(String expectedFieldName, String expectedFieldType) {
+        this.expectedFieldName = requireNonNull(expectedFieldName, "Field name is required");
+        ;
+        this.expectedFieldType = requireNonNull(expectedFieldType, "Field type is required");
+        ;
+    }
+
+    @Override
+    protected boolean matchesSafely(FieldCapsResponse response, Description mismatchDescription) {
+        Map<String, Map<String, FieldCapability>> fieldCapabilitiesMap = response.fields();
+        if (!fieldCapabilitiesMap.containsKey(expectedFieldName)) {
+            mismatchDescription.appendText("Response does not contain field with name ").appendText(expectedFieldName);
+            return false;
+        }
+        if (!fieldCapabilitiesMap.get(expectedFieldName).containsKey(expectedFieldType)) {
+            mismatchDescription.appendText("Field type does not match ").appendText(expectedFieldType);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response contains field with name ")
+            .appendValue(expectedFieldName)
+            .appendText(" and type ")
+            .appendValue(expectedFieldType);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeletePitContainsExactlyIdsResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeletePitContainsExactlyIdsResponseMatcher.java
@@ -1,0 +1,48 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.DeletePitResponse;
+import org.opensearch.client.opensearch.core.pit.DeletedPit;
+
+import static java.util.Objects.isNull;
+
+class DeletePitContainsExactlyIdsResponseMatcher extends TypeSafeDiagnosingMatcher<DeletePitResponse> {
+
+    private final Set<String> expectedPitIds;
+
+    DeletePitContainsExactlyIdsResponseMatcher(String[] expectedPitIds) {
+        if (isNull(expectedPitIds) || 0 == expectedPitIds.length) {
+            throw new IllegalArgumentException("expectedPitIds cannot be null or empty");
+        }
+        this.expectedPitIds = Set.of(expectedPitIds);
+    }
+
+    @Override
+    protected boolean matchesSafely(DeletePitResponse response, Description mismatchDescription) {
+        Set<String> actualPitIds = response.pits().stream().map(DeletedPit::pitId).collect(Collectors.toSet());
+        if (!actualPitIds.equals(expectedPitIds)) {
+            mismatchDescription.appendText("Actual pit ids: ").appendValue(actualPitIds);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Should contain exactly pit with ids: ").appendValue(expectedPitIds);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeletePitsContainsExactlyIdsResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeletePitsContainsExactlyIdsResponseMatcher.java
@@ -1,0 +1,48 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.DeleteAllPitsResponse;
+import org.opensearch.client.opensearch.core.pit.DeletedPit;
+
+import static java.util.Objects.isNull;
+
+class DeletePitsContainsExactlyIdsResponseMatcher extends TypeSafeDiagnosingMatcher<DeleteAllPitsResponse> {
+
+    private final Set<String> expectedPitIds;
+
+    DeletePitsContainsExactlyIdsResponseMatcher(String[] expectedPitIds) {
+        if (isNull(expectedPitIds) || 0 == expectedPitIds.length) {
+            throw new IllegalArgumentException("expectedPitIds cannot be null or empty");
+        }
+        this.expectedPitIds = Set.of(expectedPitIds);
+    }
+
+    @Override
+    protected boolean matchesSafely(DeleteAllPitsResponse response, Description mismatchDescription) {
+        Set<String> actualPitIds = response.pits().stream().map(DeletedPit::pitId).collect(Collectors.toSet());
+        if (!actualPitIds.equals(expectedPitIds)) {
+            mismatchDescription.appendText("Actual pit ids: ").appendValue(actualPitIds);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Should contain exactly pit with ids: ").appendValue(expectedPitIds);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeleteResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/DeleteResponseMatchers.java
@@ -1,0 +1,23 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.DeleteResponse;
+
+public class DeleteResponseMatchers {
+
+    private DeleteResponseMatchers() {}
+
+    public static Matcher<DeleteResponse> isSuccessfulDeleteResponse() {
+        return new SuccessfulDeleteResponseMatcher();
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ErrorCauseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ErrorCauseMatchers.java
@@ -1,0 +1,23 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+
+public class ErrorCauseMatchers {
+
+    private ErrorCauseMatchers() {}
+
+    public static Matcher<ErrorCause> errorType(Matcher<String> type) {
+        return new ErrorCauseTypeMatcher(type);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ErrorCauseTypeMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/ErrorCauseTypeMatcher.java
@@ -1,0 +1,42 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+
+import static java.util.Objects.requireNonNull;
+
+class ErrorCauseTypeMatcher extends TypeSafeDiagnosingMatcher<ErrorCause> {
+
+    private final Matcher<String> errorMessageMatcher;
+
+    public ErrorCauseTypeMatcher(Matcher<String> errorMessageMatcher) {
+        this.errorMessageMatcher = requireNonNull(errorMessageMatcher, "Error message matcher is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(ErrorCause err, Description mismatchDescription) {
+        boolean matches = errorMessageMatcher.matches(err.type());
+        if (matches == false) {
+            mismatchDescription.appendText("Error of type ").appendValue(err.type()).appendText("contains unexpected type");
+        }
+        return matches;
+
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Error type matches").appendValue(errorMessageMatcher);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/FailureBulkResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/FailureBulkResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.BulkResponse;
+
+class FailureBulkResponseMatcher extends TypeSafeDiagnosingMatcher<BulkResponse> {
+
+    @Override
+    protected boolean matchesSafely(BulkResponse response, Description mismatchDescription) {
+        if (response.errors() == false) {
+            mismatchDescription.appendText(" bulk operation was executed correctly what is not expected.");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("bulk operation failure");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/FieldCapsResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/FieldCapsResponseMatchers.java
@@ -1,0 +1,31 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+
+public class FieldCapsResponseMatchers {
+
+    private FieldCapsResponseMatchers() {}
+
+    public static Matcher<FieldCapsResponse> containsExactlyIndices(String... expectedIndices) {
+        return new ContainsExactlyIndicesMatcher(expectedIndices);
+    }
+
+    public static Matcher<FieldCapsResponse> containsFieldWithNameAndType(String expectedFieldName, String expectedFieldType) {
+        return new ContainsFieldWithTypeMatcher(expectedFieldName, expectedFieldType);
+    }
+
+    public static Matcher<FieldCapsResponse> numberOfFieldsIsEqualTo(int expectedNumberOfFields) {
+        return new NumberOfFieldsIsEqualToMatcher(expectedNumberOfFields);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetAllPitsContainsExactlyIdsResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetAllPitsContainsExactlyIdsResponseMatcher.java
@@ -1,0 +1,48 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.GetAllPitsResponse;
+import org.opensearch.client.opensearch.core.pit.PitDetail;
+
+import static java.util.Objects.isNull;
+
+class GetAllPitsContainsExactlyIdsResponseMatcher extends TypeSafeDiagnosingMatcher<GetAllPitsResponse> {
+
+    private final Set<String> expectedPitIds;
+
+    GetAllPitsContainsExactlyIdsResponseMatcher(String[] expectedPitIds) {
+        if (isNull(expectedPitIds) || 0 == expectedPitIds.length) {
+            throw new IllegalArgumentException("expectedPitIds cannot be null or empty");
+        }
+        this.expectedPitIds = Set.of(expectedPitIds);
+    }
+
+    @Override
+    protected boolean matchesSafely(GetAllPitsResponse response, Description mismatchDescription) {
+        Set<String> actualPitIds = response.pits().stream().map(PitDetail::pitId).collect(Collectors.toSet());
+        if (!actualPitIds.equals(expectedPitIds)) {
+            mismatchDescription.appendText("Actual pit ids: ").appendValue(actualPitIds);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Should contain exactly pit with ids: ").appendValue(expectedPitIds);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetIndexResponseContainsIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetIndexResponseContainsIndicesMatcher.java
@@ -1,0 +1,48 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Set;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+
+import static java.util.Objects.isNull;
+
+class GetIndexResponseContainsIndicesMatcher extends TypeSafeDiagnosingMatcher<GetIndexResponse> {
+
+    private final String[] expectedIndices;
+
+    GetIndexResponseContainsIndicesMatcher(String[] expectedIndices) {
+        if (isNull(expectedIndices) || 0 == expectedIndices.length) {
+            throw new IllegalArgumentException("expectedIndices cannot be null or empty");
+        }
+        this.expectedIndices = expectedIndices;
+    }
+
+    @Override
+    protected boolean matchesSafely(GetIndexResponse response, Description mismatchDescription) {
+        Set<String> actual = response.result().keySet();
+        for (String index : expectedIndices) {
+            if (!actual.contains(index)) {
+                mismatchDescription.appendText("Actual indices: ").appendValue(response.result().keySet());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain indices: ").appendValue(expectedIndices);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetMappingsResponseContainsIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetMappingsResponseContainsIndicesMatcher.java
@@ -1,0 +1,49 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.GetMappingResponse;
+import org.opensearch.client.opensearch.indices.get_mapping.IndexMappingRecord;
+
+import static java.util.Objects.isNull;
+
+class GetMappingsResponseContainsIndicesMatcher extends TypeSafeDiagnosingMatcher<GetMappingResponse> {
+
+    private final String[] expectedIndices;
+
+    GetMappingsResponseContainsIndicesMatcher(String[] expectedIndices) {
+        if (isNull(expectedIndices) || 0 == expectedIndices.length) {
+            throw new IllegalArgumentException("expectedIndices cannot be null or empty");
+        }
+        this.expectedIndices = expectedIndices;
+    }
+
+    @Override
+    protected boolean matchesSafely(GetMappingResponse response, Description mismatchDescription) {
+        Map<String, IndexMappingRecord> indicesMappings = response.result();
+        for (String index : expectedIndices) {
+            if (!indicesMappings.containsKey(index)) {
+                mismatchDescription.appendText("Response contains mappings of indices: ").appendValue(indicesMappings.keySet());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain mappings of indices: ").appendValue(expectedIndices);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseContainsDocumentWithIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseContainsDocumentWithIdMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.GetResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResponseContainsDocumentWithIdMatcher extends TypeSafeDiagnosingMatcher<GetResponse<?>> {
+
+    private final String indexName;
+    private final String documentId;
+
+    public GetResponseContainsDocumentWithIdMatcher(String indexName, String documentId) {
+        this.indexName = requireNonNull(indexName, "Index name is required");
+        this.documentId = requireNonNull(documentId, "Document id is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResponse<?> response, Description mismatchDescription) {
+        if (indexName.equals(response.index()) == false) {
+            mismatchDescription.appendText("Document should not belong to index ").appendValue(response.index());
+            return false;
+        }
+        if (documentId.equals(response.id()) == false) {
+            mismatchDescription.appendText("Document contain incorrect id which is ").appendValue(response.id());
+            return false;
+        }
+        if (response.found() == false) {
+            mismatchDescription.appendText("Document does not exist or is inaccessible");
+            return false;
+        }
+        if (response.source() == null) {
+            mismatchDescription.appendText("Document source is empty");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain document from index ")
+            .appendValue(indexName)
+            .appendText(" with id ")
+            .appendValue(documentId);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseDocumentFieldValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseDocumentFieldValueMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.GetResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResponseDocumentFieldValueMatcher extends TypeSafeDiagnosingMatcher<GetResponse<?>> {
+
+    private final String fieldName;
+    private final Object fieldValue;
+
+    public GetResponseDocumentFieldValueMatcher(String fieldName, Object fieldValue) {
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+        this.fieldValue = requireNonNull(fieldValue, "Field value is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResponse<?> response, Description mismatchDescription) {
+        Map<String, Object> source = (Map<String, Object>) response.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source is not available in search results");
+            return false;
+        }
+        if (source.containsKey(fieldName) == false) {
+            mismatchDescription.appendText("Document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        Object actualFieldValue = source.get(fieldName);
+        if (fieldValue.equals(actualFieldValue) == false) {
+            mismatchDescription.appendText("Field ")
+                .appendValue(fieldName)
+                .appendText(" has incorrect value ")
+                .appendValue(actualFieldValue);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Document contain field ").appendValue(fieldName).appendText(" with value ").appendValue(fieldValue);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResponseMatchers.java
@@ -1,0 +1,27 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.GetResponse;
+
+public class GetResponseMatchers {
+
+    private GetResponseMatchers() {}
+
+    public static Matcher<GetResponse<?>> documentContainField(String fieldName, Object fieldValue) {
+        return new GetResponseDocumentFieldValueMatcher(fieldName, fieldValue);
+    }
+
+    public static Matcher<GetResponse<?>> containDocument(String indexName, String documentId) {
+        return new GetResponseContainsDocumentWithIdMatcher(indexName, documentId);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultContainOnlyDocumentIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultContainOnlyDocumentIdMatcher.java
@@ -1,0 +1,54 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.get.GetResult;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResultContainOnlyDocumentIdMatcher extends TypeSafeDiagnosingMatcher<GetResult<?>> {
+
+    private final String indexName;
+    private final String documentId;
+
+    public GetResultContainOnlyDocumentIdMatcher(String indexName, String documentId) {
+        this.indexName = requireNonNull(indexName, "Index name is required");
+        this.documentId = requireNonNull(documentId, "Document id is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResult<?> response, Description mismatchDescription) {
+        if (indexName.equals(response.index()) == false) {
+            mismatchDescription.appendText(" index name ").appendValue(response.index()).appendText(" is incorrect ");
+            return false;
+        }
+        if (documentId.equals(response.id()) == false) {
+            mismatchDescription.appendText(" id ").appendValue(response.id()).appendText(" is incorrect ");
+            return false;
+        }
+        if (response.found()) {
+            mismatchDescription.appendText(" document exist what is not desired ");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain document id from index ")
+            .appendValue(indexName)
+            .appendText(" with id ")
+            .appendValue(documentId)
+            .appendText(" but document should not be present ");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultContainsDocumentWithIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultContainsDocumentWithIdMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.get.GetResult;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResultContainsDocumentWithIdMatcher extends TypeSafeDiagnosingMatcher<GetResult<?>> {
+
+    private final String indexName;
+    private final String documentId;
+
+    public GetResultContainsDocumentWithIdMatcher(String indexName, String documentId) {
+        this.indexName = requireNonNull(indexName, "Index name is required");
+        this.documentId = requireNonNull(documentId, "Document id is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResult<?> response, Description mismatchDescription) {
+        if (indexName.equals(response.index()) == false) {
+            mismatchDescription.appendText("Document should not belong to index ").appendValue(response.index());
+            return false;
+        }
+        if (documentId.equals(response.id()) == false) {
+            mismatchDescription.appendText("Document contain incorrect id which is ").appendValue(response.id());
+            return false;
+        }
+        if (response.found() == false) {
+            mismatchDescription.appendText("Document does not exist or is inaccessible");
+            return false;
+        }
+        if (response.source() == null) {
+            mismatchDescription.appendText("Document source is empty");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain document from index ")
+            .appendValue(indexName)
+            .appendText(" with id ")
+            .appendValue(documentId);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultDocumentDoesNotContainFieldMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultDocumentDoesNotContainFieldMatcher.java
@@ -1,0 +1,47 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.get.GetResult;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResultDocumentDoesNotContainFieldMatcher extends TypeSafeDiagnosingMatcher<GetResult<?>> {
+
+    private final String fieldName;
+
+    public GetResultDocumentDoesNotContainFieldMatcher(String fieldName) {
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResult<?> response, Description mismatchDescription) {
+        Map<String, Object> source = (Map<String, Object>) response.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source is not available in search results");
+            return false;
+        }
+        if (source.containsKey(fieldName)) {
+            mismatchDescription.appendText("Document contains field ").appendValue(fieldName);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Document does not contain field ").appendValue(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultDocumentFieldValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultDocumentFieldValueMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.get.GetResult;
+
+import static java.util.Objects.requireNonNull;
+
+class GetResultDocumentFieldValueMatcher extends TypeSafeDiagnosingMatcher<GetResult<?>> {
+
+    private final String fieldName;
+    private final Object fieldValue;
+
+    public GetResultDocumentFieldValueMatcher(String fieldName, Object fieldValue) {
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+        this.fieldValue = requireNonNull(fieldValue, "Field value is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(GetResult<?> response, Description mismatchDescription) {
+        Map<String, Object> source = (Map<String, Object>) response.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source is not available in search results");
+            return false;
+        }
+        if (source.containsKey(fieldName) == false) {
+            mismatchDescription.appendText("Document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        Object actualFieldValue = source.get(fieldName);
+        if (fieldValue.equals(actualFieldValue) == false) {
+            mismatchDescription.appendText("Field ")
+                .appendValue(fieldName)
+                .appendText(" has incorrect value ")
+                .appendValue(actualFieldValue);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Document contain field ").appendValue(fieldName).appendText(" with value ").appendValue(fieldValue);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetResultMatchers.java
@@ -1,0 +1,35 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.get.GetResult;
+
+public class GetResultMatchers {
+
+    private GetResultMatchers() {}
+
+    public static Matcher<GetResult<?>> containDocument(String indexName, String documentId) {
+        return new GetResultContainsDocumentWithIdMatcher(indexName, documentId);
+    }
+
+    public static Matcher<GetResult<?>> containOnlyDocumentId(String indexName, String documentId) {
+        return new GetResultContainOnlyDocumentIdMatcher(indexName, documentId);
+    }
+
+    public static Matcher<GetResult<?>> documentContainField(String fieldName, Object fieldValue) {
+        return new GetResultDocumentFieldValueMatcher(fieldName, fieldValue);
+    }
+
+    public static Matcher<GetResult<?>> documentDoesNotContainField(String fieldName) {
+        return new GetResultDocumentDoesNotContainFieldMatcher(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetSettingsResponseContainsIndicesMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/GetSettingsResponseContainsIndicesMatcher.java
@@ -1,0 +1,50 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.GetIndicesSettingsResponse;
+import org.opensearch.client.opensearch.indices.IndexState;
+
+import static java.util.Objects.isNull;
+
+class GetSettingsResponseContainsIndicesMatcher extends TypeSafeDiagnosingMatcher<GetIndicesSettingsResponse> {
+
+    private final String[] expectedIndices;
+
+    GetSettingsResponseContainsIndicesMatcher(String[] expectedIndices) {
+        if (isNull(expectedIndices) || 0 == expectedIndices.length) {
+            throw new IllegalArgumentException("expectedIndices cannot be null or empty");
+        }
+        this.expectedIndices = expectedIndices;
+    }
+
+    @Override
+    protected boolean matchesSafely(GetIndicesSettingsResponse response, Description mismatchDescription) {
+
+        final Map<String, IndexState> indexToSettings = response.result();
+        for (String index : expectedIndices) {
+            if (!indexToSettings.containsKey(index)) {
+                mismatchDescription.appendText("Response contains settings of indices: ").appendValue(indexToSettings.keySet());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain settings of indices: ").appendValue(expectedIndices);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/IndexResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/IndexResponseMatchers.java
@@ -1,0 +1,67 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.indices.ClearCacheResponse;
+import org.opensearch.client.opensearch.indices.CloneIndexResponse;
+import org.opensearch.client.opensearch.indices.CloseIndexResponse;
+import org.opensearch.client.opensearch.indices.CreateIndexResponse;
+import org.opensearch.client.opensearch.indices.GetIndexResponse;
+import org.opensearch.client.opensearch.indices.GetIndicesSettingsResponse;
+import org.opensearch.client.opensearch.indices.GetMappingResponse;
+import org.opensearch.client.opensearch.indices.OpenResponse;
+import org.opensearch.client.opensearch.indices.ShrinkResponse;
+import org.opensearch.client.opensearch.indices.SplitResponse;
+
+public class IndexResponseMatchers {
+
+    public static Matcher<CreateIndexResponse> isSuccessfulCreateIndexResponse(String expectedIndexName) {
+        return new SuccessfulCreateIndexResponseMatcher(expectedIndexName);
+    }
+
+    public static Matcher<GetIndexResponse> getIndexResponseContainsIndices(String... expectedIndices) {
+        return new GetIndexResponseContainsIndicesMatcher(expectedIndices);
+    }
+
+    public static Matcher<CloseIndexResponse> isSuccessfulCloseIndexResponse() {
+        return new SuccessfulCloseIndexResponseMatcher();
+    }
+
+    public static Matcher<OpenResponse> isSuccessfulOpenIndexResponse() {
+        return new SuccessfulOpenIndexResponseMatcher();
+    }
+
+    public static Matcher<ShrinkResponse> isSuccessfulResizeResponse(String expectedIndexName) {
+        return new SuccessfulResizeResponseMatcher(expectedIndexName);
+    }
+
+    public static Matcher<CloneIndexResponse> isSuccessfulCloneResponse(String expectedIndexName) {
+        return new SuccessfulCloneResponseMatcher(expectedIndexName);
+    }
+
+    public static Matcher<SplitResponse> isSuccessfulSplitResponse(String expectedIndexName) {
+        return new SuccessfulSplitResponseMatcher(expectedIndexName);
+    }
+
+    public static Matcher<GetIndicesSettingsResponse> getSettingsResponseContainsIndices(String... expectedIndices) {
+        return new GetSettingsResponseContainsIndicesMatcher(expectedIndices);
+    }
+
+    public static Matcher<ClearCacheResponse> isSuccessfulClearIndicesCacheResponse() {
+        return new SuccessfulClearIndicesCacheResponseMatcher();
+    }
+
+    public static Matcher<GetMappingResponse> getMappingsResponseContainsIndices(String... expectedIndices) {
+        return new GetMappingsResponseContainsIndicesMatcher(expectedIndices);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemContainOnlyDocumentIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemContainOnlyDocumentIdMatcher.java
@@ -1,0 +1,54 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class MultiGetResponseItemContainOnlyDocumentIdMatcher extends TypeSafeDiagnosingMatcher<MultiGetResponseItem<?>> {
+
+    private final String indexName;
+    private final String documentId;
+
+    public MultiGetResponseItemContainOnlyDocumentIdMatcher(String indexName, String documentId) {
+        this.indexName = requireNonNull(indexName, "Index name is required");
+        this.documentId = requireNonNull(documentId, "Document id is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiGetResponseItem<?> response, Description mismatchDescription) {
+        if (indexName.equals(response.result().index()) == false) {
+            mismatchDescription.appendText(" index name ").appendValue(response.result().index()).appendText(" is incorrect ");
+            return false;
+        }
+        if (documentId.equals(response.result().id()) == false) {
+            mismatchDescription.appendText(" id ").appendValue(response.result().id()).appendText(" is incorrect ");
+            return false;
+        }
+        if (response.result().found()) {
+            mismatchDescription.appendText(" document exist what is not desired ");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain document id from index ")
+            .appendValue(indexName)
+            .appendText(" with id ")
+            .appendValue(documentId)
+            .appendText(" but document should not be present ");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemContainsDocumentWithIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemContainsDocumentWithIdMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class MultiGetResponseItemContainsDocumentWithIdMatcher extends TypeSafeDiagnosingMatcher<MultiGetResponseItem<?>> {
+
+    private final String indexName;
+    private final String documentId;
+
+    public MultiGetResponseItemContainsDocumentWithIdMatcher(String indexName, String documentId) {
+        this.indexName = requireNonNull(indexName, "Index name is required");
+        this.documentId = requireNonNull(documentId, "Document id is required");
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiGetResponseItem<?> response, Description mismatchDescription) {
+        if (indexName.equals(response.result().index()) == false) {
+            mismatchDescription.appendText("Document should not belong to index ").appendValue(response.result().index());
+            return false;
+        }
+        if (documentId.equals(response.result().id()) == false) {
+            mismatchDescription.appendText("Document contain incorrect id which is ").appendValue(response.result().id());
+            return false;
+        }
+        if (response.result().found() == false) {
+            mismatchDescription.appendText("Document does not exist or is inaccessible");
+            return false;
+        }
+        if (response.result().source() == null) {
+            mismatchDescription.appendText("Document source is empty");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response should contain document from index ")
+            .appendValue(indexName)
+            .appendText(" with id ")
+            .appendValue(documentId);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemDocumentDoesNotContainFieldMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemDocumentDoesNotContainFieldMatcher.java
@@ -1,0 +1,47 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class MultiGetResponseItemDocumentDoesNotContainFieldMatcher extends TypeSafeDiagnosingMatcher<MultiGetResponseItem<?>> {
+
+    private final String fieldName;
+
+    public MultiGetResponseItemDocumentDoesNotContainFieldMatcher(String fieldName) {
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiGetResponseItem<?> response, Description mismatchDescription) {
+        Map<String, Object> source = (Map<String, Object>) response.result().source();
+        if (source == null) {
+            mismatchDescription.appendText("Source is not available in search results");
+            return false;
+        }
+        if (source.containsKey(fieldName)) {
+            mismatchDescription.appendText("Document contains field ").appendValue(fieldName);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Document does not contain field ").appendValue(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemDocumentFieldValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemDocumentFieldValueMatcher.java
@@ -1,0 +1,57 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+import static java.util.Objects.requireNonNull;
+
+class MultiGetResponseItemDocumentFieldValueMatcher extends TypeSafeDiagnosingMatcher<MultiGetResponseItem<?>> {
+
+    private final String fieldName;
+    private final Object fieldValue;
+
+    public MultiGetResponseItemDocumentFieldValueMatcher(String fieldName, Object fieldValue) {
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+        this.fieldValue = requireNonNull(fieldValue, "Field value is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiGetResponseItem<?> response, Description mismatchDescription) {
+        Map<String, Object> source = (Map<String, Object>) response.result().source();
+        if (source == null) {
+            mismatchDescription.appendText("Source is not available in search results");
+            return false;
+        }
+        if (source.containsKey(fieldName) == false) {
+            mismatchDescription.appendText("Document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        Object actualFieldValue = source.get(fieldName);
+        if (fieldValue.equals(actualFieldValue) == false) {
+            mismatchDescription.appendText("Field ")
+                .appendValue(fieldName)
+                .appendText(" has incorrect value ")
+                .appendValue(actualFieldValue);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Document contain field ").appendValue(fieldName).appendText(" with value ").appendValue(fieldValue);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseItemMatchers.java
@@ -1,0 +1,35 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+public class MultiGetResponseItemMatchers {
+
+    private MultiGetResponseItemMatchers() {}
+
+    public static Matcher<MultiGetResponseItem<?>> containDocument(String indexName, String documentId) {
+        return new MultiGetResponseItemContainsDocumentWithIdMatcher(indexName, documentId);
+    }
+
+    public static Matcher<MultiGetResponseItem<?>> containOnlyDocumentId(String indexName, String documentId) {
+        return new MultiGetResponseItemContainOnlyDocumentIdMatcher(indexName, documentId);
+    }
+
+    public static Matcher<MultiGetResponseItem<?>> documentContainField(String fieldName, Object fieldValue) {
+        return new MultiGetResponseItemDocumentFieldValueMatcher(fieldName, fieldValue);
+    }
+
+    public static Matcher<MultiGetResponseItem<?>> documentDoesNotContainField(String fieldName) {
+        return new MultiGetResponseItemDocumentDoesNotContainFieldMatcher(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiGetResponseMatchers.java
@@ -1,0 +1,28 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.MgetResponse;
+
+public class MultiGetResponseMatchers {
+
+    private MultiGetResponseMatchers() {}
+
+    public static Matcher<MgetResponse<?>> isSuccessfulMultiGetResponse() {
+        return new SuccessfulMultiGetResponseMatcher();
+    }
+
+    public static Matcher<MgetResponse<?>> numberOfGetItemResponsesIsEqualTo(int expectedNumberOfResponses) {
+        return new NumberOfGetItemResponsesIsEqualToMatcher(expectedNumberOfResponses);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemContainDocumentWithIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemContainDocumentWithIdMatcher.java
@@ -1,0 +1,64 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class MultiSearchResponseItemContainDocumentWithIdMatcher extends TypeSafeDiagnosingMatcher<MultiSearchResponseItem<?>> {
+
+    private final int hitIndex;
+    private final String indexName;
+    private final String id;
+
+    public MultiSearchResponseItemContainDocumentWithIdMatcher(int hitIndex, String indexName, String id) {
+        this.hitIndex = hitIndex;
+        this.indexName = indexName;
+        this.id = id;
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiSearchResponseItem<?> searchResponse, Description mismatchDescription) {
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Number of total hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.result().hits().hits().get(hitIndex);
+        if (indexName.equals(searchHit.index()) == false) {
+            mismatchDescription.appendText("document is part of another index ").appendValue(indexName);
+            return false;
+        }
+        if (id.equals(searchHit.id()) == false) {
+            mismatchDescription.appendText("Document has another id which is ").appendValue(searchHit.id());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search hit with index ")
+            .appendValue(hitIndex)
+            .appendText(" should contains document which is part of index ")
+            .appendValue(indexName)
+            .appendValue(" and has id ")
+            .appendValue(id);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemContainsFieldWithValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemContainsFieldWithValueMatcher.java
@@ -1,0 +1,75 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class MultiSearchResponseItemContainsFieldWithValueMatcher<T> extends TypeSafeDiagnosingMatcher<MultiSearchResponseItem<?>> {
+
+    private final int hitIndex;
+
+    private final String fieldName;
+
+    private final T expectedValue;
+
+    MultiSearchResponseItemContainsFieldWithValueMatcher(int hitIndex, String fieldName, T expectedValue) {
+        this.hitIndex = hitIndex;
+        this.fieldName = fieldName;
+        this.expectedValue = expectedValue;
+    }
+
+    @Override
+    protected boolean matchesSafely(MultiSearchResponseItem<?> searchResponse, Description mismatchDescription) {
+        mismatchDescription.appendText("Unexpected match in SearchResponse " + searchResponse.toString() + "\n");
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Total number of hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.result().hits().hits().get(hitIndex);
+        Map<String, Object> source = (Map<String, Object>) searchHit.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source document is null, is fetch source option set to true?");
+            return false;
+        }
+        if (source.containsKey(fieldName) == false) {
+            mismatchDescription.appendText("Document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        Object actualValue = source.get(fieldName);
+        if (!expectedValue.equals(actualValue)) {
+            mismatchDescription.appendText("Field value is equal to ").appendValue(actualValue);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search hit with index ")
+            .appendValue(hitIndex)
+            .appendText(" should contain field ")
+            .appendValue(fieldName)
+            .appendValue(" with value equal to ")
+            .appendValue(expectedValue);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseItemMatchers.java
@@ -1,0 +1,27 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+
+public class MultiSearchResponseItemMatchers {
+
+    private MultiSearchResponseItemMatchers() {}
+
+    public static <T> Matcher<MultiSearchResponseItem<?>> searchHitContainsFieldWithValue(int hitIndex, String fieldName, T expectedValue) {
+        return new MultiSearchResponseItemContainsFieldWithValueMatcher<>(hitIndex, fieldName, expectedValue);
+    }
+
+    public static Matcher<MultiSearchResponseItem<?>> searchHitsContainDocumentWithId(int hitIndex, String indexName, String documentId) {
+        return new MultiSearchResponseItemContainDocumentWithIdMatcher(hitIndex, indexName, documentId);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/MultiSearchResponseMatchers.java
@@ -1,0 +1,28 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.MsearchResponse;
+
+public class MultiSearchResponseMatchers {
+
+    private MultiSearchResponseMatchers() {}
+
+    public static Matcher<MsearchResponse<?>> isSuccessfulMultiSearchResponse() {
+        return new SuccessfulMultiSearchResponseMatcher();
+    }
+
+    public static Matcher<MsearchResponse<?>> numberOfSearchItemResponsesIsEqualTo(int expectedNumberOfResponses) {
+        return new NumberOfSearchItemResponsesIsEqualToMatcher(expectedNumberOfResponses);
+    }
+
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfFieldsIsEqualToMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfFieldsIsEqualToMatcher.java
@@ -1,0 +1,38 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.FieldCapsResponse;
+
+class NumberOfFieldsIsEqualToMatcher extends TypeSafeDiagnosingMatcher<FieldCapsResponse> {
+
+    private final int expectedNumberOfFields;
+
+    NumberOfFieldsIsEqualToMatcher(int expectedNumberOfFields) {
+        this.expectedNumberOfFields = expectedNumberOfFields;
+    }
+
+    @Override
+    protected boolean matchesSafely(FieldCapsResponse response, Description mismatchDescription) {
+        if (expectedNumberOfFields != response.fields().size()) {
+            mismatchDescription.appendText("Actual number of fields: ").appendValue(response.fields().size());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Response contains information about ").appendValue(expectedNumberOfFields).appendText(" fields");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfGetItemResponsesIsEqualToMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfGetItemResponsesIsEqualToMatcher.java
@@ -1,0 +1,38 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.MgetResponse;
+
+class NumberOfGetItemResponsesIsEqualToMatcher extends TypeSafeDiagnosingMatcher<MgetResponse<?>> {
+
+    private final int expectedNumberOfResponses;
+
+    NumberOfGetItemResponsesIsEqualToMatcher(int expectedNumberOfResponses) {
+        this.expectedNumberOfResponses = expectedNumberOfResponses;
+    }
+
+    @Override
+    protected boolean matchesSafely(MgetResponse<?> response, Description mismatchDescription) {
+        if (expectedNumberOfResponses != response.docs().size()) {
+            mismatchDescription.appendText("Actual number of responses: ").appendValue(response.docs().size());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Multi get response contains: ").appendValue(expectedNumberOfResponses).appendText(" item responses");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfHitsInPageIsEqualToMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfHitsInPageIsEqualToMatcher.java
@@ -1,0 +1,45 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+
+class NumberOfHitsInPageIsEqualToMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int expectedNumberOfHits;
+
+    public NumberOfHitsInPageIsEqualToMatcher(int expectedNumberOfHits) {
+        this.expectedNumberOfHits = expectedNumberOfHits;
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        HitsMetadata<?> hits = searchResponse.hits();
+        if ((hits == null) || (hits.hits() == null)) {
+            mismatchDescription.appendText("contains null hits");
+            return false;
+        }
+        int actualNumberOfHits = hits.hits().size();
+        if (expectedNumberOfHits != actualNumberOfHits) {
+            mismatchDescription.appendText("actual number of hits is equal to ").appendValue(actualNumberOfHits);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Number of hits on current page should be equal to ").appendValue(expectedNumberOfHits);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfSearchItemResponsesIsEqualToMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfSearchItemResponsesIsEqualToMatcher.java
@@ -1,0 +1,39 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.MsearchResponse;
+
+class NumberOfSearchItemResponsesIsEqualToMatcher extends TypeSafeDiagnosingMatcher<MsearchResponse<?>> {
+
+    private final int expectedNumberOfResponses;
+
+    NumberOfSearchItemResponsesIsEqualToMatcher(int expectedNumberOfResponses) {
+        this.expectedNumberOfResponses = expectedNumberOfResponses;
+    }
+
+    @Override
+    protected boolean matchesSafely(MsearchResponse<?> response, Description mismatchDescription) {
+        if (expectedNumberOfResponses != response.responses().size()) {
+            mismatchDescription.appendText("Actual number of responses: ").appendValue(response.responses().size());
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Multi search response contains: ").appendValue(expectedNumberOfResponses).appendText(" item responses");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfTotalHitsIsEqualToMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/NumberOfTotalHitsIsEqualToMatcher.java
@@ -1,0 +1,56 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+
+class NumberOfTotalHitsIsEqualToMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int expectedNumberOfHits;
+
+    NumberOfTotalHitsIsEqualToMatcher(int expectedNumberOfHits) {
+        this.expectedNumberOfHits = expectedNumberOfHits;
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        HitsMetadata<?> hits = searchResponse.hits();
+        if (hits == null) {
+            mismatchDescription.appendText("contains null hits");
+            return false;
+        }
+        TotalHits totalHits = hits.total();
+        if (totalHits == null) {
+            mismatchDescription.appendText("Total hits number is null.");
+            return false;
+        }
+        if (expectedNumberOfHits != totalHits.value()) {
+            String documentIds = hits.hits().stream().map(hit -> hit.index() + "/" + hit.id()).collect(Collectors.joining(","));
+            mismatchDescription.appendText("contains ")
+                .appendValue(hits.hits().size())
+                .appendText(" hits, found document ids ")
+                .appendValue(documentIds);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search response should contains ").appendValue(expectedNumberOfHits).appendText(" hits");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/PitResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/PitResponseMatchers.java
@@ -1,0 +1,46 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.CreatePitResponse;
+import org.opensearch.client.opensearch.core.DeleteAllPitsResponse;
+import org.opensearch.client.opensearch.core.DeletePitResponse;
+import org.opensearch.client.opensearch.core.GetAllPitsResponse;
+
+public class PitResponseMatchers {
+
+    private PitResponseMatchers() {}
+
+    public static Matcher<CreatePitResponse> isSuccessfulCreatePitResponse() {
+        return new SuccessfulCreatePitResponseMatcher();
+    }
+
+    public static Matcher<GetAllPitsResponse> getAllResponseContainsExactlyPitWithIds(String... expectedPitIds) {
+        return new GetAllPitsContainsExactlyIdsResponseMatcher(expectedPitIds);
+    }
+
+    public static Matcher<DeletePitResponse> isSuccessfulDeletePitResponse() {
+        return new SuccessfulDeletePitResponseMatcher();
+    }
+
+    public static Matcher<DeleteAllPitsResponse> isSuccessfulDeletePitsResponse() {
+        return new SuccessfulDeletePitsResponseMatcher();
+    }
+
+    public static Matcher<DeletePitResponse> deleteResponseContainsExactlyPitWithIds(String... expectedPitIds) {
+        return new DeletePitContainsExactlyIdsResponseMatcher(expectedPitIds);
+    }
+
+    public static Matcher<DeleteAllPitsResponse> deletePitsResponseContainsExactlyPitWithIds(String... expectedPitIds) {
+        return new DeletePitsContainsExactlyIdsResponseMatcher(expectedPitIds);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitContainsFieldWithValueMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitContainsFieldWithValueMatcher.java
@@ -1,0 +1,75 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class SearchHitContainsFieldWithValueMatcher<T> extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int hitIndex;
+
+    private final String fieldName;
+
+    private final T expectedValue;
+
+    SearchHitContainsFieldWithValueMatcher(int hitIndex, String fieldName, T expectedValue) {
+        this.hitIndex = hitIndex;
+        this.fieldName = fieldName;
+        this.expectedValue = expectedValue;
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        mismatchDescription.appendText("Unexpected match in SearchResponse " + searchResponse.toString() + "\n");
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Total number of hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.hits().hits().get(hitIndex);
+        Map<String, Object> source = (Map<String, Object>) searchHit.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source document is null, is fetch source option set to true?");
+            return false;
+        }
+        if (source.containsKey(fieldName) == false) {
+            mismatchDescription.appendText("Document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        Object actualValue = source.get(fieldName);
+        if (!expectedValue.equals(actualValue)) {
+            mismatchDescription.appendText("Field value is equal to ").appendValue(actualValue);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search hit with index ")
+            .appendValue(hitIndex)
+            .appendText(" should contain field ")
+            .appendValue(fieldName)
+            .appendValue(" with value equal to ")
+            .appendValue(expectedValue);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitDoesContainFieldMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitDoesContainFieldMatcher.java
@@ -1,0 +1,62 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static java.util.Objects.requireNonNull;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class SearchHitDoesContainFieldMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int hitIndex;
+
+    private final String fieldName;
+
+    public SearchHitDoesContainFieldMatcher(int hitIndex, String fieldName) {
+        this.hitIndex = hitIndex;
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Total number of hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.hits().hits().get(hitIndex);
+        Map<String, Object> source = (Map<String, Object>) searchHit.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source document is null, is fetch source option set to true?");
+            return false;
+        }
+        if (!source.containsKey(fieldName)) {
+            mismatchDescription.appendText(" document does not contain field ").appendValue(fieldName);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("search hit with index ").appendValue(hitIndex).appendText(" does contain field ").appendValue(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitDoesNotContainFieldMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitDoesNotContainFieldMatcher.java
@@ -1,0 +1,65 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static java.util.Objects.requireNonNull;
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class SearchHitDoesNotContainFieldMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int hitIndex;
+
+    private final String fieldName;
+
+    public SearchHitDoesNotContainFieldMatcher(int hitIndex, String fieldName) {
+        this.hitIndex = hitIndex;
+        this.fieldName = requireNonNull(fieldName, "Field name is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Total number of hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.hits().hits().get(hitIndex);
+        Map<String, Object> source = (Map<String, Object>) searchHit.source();
+        if (source == null) {
+            mismatchDescription.appendText("Source document is null, is fetch source option set to true?");
+            return false;
+        }
+        if (source.containsKey(fieldName)) {
+            mismatchDescription.appendText(" document contains field ").appendValue(fieldName);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("search hit with index ")
+            .appendValue(hitIndex)
+            .appendText(" does not contain field ")
+            .appendValue(fieldName);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitsContainDocumentWithIdMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitsContainDocumentWithIdMatcher.java
@@ -1,0 +1,64 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+
+import static org.opensearch.test.framework.matcher.client.SearchResponseMatchers.readTotalHits;
+
+class SearchHitsContainDocumentWithIdMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    private final int hitIndex;
+    private final String indexName;
+    private final String id;
+
+    public SearchHitsContainDocumentWithIdMatcher(int hitIndex, String indexName, String id) {
+        this.hitIndex = hitIndex;
+        this.indexName = indexName;
+        this.id = id;
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        Long numberOfHits = readTotalHits(searchResponse);
+        if (numberOfHits == null) {
+            mismatchDescription.appendText("Number of total hits is unknown.");
+            return false;
+        }
+        if (hitIndex >= numberOfHits) {
+            mismatchDescription.appendText("Search result contain only ").appendValue(numberOfHits).appendText(" hits");
+            return false;
+        }
+        Hit<?> searchHit = searchResponse.hits().hits().get(hitIndex);
+        if (indexName.equals(searchHit.index()) == false) {
+            mismatchDescription.appendText("document is part of another index ").appendValue(indexName);
+            return false;
+        }
+        if (id.equals(searchHit.id()) == false) {
+            mismatchDescription.appendText("Document has another id which is ").appendValue(searchHit.id());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Search hit with index ")
+            .appendValue(hitIndex)
+            .appendText(" should contains document which is part of index ")
+            .appendValue(indexName)
+            .appendValue(" and has id ")
+            .appendValue(id);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitsContainDocumentsInAnyOrderMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchHitsContainDocumentsInAnyOrderMatcher.java
@@ -1,0 +1,76 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+
+import static java.util.Objects.requireNonNull;
+
+class SearchHitsContainDocumentsInAnyOrderMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    /**
+    * Pair contain index name and document id
+    */
+    private final List<Pair<String, String>> documentIds;
+
+    /**
+    *
+    * @param documentIds Pair contain index name and document id
+    */
+    public SearchHitsContainDocumentsInAnyOrderMatcher(List<Pair<String, String>> documentIds) {
+        this.documentIds = requireNonNull(documentIds, "Document ids are required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> response, Description mismatchDescription) {
+        HitsMetadata<?> hits = response.hits();
+        if (hits == null) {
+            mismatchDescription.appendText("Search response does not contains hits (null).");
+            return false;
+        }
+        TotalHits hitsArray = hits.total();
+        if (hitsArray == null) {
+            mismatchDescription.appendText("Search hits array is null");
+            return false;
+        }
+        Set<Pair<String, String>> actualDocumentIds = hits.hits()
+            .stream()
+            .map(result -> Pair.of(result.index(), result.id()))
+            .collect(Collectors.toSet());
+        for (Pair<String, String> desiredDocumentId : documentIds) {
+            if (actualDocumentIds.contains(desiredDocumentId) == false) {
+                mismatchDescription.appendText("search result does not contain document with id ")
+                    .appendValue(desiredDocumentId.getKey())
+                    .appendText("/")
+                    .appendValue(desiredDocumentId.getValue());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        String documentIdsString = documentIds.stream()
+            .map(pair -> pair.getKey() + "/" + pair.getValue())
+            .collect(Collectors.joining(", "));
+        description.appendText("Search response should contains following documents ").appendValue(documentIdsString);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SearchResponseMatchers.java
@@ -1,0 +1,93 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+
+public class SearchResponseMatchers {
+
+    private SearchResponseMatchers() {}
+
+    public static Matcher<SearchResponse<?>> isSuccessfulSearchResponse() {
+        return new SuccessfulSearchResponseMatcher();
+    }
+
+    public static Matcher<SearchResponse<?>> numberOfTotalHitsIsEqualTo(int expectedNumberOfHits) {
+        return new NumberOfTotalHitsIsEqualToMatcher(expectedNumberOfHits);
+    }
+
+    public static Matcher<SearchResponse<?>> numberOfHitsInPageIsEqualTo(int expectedNumberOfHits) {
+        return new NumberOfHitsInPageIsEqualToMatcher(expectedNumberOfHits);
+    }
+
+    public static <T> Matcher<SearchResponse<?>> searchHitContainsFieldWithValue(int hitIndex, String fieldName, T expectedValue) {
+        return new SearchHitContainsFieldWithValueMatcher<>(hitIndex, fieldName, expectedValue);
+    }
+
+    public static Matcher<SearchResponse<?>> searchHitDoesNotContainField(int hitIndex, String fieldName) {
+        return new SearchHitDoesNotContainFieldMatcher(hitIndex, fieldName);
+    }
+
+    public static Matcher<SearchResponse<?>> searchHitDoesContainField(int hitIndex, String fieldName) {
+        return new SearchHitDoesContainFieldMatcher(hitIndex, fieldName);
+    }
+
+    public static Matcher<SearchResponse<?>> searchHitsContainDocumentWithId(int hitIndex, String indexName, String documentId) {
+        return new SearchHitsContainDocumentWithIdMatcher(hitIndex, indexName, documentId);
+    }
+
+    public static Matcher<SearchResponse<?>> containNotEmptyScrollingId() {
+        return new ContainNotEmptyScrollingIdMatcher();
+    }
+
+    public static Matcher<SearchResponse<?>> containAggregationWithNameAndType(
+        String expectedAggregationName,
+        String expectedAggregationType
+    ) {
+        return new ContainsAggregationWithNameAndTypeMatcher(expectedAggregationName, expectedAggregationType);
+    }
+
+    /**
+    * Matcher checks if search result contains all expected documents
+    *
+    * @param documentIds Pair contain index name and document id
+    * @return matcher
+    */
+    public static Matcher<SearchResponse<?>> searchHitsContainDocumentsInAnyOrder(List<Pair<String, String>> documentIds) {
+        return new SearchHitsContainDocumentsInAnyOrderMatcher(documentIds);
+    }
+
+    public static Matcher<SearchResponse<?>> searchHitsContainDocumentsInAnyOrder(Pair<String, String>... documentIds) {
+        return new SearchHitsContainDocumentsInAnyOrderMatcher(Arrays.asList(documentIds));
+    }
+
+    static Long readTotalHits(SearchResponse<?> searchResponse) {
+        return Optional.ofNullable(searchResponse).map(SearchResponse::hits).map(HitsMetadata::total).map(TotalHits::value).orElse(null);
+    }
+
+    static Long readTotalHits(MultiSearchResponseItem<?> searchResponse) {
+        return Optional.ofNullable(searchResponse)
+            .map(MultiSearchResponseItem::result)
+            .map(SearchResponse::hits)
+            .map(HitsMetadata::total)
+            .map(TotalHits::value)
+            .orElse(null);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessBulkResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessBulkResponseMatcher.java
@@ -1,0 +1,42 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.util.stream.Collectors;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+
+class SuccessBulkResponseMatcher extends TypeSafeDiagnosingMatcher<BulkResponse> {
+
+    @Override
+    protected boolean matchesSafely(BulkResponse response, Description mismatchDescription) {
+        if (response.errors()) {
+            String failureDescription = response.items()
+                .stream()
+                .filter(i -> i.error() != null)
+                .map(BulkResponseItem::error)
+                .map(ErrorCause::reason)
+                .collect(Collectors.joining(",\n"));
+            mismatchDescription.appendText("bulk response contains failures ").appendValue(failureDescription);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("success bulk response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulClearIndicesCacheResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulClearIndicesCacheResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.ClearCacheResponse;
+
+class SuccessfulClearIndicesCacheResponseMatcher extends TypeSafeDiagnosingMatcher<ClearCacheResponse> {
+
+    @Override
+    protected boolean matchesSafely(ClearCacheResponse response, Description mismatchDescription) {
+        if (response.shards().failed() != 0) {
+            mismatchDescription.appendText("Contains ").appendValue(response.shards().failed()).appendText(" shard failures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful clear index cache response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCloneResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCloneResponseMatcher.java
@@ -1,0 +1,51 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.CloneIndexResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class SuccessfulCloneResponseMatcher extends TypeSafeDiagnosingMatcher<CloneIndexResponse> {
+
+    private final String expectedIndexName;
+
+    SuccessfulCloneResponseMatcher(String expectedIndexName) {
+        this.expectedIndexName = requireNonNull(expectedIndexName);
+    }
+
+    @Override
+    protected boolean matchesSafely(CloneIndexResponse response, Description mismatchDescription) {
+        if (!expectedIndexName.equals(response.index())) {
+            mismatchDescription.appendText("Index name ")
+                .appendValue(response.index())
+                .appendText(" does not match expected index name ")
+                .appendValue(expectedIndexName);
+            return false;
+        }
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful create index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCloseIndexResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCloseIndexResponseMatcher.java
@@ -1,0 +1,36 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.CloseIndexResponse;
+
+class SuccessfulCloseIndexResponseMatcher extends TypeSafeDiagnosingMatcher<CloseIndexResponse> {
+
+    @Override
+    protected boolean matchesSafely(CloseIndexResponse response, Description mismatchDescription) {
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful close index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCreateIndexResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCreateIndexResponseMatcher.java
@@ -1,0 +1,51 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.CreateIndexResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class SuccessfulCreateIndexResponseMatcher extends TypeSafeDiagnosingMatcher<CreateIndexResponse> {
+
+    private final String expectedIndexName;
+
+    SuccessfulCreateIndexResponseMatcher(String expectedIndexName) {
+        this.expectedIndexName = requireNonNull(expectedIndexName);
+    }
+
+    @Override
+    protected boolean matchesSafely(CreateIndexResponse response, Description mismatchDescription) {
+        if (!expectedIndexName.equals(response.index())) {
+            mismatchDescription.appendText("Index name ")
+                .appendValue(response.index())
+                .appendText(" does not match expected index name ")
+                .appendValue(expectedIndexName);
+            return false;
+        }
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful create index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCreatePitResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulCreatePitResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.CreatePitResponse;
+
+class SuccessfulCreatePitResponseMatcher extends TypeSafeDiagnosingMatcher<CreatePitResponse> {
+
+    @Override
+    protected boolean matchesSafely(CreatePitResponse response, Description mismatchDescription) {
+        if (response.shards().failed() != 0) {
+            mismatchDescription.appendText("contains ").appendValue(response.shards().failed()).appendText(" shard failures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful create pit response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeletePitResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeletePitResponseMatcher.java
@@ -1,0 +1,37 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.DeletePitResponse;
+import org.opensearch.client.opensearch.core.pit.DeletedPit;
+
+class SuccessfulDeletePitResponseMatcher extends TypeSafeDiagnosingMatcher<DeletePitResponse> {
+
+    @Override
+    protected boolean matchesSafely(DeletePitResponse response, Description mismatchDescription) {
+        for (DeletedPit deletePitInfo : response.pits()) {
+            if (!deletePitInfo.successful()) {
+                mismatchDescription.appendValue("Pit: ")
+                    .appendValue(deletePitInfo.pitId())
+                    .appendText(" - delete result was not successful");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful delete pit response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeletePitsResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeletePitsResponseMatcher.java
@@ -1,0 +1,37 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.DeleteAllPitsResponse;
+import org.opensearch.client.opensearch.core.pit.DeletedPit;
+
+class SuccessfulDeletePitsResponseMatcher extends TypeSafeDiagnosingMatcher<DeleteAllPitsResponse> {
+
+    @Override
+    protected boolean matchesSafely(DeleteAllPitsResponse response, Description mismatchDescription) {
+        for (DeletedPit deletePitInfo : response.pits()) {
+            if (!deletePitInfo.successful()) {
+                mismatchDescription.appendValue("Pit: ")
+                    .appendValue(deletePitInfo.pitId())
+                    .appendText(" - delete result was not successful");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful delete pit response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeleteResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulDeleteResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.DeleteResponse;
+
+class SuccessfulDeleteResponseMatcher extends TypeSafeDiagnosingMatcher<DeleteResponse> {
+
+    @Override
+    protected boolean matchesSafely(DeleteResponse response, Description mismatchDescription) {
+        if (response.shards().failed() != 0) {
+            mismatchDescription.appendText("contains ").appendValue(response.shards().failed()).appendText(" shard failures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful delete response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulMultiGetResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulMultiGetResponseMatcher.java
@@ -1,0 +1,39 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.MgetResponse;
+import org.opensearch.client.opensearch.core.mget.MultiGetResponseItem;
+
+class SuccessfulMultiGetResponseMatcher extends TypeSafeDiagnosingMatcher<MgetResponse<?>> {
+
+    @Override
+    protected boolean matchesSafely(MgetResponse<?> response, Description mismatchDescription) {
+        for (MultiGetResponseItem<?> getItemResponse : response.docs()) {
+            if (getItemResponse.isFailure()) {
+                mismatchDescription.appendValue("Get an item from index: ")
+                    .appendValue(getItemResponse.failure().index())
+                    .appendText(" failed: ")
+                    .appendValue(getItemResponse.failure().error().reason());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful multi get response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulMultiSearchResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulMultiSearchResponseMatcher.java
@@ -1,0 +1,36 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.MsearchResponse;
+import org.opensearch.client.opensearch.core.msearch.MultiSearchResponseItem;
+
+class SuccessfulMultiSearchResponseMatcher extends TypeSafeDiagnosingMatcher<MsearchResponse<?>> {
+
+    @Override
+    protected boolean matchesSafely(MsearchResponse<?> response, Description mismatchDescription) {
+        for (MultiSearchResponseItem<?> itemResponse : response.responses()) {
+            if (itemResponse.isFailure()) {
+                mismatchDescription.appendValue("Get an item failed: ").appendValue(itemResponse.failure().error().reason());
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful multi search response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulOpenIndexResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulOpenIndexResponseMatcher.java
@@ -1,0 +1,36 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.OpenResponse;
+
+class SuccessfulOpenIndexResponseMatcher extends TypeSafeDiagnosingMatcher<OpenResponse> {
+
+    @Override
+    protected boolean matchesSafely(OpenResponse response, Description mismatchDescription) {
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful open index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulResizeResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulResizeResponseMatcher.java
@@ -1,0 +1,51 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.ShrinkResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class SuccessfulResizeResponseMatcher extends TypeSafeDiagnosingMatcher<ShrinkResponse> {
+
+    private final String expectedIndexName;
+
+    SuccessfulResizeResponseMatcher(String expectedIndexName) {
+        this.expectedIndexName = requireNonNull(expectedIndexName);
+    }
+
+    @Override
+    protected boolean matchesSafely(ShrinkResponse response, Description mismatchDescription) {
+        if (!expectedIndexName.equals(response.index())) {
+            mismatchDescription.appendText("Index name ")
+                .appendValue(response.index())
+                .appendText(" does not match expected index name ")
+                .appendValue(expectedIndexName);
+            return false;
+        }
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful create index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulSearchResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulSearchResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+class SuccessfulSearchResponseMatcher extends TypeSafeDiagnosingMatcher<SearchResponse<?>> {
+
+    @Override
+    protected boolean matchesSafely(SearchResponse<?> searchResponse, Description mismatchDescription) {
+        if (searchResponse.shards().failed() != 0) {
+            mismatchDescription.appendText("contains ").appendValue(searchResponse.shards().failed()).appendText(" shard failures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful search response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulSplitResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulSplitResponseMatcher.java
@@ -1,0 +1,51 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.indices.SplitResponse;
+
+import static java.util.Objects.requireNonNull;
+
+class SuccessfulSplitResponseMatcher extends TypeSafeDiagnosingMatcher<SplitResponse> {
+
+    private final String expectedIndexName;
+
+    SuccessfulSplitResponseMatcher(String expectedIndexName) {
+        this.expectedIndexName = requireNonNull(expectedIndexName);
+    }
+
+    @Override
+    protected boolean matchesSafely(SplitResponse response, Description mismatchDescription) {
+        if (!expectedIndexName.equals(response.index())) {
+            mismatchDescription.appendText("Index name ")
+                .appendValue(response.index())
+                .appendText(" does not match expected index name ")
+                .appendValue(expectedIndexName);
+            return false;
+        }
+        if (!response.shardsAcknowledged()) {
+            mismatchDescription.appendText("shardsAcknowledged is equal to ").appendValue(response.shardsAcknowledged());
+            return false;
+        }
+        if (!response.acknowledged()) {
+            mismatchDescription.appendText("acknowledged is equal to ").appendValue(response.acknowledged());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful create index response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulUpdateResponseMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/SuccessfulUpdateResponseMatcher.java
@@ -1,0 +1,32 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch.core.UpdateResponse;
+
+class SuccessfulUpdateResponseMatcher extends TypeSafeDiagnosingMatcher<UpdateResponse<?>> {
+
+    @Override
+    protected boolean matchesSafely(UpdateResponse<?> response, Description mismatchDescription) {
+        if (response.shards().failed() != 0) {
+            mismatchDescription.appendText("contains ").appendValue(response.shards().failed()).appendText(" shard failures");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Successful update response");
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/TransportExceptionMatcher.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/TransportExceptionMatcher.java
@@ -1,0 +1,78 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import java.io.IOException;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.transport.TransportException;
+import org.opensearch.client.transport.httpclient5.ResponseException;
+import org.opensearch.core.rest.RestStatus;
+
+import static java.util.Objects.requireNonNull;
+
+class TransportExceptionMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+    private final RestStatus expectedRestStatus;
+
+    public TransportExceptionMatcher(RestStatus expectedRestStatus) {
+        this.expectedRestStatus = requireNonNull(expectedRestStatus, "Expected rest status is required.");
+    }
+
+    @Override
+    protected boolean matchesSafely(Throwable throwable, Description mismatchDescription) {
+        Throwable cause = throwable;
+
+        if (cause instanceof IOException && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+
+        if (cause instanceof TransportException && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+
+        if (cause instanceof OpenSearchException ose) {
+            if (expectedRestStatus.getStatus() != ose.status()) {
+                mismatchDescription.appendText("actual status code is ")
+                    .appendValue(ose.status())
+                    .appendText(", error message ")
+                    .appendValue(cause.getMessage());
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        if ((cause instanceof ResponseException) == false) {
+            mismatchDescription.appendText("actual exception type is ")
+                .appendValue(cause.getClass().getCanonicalName())
+                .appendText(", error message ")
+                .appendValue(cause.getMessage());
+            return false;
+        }
+        ResponseException openSearchException = (ResponseException) cause;
+        if (expectedRestStatus.getStatus() != openSearchException.status()) {
+            mismatchDescription.appendText("actual status code is ")
+                .appendValue(openSearchException.status())
+                .appendText(", error message ")
+                .appendValue(cause.getMessage());
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("OpenSearchException with status code ").appendValue(expectedRestStatus);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/TransportExceptionMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/TransportExceptionMatchers.java
@@ -1,0 +1,23 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.core.rest.RestStatus;
+
+public class TransportExceptionMatchers {
+
+    private TransportExceptionMatchers() {}
+
+    public static Matcher<Throwable> statusException(RestStatus expectedRestStatus) {
+        return new TransportExceptionMatcher(expectedRestStatus);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/test/framework/matcher/client/UpdateResponseMatchers.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/matcher/client/UpdateResponseMatchers.java
@@ -1,0 +1,23 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*
+*/
+package org.opensearch.test.framework.matcher.client;
+
+import org.hamcrest.Matcher;
+
+import org.opensearch.client.opensearch.core.UpdateResponse;
+
+public class UpdateResponseMatchers {
+
+    private UpdateResponseMatchers() {}
+
+    public static Matcher<UpdateResponse<?>> isSuccessfulUpdateResponse() {
+        return new SuccessfulUpdateResponseMatcher();
+    }
+}

--- a/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
+++ b/src/test/java/org/opensearch/security/InitializationIntegrationTests.java
@@ -28,6 +28,8 @@ package org.opensearch.security;
 
 import java.io.File;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.core5.http.Header;
@@ -41,9 +43,11 @@ import org.opensearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.opensearch.action.admin.cluster.node.info.NodesInfoRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.generic.Body;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.generic.Response;
+import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.cluster.health.ClusterHealthStatus;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.core.common.transport.TransportAddress;
@@ -141,12 +145,13 @@ public class InitializationIntegrationTests extends SingleClusterTest {
             true
         );
 
-        try (RestHighLevelClient restHighLevelClient = getRestClient(clusterInfo, "spock-keystore", "truststore")) {
-            Response whoAmIRes = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "/_plugins/_security/whoami"));
-            assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
+        try (OpenSearchTransport transport = getClientTransport(clusterInfo, "spock-keystore", "truststore")) {
+            OpenSearchClient client = new OpenSearchClient(transport);
+            Response whoAmIRes = client.generic().execute(Requests.create("GET", "/_plugins/_security/whoami", List.of(), Map.of(), null));
+            assertThat(200, is(whoAmIRes.getStatus()));
             // Should be using HTTP/2 by default
-            assertThat(HttpVersion.HTTP_2, is(whoAmIRes.getStatusLine().getProtocolVersion()));
-            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getEntity().getContent());
+            assertThat(whoAmIRes.getProtocol(), is(HttpVersion.HTTP_2.toString()));
+            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getBody().map(Body::bodyAsString).orElse(null));
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
             assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_admin").asBoolean());
@@ -169,18 +174,14 @@ public class InitializationIntegrationTests extends SingleClusterTest {
         );
 
         try (
-            RestHighLevelClient restHighLevelClient = getRestClient(
-                clusterInfo,
-                "spock-keystore",
-                "truststore",
-                HttpVersionPolicy.FORCE_HTTP_1
-            )
+            OpenSearchTransport transport = getClientTransport(clusterInfo, "spock-keystore", "truststore", HttpVersionPolicy.FORCE_HTTP_1)
         ) {
-            Response whoAmIRes = restHighLevelClient.getLowLevelClient().performRequest(new Request("GET", "/_plugins/_security/whoami"));
-            assertThat(200, is(whoAmIRes.getStatusLine().getStatusCode()));
+            OpenSearchClient client = new OpenSearchClient(transport);
+            Response whoAmIRes = client.generic().execute(Requests.create("GET", "/_plugins/_security/whoami", List.of(), Map.of(), null));
+            assertThat(200, is(whoAmIRes.getStatus()));
             // The HTTP/1.1 is forced and should be used instead
-            assertThat(whoAmIRes.getStatusLine().getProtocolVersion(), is(HttpVersion.HTTP_1_1));
-            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getEntity().getContent());
+            assertThat(whoAmIRes.getProtocol(), is(HttpVersion.HTTP_1_1.toString()));
+            JsonNode whoAmIResNode = DefaultObjectMapper.objectMapper().readTree(whoAmIRes.getBody().map(Body::bodyAsString).orElse(null));
             String whoAmIResponsePayload = whoAmIResNode.toPrettyString();
             assertThat(whoAmIResponsePayload, whoAmIResNode.get("dn").asText(), is("CN=spock,OU=client,O=client,L=Test,C=DE"));
             Assert.assertFalse(whoAmIResponsePayload, whoAmIResNode.get("is_admin").asBoolean());

--- a/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
+++ b/src/test/java/org/opensearch/security/auditlog/compliance/ComplianceAuditlogTest.java
@@ -22,12 +22,12 @@ import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
 
-import org.opensearch.action.get.GetRequest;
-import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
-import org.opensearch.client.RequestOptions;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.BooleanResponse;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.auditlog.AbstractAuditlogUnitTest;
 import org.opensearch.security.auditlog.AuditTestUtils;
@@ -278,11 +278,17 @@ public class ComplianceAuditlogTest extends AbstractAuditlogUnitTest {
             "audit"
         );
         final List<AuditMessage> messages = TestAuditlogImpl.doThenWaitForMessages(() -> {
-            try (RestHighLevelClient restHighLevelClient = getRestClient(clusterInfo, "kirk-keystore", "truststore")) {
+            try (OpenSearchTransport transport = getClientTransport(clusterInfo, "kirk-keystore", "truststore")) {
+                OpenSearchClient client = new OpenSearchClient(transport);
+
                 for (IndexRequest ir : new DynamicSecurityConfig().setSecurityRoles("roles_2.yml").getDynamicConfig(getResourceFolder())) {
-                    restHighLevelClient.index(ir, RequestOptions.DEFAULT);
-                    GetResponse getDocumentResponse = restHighLevelClient.get(new GetRequest(ir.index(), ir.id()), RequestOptions.DEFAULT);
-                    assertThat(getDocumentResponse.isExists(), equalTo(true));
+                    org.opensearch.client.opensearch.core.IndexRequest<?> request = org.opensearch.client.opensearch.core.IndexRequest.of(
+                        b -> b.document(ir.source()).id(ir.id()).index(ir.index()).refresh(Refresh.True)
+                    );
+                    client.index(request);
+
+                    BooleanResponse getDocumentResponse = client.exists(b -> b.index(ir.index()).id(ir.id()));
+                    assertThat(getDocumentResponse.value(), equalTo(true));
                 }
             } catch (IOException ioe) {
                 throw new RuntimeException("Unexpected exception", ioe);

--- a/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
+++ b/src/test/java/org/opensearch/security/test/AbstractSecurityUnitTest.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
@@ -49,13 +48,11 @@ import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBu
 import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.core5.function.Factory;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.http2.HttpVersionPolicy;
-import org.apache.hc.core5.reactor.ssl.TlsDetails;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.logging.log4j.LogManager;
@@ -73,9 +70,9 @@ import org.opensearch.action.admin.indices.create.CreateIndexRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.RestClient;
-import org.opensearch.client.RestClientBuilder;
-import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.client.json.jackson3.JacksonJsonpMapper;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.opensearch.cluster.node.DiscoveryNodeRole;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.security.action.configupdate.ConfigUpdateAction;
@@ -92,6 +89,7 @@ import org.opensearch.security.test.helper.rest.RestHelper.HttpResponse;
 import org.opensearch.security.test.helper.rules.SecurityTestWatcher;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
+import org.opensearch.transport.netty4.ssl.SslUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -151,11 +149,11 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
         );
     }
 
-    protected RestHighLevelClient getRestClient(ClusterInfo info, String keyStoreName, String trustStoreName) {
-        return getRestClient(info, keyStoreName, trustStoreName, null);
+    protected OpenSearchTransport getClientTransport(ClusterInfo info, String keyStoreName, String trustStoreName) {
+        return getClientTransport(info, keyStoreName, trustStoreName, null);
     }
 
-    protected RestHighLevelClient getRestClient(
+    protected OpenSearchTransport getClientTransport(
         ClusterInfo info,
         String keyStoreName,
         String trustStoreName,
@@ -181,30 +179,24 @@ public abstract class AbstractSecurityUnitTest extends RandomizedTest {
 
             HttpHost httpHost = new HttpHost("https", info.httpHost, info.httpPort);
 
-            RestClientBuilder restClientBuilder = RestClient.builder(httpHost).setHttpClientConfigCallback(builder -> {
-                TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
-                    .setSslContext(sslContext)
-                    .setTlsVersions(new String[] { "TLSv1", "TLSv1.1", "TLSv1.2", "SSLv3" })
-                    .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
-                    .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                    // See please https://issues.apache.org/jira/browse/HTTPCLIENT-2219
-                    .setTlsDetailsFactory(new Factory<SSLEngine, TlsDetails>() {
-                        @Override
-                        public TlsDetails create(final SSLEngine sslEngine) {
-                            return new TlsDetails(sslEngine.getSession(), sslEngine.getApplicationProtocol());
-                        }
-                    })
-                    .build();
+            final ApacheHttpClient5TransportBuilder transportBuilder = ApacheHttpClient5TransportBuilder.builder(httpHost)
+                .setHttpClientConfigCallback(builder -> {
+                    TlsStrategy tlsStrategy = ClientTlsStrategyBuilder.create()
+                        .setSslContext(sslContext)
+                        .setTlsVersions(SslUtils.DEFAULT_SSL_PROTOCOLS)
+                        .setHostVerificationPolicy(HostnameVerificationPolicy.CLIENT)
+                        .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                        .buildAsync();
 
-                final PoolingAsyncClientConnectionManagerBuilder cm = PoolingAsyncClientConnectionManagerBuilder.create()
-                    .setTlsStrategy(tlsStrategy);
+                    final PoolingAsyncClientConnectionManagerBuilder cm = PoolingAsyncClientConnectionManagerBuilder.create()
+                        .setTlsStrategy(tlsStrategy);
 
-                if (httpVersionPolicy != null) {
-                    cm.setDefaultTlsConfig(TlsConfig.custom().setVersionPolicy(httpVersionPolicy).build());
-                }
-                return builder.setConnectionManager(cm.build());
-            });
-            return new RestHighLevelClient(restClientBuilder);
+                    if (httpVersionPolicy != null) {
+                        cm.setDefaultTlsConfig(TlsConfig.custom().setVersionPolicy(httpVersionPolicy).build());
+                    }
+                    return builder.setConnectionManager(cm.build());
+                });
+            return transportBuilder.setMapper(new JacksonJsonpMapper()).build();
         } catch (Exception e) {
             log.error("Cannot create client", e);
             throw new RuntimeException("Cannot create client", e);


### PR DESCRIPTION
### Description
In scope of https://github.com/opensearch-project/OpenSearch/issues/22578, the suggestion is to deprecate the `RestHighLevelClient` in favor of a single official Java client (OpenSearch Java Client). To make the case that we have no gaps, replacing `RestHighLevelClient` usage with `OpenSearchClient`.

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/22578

Is this a backport? If so, please add backport PR # and/or commits #, and remove `backport-failed` label from the original PR.

Do these changes introduce new permission(s) to be displayed in the static dropdown on the front-end? If so, please open a draft PR in the security dashboards plugin and link the draft PR here

### Testing
Covered by existing tests

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
