### PR TITLE
Bump com.google.guava:guava from 33.6.0-jre to 33.7.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -498,6 +498,7 @@ configurations {
             force "io.netty:netty-transport-native-unix-common:${versions.netty}"
             force "com.github.luben:zstd-jni:${versions.zstd}"
             force libs.google.guava
+            force libs.jspecify
             force libs.lz4.java
             force libs.snappy.java
 
@@ -695,6 +696,7 @@ dependencies {
     implementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
     implementation "org.apache.httpcomponents:httpasyncclient:${versions.httpasyncclient}"
     implementation libs.google.guava
+
     implementation 'org.greenrobot:eventbus-java:3.3.1'
     implementation 'commons-cli:commons-cli:1.11.0'
     // When building with crypto.standard=FIPS-140-3 (set in gradle.properties), bcFips jars are provided by OpenSearch
@@ -768,8 +770,8 @@ dependencies {
     runtimeOnly 'org.apache.ws.xmlschema:xmlschema-core:2.3.2'
     runtimeOnly 'org.apache.santuario:xmlsec:2.3.5'
     runtimeOnly "com.github.luben:zstd-jni:${versions.zstd}"
-    testRuntimeOnly 'com.google.guava:failureaccess:1.0.3'
-    testRuntimeOnly 'org.checkerframework:checker-qual:3.55.1'
+    testRuntimeOnly "com.google.guava:failureaccess:1.0.3"
+    testRuntimeOnly "org.checkerframework:checker-qual:3.55.1"
 
 
     testImplementation libs.opensaml.messaging.impl

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,10 @@ jjwt                = "0.13.0"
 jaxb                = "2.3.9"
 lz4_java            = "1.11.2"
 snappy_java         = "1.1.10.8"
-guava               = "33.6.0-jre"
+guava               = "33.7.1-jre"
+jspecify            = "1.0.1"
 spring_framework    = "7.0.9"
+
 
 [libraries]
 #OneLogin saml
@@ -50,6 +52,7 @@ lz4-java = { group = "at.yawk.lz4", name = "lz4-java", version.ref = "lz4_java" 
 snappy-java = { group = "org.xerial.snappy", name = "snappy-java", version.ref = "snappy_java" }
 
 google-guava = { group = "com.google.guava", name="guava", version.ref = "guava" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 
 #spring framework
 springframework-core = { group = "org.springframework", name = "spring-core", version.ref = "spring_framework" }

--- a/sample-resource-plugin/build.gradle
+++ b/sample-resource-plugin/build.gradle
@@ -80,6 +80,8 @@ configurations {
             force "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
             force "com.google.protobuf:protobuf-java:${versions.protobuf}"
             force libs.google.guava
+            force libs.jspecify
+
             force "com.google.guava:failureaccess:1.0.3"
             force "io.projectreactor:reactor-core:3.8.6"
 


### PR DESCRIPTION
### Description
Bump com.google.guava:guava from 33.6.0-jre to 33.7.1-jre

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] New Roles/Permissions have a corresponding security dashboards plugin PR
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md)
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/security/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
